### PR TITLE
Fix visibility behavior of PermissionModal

### DIFF
--- a/frontend/app/components/PermissionModal/PermissionModal.tsx
+++ b/frontend/app/components/PermissionModal/PermissionModal.tsx
@@ -51,8 +51,6 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
   useEffect(() => {
     if (isVisible) {
       sheetRef.current?.expand();
-    } else {
-      sheetRef.current?.close();
     }
   }, [isVisible]);
 
@@ -83,6 +81,10 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
       console.error('Error during logout:', error);
     }
   };
+
+  if (!isVisible) {
+    return null;
+  }
 
   return (
     <BaseBottomSheet


### PR DESCRIPTION
## Summary
- make `PermissionModal` render only while `isVisible` is true
- avoid closing logic when hidden

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de55353b883309fb91efad1a55fb6