### PR TITLE
Replace PermissionModal with BaseBottomSheet

### DIFF
--- a/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -29,7 +29,7 @@ import {
   UPDATE_PROFILE,
 } from '@/redux/Types/types';
 import MenuSheet from '@/components/MenuSheet/MenuSheet';
-import PermissionModal from '@/components/PermissionModal/PermissionModal';
+import PermissionSheet from '@/components/PermissionSheet';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import NotificationSheet from '@/components/NotificationSheet/NotificationSheet';
@@ -108,7 +108,9 @@ export default function FoodDetailsScreen() {
     appSettings.foods_placeholder_image_remote_url ||
     getImageUrl(serverInfo?.info?.project?.project_logo);
 
-  const [warning, setWarning] = useState(false);
+  const permissionSheetRef = useRef<BottomSheet>(null);
+  const openPermissionSheet = () => permissionSheetRef.current?.expand();
+  const closePermissionSheet = () => permissionSheetRef.current?.close();
   const { selectedCanteen } = useSelector(
     (state: RootState) => state.canteenReducer
   );
@@ -257,7 +259,7 @@ export default function FoodDetailsScreen() {
       canteenId: foodOfferCanteenId,
       previousFeedback,
       dispatch,
-      setWarning,
+      setWarning: () => openPermissionSheet(),
     });
   };
 
