### PR TITLE
Fix BaseBottomSheet visibility while closed

### DIFF
--- a/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -48,6 +48,8 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
       <BottomSheet
         ref={ref}
         snapPoints={snapPoints}
+        detached
+        style={styles.container}
         enableDynamicSizing
         maxDynamicContentSize={MAX_HEIGHT}
         backdropComponent={renderBackdrop}

--- a/frontend/app/components/BaseBottomSheet/styles.ts
+++ b/frontend/app/components/BaseBottomSheet/styles.ts
@@ -1,6 +1,13 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 50,
+  },
   header: {
     width: '100%',
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- ensure BottomSheet component is detached from the layout
- position BaseBottomSheet absolutely so it doesn't appear when scrolling

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd7ab6a0833095132b15239399d0