### PR TITLE
Implement drawer-based close icon positioning

### DIFF
--- a/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -33,7 +33,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
       [onClose]
     );
     const { theme } = useTheme();
-    const { selectedTheme: mode } = useSelector(
+    const { selectedTheme: mode, drawerPosition } = useSelector(
       (state: RootState) => state.settings
     );
     const snapPoints = useMemo(() => ['80%'], []);
@@ -64,14 +64,29 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
         {...props}
       >
         <View style={[styles.header, { backgroundColor: headerBg }]}>
-          <View style={styles.placeholder} />
-          <View style={[styles.handle, { backgroundColor: handleColor }]} />
-          <TouchableOpacity
-            style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
-            onPress={onClose}
-          >
-            <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-          </TouchableOpacity>
+          {drawerPosition === 'left' ? (
+            <>
+              <TouchableOpacity
+                style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
+                onPress={onClose}
+              >
+                <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
+              </TouchableOpacity>
+              <View style={[styles.handle, { backgroundColor: handleColor }]} />
+              <View style={styles.placeholder} />
+            </>
+          ) : (
+            <>
+              <View style={styles.placeholder} />
+              <View style={[styles.handle, { backgroundColor: handleColor }]} />
+              <TouchableOpacity
+                style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
+                onPress={onClose}
+              >
+                <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
+              </TouchableOpacity>
+            </>
+          )}
         </View>
         {children}
       </BottomSheet>


### PR DESCRIPTION
## Summary
- adjust `BaseBottomSheet` to support left/right close icon based on drawer position

## Testing
- `npm test --prefix frontend/app --silent`

------
https://chatgpt.com/codex/tasks/task_e_685deb7d744c8330aa0f63e1ae24b560