### PR TITLE
Fix contrast color on setting buttons

### DIFF
--- a/frontend/app/app/(app)/price-group/index.tsx
+++ b/frontend/app/app/(app)/price-group/index.tsx
@@ -24,6 +24,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { Profiles } from '@/constants/types';
 import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 
 const index = () => {
   useSetPageTitle(TranslationKeys.price_group);
@@ -33,9 +34,10 @@ const index = () => {
   const profileHelper = new ProfileHelper();
   const [loading, setLoading] = useState(false);
   const { profile } = useSelector((state: RootState) => state.authReducer);
-  const { primaryColor, appSettings } = useSelector(
+  const { primaryColor, appSettings, selectedTheme: mode } = useSelector(
     (state: RootState) => state.settings
   );
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
   const [autoPlay, setAutoPlay] = useState(appSettings?.animations_auto_start);
   const animationRef = useRef<LottieView>(null);
   const [animationJson, setAmimationJson] = useState<any>(null);
@@ -149,9 +151,7 @@ const index = () => {
               {cloneElement(
                 option.icon,
                 selectedOption === option.id
-                  ? {
-                      color: theme.activeText,
-                    }
+                  ? { color: contrastColor }
                   : { color: theme.screen.icon }
               )}
               <Text
@@ -159,7 +159,7 @@ const index = () => {
                   styles.label,
                   selectedOption === option.id
                     ? {
-                        color: theme.activeText,
+                        color: contrastColor,
                       }
                     : { color: theme.screen.text },
                 ]}

--- a/frontend/app/components/AmountColumn/AmountColumns.tsx
+++ b/frontend/app/components/AmountColumn/AmountColumns.tsx
@@ -7,6 +7,7 @@ import { isWeb } from '@/constants/Constants';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 
 // Define the type for the theme prop
 type Position = {
@@ -29,7 +30,10 @@ const AmountColumns: React.FC<AmountColumnsProps> = ({
 }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
-  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
   return (
     <TouchableOpacity
       style={{
@@ -44,7 +48,7 @@ const AmountColumns: React.FC<AmountColumnsProps> = ({
       <Text
         style={{
           ...styles.text,
-          color: isSelected ? theme.activeText : theme.header.text,
+          color: isSelected ? contrastColor : theme.header.text,
         }}
       >
         {position?.id === 0
@@ -56,7 +60,7 @@ const AmountColumns: React.FC<AmountColumnsProps> = ({
       <MaterialCommunityIcons
         name={isSelected ? 'checkbox-marked' : 'checkbox-blank'}
         size={24}
-        color={isSelected ? '#ffffff' : '#ffffff'}
+        color={isSelected ? contrastColor : theme.screen.icon}
         style={styles.radioButton}
       />
     </TouchableOpacity>

--- a/frontend/app/components/ColorScheme/ColorScheme.tsx
+++ b/frontend/app/components/ColorScheme/ColorScheme.tsx
@@ -6,6 +6,7 @@ import { isWeb } from '@/constants/Constants';
 import { useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 // Define the type for the theme prop
 type Theme = {
   id: string;
@@ -26,7 +27,10 @@ const ColorScheme: React.FC<ColorSchemeProps> = ({
   onPress,
 }) => {
   const { theme: themes } = useTheme();
-  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
+  const contrastColor = myContrastColor(primaryColor, themes, mode === 'dark');
   const { translate } = useLanguage();
   return (
     <TouchableOpacity
@@ -41,7 +45,7 @@ const ColorScheme: React.FC<ColorSchemeProps> = ({
       <MaterialCommunityIcons
         name={theme.icon}
         size={24}
-        color={isSelected ? themes.activeText : themes.screen.icon}
+        color={isSelected ? contrastColor : themes.screen.icon}
         style={styles.icon}
       />
 
@@ -49,7 +53,7 @@ const ColorScheme: React.FC<ColorSchemeProps> = ({
       <Text
         style={{
           ...styles.text,
-          color: isSelected ? themes.activeText : themes.header.text,
+          color: isSelected ? contrastColor : themes.header.text,
         }}
       >
         {translate(theme.name)}
@@ -59,7 +63,7 @@ const ColorScheme: React.FC<ColorSchemeProps> = ({
       <MaterialCommunityIcons
         name={isSelected ? 'checkbox-marked' : 'checkbox-blank'}
         size={24}
-        color={isSelected ? '#ffffff' : '#ffffff'}
+        color={isSelected ? contrastColor : themes.screen.icon}
         style={styles.radioButton}
       />
     </TouchableOpacity>

--- a/frontend/app/components/Details/index.tsx
+++ b/frontend/app/components/Details/index.tsx
@@ -253,7 +253,6 @@ const handleRedirect = () => {
         label={food_responsible_organization_name}
         onClick={handleRedirect}
         backgroundColor={foods_area_color}
-        color={theme.light}
       />
     </View>
   );

--- a/frontend/app/components/Drawer/DrawerPosition.tsx
+++ b/frontend/app/components/Drawer/DrawerPosition.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import { isWeb } from '@/constants/Constants';
 import { useLanguage } from '@/hooks/useLanguage';
 import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 
 // Define the type for the theme prop
 type Position = {
@@ -27,7 +28,10 @@ const DrawerPosition: React.FC<DrawerPositionProps> = ({
   onPress,
 }) => {
   const { theme } = useTheme();
-  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
   const { translate } = useLanguage();
   return (
     <TouchableOpacity
@@ -43,7 +47,7 @@ const DrawerPosition: React.FC<DrawerPositionProps> = ({
       <MaterialCommunityIcons
         name={position.icon}
         size={24}
-        color={isSelected ? theme.activeText : theme.screen.icon}
+        color={isSelected ? contrastColor : theme.screen.icon}
         style={styles.icon}
       />
 
@@ -51,7 +55,7 @@ const DrawerPosition: React.FC<DrawerPositionProps> = ({
       <Text
         style={{
           ...styles.text,
-          color: isSelected ? theme.activeText : theme.header.text,
+          color: isSelected ? contrastColor : theme.header.text,
         }}
       >
         {translate(position.name)}
@@ -61,7 +65,7 @@ const DrawerPosition: React.FC<DrawerPositionProps> = ({
       <MaterialCommunityIcons
         name={isSelected ? 'checkbox-marked' : 'checkbox-blank'}
         size={24}
-        color={isSelected ? '#ffffff' : '#ffffff'}
+        color={isSelected ? contrastColor : theme.screen.icon}
         style={styles.radioButton}
       />
     </TouchableOpacity>

--- a/frontend/app/components/FirstDay/FirstDayOfWeek.tsx
+++ b/frontend/app/components/FirstDay/FirstDayOfWeek.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import { isWeb } from '@/constants/Constants';
 import { useLanguage } from '@/hooks/useLanguage';
 import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 
 // Define the type for the theme prop
 type Position = {
@@ -28,7 +29,10 @@ const FirstDayOfWeek: React.FC<FirstDayOfWeekProps> = ({
 }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
-  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
   return (
     <TouchableOpacity
       style={{
@@ -42,7 +46,7 @@ const FirstDayOfWeek: React.FC<FirstDayOfWeekProps> = ({
       <Text
         style={{
           ...styles.text,
-          color: isSelected ? theme.activeText : theme.header.text,
+          color: isSelected ? contrastColor : theme.header.text,
         }}
       >
         {translate(position.name)}
@@ -52,7 +56,7 @@ const FirstDayOfWeek: React.FC<FirstDayOfWeekProps> = ({
       <MaterialCommunityIcons
         name={isSelected ? 'checkbox-marked' : 'checkbox-blank'}
         size={24}
-        color={isSelected ? '#ffffff' : '#ffffff'}
+        color={isSelected ? contrastColor : theme.screen.icon}
         style={styles.radioButton}
       />
     </TouchableOpacity>

--- a/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -11,6 +11,7 @@ import styles from './styles';
 import { LanguageSheetProps } from './types';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 
 const LanguageSheet: React.FC<LanguageSheetProps> = ({
   closeSheet,
@@ -19,7 +20,10 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({
 }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
-  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
   return (
     <BottomSheetScrollView
@@ -75,7 +79,7 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({
                 ...styles.languageText,
                 color:
                   selectedLanguage === language.value
-                    ? theme.activeText
+                    ? contrastColor
                     : theme.screen.text,
               }}
             >
@@ -88,7 +92,11 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({
                   : 'checkbox-blank'
               }
               size={24}
-              color={'#ffffff'}
+              color={
+                selectedLanguage === language.value
+                  ? contrastColor
+                  : theme.screen.icon
+              }
               style={styles.radioButton}
             />
           </TouchableOpacity>


### PR DESCRIPTION
## Summary
- use contrastColor for language sheet option text and checkbox
- improve color scheme, menu position, amount column, and first day options
- adjust price group item icon/text color using contrast color
- use contrast color for responsible organization button in food details

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2b6fb6fc833085473e0160d162dd