### PR TITLE
Update text for missing canteen meals

### DIFF
--- a/frontend/app/locales/translations.json
+++ b/frontend/app/locales/translations.json
@@ -950,14 +950,14 @@
     "zh": "食品优惠"
   },
   "no_foodoffers_found_for_selection": {
-    "de": "Keine Angebote gefunden.",
-    "en": "No offers found.",
-    "ar": "لم يتم العثور على عروض.",
-    "es": "No se encontraron ofertas.",
-    "fr": "Aucune offre trouvée.",
-    "ru": "Предложений не найдено.",
-    "tr": "Teklif bulunamadı.",
-    "zh": "未找到优惠。"
+    "de": "Keine Angebote gefunden oder Mensa geschlossen.",
+    "en": "No offers found or canteen closed.",
+    "ar": "لم يتم العثور على عروض أو المقصف مغلق.",
+    "es": "No se encontraron ofertas o la cantina está cerrada.",
+    "fr": "Aucune offre trouvée ou cantine fermée.",
+    "ru": "Предложений не найдено или столовая закрыта.",
+    "tr": "Teklif bulunamadı veya yemekhane kapalı.",
+    "zh": "未找到优惠或食堂已关闭。"
   },
   "error": {
     "de": "Fehler",


### PR DESCRIPTION
## Summary
- adjust "no food offers" message to also mention when the canteen is closed
- provide translations for all supported languages

## Testing
- `npm test --silent --runTestsByPath ""` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ade9c9dc833097bf985d2c142254