### PR TITLE
Create reusable button component

### DIFF
--- a/frontend/app/app/(app)/course-timetable/index.tsx
+++ b/frontend/app/app/(app)/course-timetable/index.tsx
@@ -5,7 +5,8 @@ import React, {
   useMemo,
   useEffect,
 } from 'react';
-import { Linking, Platform, Text, TouchableOpacity, View } from 'react-native';
+import { Linking, Platform, Text, View } from 'react-native';
+import AppButton from '@/components/AppButton';
 import { useTheme } from '@/hooks/useTheme';
 import { useFocusEffect } from 'expo-router';
 import TimeTableData from '@/constants/TimeTable';
@@ -164,22 +165,19 @@ const TimetableScreen = () => {
     <View
       style={{ ...styles.container, backgroundColor: theme.screen.background }}
     >
-      <TouchableOpacity
+      <AppButton
         style={{
           ...styles.createButton,
           backgroundColor: course_timetable_area_color,
         }}
+        label={`${translate(TranslationKeys.event)} ${translate(
+          TranslationKeys.create
+        )}`}
+        labelStyle={{ ...styles.createButtonText, color: contrastColor }}
+        icon={<FontAwesome name='calendar-plus-o' size={20} color={contrastColor} />}
         onPress={openSheet}
-      >
-        <FontAwesome name='calendar-plus-o' size={20} color={contrastColor} />
-        <View>
-          <Text style={{ ...styles.createButtonText, color: contrastColor }}>
-            {`${translate(TranslationKeys.event)} ${translate(
-              TranslationKeys.create
-            )}`}
-          </Text>
-        </View>
-      </TouchableOpacity>
+        useProjectColor
+      />
       {events && events?.length > 0 ? (
         <CourseTimetable
           events={events}

--- a/frontend/app/app/(user)/delete-user/index.tsx
+++ b/frontend/app/app/(user)/delete-user/index.tsx
@@ -16,6 +16,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
 } from 'react-native';
+import AppButton from '@/components/AppButton';
 import { useTheme } from '@/hooks/useTheme';
 import { router, useFocusEffect } from 'expo-router';
 import SupportFAQ from '../../../components/SupportFAQ/SupportFAQ';
@@ -305,26 +306,26 @@ const index = () => {
             {translate(TranslationKeys.are_you_sure_to_delete_your_account)}
           </Text>
           <View style={styles.attentionActions}>
-            <TouchableOpacity
+            <AppButton
               style={[styles.confirmButton, { backgroundColor: primaryColor }]}
+              label={
+                loading ? '' : translate(TranslationKeys.confirm)
+              }
+              labelStyle={[styles.confirmLabel, { color: theme.light }]}
               onPress={handleDeleteAccount}
-            >
-              {loading ? (
-                <ActivityIndicator size={24} color={theme.screen.text} />
-              ) : (
-                <Text style={[styles.confirmLabel, { color: theme.light }]}>
-                  {translate(TranslationKeys.confirm)}
-                </Text>
-              )}
-            </TouchableOpacity>
-            <TouchableOpacity
+              icon={
+                loading ? (
+                  <ActivityIndicator size={24} color={theme.screen.text} />
+                ) : undefined
+              }
+              useProjectColor
+            />
+            <AppButton
               style={styles.cancleButton}
+              label={translate(TranslationKeys.cancel)}
+              labelStyle={styles.confirmLabel}
               onPress={closeDeleteAccountModal}
-            >
-              <Text style={styles.confirmLabel}>
-                {translate(TranslationKeys.cancel)}
-              </Text>
-            </TouchableOpacity>
+            />
           </View>
         </View>
       </ModalComponent>

--- a/frontend/app/components/AppButton/AppButton.tsx
+++ b/frontend/app/components/AppButton/AppButton.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import { useTheme } from '@/hooks/useTheme';
+import { myContrastColor } from '@/helper/colorHelper';
+import styles from './styles';
+import type { AppButtonProps } from './types';
+
+const AppButton: React.FC<AppButtonProps> = ({
+  label,
+  onPress,
+  icon,
+  style,
+  labelStyle,
+  backgroundColor,
+  textColor,
+  disabled,
+  useProjectColor = false,
+}) => {
+  const { theme } = useTheme();
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
+
+  const flattenedStyle = StyleSheet.flatten(style) || {};
+  const flattenedLabelStyle = StyleSheet.flatten(labelStyle) || {};
+
+  const bgColor =
+    backgroundColor ??
+    flattenedStyle.backgroundColor ??
+    (useProjectColor ? primaryColor : undefined);
+  const color =
+    textColor ??
+    flattenedLabelStyle.color ??
+    (useProjectColor ? myContrastColor(bgColor || primaryColor, theme, mode === 'dark') : undefined);
+
+  return (
+    <TouchableOpacity
+      style={[styles.container, style, { backgroundColor: bgColor }]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      {icon}
+      <Text style={[styles.label, labelStyle, { color }]}>{label}</Text>
+    </TouchableOpacity>
+  );
+};
+
+export default AppButton;

--- a/frontend/app/components/AppButton/index.ts
+++ b/frontend/app/components/AppButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './AppButton';
+export type { AppButtonProps } from './types';

--- a/frontend/app/components/AppButton/styles.ts
+++ b/frontend/app/components/AppButton/styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 50,
+    borderRadius: 10,
+    paddingHorizontal: 18,
+    gap: 10,
+  },
+  label: {
+    fontSize: 16,
+    fontFamily: 'Poppins_700Bold',
+  },
+});

--- a/frontend/app/components/AppButton/types.ts
+++ b/frontend/app/components/AppButton/types.ts
@@ -1,0 +1,11 @@
+export interface AppButtonProps {
+  label: string;
+  onPress?: () => void;
+  icon?: React.ReactNode;
+  style?: any;
+  labelStyle?: any;
+  backgroundColor?: string;
+  textColor?: string;
+  disabled?: boolean;
+  useProjectColor?: boolean;
+}

--- a/frontend/app/components/Login/AttentionSheet.tsx
+++ b/frontend/app/components/Login/AttentionSheet.tsx
@@ -1,4 +1,5 @@
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, View } from 'react-native';
+import AppButton from '@/components/AppButton';
 import React, { useCallback, useRef, useState } from 'react';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
@@ -74,21 +75,21 @@ const AttentionSheet: React.FC<AttentionSheetProps> = ({
         <View
           style={{ ...styles.attentionActions, width: isWeb ? '60%' : '100%' }}
         >
-          <TouchableOpacity
+          <AppButton
             style={[styles.confirmButton, { backgroundColor: primaryColor }]}
+            label={translate(TranslationKeys.confirm)}
+            labelStyle={[styles.confirmLabel, { color: contrastColor }]}
             onPress={() => {
               handleLogin();
             }}
-          >
-            <Text style={[styles.confirmLabel, { color: contrastColor }]}>
-              {translate(TranslationKeys.confirm)}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.cancleButton} onPress={closeSheet}>
-            <Text style={styles.confirmLabel}>
-              {translate(TranslationKeys.cancel)}
-            </Text>
-          </TouchableOpacity>
+            useProjectColor
+          />
+          <AppButton
+            style={styles.cancleButton}
+            label={translate(TranslationKeys.cancel)}
+            labelStyle={styles.confirmLabel}
+            onPress={closeSheet}
+          />
         </View>
       </View>
     </BottomSheetView>


### PR DESCRIPTION
## Summary
- add `AppButton` component to share styling for text/icon buttons
- migrate login and delete-user sheets to `AppButton`
- update course timetable screen to use `AppButton`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ec3dd9083309cccb874545c866d