### PR TITLE
Fix display of menu position in settings

### DIFF
--- a/frontend/app/app/(app)/settings/index.tsx
+++ b/frontend/app/app/(app)/settings/index.tsx
@@ -498,7 +498,13 @@ const Settings = () => {
               <Entypo name='menu' size={24} color={theme.screen.icon} />
             }
             label={translate(TranslationKeys.drawer_config_position)}
-            value={translate(TranslationKeys.drawer_config_position_system)}
+            value={
+              drawerPosition === 'left'
+                ? translate(TranslationKeys.drawer_config_position_left)
+                : drawerPosition === 'right'
+                ? translate(TranslationKeys.drawer_config_position_right)
+                : translate(TranslationKeys.drawer_config_position_system)
+            }
             rightIcon={
               <Octicons
                 name='chevron-right'


### PR DESCRIPTION
## Summary
- show selected drawer position in settings instead of always showing System

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4cd6bf288330ad59503cc0e54648