### PR TITLE
Auto language fallback based on device locale

### DIFF
--- a/frontend/app/components/Login/Header.tsx
+++ b/frontend/app/components/Login/Header.tsx
@@ -27,29 +27,33 @@ const LoginHeader = () => {
   );
 
   function useDeviceLocaleCodesWithoutRegionCode(): string[] {
-    let localeCodes: string[] = [];
-
-    for (let i = 0; i < locales.length; i++) {
-      let locale = locales[i];
-      localeCodes.push(locale.languageTag);
-    }
-
     const defaultLanguageCode = 'de';
     const defaultFallbackLanguageCode = 'en';
 
-    if (Platform.OS === 'web') {
-      localeCodes = localeCodes.sort((a, b) => {
-        if (a.startsWith(defaultLanguageCode)) {
-          return -1;
-        } else if (b.startsWith(defaultLanguageCode)) {
-          return 1;
-        } else {
-          return 0;
-        }
-      });
+    // Collect language codes without region part
+    let localeCodes = locales
+      .map((loc) => loc.languageCode || loc.languageTag.split('-')[0])
+      .filter(Boolean)
+      .map((code) => code.split('-')[0]);
+
+    // Remove duplicates while preserving order
+    localeCodes = localeCodes.filter(
+      (code, index) => localeCodes.indexOf(code) === index
+    );
+
+    // If German is among the locales, prefer it
+    if (localeCodes.includes(defaultLanguageCode)) {
+      localeCodes = [
+        defaultLanguageCode,
+        ...localeCodes.filter((c) => c !== defaultLanguageCode),
+      ];
     }
 
-    return localeCodes.length > 0 ? localeCodes : [defaultFallbackLanguageCode];
+    if (localeCodes.length === 0) {
+      localeCodes.push(defaultFallbackLanguageCode);
+    }
+
+    return localeCodes;
   }
 
   useEffect(() => {

--- a/frontend/app/redux/reducer/settingsReducer.ts
+++ b/frontend/app/redux/reducer/settingsReducer.ts
@@ -26,7 +26,7 @@ const initialState = {
   serverInfo: {},
   primaryColor: '#FCDE31',
   appSettings: {},
-  language: 'de',
+  language: '',
   firstDayOfTheWeek: { id: 'monday', name: 'Mon' },
   drawerPosition: 'left',
   wikisPages: [],


### PR DESCRIPTION
## Summary
- default to no language so login header auto-selects language
- determine preferred device languages without region codes
- fall back to English if no locales found

## Testing
- `npm test` in `frontend/app` *(no tests found)*
- `npm run lint` in `frontend/app` *(fails: couldn't find script "eslint")*
- `yarn test` in `backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle` *(fails: network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_685daca978e88330ad1cdb01ca3930a1