### PR TITLE
Use BaseBottomSheet in settings

### DIFF
--- a/frontend/app/app/(app)/settings/index.tsx
+++ b/frontend/app/app/(app)/settings/index.tsx
@@ -70,6 +70,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import CanteenSelectionSheet from '@/components/CanteenSelectionSheet/CanteenSelectionSheet';
+import LanguageSheet from '@/components/LanguageSheet/LanguageSheet';
+import AmountColumnSheet from '@/components/AmountColumnSheet/AmountColumnSheet';
+import FirstDaySheet from '@/components/FirstDaySheet/FirstDaySheet';
 import {
   excerpt,
   formatPrice,
@@ -89,15 +92,15 @@ const Settings = () => {
   const canteenSheetRef = useRef<BottomSheet>(null);
   const [isActive, setIsActive] = useState(false);
   const { translate, setLanguageMode, language } = useLanguage();
-  const [isLanguageModalVisible, setIsLanguageModalVisible] = useState(false);
   const [isNicknameModalVisible, setIsNicknameModalVisible] = useState(false);
   const [nickname, setNickname] = useState<string>('');
   const openModal = () => setIsNicknameModalVisible(true);
   const closeModal = () => setIsNicknameModalVisible(false);
   const [selectedLanguage, setSelectedLanguage] = useState<string>('');
   const [isDrawerModalVisible, setIsDrawerModalVisible] = useState(false);
-  const [isAmountColumnModal, setIsAmountColumnModal] = useState(false);
-  const [isFirstDayModalVisible, setIsFirstDayModalVisible] = useState(false);
+  const languageSheetRef = useRef<BottomSheet>(null);
+  const amountColumnSheetRef = useRef<BottomSheet>(null);
+  const firstDaySheetRef = useRef<BottomSheet>(null);
   const [disabled, setDisabled] = useState(false);
   const [isColorSchemeModalVisible, setIsColorSchemeModalVisible] =
     useState(false);
@@ -175,16 +178,12 @@ const Settings = () => {
     setSelectedLanguage(language);
   }, [language]);
 
-  const saveLanguage = () => {
-    closeModal();
-  };
-
   const openLanguageModal = () => {
-    setIsLanguageModalVisible(true);
+    languageSheetRef?.current?.expand();
   };
 
   const closeLanguageModal = () => {
-    setIsLanguageModalVisible(false);
+    languageSheetRef?.current?.close();
   };
 
   // ColorScheme
@@ -217,30 +216,22 @@ const Settings = () => {
 
   // Amount Column Card
 
-  const saveAmount = () => {
-    closeModal();
-  };
-
   const openAmountColumnModal = () => {
-    setIsAmountColumnModal(true);
+    amountColumnSheetRef?.current?.expand();
   };
 
   const closeAmountColumnModal = () => {
-    setIsAmountColumnModal(false);
+    amountColumnSheetRef?.current?.close();
   };
 
   // first day of week
 
-  const saveFirstDay = () => {
-    closeModal();
-  };
-
   const openFirstDayModal = () => {
-    setIsFirstDayModalVisible(true);
+    firstDaySheetRef?.current?.expand();
   };
 
   const closeFirstDayModal = () => {
-    setIsFirstDayModalVisible(false);
+    firstDaySheetRef?.current?.close();
   };
 
   const changeLanguage = (language: {
@@ -403,68 +394,6 @@ const Settings = () => {
             }}
           />
           {/* Language */}
-          <ModalComponent
-            isVisible={isLanguageModalVisible}
-            onClose={closeLanguageModal}
-            title={translate(TranslationKeys.language)}
-            onSave={saveLanguage}
-            showButtons={false}
-          >
-            <View style={styles.languageContainer}>
-              {languages.map((language, index) => (
-                <TouchableOpacity
-                  key={index}
-                  style={{
-                    ...styles.languageRow,
-                    paddingHorizontal: isWeb ? 20 : 10,
-
-                    backgroundColor:
-                      selectedLanguage === language.value
-                        ? primaryColor
-                        : theme.screen.iconBg,
-                  }}
-                  onPress={() => {
-                    changeLanguage(language);
-                  }}
-                >
-                  <Image
-                    source={language.flag}
-                    style={styles.flagIcon}
-                    cachePolicy={'memory-disk'}
-                    transition={500}
-                    contentFit='cover'
-                  />
-                  <Text
-                    style={{
-                      ...styles.languageText,
-                      color:
-                        selectedLanguage === language.value
-                          ? theme.activeText
-                          : theme.screen.text,
-                    }}
-                  >
-                    {language.label}
-                  </Text>
-
-                  {/* Radio Button */}
-                  <MaterialCommunityIcons
-                    name={
-                      selectedLanguage === language.value
-                        ? 'checkbox-marked'
-                        : 'checkbox-blank'
-                    }
-                    size={24}
-                    color={
-                      selectedLanguage === language.value
-                        ? '#ffffff'
-                        : '#ffffff'
-                    }
-                    style={styles.radioButton}
-                  />
-                </TouchableOpacity>
-              ))}
-            </View>
-          </ModalComponent>
           <SettingList
             leftIcon={
               <Ionicons name='language' size={24} color={theme.screen.icon} />
@@ -660,30 +589,6 @@ const Settings = () => {
             handleFunction={() => openDrawerModal()}
           />
 
-          <ModalComponent
-            isVisible={isAmountColumnModal}
-            onClose={closeAmountColumnModal}
-            title={translate(TranslationKeys.amount_columns_for_cards)}
-            onSave={saveAmount}
-            showButtons={false}
-          >
-            <ScrollView style={styles.amountOfCardContainer}>
-              {AmountColumn.map((column) => (
-                <AmountColumns
-                  key={column.id}
-                  position={column}
-                  isSelected={amountColumnsForcard === column.id}
-                  onPress={() => {
-                    dispatch({
-                      type: SET_AMOUNT_COLUMNS_FOR_CARDS,
-                      payload: column.id,
-                    });
-                    closeAmountColumnModal();
-                  }}
-                />
-              ))}
-            </ScrollView>
-          </ModalComponent>
           <SettingList
             leftIcon={
               <FontAwesome5
@@ -707,30 +612,6 @@ const Settings = () => {
             }
             handleFunction={() => openAmountColumnModal()}
           />
-          <ModalComponent
-            isVisible={isFirstDayModalVisible}
-            onClose={closeFirstDayModal}
-            title={translate(TranslationKeys.first_day_of_week)}
-            onSave={saveFirstDay}
-            showButtons={false}
-          >
-            <View style={styles.languageContainer}>
-              {days.map((firstDay) => (
-                <FirstDayOfWeek
-                  key={firstDay.id}
-                  position={firstDay}
-                  isSelected={firstDayOfTheWeek?.name === firstDay?.name}
-                  onPress={() => {
-                    dispatch({
-                      type: SET_FIRST_DAY_OF_THE_WEEK,
-                      payload: { id: firstDay.id, name: firstDay?.name },
-                    });
-                    closeFirstDayModal();
-                  }}
-                />
-              ))}
-            </View>
-          </ModalComponent>
           <SettingList
             leftIcon={
               <Feather name='calendar' size={24} color={theme.screen.icon} />
@@ -913,19 +794,84 @@ const Settings = () => {
         </View>
       </ScrollView>
       {isActive && (
-        <BaseBottomSheet
-          ref={canteenSheetRef}
-          index={-1}
-          backgroundStyle={{
-            ...styles.sheetBackground,
-            backgroundColor: theme.sheet.sheetBg,
-          }}
-          enablePanDownToClose
-          handleComponent={null}
-          onClose={closeCanteenSheet}
-        >
-          <CanteenSelectionSheet closeSheet={closeCanteenSheet} />
-        </BaseBottomSheet>
+        <>
+          <BaseBottomSheet
+            ref={canteenSheetRef}
+            index={-1}
+            backgroundStyle={{
+              ...styles.sheetBackground,
+              backgroundColor: theme.sheet.sheetBg,
+            }}
+            enablePanDownToClose
+            handleComponent={null}
+            onClose={closeCanteenSheet}
+          >
+            <CanteenSelectionSheet closeSheet={closeCanteenSheet} />
+          </BaseBottomSheet>
+          <BaseBottomSheet
+            ref={languageSheetRef}
+            index={-1}
+            backgroundStyle={{
+              ...styles.sheetBackground,
+              backgroundColor: theme.sheet.sheetBg,
+            }}
+            enablePanDownToClose
+            handleComponent={null}
+            onClose={closeLanguageModal}
+          >
+            <LanguageSheet
+              closeSheet={closeLanguageModal}
+              selectedLanguage={selectedLanguage}
+              onSelect={(value) => {
+                changeLanguage({ value } as any);
+              }}
+            />
+          </BaseBottomSheet>
+          <BaseBottomSheet
+            ref={amountColumnSheetRef}
+            index={-1}
+            backgroundStyle={{
+              ...styles.sheetBackground,
+              backgroundColor: theme.sheet.sheetBg,
+            }}
+            enablePanDownToClose
+            handleComponent={null}
+            onClose={closeAmountColumnModal}
+          >
+            <AmountColumnSheet
+              closeSheet={closeAmountColumnModal}
+              selectedAmount={amountColumnsForcard}
+              onSelect={(val) => {
+                dispatch({
+                  type: SET_AMOUNT_COLUMNS_FOR_CARDS,
+                  payload: val,
+                });
+              }}
+            />
+          </BaseBottomSheet>
+          <BaseBottomSheet
+            ref={firstDaySheetRef}
+            index={-1}
+            backgroundStyle={{
+              ...styles.sheetBackground,
+              backgroundColor: theme.sheet.sheetBg,
+            }}
+            enablePanDownToClose
+            handleComponent={null}
+            onClose={closeFirstDayModal}
+          >
+            <FirstDaySheet
+              closeSheet={closeFirstDayModal}
+              selectedDay={firstDayOfTheWeek?.name}
+              onSelect={(day) => {
+                dispatch({
+                  type: SET_FIRST_DAY_OF_THE_WEEK,
+                  payload: day,
+                });
+              }}
+            />
+          </BaseBottomSheet>
+        </>
       )}
     </SafeAreaView>
   );

--- a/frontend/app/components/AmountColumnSheet/AmountColumnSheet.tsx
+++ b/frontend/app/components/AmountColumnSheet/AmountColumnSheet.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import AmountColumns from '@/components/AmountColumn/AmountColumns';
+import { AmountColumn } from '@/constants/SettingData';
+import { isWeb } from '@/constants/Constants';
+import styles from './styles';
+import { AmountColumnSheetProps } from './types';
+import { TranslationKeys } from '@/locales/keys';
+
+const AmountColumnSheet: React.FC<AmountColumnSheetProps> = ({
+  closeSheet,
+  selectedAmount,
+  onSelect,
+}) => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+
+  return (
+    <BottomSheetScrollView
+      style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View
+        style={{
+          ...styles.sheetHeader,
+          paddingRight: isWeb ? 10 : 0,
+          paddingTop: isWeb ? 10 : 0,
+        }}
+      >
+        <View />
+        <Text
+          style={{
+            ...styles.sheetHeading,
+            fontSize: isWeb ? 40 : 28,
+            color: theme.sheet.text,
+          }}
+        >
+          {translate(TranslationKeys.amount_columns_for_cards)}
+        </Text>
+      </View>
+      <View style={styles.optionsContainer}>
+        {AmountColumn.map((column) => (
+          <AmountColumns
+            key={column.id}
+            position={column}
+            isSelected={selectedAmount === column.id}
+            onPress={() => {
+              onSelect(column.id);
+              closeSheet();
+            }}
+          />
+        ))}
+      </View>
+    </BottomSheetScrollView>
+  );
+};
+
+export default AmountColumnSheet;

--- a/frontend/app/components/AmountColumnSheet/styles.ts
+++ b/frontend/app/components/AmountColumnSheet/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  sheetView: {
+    width: '100%',
+    height: '100%',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+    paddingBottom: 0,
+  },
+  contentContainer: {
+    alignItems: 'center',
+  },
+  sheetHeader: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+  },
+  sheetHeading: {
+    fontFamily: 'Poppins_700Bold',
+  },
+  optionsContainer: {
+    width: '100%',
+    paddingHorizontal: 10,
+    marginTop: 20,
+  },
+});

--- a/frontend/app/components/AmountColumnSheet/types.ts
+++ b/frontend/app/components/AmountColumnSheet/types.ts
@@ -1,0 +1,5 @@
+export interface AmountColumnSheetProps {
+  closeSheet: () => void;
+  selectedAmount: number;
+  onSelect: (value: number) => void;
+}

--- a/frontend/app/components/FirstDaySheet/FirstDaySheet.tsx
+++ b/frontend/app/components/FirstDaySheet/FirstDaySheet.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { days } from '@/constants/SettingData';
+import FirstDayOfWeek from '@/components/FirstDay/FirstDayOfWeek';
+import { isWeb } from '@/constants/Constants';
+import styles from './styles';
+import { FirstDaySheetProps } from './types';
+import { TranslationKeys } from '@/locales/keys';
+
+const FirstDaySheet: React.FC<FirstDaySheetProps> = ({
+  closeSheet,
+  selectedDay,
+  onSelect,
+}) => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+
+  return (
+    <BottomSheetScrollView
+      style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View
+        style={{
+          ...styles.sheetHeader,
+          paddingRight: isWeb ? 10 : 0,
+          paddingTop: isWeb ? 10 : 0,
+        }}
+      >
+        <View />
+        <Text
+          style={{
+            ...styles.sheetHeading,
+            fontSize: isWeb ? 40 : 28,
+            color: theme.sheet.text,
+          }}
+        >
+          {translate(TranslationKeys.first_day_of_week)}
+        </Text>
+      </View>
+      <View style={styles.optionsContainer}>
+        {days.map((firstDay) => (
+          <FirstDayOfWeek
+            key={firstDay.id}
+            position={firstDay}
+            isSelected={selectedDay === firstDay.name}
+            onPress={() => {
+              onSelect({ id: firstDay.id, name: firstDay.name });
+              closeSheet();
+            }}
+          />
+        ))}
+      </View>
+    </BottomSheetScrollView>
+  );
+};
+
+export default FirstDaySheet;

--- a/frontend/app/components/FirstDaySheet/styles.ts
+++ b/frontend/app/components/FirstDaySheet/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  sheetView: {
+    width: '100%',
+    height: '100%',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+    paddingBottom: 0,
+  },
+  contentContainer: {
+    alignItems: 'center',
+  },
+  sheetHeader: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+  },
+  sheetHeading: {
+    fontFamily: 'Poppins_700Bold',
+  },
+  optionsContainer: {
+    width: '100%',
+    paddingHorizontal: 10,
+    marginTop: 20,
+  },
+});

