### PR TITLE
Restore BaseBottomSheetModal

### DIFF
--- a/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -48,6 +48,9 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
       <BottomSheet
         ref={ref}
         snapPoints={snapPoints}
+        detached
+        bottomInset={0}
+        containerStyle={styles.container}
         enableDynamicSizing
         maxDynamicContentSize={MAX_HEIGHT}
         backdropComponent={renderBackdrop}

--- a/frontend/app/components/BaseBottomSheet/styles.ts
+++ b/frontend/app/components/BaseBottomSheet/styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
+  container: {
+    zIndex: 50,
+  },
   header: {
     width: '100%',
     flexDirection: 'row',

--- a/frontend/app/components/BaseBottomSheetModal/BaseBottomSheetModal.tsx
+++ b/frontend/app/components/BaseBottomSheetModal/BaseBottomSheetModal.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Dimensions } from 'react-native';
+import Modal from 'react-native-modal';
+import BottomSheet from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '../BaseBottomSheet';
+import { isWeb } from '@/constants/Constants';
+import { useTheme } from '@/hooks/useTheme';
+
+export interface BaseBottomSheetModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const BaseBottomSheetModal: React.FC<BaseBottomSheetModalProps> = ({
+  isVisible,
+  onClose,
+  children,
+}) => {
+  const sheetRef = useRef<BottomSheet>(null);
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    if (!isWeb()) {
+      if (isVisible) {
+        sheetRef.current?.expand();
+      } else {
+        sheetRef.current?.close();
+      }
+    }
+  }, [isVisible]);
+
+  if (isWeb()) {
+    const maxHeight = Dimensions.get('window').height * 0.8;
+    return (
+      <Modal
+        isVisible={isVisible}
+        style={{ justifyContent: 'flex-end', margin: 0 }}
+        onBackdropPress={onClose}
+        onBackButtonPress={onClose}
+      >
+        <View
+          style={{
+            backgroundColor: theme.sheet.sheetBg,
+            borderTopLeftRadius: 28,
+            borderTopRightRadius: 28,
+            maxHeight,
+          }}
+        >
+          {children}
+        </View>
+      </Modal>
+    );
+  }
+
+  return (
+    <BaseBottomSheet ref={sheetRef} index={-1} enablePanDownToClose onClose={onClose}>
+      {children}
+    </BaseBottomSheet>
+  );
+};
+
+export default BaseBottomSheetModal;

--- a/frontend/app/components/BaseBottomSheetModal/index.ts
+++ b/frontend/app/components/BaseBottomSheetModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './BaseBottomSheetModal';
+export type { BaseBottomSheetModalProps } from './BaseBottomSheetModal';


### PR DESCRIPTION
## Summary
- reintroduce `BaseBottomSheetModal` wrapper to keep bottom sheet hidden when closed

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd7ab6a0833095132b15239399d0