### PR TITLE
Fix markings refresh

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -439,6 +439,9 @@ export default function Layout() {
 
   const fetchConfig: { key: string; action: () => Promise<void> }[] = [
     { key: CollectionKeys.APP_ELEMENTS, action: getAllAppElements },
+    // also refresh markings when the markings or translation tables changed
+    { key: CollectionKeys.MARKINGS, action: getMarkings },
+    { key: CollectionKeys.MARKINGS_TRANSLATIONS, action: getMarkings },
     { key: CollectionKeys.MARKINGS_GROUPS, action: getMarkings },
     { key: CollectionKeys.FOODS_CATEGORIES, action: getFoodCategories },
     {


### PR DESCRIPTION
## Summary
- ensure mobile app refreshes markings when marking tables update

## Testing
- `npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_e_685ea7b974f083308e0d83c33a63c7b0