### PR TITLE
Improve markdown rendering for marking sheets

### DIFF
--- a/frontend/app/components/MenuSheet/MenuSheet.tsx
+++ b/frontend/app/components/MenuSheet/MenuSheet.tsx
@@ -1,11 +1,4 @@
-import {
-  Image,
-  Linking,
-  Platform,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Image, Text, View } from 'react-native';
 import React from 'react';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
@@ -18,59 +11,17 @@ import {
   getDescriptionFromTranslation,
   getTextFromTranslation,
 } from '@/helper/resourceHelper';
-import RedirectButton from '../RedirectButton';
-import useToast from '@/hooks/useToast';
+import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { RootState } from '@/redux/reducer';
-
-const extractTextAndLink = (description: string) => {
-  // Remove unintended spaces between `]` and `(`
-  const cleanedDescription = description.replace(/\]\s+\(/g, '](');
-
-  const regex = /\[(.*?)\]\((.*?)\)/g;
-  const match = regex.exec(cleanedDescription);
-
-  if (match) {
-    const label = match[1]; // The text inside the square brackets
-    const link = match[2]; // The URL inside the parentheses
-    const textWithoutLinkAndLabel = cleanedDescription
-      .replace(match[0], '')
-      .trim(); // Remove the entire match
-    return { text: textWithoutLinkAndLabel, label, link };
-  }
-
-  return { text: description, label: '', link: null };
-};
 
 const MenuSheet: React.FC<MenuSheetProps> = ({ closeSheet }) => {
   const { theme } = useTheme();
-  const toast = useToast();
   const { markingDetails } = useSelector((state: RootState) => state.food);
   const { language } = useSelector((state: RootState) => state.settings);
   const description = getDescriptionFromTranslation(
     markingDetails?.translations,
     language
   );
-  const { text, label, link } = extractTextAndLink(description);
-
-  const handleOpenInBrowser = async () => {
-    if (link) {
-      try {
-        if (Platform.OS === 'web') {
-          window.open(link, '_blank');
-        } else {
-          const supported = await Linking.canOpenURL(link);
-
-          if (supported) {
-            await Linking.openURL(link);
-          } else {
-            toast(`Cannot open URL: ${link}`, 'error');
-          }
-        }
-      } catch (error) {
-        console.error('An error occurred:', error);
-      }
-    }
-  };
   return (
     <BottomSheetScrollView
       style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
@@ -117,21 +68,14 @@ const MenuSheet: React.FC<MenuSheetProps> = ({ closeSheet }) => {
             }}
           />
         </View>
-        <Text
-          style={{
-            ...styles.body,
-            color: theme.sheet.text,
-          }}
-        >
-          {text}
-        </Text>
-        {link && (
-          <RedirectButton
-            label={label}
-            type='link'
-            backgroundColor=''
-            color=''
-            onClick={handleOpenInBrowser}
+        {description && (
+          <CustomMarkdown
+            content={description}
+            backgroundColor={
+              markingDetails?.background_color || theme.sheet.sheetBg
+            }
+            imageWidth={'100%'}
+            imageHeight={400}
           />
         )}
       </View>

--- a/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
+++ b/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Linking, Text, TouchableOpacity, View } from 'react-native';
+import { Image, Text, View } from 'react-native';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -7,13 +7,11 @@ import { isWeb } from '@/constants/Constants';
 import { useSelector } from 'react-redux';
 import { PopupEventSheetProps } from './types';
 import { getImageUrl } from '@/constants/HelperFunctions';
-import CustomCollapsible from '../CustomCollapsible/CustomCollapsible';
-import { myContrastColor } from '@/helper/colorHelper';
+import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import {
   getTextFromTranslation,
   getTitleFromTranslation,
 } from '@/helper/resourceHelper';
-import RedirectButton from '../RedirectButton';
 import { RootState } from '@/redux/reducer';
 
 const PopupEventSheet: React.FC<PopupEventSheetProps> = ({
@@ -32,261 +30,12 @@ const PopupEventSheet: React.FC<PopupEventSheetProps> = ({
   const title = eventData?.translations
     ? getTitleFromTranslation(eventData?.translations, language)
     : '';
+  const description = eventData?.translations
+    ? getTextFromTranslation(eventData?.translations, language)
+    : '';
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : primaryColor;
-  const contrastColor = myContrastColor(
-    foods_area_color,
-    theme,
-    mode === 'dark'
-  );
-
-  const getContent = () => {
-    // Regex patterns for different content types
-    const contentPatterns = {
-      email: /\[([^\]]+)]\((mailto:[^\)]+)\)/,
-      link: /\[([^\]]+)]\((https?:\/\/[^\)]+)\)/,
-      image: /!\[([^\]]*)]\(([^)]+)\)/,
-      heading: /^#{1,3}\s*(.*)$/,
-    };
-
-    if (eventData?.translations) {
-      const rawText = getTextFromTranslation(eventData?.translations, language);
-      const lines = rawText.split('\n').filter((line) => line.trim() !== '');
-
-      // Process content into a structured format
-      const processContent = (lines: string[]) => {
-        const result: any[] = [];
-        let stack = [{ level: 0, items: result }];
-        let currentText = '';
-
-        const flushTextContent = () => {
-          if (currentText.trim()) {
-            stack[stack.length - 1].items.push({
-              type: 'text',
-              content: currentText.trim(),
-            });
-            currentText = '';
-          }
-        };
-
-        lines.forEach((line) => {
-          // Check for headings first
-          const headingMatch = line.match(contentPatterns.heading);
-          if (headingMatch) {
-            flushTextContent();
-
-            const level = headingMatch[0].match(/#/g)?.length || 1;
-            const headerText = headingMatch[1].trim();
-
-            // Close previous sections at this level or higher
-            while (stack.length > 1 && stack[stack.length - 1].level >= level) {
-              stack.pop();
-            }
-
-            const newSection = {
-              type: 'collapsible',
-              header: headerText,
-              items: [],
-              level,
-            };
-
-            stack[stack.length - 1].items.push(newSection);
-            stack.push({ level, items: newSection.items });
-            return;
-          }
-
-          // Check for other content types
-          if (contentPatterns.image.test(line)) {
-            flushTextContent();
-            const match = line.match(contentPatterns.image);
-            stack[stack.length - 1].items.push({
-              type: 'image',
-              altText: match?.[1] || '',
-              url: match?.[2] || '',
-            });
-          } else if (contentPatterns.email.test(line)) {
-            flushTextContent();
-            const match = line.match(contentPatterns.email);
-            stack[stack.length - 1].items.push({
-              type: 'email',
-              displayText: match?.[1],
-              email: match?.[2],
-            });
-          } else if (contentPatterns.link.test(line)) {
-            flushTextContent();
-            const match = line.match(contentPatterns.link);
-            stack[stack.length - 1].items.push({
-              type: 'link',
-              displayText: match?.[1],
-              url: match?.[2],
-            });
-          } else {
-            currentText += `${line}\n`;
-          }
-        });
-
-        flushTextContent();
-        return result;
-      };
-
-      // Component for rendering text with proper formatting
-      const TextContent = ({
-        text,
-        level,
-      }: {
-        text: string;
-        level: number;
-      }) => (
-        <Text
-          style={{
-            fontSize: 16,
-            fontFamily: 'Poppins_400Regular',
-            color: theme.screen.text,
-            marginLeft: level * 16,
-            marginBottom: 10,
-            lineHeight: 24,
-            textAlign: 'center',
-          }}
-        >
-          {text}
-        </Text>
-      );
-
-      // Component for rendering images
-      const ImageContent = ({
-        url,
-        altText,
-        level,
-      }: {
-        url: string;
-        altText: string;
-        level: number;
-      }) => (
-        <View
-          style={{
-            marginLeft: level * 16,
-            marginVertical: 10,
-            backgroundColor: theme.screen.iconBg,
-            borderRadius: 8,
-            overflow: 'hidden',
-          }}
-        >
-          <Image
-            source={{ uri: url }}
-            style={{
-              width: '100%',
-              height: 400,
-              resizeMode: 'cover',
-            }}
-            alt={altText}
-          />
-          {altText && (
-            <Text
-              style={{
-                padding: 8,
-                fontSize: 12,
-                color: theme.screen.text,
-                fontFamily: 'Poppins_400Regular',
-              }}
-            >
-              {altText}
-            </Text>
-          )}
-        </View>
-      );
-
-      // Main renderer for content items
-      const renderContentItem = (item: any, level: number, index: number) => {
-        switch (item.type) {
-          case 'text':
-            return (
-              <TextContent
-                key={`text-${level}-${index}`}
-                text={item.content}
-                level={level}
-              />
-            );
-
-          case 'email':
-            return (
-              <View
-                key={`email-${level}-${index}`}
-                style={{ marginLeft: level * 16, marginBottom: 10 }}
-              >
-                <RedirectButton
-                  type='email'
-                  label={item.displayText}
-                  onClick={() => Linking.openURL(`mailto:${item.email}`)}
-                  backgroundColor={foods_area_color}
-                  color={contrastColor}
-                />
-              </View>
-            );
-
-          case 'link':
-            return (
-              <View
-                key={`link-${level}-${index}`}
-                style={{ marginLeft: level * 16, marginBottom: 10 }}
-              >
-                <RedirectButton
-                  type='link'
-                  label={item.displayText}
-                  onClick={() => Linking.openURL(item.url)}
-                  backgroundColor={foods_area_color}
-                  color={contrastColor}
-                />
-              </View>
-            );
-
-          case 'image':
-            return (
-              <ImageContent
-                key={`image-${level}-${index}`}
-                url={item.url}
-                altText={item.altText}
-                level={level}
-              />
-            );
-
-          case 'collapsible':
-            return (
-              <View
-                key={`collapsible-${level}-${index}`}
-                style={{ marginTop: level > 0 ? 5 : 10 }}
-              >
-                <CustomCollapsible
-                  headerText={item.header}
-                  customColor={foods_area_color}
-                >
-                  {renderContent(item.items, level + 1)}
-                </CustomCollapsible>
-              </View>
-            );
-
-          default:
-            return null;
-        }
-      };
-
-      // Recursive content renderer
-      const renderContent = (items: any[], level = 0) => {
-        return items.map((item, index) =>
-          renderContentItem(item, level, index)
-        );
-      };
-
-      const hierarchicalContent = processContent(lines);
-      return (
-        <View style={{ paddingBottom: 20 }}>
-          {renderContent(hierarchicalContent)}
-        </View>
-      );
-    }
-
-    return null;
-  };
 
   return (
     <BottomSheetScrollView
@@ -332,7 +81,14 @@ const PopupEventSheet: React.FC<PopupEventSheetProps> = ({
                 </View>
             )
         }
-        {getContent()}
+        {description && (
+          <CustomMarkdown
+            content={description}
+            backgroundColor={foods_area_color}
+            imageWidth={'100%'}
+            imageHeight={400}
+          />
+        )}
       </View>
     </BottomSheetScrollView>
   );


### PR DESCRIPTION
## Summary
- render marking details using `CustomMarkdown`
- replace popup event sheet parser with `CustomMarkdown`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea74ea7488330b00ffa850dbdb057