### PR TITLE
Implement sticky close header for sheets

### DIFF
--- a/frontend/app/app/(app)/account-balance/index.tsx
+++ b/frontend/app/app/(app)/account-balance/index.tsx
@@ -25,10 +25,9 @@ import { format } from 'date-fns';
 import useMyCardReader, { MyCardReaderInterface } from './MyCardReader';
 import { isWeb } from '@/constants/Constants';
 import CardResponse from '@/helper/nfcCardReaderHelper/CardResponse';
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetView,
-} from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useFocusEffect } from 'expo-router';
 import { AntDesign } from '@expo/vector-icons';
 import useToast from '@/hooks/useToast';
@@ -70,7 +69,6 @@ const AccountBalanceScreen = () => {
   const [autoPlay, setAutoPlay] = useState(appSettings?.animations_auto_start);
   const animationRef = useRef<LottieView>(null);
   const nfcSheetRef = useRef<BottomSheet>(null);
-  const nfcPoints = useMemo(() => ['80%'], []);
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
@@ -365,17 +363,16 @@ const AccountBalanceScreen = () => {
         </View>
       </View>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={nfcSheetRef}
           index={-1}
-          snapPoints={nfcPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={hideInstruction}
         >
           <BottomSheetView>
             <View
@@ -393,19 +390,6 @@ const AccountBalanceScreen = () => {
               >
                 NFC
               </Text>
-              <TouchableOpacity
-                style={{
-                  ...styles.sheetcloseButton,
-                  backgroundColor: theme.sheet.closeBg,
-                }}
-                onPress={hideInstruction}
-              >
-                <AntDesign
-                  name='close'
-                  size={24}
-                  color={theme.sheet.closeIcon}
-                />
-              </TouchableOpacity>
             </View>
             <View style={styles.sheetView}>
               <Text
@@ -434,7 +418,7 @@ const AccountBalanceScreen = () => {
               </View>
             </View>
           </BottomSheetView>
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </ScrollView>
   );

--- a/frontend/app/app/(app)/account-balance/styles.ts
+++ b/frontend/app/app/(app)/account-balance/styles.ts
@@ -12,7 +12,7 @@ export const styles = StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -27,7 +27,7 @@ export const styles = StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   additionalInfoContainer: {
     width: '100%',

--- a/frontend/app/app/(app)/campus/index.tsx
+++ b/frontend/app/app/(app)/campus/index.tsx
@@ -38,7 +38,8 @@ import {
 } from '@/redux/Types/types';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { calculateDistanceInMeter } from '@/helper/distanceHelper';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import BuildingSortSheet from '@/components/BuildingSortSheet/BuildingSortSheet';
 import useToast from '@/hooks/useToast';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -81,9 +82,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
 
   const sortSheetRef = useRef<BottomSheet>(null);
-  const sortPoints = useMemo(() => ['80%'], []);
   const imageManagementSheetRef = useRef<BottomSheet>(null);
-  const imageManagementPoints = useMemo(() => ['70%'], []);
 
   const openSortSheet = () => {
     sortSheetRef.current?.expand();
@@ -421,26 +420,24 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           </View>
         </ScrollView>
         {isActive && (
-          <BottomSheet
+          <BaseBottomSheet
             ref={sortSheetRef}
             index={-1}
-            snapPoints={sortPoints}
             backgroundStyle={{
               ...styles.sheetBackground,
               backgroundColor: theme.sheet.sheetBg,
             }}
             enablePanDownToClose
             handleComponent={null}
-            backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+            onClose={closeSortSheet}
           >
             <BuildingSortSheet closeSheet={closeSortSheet} freeRooms={false} />
-          </BottomSheet>
+          </BaseBottomSheet>
         )}
         {isActive && (
-          <BottomSheet
+          <BaseBottomSheet
             ref={imageManagementSheetRef}
             index={-1}
-            snapPoints={imageManagementPoints}
             backgroundStyle={{
               ...styles.sheetBackground,
               backgroundColor: theme.sheet.sheetBg,
@@ -449,7 +446,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
             enablePanDownToClose
             enableHandlePanningGesture={false}
             enableContentPanningGesture={false}
-            backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+            onClose={closeImageManagementSheet}
           >
             <ImageManagementSheet
               closeSheet={closeImageManagementSheet}
@@ -460,7 +457,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
               }}
               fileName='buildings'
             />
-          </BottomSheet>
+          </BaseBottomSheet>
         )}
       </View>
     </SafeAreaView>

--- a/frontend/app/app/(app)/course-timetable/index.tsx
+++ b/frontend/app/app/(app)/course-timetable/index.tsx
@@ -13,7 +13,8 @@ import CourseTimetable from '../../../components/CourseTimeTable/CourseTimetable
 import CourseBottomSheet from '../../../components/CourseTimeTable/CourseBottomSheet';
 import styles from './styles';
 import { FontAwesome } from '@expo/vector-icons';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { useSelector } from 'react-redux';
 import { EventTypes } from './types';
 import { courseTimetableDescriptionEmpty } from '@/constants/translationConstants';
@@ -57,7 +58,6 @@ const TimetableScreen = () => {
   } = useSelector((state: RootState) => state.settings);
   const { profile } = useSelector((state: RootState) => state.authReducer);
   const bottomSheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => ['90%'], []);
   const [events, setEvents] = useState<EventTypes[]>([]);
   const [isActive, setIsActive] = useState(false);
   const [isUpdate, setIsUpdate] = useState(false);
@@ -210,17 +210,16 @@ const TimetableScreen = () => {
         </View>
       )}
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={bottomSheetRef}
           index={-1}
-          snapPoints={snapPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeSheet}
         >
           <CourseBottomSheet
             timeTableData={timeTableData}
@@ -228,7 +227,7 @@ const TimetableScreen = () => {
             isUpdate={isUpdate}
             selectedEventId={selectedEventId}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </View>
   );

--- a/frontend/app/app/(app)/course-timetable/styles.ts
+++ b/frontend/app/app/(app)/course-timetable/styles.ts
@@ -101,7 +101,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '60%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     alignSelf: 'flex-end',
     borderTopRightRadius: 28,

--- a/frontend/app/app/(app)/data-access/index.tsx
+++ b/frontend/app/app/(app)/data-access/index.tsx
@@ -4,7 +4,8 @@ import DataAcess from '../../../components/DataAcces/DataAccess';
 import DataSheet from '../../../components/DataAccesheet/DataSheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { useFocusEffect } from 'expo-router';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -13,7 +14,6 @@ const index = () => {
   useSetPageTitle(TranslationKeys.dataAccess);
   const { theme } = useTheme();
   const bottomSheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => ['90%'], []);
   const [isActive, setIsActive] = useState(false);
   const [content, setContent] = useState([]);
 
@@ -39,20 +39,19 @@ const index = () => {
     <View style={styles.container}>
       <DataAcess onOpenBottomSheet={handleOpenBottomSheet} />
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={bottomSheetRef}
           index={-1}
-          snapPoints={snapPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeCanteenSheet}
         >
           <DataSheet closeSheet={closeCanteenSheet} content={content} />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </View>
   );

--- a/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -30,7 +30,8 @@ import {
 } from '@/redux/Types/types';
 import MenuSheet from '@/components/MenuSheet/MenuSheet';
 import PermissionModal from '@/components/PermissionModal/PermissionModal';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import NotificationSheet from '@/components/NotificationSheet/NotificationSheet';
 import usePlatformHelper from '@/helper/platformHelper';
 import { NotificationHelper } from '@/helper/NotificationHelper';
@@ -66,7 +67,6 @@ export default function FoodDetailsScreen() {
   const { translate } = useLanguage();
   const dispatch = useDispatch();
   const menuSheetRef = useRef<BottomSheet>(null);
-  const menuPoints = useMemo(() => ['90%'], []);
   const { isSmartPhone, isAndroid, isIOS } = usePlatformHelper();
   const { user, profile } = useSelector(
     (state: RootState) => state.authReducer
@@ -117,7 +117,6 @@ export default function FoodDetailsScreen() {
     Dimensions.get('window').width
   );
   const notificationSheetRef = useRef<BottomSheet>(null);
-  const notificationPoints = useMemo(() => ['90%'], []);
 
   const openNotificationSheet = () => {
     notificationSheetRef?.current?.expand();
@@ -868,32 +867,30 @@ export default function FoodDetailsScreen() {
         </View>
       </ScrollView>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={notificationSheetRef}
           index={-1}
-          snapPoints={notificationPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeNotificationSheet}
         >
           <NotificationSheet
             closeSheet={closeNotificationSheet}
             previousFeedback={previousFeedback}
             foodDetails={foodDetails}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
       {/* Menu sheet */}
 
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={menuSheetRef}
           index={-1}
-          snapPoints={menuPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
@@ -902,10 +899,10 @@ export default function FoodDetailsScreen() {
           handleComponent={null}
           enableHandlePanningGesture={false}
           enableContentPanningGesture={false}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeMenuSheet}
         >
           <MenuSheet closeSheet={closeMenuSheet} />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </SafeAreaView>
   );

--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -49,7 +49,8 @@ import {
   MaterialIcons,
 } from '@expo/vector-icons';
 import { RootDrawerParamList } from './types';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import CanteenSelectionSheet from '@/components/CanteenSelectionSheet/CanteenSelectionSheet';
 import SortSheet from '@/components/SortSheet/SortSheet';
 import HourSheet from '@/components/HoursSheet/HoursSheet';
@@ -94,16 +95,6 @@ export const SHEET_COMPONENTS = {
   eatingHabits: EatingHabitsSheet,
 };
 
-const SHEET_POINTS = {
-  canteen: ['100%'],
-  sort: ['80%'],
-  hours: ['85%'],
-  calendar: ['80%'],
-  forecast: ['80%'],
-  menu: ['90%'],
-  imageManagement: ['80%'],
-  eatingHabits: ['90%'],
-};
 
 const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const dispatch = useDispatch();
@@ -113,7 +104,6 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const drawerNavigation =
     useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
   const bottomSheetRef = useRef<BottomSheet>(null);
-  const eventPoints = useMemo(() => ['100%'], []);
   const eventSheetRef = useRef<BottomSheet>(null);
   const businessHoursHelper = new BusinessHoursHelper();
   const canteenFeedbackLabelHelper = new CanteenFeedbackLabelHelper();
@@ -302,10 +292,6 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     if (isActive && selectedSheet) {
       setTimeout(() => {
         bottomSheetRef.current?.expand();
-        bottomSheetRef.current?.snapToIndex(0);
-        bottomSheetRef.current?.snapToPosition(
-          SHEET_POINTS[selectedSheet!][0] || '80%'
-        );
       }, 150);
     }
   }, [selectedSheet, isActive]);
@@ -958,7 +944,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           </ScrollView>
         </View>
         {isActive && (
-          <BottomSheet
+          <BaseBottomSheet
             key={selectedSheet}
             ref={bottomSheetRef}
             // snapPoints={['40%']}
@@ -978,35 +964,32 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 closeSheet();
               }
             }}
-            backdropComponent={(props) => (
-              <BottomSheetBackdrop {...props} onPress={closeSheet} />
-            )}
+            onClose={closeSheet}
             handleComponent={null}
           >
             {SheetComponent && (
               <SheetComponent closeSheet={closeSheet} {...sheetProps} />
             )}
-          </BottomSheet>
+          </BaseBottomSheet>
         )}
 
         {isActive && (
-          <BottomSheet
+          <BaseBottomSheet
             ref={eventSheetRef}
             index={-1}
-            snapPoints={eventPoints}
             backgroundStyle={{
               ...styles.sheetBackground,
               backgroundColor: theme.sheet.sheetBg,
             }}
             enablePanDownToClose={false}
-            enableDynamicSizing={false}
             handleComponent={null}
+            onClose={closeEventSheet}
           >
             <PopupEventSheet
               closeSheet={closeEventSheet}
               eventData={popupEvents?.find((e: any) => e.isCurrent) || {}}
             />
-          </BottomSheet>
+          </BaseBottomSheet>
         )}
       </SafeAreaView>
     </>

--- a/frontend/app/app/(app)/form-submission/index.tsx
+++ b/frontend/app/app/(app)/form-submission/index.tsx
@@ -25,7 +25,8 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { isWeb } from '@/constants/Constants';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import useToast from '@/hooks/useToast';
 import { FormAnswersHelper } from '@/redux/actions/Forms/FormAnswers';
 import SubmissionWarningModal from '@/components/SubmissionWarningModal/SubmissionWarningModal';
@@ -82,11 +83,8 @@ const index = () => {
   const formAnswersHelper = new FormAnswersHelper();
   const formsSubmissionsHelper = new FormsSubmissionsHelper();
   const sheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => ['80%'], []);
   const editSheetRef = useRef<BottomSheet>(null);
-  const editSnapPoints = useMemo(() => ['80%'], []);
   const warningSheetRef = useRef<BottomSheet>(null);
-  const warningSnapPoints = useMemo(() => ['60%'], []);
   const [loading, setLoading] = useState(false);
   const [isActive, setIsActive] = useState(false);
   const [isWarning, setIsWarning] = useState(false);
@@ -995,55 +993,51 @@ const index = () => {
         id={String(form_submission_id)}
       />
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={editSheetRef}
           index={-1}
-          snapPoints={editSnapPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeEditSheet}
         >
           <EditFormSubmissionSheet
             id={String(form_submission_id)}
             closeSheet={closeEditSheet}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={warningSheetRef}
           index={-1}
-          snapPoints={warningSnapPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose={false}
-          enableDynamicSizing={false}
           handleComponent={null}
         >
           <SubmissionWarningSheet
             id={String(form_submission_id)}
             closeSheet={closeWarningSheet}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={sheetRef}
           index={-1}
-          snapPoints={snapPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeFilterSheet}
         >
           <FilterFormSheet
             closeSheet={closeFilterSheet}
@@ -1053,7 +1047,7 @@ const index = () => {
             options={filterOptions}
             isEditMode={isEditMode}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </View>
   );

--- a/frontend/app/app/(app)/form-submissions/index.tsx
+++ b/frontend/app/app/(app)/form-submissions/index.tsx
@@ -23,7 +23,8 @@ import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useSelector } from 'react-redux';
 import { isWeb } from '@/constants/Constants';
 import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import FilterFormSheet from '@/components/FilterFormSheet/FilterFormSheet';
 import { excerpt } from '@/constants/HelperFunctions';
 import { filterOptions } from './constants';
@@ -37,7 +38,6 @@ const index = () => {
   const { theme } = useTheme();
   const { form_id } = useLocalSearchParams();
   const sheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => ['80%'], []);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState<string>('');
   const [isActive, setIsActive] = useState(false);
@@ -291,17 +291,16 @@ const index = () => {
         </View>
       </View>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={sheetRef}
           index={-1}
-          snapPoints={snapPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeFilterSheet}
         >
           <FilterFormSheet
             closeSheet={closeFilterSheet}
@@ -310,7 +309,7 @@ const index = () => {
             selectedOption={selectedOption}
             options={filterOptions}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </View>
   );

--- a/frontend/app/app/(app)/housing/index.tsx
+++ b/frontend/app/app/(app)/housing/index.tsx
@@ -38,7 +38,8 @@ import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { calculateDistanceInMeter } from '@/helper/distanceHelper';
 import { ApartmentsHelper } from '@/redux/actions/Apartments/Apartments';
 import ApartmentItem from '@/components/ApartmentItem/ApartmentItem';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import BuildingSortSheet from '@/components/BuildingSortSheet/BuildingSortSheet';
 import useToast from '@/hooks/useToast';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -62,9 +63,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const [loading, setLoading] = useState(false);
   const [isActive, setIsActive] = useState(false);
   const sortSheetRef = useRef<BottomSheet>(null);
-  const sortPoints = useMemo(() => ['80%'], []);
   const imageManagementSheetRef = useRef<BottomSheet>(null);
-  const imageManagementPoints = useMemo(() => ['70%'], []);
   const [apartmentsDispatched, setApartmentsDispatched] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [distanceAdded, setDistanceAdded] = useState(false);
@@ -525,27 +524,25 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           </View>
         </ScrollView>
         {isActive && (
-          <BottomSheet
+          <BaseBottomSheet
             ref={sortSheetRef}
             index={-1}
-            snapPoints={sortPoints}
             backgroundStyle={{
               ...styles.sheetBackground,
               backgroundColor: theme.sheet.sheetBg,
             }}
             enablePanDownToClose
             handleComponent={null}
-            backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+            onClose={closeSortSheet}
           >
             <BuildingSortSheet closeSheet={closeSortSheet} freeRooms={true} />
-          </BottomSheet>
+          </BaseBottomSheet>
         )}
 
         {isActive && (
-          <BottomSheet
+          <BaseBottomSheet
             ref={imageManagementSheetRef}
             index={-1}
-            snapPoints={imageManagementPoints}
             backgroundStyle={{
               ...styles.sheetBackground,
               backgroundColor: theme.sheet.sheetBg,
@@ -554,7 +551,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
             enablePanDownToClose
             enableHandlePanningGesture={false}
             enableContentPanningGesture={false}
-            backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+            onClose={closeImageManagementSheet}
           >
             <ImageManagementSheet
               closeSheet={closeImageManagementSheet}
@@ -565,7 +562,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
               }}
               fileName='buildings'
             />
-          </BottomSheet>
+          </BaseBottomSheet>
         )}
       </View>
     </SafeAreaView>

--- a/frontend/app/app/(app)/settings/index.tsx
+++ b/frontend/app/app/(app)/settings/index.tsx
@@ -67,7 +67,8 @@ import {
 } from '@/redux/Types/types';
 import { performLogout } from '@/helper/logoutHelper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import CanteenSelectionSheet from '@/components/CanteenSelectionSheet/CanteenSelectionSheet';
 import {
   excerpt,
@@ -86,7 +87,6 @@ const Settings = () => {
   const { theme, setThemeMode } = useTheme();
   const dispatch = useDispatch();
   const canteenSheetRef = useRef<BottomSheet>(null);
-  const canteenPoints = useMemo(() => ['100%'], []);
   const [isActive, setIsActive] = useState(false);
   const { translate, setLanguageMode, language } = useLanguage();
   const [isLanguageModalVisible, setIsLanguageModalVisible] = useState(false);
@@ -913,20 +913,19 @@ const Settings = () => {
         </View>
       </ScrollView>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={canteenSheetRef}
           index={-1}
-          snapPoints={canteenPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeCanteenSheet}
         >
           <CanteenSelectionSheet closeSheet={closeCanteenSheet} />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </SafeAreaView>
   );

--- a/frontend/app/app/(monitor)/foodPlanDay/index.tsx
+++ b/frontend/app/app/(monitor)/foodPlanDay/index.tsx
@@ -18,10 +18,9 @@ import { useTheme } from '@/hooks/useTheme';
 import { router, useFocusEffect } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import styles from './styles';
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetView,
-} from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import { BottomSheetView } from '@gorhom/bottom-sheet';
 import {
   AntDesign,
   Entypo,
@@ -52,11 +51,8 @@ const Index = () => {
   const [isActive, setIsActive] = useState(false);
   const [value, setValue] = useState('');
   const canteenSheetRef = useRef<BottomSheet>(null);
-  const canteenPoints = useMemo(() => ['90%'], []);
   const foodCategorySheetRef = useRef<BottomSheet>(null);
-  const foodCategoryPoints = useMemo(() => ['90%'], []);
   const intervalSheetRef = useRef<BottomSheet>(null);
-  const intervalPoints = useMemo(() => ['90%'], []);
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
@@ -429,36 +425,34 @@ const Index = () => {
         </TouchableOpacity>
       </ScrollView>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={canteenSheetRef}
           index={-1}
-          snapPoints={canteenPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeCanteenSheet}
         >
           <ManagementCanteensSheet
             closeSheet={closeCanteenSheet}
             handleSelectCanteen={handleSelectCanteen}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={intervalSheetRef}
           index={-1}
-          snapPoints={intervalPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeIntervalSheet}
         >
           <BottomSheetView
             style={{
@@ -571,26 +565,25 @@ const Index = () => {
               </View>
             </View>
           </BottomSheetView>
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={foodCategorySheetRef}
           index={-1}
-          snapPoints={foodCategoryPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeFoodCategorySheet}
         >
           <ManagementFoodCategorySheet
             closeSheet={closeFoodCategorySheet}
             selectedFoodCategory={selectedFoodCategory}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </>
   );

--- a/frontend/app/app/(monitor)/foodPlanDay/styles.ts
+++ b/frontend/app/app/(monitor)/foodPlanDay/styles.ts
@@ -73,7 +73,7 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_700Bold',
     alignSelf: 'center',
     textAlign: 'center',
-    marginLeft: 30,
+    
   },
   closeButton: {
     borderRadius: 50,

--- a/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -17,10 +17,9 @@ import { useTheme } from '@/hooks/useTheme';
 import { router, useFocusEffect } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import styles from './styles';
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetView,
-} from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import { BottomSheetView } from '@gorhom/bottom-sheet';
 import {
   AntDesign,
   Entypo,
@@ -73,9 +72,7 @@ const Index = () => {
   const [value, setValue] = useState('');
   const [selectedCanteenOption, setSelectedCanteenOption] = useState('');
   const canteenSheetRef = useRef<BottomSheet>(null);
-  const canteenPoints = useMemo(() => ['90%'], []);
   const intervalSheetRef = useRef<BottomSheet>(null);
-  const intervalPoints = useMemo(() => ['90%'], []);
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
@@ -466,36 +463,34 @@ const Index = () => {
       </ScrollView>
 
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={canteenSheetRef}
           index={-1}
-          snapPoints={canteenPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeCanteenSheet}
         >
           <ManagementCanteensSheet
             closeSheet={closeCanteenSheet}
             handleSelectCanteen={handleSelectCanteen}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={intervalSheetRef}
           index={-1}
-          snapPoints={intervalPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeIntervalSheet}
         >
           <BottomSheetView
             style={{
@@ -608,7 +603,7 @@ const Index = () => {
               </View>
             </View>
           </BottomSheetView>
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </>
   );

--- a/frontend/app/app/(monitor)/foodPlanList/styles.ts
+++ b/frontend/app/app/(monitor)/foodPlanList/styles.ts
@@ -72,7 +72,7 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_700Bold',
     alignSelf: 'center',
     textAlign: 'center',
-    marginLeft: 30,
+    
   },
   closeButton: {
     borderRadius: 50,

--- a/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
+++ b/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
@@ -16,7 +16,8 @@ import { useTheme } from '@/hooks/useTheme';
 import { router, useFocusEffect } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import styles from './styles';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { Entypo, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { useLanguage } from '@/hooks/useLanguage';
 import ManagementCanteensSheet from '@/components/ManagementCanteensSheet/ManagementCanteensSheet';
@@ -38,7 +39,6 @@ const Index = () => {
   const { weekPlan } = useSelector((state: RootState) => state.management);
   const [isActive, setIsActive] = useState(false);
   const canteenSheetRef = useRef<BottomSheet>(null);
-  const canteenPoints = useMemo(() => ['90%'], []);
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
@@ -191,23 +191,22 @@ const Index = () => {
         </TouchableOpacity>
       </ScrollView>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={canteenSheetRef}
           index={-1}
-          snapPoints={canteenPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
           }}
           enablePanDownToClose
           handleComponent={null}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeCanteenSheet}
         >
           <ManagementCanteensSheet
             closeSheet={closeCanteenSheet}
             handleSelectCanteen={handleSelectCanteen}
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </>
   );

--- a/frontend/app/app/(monitor)/foodPlanWeek/styles.ts
+++ b/frontend/app/app/(monitor)/foodPlanWeek/styles.ts
@@ -72,7 +72,7 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_700Bold',
     alignSelf: 'center',
     textAlign: 'center',
-    marginLeft: 30,
+    
   },
   closeButton: {
     borderRadius: 50,

--- a/frontend/app/app/(monitor)/statistics/index.tsx
+++ b/frontend/app/app/(monitor)/statistics/index.tsx
@@ -16,7 +16,8 @@ import {
   SET_MOST_LIKED_FOODS,
 } from '@/redux/Types/types';
 import { Foods } from '@/constants/types';
-import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import { useFocusEffect } from 'expo-router';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -30,7 +31,6 @@ const index = () => {
   const [isActive, setIsActive] = useState(false);
   const [selectedFoodId, setSelectedFoodId] = useState('');
   const imageManagementSheetRef = useRef<BottomSheet>(null);
-  const imageManagementPoints = useMemo(() => ['70%'], []);
 
   const { mostLikedFoods, mostDislikedFoods } = useSelector(
     (state: RootState) => state.food
@@ -145,10 +145,9 @@ const index = () => {
         </View>
       </View>
       {isActive && (
-        <BottomSheet
+        <BaseBottomSheet
           ref={imageManagementSheetRef}
           index={-1}
-          snapPoints={imageManagementPoints}
           backgroundStyle={{
             ...styles.sheetBackground,
             backgroundColor: theme.sheet.sheetBg,
@@ -157,7 +156,7 @@ const index = () => {
           enablePanDownToClose
           enableHandlePanningGesture={false}
           enableContentPanningGesture={false}
-          backdropComponent={(props) => <BottomSheetBackdrop {...props} />}
+          onClose={closeImageManagementSheet}
         >
           <ImageManagementSheet
             closeSheet={closeImageManagementSheet}
@@ -165,7 +164,7 @@ const index = () => {
             handleFetch={fetchFoods}
             fileName='foods'
           />
-        </BottomSheet>
+        </BaseBottomSheet>
       )}
     </View>
   );

--- a/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -1,0 +1,60 @@
+import React, { forwardRef, useCallback, useMemo } from 'react';
+import { Dimensions, View, TouchableOpacity } from 'react-native';
+import BottomSheet, {
+  BottomSheetBackdrop,
+  type BottomSheetProps,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { AntDesign } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/useTheme';
+import styles from './styles';
+
+export interface BaseBottomSheetProps extends Omit<BottomSheetProps, 'backdropComponent'> {
+  onClose?: () => void;
+}
+
+const MAX_HEIGHT = Dimensions.get('window').height * 0.8;
+
+const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
+  ({ onClose, children, backgroundStyle, ...props }, ref) => {
+    const renderBackdrop = useCallback(
+      (backdropProps: BottomSheetBackdropProps) => (
+        <BottomSheetBackdrop
+          {...backdropProps}
+          appearsOnIndex={0}
+          disappearsOnIndex={-1}
+          onPress={onClose}
+        />
+      ),
+      [onClose]
+    );
+    const { theme } = useTheme();
+    const snapPoints = useMemo(() => [MAX_HEIGHT], []);
+
+    const headerBg = backgroundStyle?.backgroundColor || theme.sheet.sheetBg;
+
+    return (
+      <BottomSheet
+        ref={ref}
+        snapPoints={snapPoints}
+        style={{ height: MAX_HEIGHT }}
+        backdropComponent={renderBackdrop}
+        backgroundStyle={backgroundStyle}
+        handleComponent={null}
+        {...props}
+      >
+        <View style={[styles.header, { backgroundColor: headerBg }]}>
+          <TouchableOpacity
+            style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
+            onPress={onClose}
+          >
+            <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
+          </TouchableOpacity>
+        </View>
+        {children}
+      </BottomSheet>
+    );
+  }
+);
+
+export default BaseBottomSheet;

--- a/frontend/app/components/BaseBottomSheet/index.ts
+++ b/frontend/app/components/BaseBottomSheet/index.ts
@@ -1,0 +1,2 @@
+export { default } from './BaseBottomSheet';
+export type { BaseBottomSheetProps } from './BaseBottomSheet';

--- a/frontend/app/components/BaseBottomSheet/styles.ts
+++ b/frontend/app/components/BaseBottomSheet/styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  header: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+  },
+  closeButton: {
+    width: 45,
+    height: 45,
+    borderRadius: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/frontend/app/components/BuildingSortSheet/BuildingSortSheet.tsx
+++ b/frontend/app/components/BuildingSortSheet/BuildingSortSheet.tsx
@@ -5,7 +5,6 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
 import {
-  AntDesign,
   FontAwesome5,
   MaterialCommunityIcons,
 } from '@expo/vector-icons';
@@ -122,15 +121,6 @@ const BuildingSortSheet: React.FC<BuildingSortSheetProps> = ({
         >
           {translate(TranslationKeys.sort)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={styles.sortingListContainer}>
         {filteredSortingOptions.map((option) => {

--- a/frontend/app/components/BuildingSortSheet/styles.ts
+++ b/frontend/app/components/BuildingSortSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -29,7 +29,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   sortingListContainer: {
     width: '100%',

--- a/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -116,15 +116,6 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
           {translate(TranslationKeys.select)} :{' '}
           {translate(TranslationKeys.date)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
 
       <View

--- a/frontend/app/components/CalendarSheet/styles.ts
+++ b/frontend/app/components/CalendarSheet/styles.ts
@@ -13,7 +13,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -27,7 +27,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   calendarView: {
     justifyContent: 'center',

--- a/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
+++ b/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
@@ -11,7 +11,7 @@ import {
   SET_CANTEENS,
   SET_SELECTED_CANTEEN,
 } from '@/redux/Types/types';
-import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
 import { Buildings, Canteens } from '@/constants/types';
@@ -129,15 +129,6 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
           paddingTop: isWeb ? 10 : 0,
         }}
       >
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <Text
         style={{

--- a/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -355,15 +355,6 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({
                 TranslationKeys.create
               )}`}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={SheetClose}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
 
       <BottomSheetScrollView

--- a/frontend/app/components/CourseTimeTable/styles.ts
+++ b/frontend/app/components/CourseTimeTable/styles.ts
@@ -143,7 +143,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '95%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,

--- a/frontend/app/components/DataAccesheet/DataSheet.tsx
+++ b/frontend/app/components/DataAccesheet/DataSheet.tsx
@@ -5,7 +5,6 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { DataSheetProps } from './types';
 import { isWeb } from '@/constants/Constants';
-import { AntDesign } from '@expo/vector-icons';
 import { useLanguage } from '@/hooks/useLanguage';
 
 const DataSheet: React.FC<DataSheetProps> = ({ closeSheet, content }) => {
@@ -36,15 +35,6 @@ const DataSheet: React.FC<DataSheetProps> = ({ closeSheet, content }) => {
         >
           {translate(content?.label)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
 
       <Text style={{ fontSize: isWeb ? 18 : 16, color: theme.sheet.text }}>

--- a/frontend/app/components/DataAccesheet/styles.ts
+++ b/frontend/app/components/DataAccesheet/styles.ts
@@ -16,7 +16,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,

--- a/frontend/app/components/EatingHabitsSheet/EatingHabitsSheet.tsx
+++ b/frontend/app/components/EatingHabitsSheet/EatingHabitsSheet.tsx
@@ -2,7 +2,6 @@ import { Text, TouchableOpacity, View } from 'react-native';
 import React from 'react';
 import { isWeb } from '@/constants/Constants';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { AntDesign } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
 import { EatingHabitsSheetProps } from './types';
@@ -42,15 +41,6 @@ const EatingHabitsSheet: React.FC<EatingHabitsSheetProps> = ({
         >
           {translate(TranslationKeys.eating_habits)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={styles.eatingHabitsList}>
         {selectedFoodMarkings?.map((marking: any, index: number) => (

--- a/frontend/app/components/EatingHabitsSheet/styles.ts
+++ b/frontend/app/components/EatingHabitsSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -29,7 +29,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   eatingHabitsList: {
     width: '90%',

--- a/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
+++ b/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
@@ -10,7 +10,6 @@ import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
-import { AntDesign } from '@expo/vector-icons';
 import { sheetProps } from './types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -74,15 +73,6 @@ const EditFormSubmissionSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
         >
           {translate(TranslationKeys.edit)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={styles.editContentContainer}>
         <View

--- a/frontend/app/components/EditFormSubmissionSheet/styles.ts
+++ b/frontend/app/components/EditFormSubmissionSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -29,7 +29,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   editContentContainer: {
     width: '100%',

--- a/frontend/app/components/FilterFormSheet/FilterFormSheet.tsx
+++ b/frontend/app/components/FilterFormSheet/FilterFormSheet.tsx
@@ -5,7 +5,6 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
 import {
-  AntDesign,
   MaterialCommunityIcons,
   MaterialIcons,
 } from '@expo/vector-icons';
@@ -65,15 +64,6 @@ const FilterFormSheet: React.FC<FilterFormSheetProps> = ({
         >
           {translate(TranslationKeys.filter)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={styles.sortingListContainer}>
         {options.map((option, index) => {

--- a/frontend/app/components/FilterFormSheet/styles.ts
+++ b/frontend/app/components/FilterFormSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -29,7 +29,6 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    // marginLeft: 30,
   },
   sortingListContainer: {
     width: '100%',

--- a/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -11,7 +11,6 @@ import { useTheme } from '@/hooks/useTheme';
 import { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
-import { AntDesign } from '@expo/vector-icons';
 import { ForecastSheetProps } from './types';
 import { BarChart } from 'react-native-chart-kit';
 import { format, parseISO } from 'date-fns';
@@ -170,15 +169,6 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({
         >
           {translate(TranslationKeys.forecast)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <BottomSheetScrollView
         ref={scrollViewRef}

--- a/frontend/app/components/ForecastSheet/styles.ts
+++ b/frontend/app/components/ForecastSheet/styles.ts
@@ -13,7 +13,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -27,7 +27,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   forecastContainer: {
     width: '100%',

--- a/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -7,7 +7,6 @@ import {
   View,
 } from 'react-native';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { AntDesign } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -542,15 +541,6 @@ const HourSheet: React.FC<HourSheetProps> = ({ closeSheet }) => {
         >
           {translate(TranslationKeys.businesshours)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       {loading ? (
         <View

--- a/frontend/app/components/HoursSheet/styles.ts
+++ b/frontend/app/components/HoursSheet/styles.ts
@@ -14,7 +14,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -28,7 +28,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   hoursContainer: {
     paddingHorizontal: 20,

--- a/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
+++ b/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
@@ -11,7 +11,6 @@ import React, { useEffect, useState } from 'react';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
 import {
-  AntDesign,
   Ionicons,
   MaterialCommunityIcons,
 } from '@expo/vector-icons';
@@ -241,19 +240,6 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({
         >
           Edit: Image
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={() => {
-            setIsDelete(false);
-            setSelectedImage(undefined);
-            closeSheet();
-          }}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View
         style={{

--- a/frontend/app/components/ImageManagementSheet/styles.ts
+++ b/frontend/app/components/ImageManagementSheet/styles.ts
@@ -13,7 +13,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -27,7 +27,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
     fontSize: 24,
     textAlign: 'center',
   },

--- a/frontend/app/components/Login/AttentionSheet.tsx
+++ b/frontend/app/components/Login/AttentionSheet.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useRef, useState } from 'react';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
 import { AttentionSheetProps } from './types';
-import { AntDesign } from '@expo/vector-icons';
 import { styles } from './styles';
 import { isWeb } from '@/constants/Constants';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -47,18 +46,6 @@ const AttentionSheet: React.FC<AttentionSheetProps> = ({
       <View style={styles.attentionSheetHeader}>
         <View />
 
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={() => {
-            closeSheet();
-            setHasPlayed(false);
-          }}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
 
       <View style={styles.gifContainer}>

--- a/frontend/app/components/Login/ManagementModal.tsx
+++ b/frontend/app/components/Login/ManagementModal.tsx
@@ -89,7 +89,7 @@ const ManagementModal: React.FC<ManagementModalProps> = ({
     <Modal
       isVisible={isVisible}
       style={styles.modalContainer}
-      onBackdropPress={() => setIsVisible(false)}
+      onClose={() => setIsVisible(false)}
     >
       <View
         style={{

--- a/frontend/app/components/Login/ManagementSheet.tsx
+++ b/frontend/app/components/Login/ManagementSheet.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react-native';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { styles } from './styles';
-import { AntDesign } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
 import { SheetProps } from './types';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -55,15 +54,6 @@ const ManagementSheet: React.FC<SheetProps> = ({
       style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
     >
       <View style={styles.sheetHeader}>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>
         {translate(

--- a/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
+++ b/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
@@ -6,7 +6,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { CanteenProps, ManagementCanteensSheetProps } from './types';
 import { isWeb, canteensData } from '@/constants/Constants';
-import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CanteenHelper } from '@/redux/actions';
@@ -121,15 +121,6 @@ const ManagementCanteensSheet: React.FC<ManagementCanteensSheetProps> = ({
           paddingTop: isWeb ? 10 : 0,
         }}
       >
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <Text
         style={{

--- a/frontend/app/components/ManagementFoodCategorySheet/ManagementFoodCategorySheet.tsx
+++ b/frontend/app/components/ManagementFoodCategorySheet/ManagementFoodCategorySheet.tsx
@@ -10,7 +10,7 @@ import { ManagementFoodCategorySheetProps } from './types';
 import { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
-import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useDispatch, useSelector } from 'react-redux';
 import { isWeb } from '@/constants/Constants';
 import { SET_DAY_PLAN } from '@/redux/Types/types';
@@ -126,17 +126,6 @@ const ManagementFoodCategorySheet: React.FC<
           {selectedFoodCategory.label}
         </Text>
 
-        <TouchableOpacity
-          style={{
-            ...styles.closeButton,
-            backgroundColor: theme.modal.closeBg,
-            height: 40,
-            width: 40,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={26} color={theme.modal.closeIcon} />
-        </TouchableOpacity>
       </View>
       {isCustom ? (
         <View style={styles.modalContent}>

--- a/frontend/app/components/ManagementFoodCategorySheet/styles.ts
+++ b/frontend/app/components/ManagementFoodCategorySheet/styles.ts
@@ -26,7 +26,7 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_700Bold',
     alignSelf: 'center',
     textAlign: 'center',
-    marginLeft: 30,
+    
   },
   closeButton: {
     borderRadius: 50,

--- a/frontend/app/components/MenuSheet/MenuSheet.tsx
+++ b/frontend/app/components/MenuSheet/MenuSheet.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react-native';
 import React from 'react';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { AntDesign } from '@expo/vector-icons';
 import styles from './styles';
 import { MenuSheetProps } from './types';
 import { isWeb } from '@/constants/Constants';
@@ -96,15 +95,6 @@ const MenuSheet: React.FC<MenuSheetProps> = ({ closeSheet }) => {
           {getTextFromTranslation(markingDetails?.translations, language)}
           {` (${markingDetails?.external_identifier})`}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={{ ...styles.menuContainer, width: isWeb ? '90%' : '100%' }}>
         <View style={styles.imageContainer}>

--- a/frontend/app/components/MenuSheet/styles.ts
+++ b/frontend/app/components/MenuSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -29,7 +29,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
     fontSize: 22,
     textAlign: 'center',
   },

--- a/frontend/app/components/ModalSetting/ModalComponent.tsx
+++ b/frontend/app/components/ModalSetting/ModalComponent.tsx
@@ -51,7 +51,7 @@ const ModalComponent: React.FC<ModalComponentProps> = ({
   return (
     <Modal
       isVisible={isVisible}
-      onBackdropPress={onClose}
+      onClose={onClose}
       animationIn='slideInUp'
       animationOut='slideOutDown'
       backdropOpacity={backdropOpacity}

--- a/frontend/app/components/ModalSetting/styles.ts
+++ b/frontend/app/components/ModalSetting/styles.ts
@@ -21,7 +21,7 @@ export const styles = StyleSheet.create({
     fontFamily: 'Poppins_700Bold',
     alignSelf: 'center',
     textAlign: 'center',
-    marginLeft: 30,
+    
   },
 
   closeButton: {

--- a/frontend/app/components/NotificationSheet/NotificationSheet.tsx
+++ b/frontend/app/components/NotificationSheet/NotificationSheet.tsx
@@ -7,7 +7,6 @@ import React, {
   useState,
 } from 'react';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { AntDesign } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
 import { NotificationSheetProps } from './types';
@@ -159,15 +158,6 @@ const NotificationSheet: React.FC<NotificationSheetProps> = ({
         >
           {translate(TranslationKeys.notification)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={styles.notificationContent}>
         <View style={styles.gifContainer}>{renderLottie}</View>

--- a/frontend/app/components/NotificationSheet/styles.ts
+++ b/frontend/app/components/NotificationSheet/styles.ts
@@ -17,7 +17,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -31,7 +31,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   notificationContent: {
     width: '100%',

--- a/frontend/app/components/PermissionModal/PermissionModal.tsx
+++ b/frontend/app/components/PermissionModal/PermissionModal.tsx
@@ -74,7 +74,7 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
     <Modal
       isVisible={isVisible}
       style={styles.modalContainer}
-      onBackdropPress={() => setIsVisible(false)}
+      onClose={() => setIsVisible(false)}
     >
       <View
         style={{

--- a/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
+++ b/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
@@ -4,7 +4,6 @@ import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
-import { AntDesign } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 import { PopupEventSheetProps } from './types';
 import { getImageUrl } from '@/constants/HelperFunctions';
@@ -300,15 +299,6 @@ const PopupEventSheet: React.FC<PopupEventSheetProps> = ({
         paddingTop: isWeb ? 10 : 0,
         alignItems: 'flex-end',
       }}>
-        <TouchableOpacity
-            style={{
-              ...styles.sheetcloseButton,
-              backgroundColor: theme.sheet.closeBg,
-            }}
-            onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View
         style={{

--- a/frontend/app/components/SortSheet/SortSheet.tsx
+++ b/frontend/app/components/SortSheet/SortSheet.tsx
@@ -155,15 +155,6 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
         >
           {translate(TranslationKeys.sort)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={closeSheet}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <View style={styles.sortingListContainer}>
         {sortingOptions.map((option, index) => (

--- a/frontend/app/components/SortSheet/styles.ts
+++ b/frontend/app/components/SortSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
@@ -29,7 +29,7 @@ export default StyleSheet.create({
   },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    marginLeft: 30,
+    
   },
   sortingListContainer: {
     width: '100%',

--- a/frontend/app/components/SubmissionWarningModal/SubmissionWarningModal.tsx
+++ b/frontend/app/components/SubmissionWarningModal/SubmissionWarningModal.tsx
@@ -67,7 +67,7 @@ const SubmissionWarningModal: React.FC<SubmissionWarningModalProps> = ({
         styles.modalContainer,
         screenWidth > 600 && { alignItems: 'center' },
       ]}
-      onBackdropPress={() => {
+      onClose={() => {
         setIsVisible(false);
         router.navigate('/form-submissions');
       }}

--- a/frontend/app/components/SubmissionWarningSheet/SubmissionWarningSheet.tsx
+++ b/frontend/app/components/SubmissionWarningSheet/SubmissionWarningSheet.tsx
@@ -10,7 +10,6 @@ import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
-import { AntDesign } from '@expo/vector-icons';
 import { sheetProps } from './types';
 import { useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -64,15 +63,6 @@ const SubmissionWarningSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
         >
           {translate(TranslationKeys.warning)}
         </Text>
-        <TouchableOpacity
-          style={{
-            ...styles.sheetcloseButton,
-            backgroundColor: theme.sheet.closeBg,
-          }}
-          onPress={() => router.navigate('/form-submissions')}
-        >
-          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-        </TouchableOpacity>
       </View>
       <Text
         style={{

--- a/frontend/app/components/SubmissionWarningSheet/styles.ts
+++ b/frontend/app/components/SubmissionWarningSheet/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,

--- a/frontend/app/components/TimeTable/styles.ts
+++ b/frontend/app/components/TimeTable/styles.ts
@@ -30,7 +30,7 @@ export default StyleSheet.create({
   sheetHeader: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,


### PR DESCRIPTION
## Summary
- have BaseBottomSheet always use 80% screen height
- center sheet titles by default

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9e46c9f08330aebe0b7ba2970e17