--- a/frontend/app/components/FirstDaySheet/types.ts
+++ b/frontend/app/components/FirstDaySheet/types.ts
@@ -1,0 +1,5 @@
+export interface FirstDaySheetProps {
+  closeSheet: () => void;
+  selectedDay: string;
+  onSelect: (day: { id: string; name: string }) => void;
+}

--- a/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, Image } from 'react-native';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { languages } from '@/constants/SettingData';
+import { isWeb } from '@/constants/Constants';
+import styles from './styles';
+import { LanguageSheetProps } from './types';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+
+const LanguageSheet: React.FC<LanguageSheetProps> = ({
+  closeSheet,
+  selectedLanguage,
+  onSelect,
+}) => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+  return (
+    <BottomSheetScrollView
+      style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View
+        style={{
+          ...styles.sheetHeader,
+          paddingRight: isWeb ? 10 : 0,
+          paddingTop: isWeb ? 10 : 0,
+        }}
+      >
+        <View />
+        <Text
+          style={{
+            ...styles.sheetHeading,
+            fontSize: isWeb ? 40 : 28,
+            color: theme.sheet.text,
+          }}
+        >
+          {translate(TranslationKeys.language)}
+        </Text>
+      </View>
+      <View style={styles.optionsContainer}>
+        {languages.map((language, index) => (
+          <TouchableOpacity
+            key={index}
+            style={[
+              styles.languageRow,
+              {
+                paddingHorizontal: isWeb ? 20 : 10,
+                backgroundColor:
+                  selectedLanguage === language.value
+                    ? primaryColor
+                    : theme.screen.iconBg,
+              },
+            ]}
+            onPress={() => {
+              onSelect(language.value);
+              closeSheet();
+            }}
+          >
+            <Image
+              source={language.flag}
+              style={styles.flagIcon}
+              cachePolicy={'memory-disk'}
+              transition={500}
+              contentFit='cover'
+            />
+            <Text
+              style={{
+                ...styles.languageText,
+                color:
+                  selectedLanguage === language.value
+                    ? theme.activeText
+                    : theme.screen.text,
+              }}
+            >
+              {language.label}
+            </Text>
+            <MaterialCommunityIcons
+              name={
+                selectedLanguage === language.value
+                  ? 'checkbox-marked'
+                  : 'checkbox-blank'
+              }
+              size={24}
+              color={'#ffffff'}
+              style={styles.radioButton}
+            />
+          </TouchableOpacity>
+        ))}
+      </View>
+    </BottomSheetScrollView>
+  );
+};
+
+export default LanguageSheet;

