### PR TITLE
Fix HoursSheet bottom sheet size

### DIFF
--- a/frontend/app/components/HoursSheet/styles.ts
+++ b/frontend/app/components/HoursSheet/styles.ts
@@ -2,7 +2,8 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   sheetView: {
-    flex: 1,
+    width: '100%',
+    height: '100%',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
     padding: 10,


### PR DESCRIPTION
## Summary
- update HoursSheet sheetView style to use width/height instead of flex

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5e36990c83308f6797dc4322bfdf