@@ -405,7 +407,7 @@ export default function FoodDetailsScreen() {
 
   const updateNotification = async () => {
     if (!user?.id) {
-      setWarning(true);
+      openPermissionSheet();
       return;
     }
     if (isSmartPhone()) {
@@ -917,7 +919,16 @@ export default function FoodDetailsScreen() {
               {foodDetails?.id && renderContent(foodDetails)}
             </View>
           </View>
-          <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+          <BaseBottomSheet
+            ref={permissionSheetRef}
+            index={-1}
+            backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+            enablePanDownToClose
+            handleComponent={null}
+            onClose={closePermissionSheet}
+          >
+            <PermissionSheet closeSheet={closePermissionSheet} />
+          </BaseBottomSheet>
         </View>
       </ScrollView>
       {isActive && (

--- a/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { Image, Pressable, Text, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
@@ -21,7 +21,9 @@ import {
   DELETE_OWN_CANTEEN_FEEDBACK_LABEL_ENTRIES,
   UPDATE_OWN_CANTEEN_FEEDBACK_LABEL_ENTRIES,
 } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
+import BaseBottomSheet from '../BaseBottomSheet';
+import PermissionSheet from '../PermissionSheet/PermissionSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { CanteenFeedbackLabelEntryHelper } from '@/redux/actions/CanteenFeedbackLabelEntries/CanteenFeedbackLabelEntries';
 import { isSameDay } from 'date-fns';
@@ -39,7 +41,9 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
   const dispatch = useDispatch();
   const { translate } = useLanguage();
   const canteenFeedbackLabelEntryHelper = new CanteenFeedbackLabelEntryHelper();
-  const [warning, setWarning] = useState(false);
+  const permissionSheetRef = useRef<BottomSheet>(null);
+  const openPermissionSheet = () => permissionSheetRef.current?.expand();
+  const closePermissionSheet = () => permissionSheetRef.current?.close();
   const [showTooltip, setShowTooltip] = useState(false);
   const {
     primaryColor,
@@ -78,7 +82,7 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
   // Function to handle updating the entry
   const handleUpdateEntry = async (isLike: boolean | null) => {
     if (!user?.id) {
-      setWarning(true);
+      openPermissionSheet();
       return;
     }
     let likeStats = null;
@@ -261,7 +265,16 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
           </TooltipContent>
         </Tooltip>
       </View>
-      <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+      <BaseBottomSheet
+        ref={permissionSheetRef}
+        index={-1}
+        backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+        enablePanDownToClose
+        handleComponent={null}
+        onClose={closePermissionSheet}
+      >
+        <PermissionSheet closeSheet={closePermissionSheet} />
+      </BaseBottomSheet>
     </View>
   );
 };

--- a/frontend/app/components/FeedbackLabel/index.tsx
+++ b/frontend/app/components/FeedbackLabel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
 import { Image, Pressable, Text, TouchableOpacity, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
@@ -16,7 +16,9 @@ import {
   DELETE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL,
   UPDATE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL,
 } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
+import BaseBottomSheet from '../BaseBottomSheet';
+import PermissionSheet from '../PermissionSheet/PermissionSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { myContrastColor } from '@/helper/colorHelper';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -39,7 +41,9 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
     appSettings,
     selectedTheme: mode,
   } = useSelector((state: RootState) => state.settings);
-  const [warning, setWarning] = useState(false);
+  const permissionSheetRef = useRef<BottomSheet>(null);
+  const openPermissionSheet = () => permissionSheetRef.current?.expand();
+  const closePermissionSheet = () => permissionSheetRef.current?.close();
   const [showTooltip, setShowTooltip] = useState(false);
   const { user, profile } = useSelector(
     (state: RootState) => state.authReducer
@@ -71,7 +75,7 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
   // Function to handle updating the entry
   const handleUpdateEntry = async (isLike: boolean | null) => {
     if (!user?.id) {
-      setWarning(true);
+      openPermissionSheet();
       return;
     }
     let likeStats = null;
@@ -210,7 +214,16 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
           </TooltipContent>
         </Tooltip>
       </View>
-      <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+      <BaseBottomSheet
+        ref={permissionSheetRef}
+        index={-1}
+        backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+        enablePanDownToClose
+        handleComponent={null}
+        onClose={closePermissionSheet}
+      >
+        <PermissionSheet closeSheet={closePermissionSheet} />
+      </BaseBottomSheet>
     </View>
   );
 };

--- a/frontend/app/components/Feedbacks/index.tsx
+++ b/frontend/app/components/Feedbacks/index.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { AntDesign, Ionicons, MaterialIcons } from '@expo/vector-icons';
@@ -26,7 +26,9 @@ import {
   DELETE_FOOD_FEEDBACK_LOCAL,
   UPDATE_FOOD_FEEDBACK_LOCAL,
 } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
+import BaseBottomSheet from '../BaseBottomSheet';
+import PermissionSheet from '../PermissionSheet/PermissionSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { createSelector } from 'reselect';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/colorHelper';
@@ -69,7 +71,9 @@ const Feedbacks: React.FC<FeedbacksProps> = ({
   } = useSelector((state: RootState) => state.settings);
   const [commentType, setCommentType] = useState('');
   const [loading, setLoading] = useState(loadingState);
-  const [warning, setWarning] = useState(false);
+  const permissionSheetRef = useRef<BottomSheet>(null);
+  const openPermissionSheet = () => permissionSheetRef.current?.expand();
+  const closePermissionSheet = () => permissionSheetRef.current?.close();
   const [comment, setComment] = useState('');
   const foodFeedbackHelper = useMemo(() => new FoodFeedbackHelper(), []);
   const { labels, labelEntries, previousFeedback } = useSelector((state: any) =>
@@ -91,7 +95,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({
 
   const submitCommentFeedback = async (string: string | null) => {
     if (!user?.id) {
-      setWarning(true);
+      openPermissionSheet();
       return;
     }
 
@@ -137,7 +141,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({
 
   const handleTextChange = (text: string) => {
     if (!user?.id) {
-      setWarning(true);
+      openPermissionSheet();
       return;
     }
 
@@ -436,7 +440,16 @@ const Feedbacks: React.FC<FeedbacksProps> = ({
         </>
       )}
 
-      <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+      <BaseBottomSheet
+        ref={permissionSheetRef}
+        index={-1}
+        backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+        enablePanDownToClose
+        handleComponent={null}
+        onClose={closePermissionSheet}
+      >
+        <PermissionSheet closeSheet={closePermissionSheet} />
+      </BaseBottomSheet>
     </View>
   );
 };

--- a/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/frontend/app/components/FoodItem/FoodItem.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import { useTheme } from '@/hooks/useTheme';
@@ -33,7 +33,9 @@ import {
   SET_MARKING_DETAILS,
   SET_SELECTED_FOOD_MARKINGS,
 } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
+import BaseBottomSheet from '../BaseBottomSheet';
+import PermissionSheet from '../PermissionSheet/PermissionSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { router } from 'expo-router';
 import { createSelector } from 'reselect';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -68,7 +70,9 @@ const FoodItem: React.FC<FoodItemProps> = memo(
     const [screenWidth, setScreenWidth] = useState(
       Dimensions.get('window').width
     );
-    const [warning, setWarning] = useState(false);
+    const permissionSheetRef = useRef<BottomSheet>(null);
+    const openPermissionSheet = () => permissionSheetRef.current?.expand();
+    const closePermissionSheet = () => permissionSheetRef.current?.close();
     const dispatch = useDispatch();
     const { theme } = useTheme();
     const { translate } = useLanguage();
@@ -155,7 +159,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
           canteenId: canteen?.id,
           previousFeedback,
           dispatch,
-          setWarning,
+          setWarning: () => openPermissionSheet(),
         });
       },
       [foodItem?.id, profile?.id, canteen?.id, previousFeedback, dispatch]
@@ -519,7 +523,16 @@ const FoodItem: React.FC<FoodItemProps> = memo(
           </TooltipContent>
         </Tooltip>
 
-        <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+        <BaseBottomSheet
+          ref={permissionSheetRef}
+          index={-1}
+          backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+          enablePanDownToClose
+          handleComponent={null}
+          onClose={closePermissionSheet}
+        >
+          <PermissionSheet closeSheet={closePermissionSheet} />
+        </BaseBottomSheet>
       </>
     );
   },

--- a/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -14,7 +14,9 @@ import { getImageUrl } from '@/constants/HelperFunctions';
 
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { SET_MARKING_DETAILS, UPDATE_PROFILE } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
+import BaseBottomSheet from '../BaseBottomSheet';
+import PermissionSheet from '../PermissionSheet/PermissionSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
 import styles from './styles';
@@ -34,7 +36,9 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
   const dispatch = useDispatch();
   const { translate } = useLanguage();
   const profileHelper = new ProfileHelper();
-  const [warning, setWarning] = useState(false);
+  const permissionSheetRef = useRef<BottomSheet>(null);
+  const openPermissionSheet = () => permissionSheetRef.current?.expand();
+  const closePermissionSheet = () => permissionSheetRef.current?.close();
   const [showTooltip, setShowTooltip] = useState(false);
   const [likeLoading, setLikeLoading] = useState(false);
   const [dislikeLoading, setDislikeLoading] = useState(false);
@@ -470,7 +474,16 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
           </TooltipContent>
         </Tooltip>
       </View>
-      <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+      <BaseBottomSheet
+        ref={permissionSheetRef}
+        index={-1}
+        backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+        enablePanDownToClose
+        handleComponent={null}
+        onClose={closePermissionSheet}
+      >
+        <PermissionSheet closeSheet={closePermissionSheet} />
+      </BaseBottomSheet>
     </View>
   );
 };

--- a/frontend/app/components/PermissionSheet/PermissionSheet.tsx
+++ b/frontend/app/components/PermissionSheet/PermissionSheet.tsx
@@ -1,0 +1,71 @@
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import React, { useState } from 'react';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import styles from './styles';
+import { useTheme } from '@/hooks/useTheme';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLanguage } from '@/hooks/useLanguage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useRouter } from 'expo-router';
+import { ON_LOGOUT } from '@/redux/Types/types';
+import { persistor } from '@/redux/store';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+import type { PermissionSheetProps } from './types';
+
+const PermissionSheet: React.FC<PermissionSheetProps> = ({ closeSheet }) => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const [loading, setLoading] = useState(false);
+
+  const handleLogout = async () => {
+    try {
+      setLoading(true);
+      await AsyncStorage.multiRemove(['auth_data', 'persist:root']);
+      dispatch({ type: ON_LOGOUT });
+      dispatch({ type: 'RESET_STORE' });
+      persistor.purge();
+      setLoading(false);
+      closeSheet();
+      router.replace('/(auth)/login');
+    } catch (error) {
+      setLoading(false);
+      console.error('Error during logout:', error);
+    }
+  };
+
+  return (
+    <BottomSheetScrollView
+      style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View style={styles.sheetHeader}>
+        <View style={{ width: 50 }} />
+        <Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>
+          {translate(TranslationKeys.access_limited)}
+        </Text>
+      </View>
+      <Text style={{ ...styles.sheetSubHeading, color: theme.sheet.text }}>
+        {translate(TranslationKeys.limited_access_description)}
+      </Text>
+      <TouchableOpacity
+        style={{ ...styles.loginButton, backgroundColor: primaryColor }}
+        onPress={handleLogout}
+      >
+        {loading ? (
+          <ActivityIndicator size={22} color={theme.background} />
+        ) : (
+          <Text style={{ ...styles.loginLabel, color: theme.activeText }}>
+            {translate(TranslationKeys.sign_in)} /{' '}
+            {translate(TranslationKeys.create_account)}
+          </Text>
+        )}
+      </TouchableOpacity>
+    </BottomSheetScrollView>
+  );
+};
+
+export default PermissionSheet;

--- a/frontend/app/components/PermissionSheet/index.ts
+++ b/frontend/app/components/PermissionSheet/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PermissionSheet';
+export type { PermissionSheetProps } from './types';

--- a/frontend/app/components/PermissionSheet/styles.ts
+++ b/frontend/app/components/PermissionSheet/styles.ts
@@ -1,0 +1,49 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  sheetView: {
+    width: '100%',
+    height: '100%',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+    paddingBottom: 0,
+  },
+  contentContainer: {
+    alignItems: 'center',
+  },
+  sheetHeader: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+  },
+  sheetHeading: {
+    fontFamily: 'Poppins_700Bold',
+    fontSize: 30,
+    textAlign: 'center',
+  },
+  sheetSubHeading: {
+    width: '95%',
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+    marginTop: 15,
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  loginButton: {
+    width: '80%',
+    height: 60,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 50,
+    marginVertical: 25,
+  },
+  loginLabel: {
+    fontFamily: 'Poppins_700Bold',
+    fontSize: 16,
+    color: '#2E2E2E',
+  },
+});

--- a/frontend/app/components/PermissionSheet/types.ts
+++ b/frontend/app/components/PermissionSheet/types.ts
@@ -1,0 +1,3 @@
+export interface PermissionSheetProps {
+  closeSheet: () => void;
+}


### PR DESCRIPTION
## Summary
- implement `PermissionSheet` bottom sheet
- use BaseBottomSheet+PermissionSheet instead of PermissionModal across the app

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dead3fc548330b8ee7c0b523ebf2f