### PR TITLE
Fix bottom sheet reopening after drag close

### DIFF
--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -973,6 +973,11 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
             enableHandlePanningGesture={
               selectedSheet === 'forecast' ? false : true
             }
+            onChange={(index) => {
+              if (index === -1) {
+                closeSheet();
+              }
+            }}
             backdropComponent={(props) => (
               <BottomSheetBackdrop {...props} onPress={closeSheet} />
             )}


### PR DESCRIPTION
## Summary
- ensure sheet resets when the bottom sheet is dismissed via drag

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af8f44d048330b2f4e129d5c1a058