--- a/frontend/app/components/LanguageSheet/styles.ts
+++ b/frontend/app/components/LanguageSheet/styles.ts
@@ -1,0 +1,53 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  sheetView: {
+    width: '100%',
+    height: '100%',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+    paddingBottom: 0,
+  },
+  contentContainer: {
+    alignItems: 'center',
+  },
+  sheetHeader: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+  },
+  sheetHeading: {
+    fontFamily: 'Poppins_700Bold',
+  },
+  optionsContainer: {
+    width: '100%',
+    paddingHorizontal: 10,
+    marginTop: 20,
+  },
+  languageRow: {
+    marginTop: 10,
+    width: '100%',
+    height: 50,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 12,
+  },
+  flagIcon: {
+    width: 35.2,
+    height: 22,
+    marginRight: 10,
+  },
+  languageText: {
+    flex: 1,
+    fontSize: 18,
+    fontFamily: 'Poppins_400Regular',
+  },
+  radioButton: {
+    marginLeft: 10,
+  },
+});

--- a/frontend/app/components/LanguageSheet/types.ts
+++ b/frontend/app/components/LanguageSheet/types.ts
@@ -1,0 +1,5 @@
+export interface LanguageSheetProps {
+  closeSheet: () => void;
+  selectedLanguage: string;
+  onSelect: (language: string) => void;
+}


### PR DESCRIPTION
## Summary
- replace modal popups for language, number of columns and first day of week with BaseBottomSheet
- add new `LanguageSheet`, `AmountColumnSheet` and `FirstDaySheet` components
- wire new sheets into settings screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d232479b4833082f653b6d66dbf22