### PR TITLE
Fix markings refresh

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -437,20 +437,29 @@ export default function Layout() {
     }
   };
 
-  const fetchConfig: { key: string; action: () => Promise<void> }[] = [
+  const fetchConfig: { key: string | string[]; action: () => Promise<void> }[] = [
     { key: CollectionKeys.APP_ELEMENTS, action: getAllAppElements },
-    { key: CollectionKeys.MARKINGS_GROUPS, action: getMarkings },
-    { key: CollectionKeys.FOODS_CATEGORIES, action: getFoodCategories },
+    // refresh markings when any of the related tables change
     {
-      key: CollectionKeys.FOODS_CATEGORIES_TRANSLATIONS,
+      key: [
+        CollectionKeys.MARKINGS,
+        CollectionKeys.MARKINGS_TRANSLATIONS,
+        CollectionKeys.MARKINGS_GROUPS,
+      ],
+      action: getMarkings,
+    },
+    {
+      key: [
+        CollectionKeys.FOODS_CATEGORIES,
+        CollectionKeys.FOODS_CATEGORIES_TRANSLATIONS,
+      ],
       action: getFoodCategories,
     },
     {
-      key: CollectionKeys.FOODOFFERS_CATEGORIES,
-      action: getFoodOffersCategories,
-    },
-    {
-      key: CollectionKeys.FOODOFFERS_CATEGORIES_TRANSLATIONS,
+      key: [
+        CollectionKeys.FOODOFFERS_CATEGORIES,
+        CollectionKeys.FOODOFFERS_CATEGORIES_TRANSLATIONS,
+      ],
       action: getFoodOffersCategories,
     },
     {
@@ -481,11 +490,13 @@ export default function Layout() {
       if (result) {
         const serverMap = transformUpdateDatesToMap(result);
         if (
-          shouldFetch(CollectionKeys.POPUP_EVENTS, serverMap, lastUpdatedMap) ||
           shouldFetch(
-            CollectionKeys.POPUP_EVENTS_TRANSLATIONS,
+            [
+              CollectionKeys.POPUP_EVENTS,
+              CollectionKeys.POPUP_EVENTS_TRANSLATIONS,
+            ],
             serverMap,
-            lastUpdatedMap
+            lastUpdatedMap,
           )
         ) {
           getAllEvents();

--- a/frontend/app/helper/shouldFetch.ts
+++ b/frontend/app/helper/shouldFetch.ts
@@ -1,14 +1,16 @@
 export const shouldFetch = (
-  key: string,
+  key: string | string[],
   serverMap: Record<string, string>,
   localMap: Record<string, string>
 ): boolean => {
-  const serverDate = new Date(serverMap[key]);
-  const localDate = localMap[key] ? new Date(localMap[key]) : null;
+  const keys = Array.isArray(key) ? key : [key];
 
-  // If no local date exists, it's the first time => fetch
-  if (!localDate) return true;
+  return keys.some((k) => {
+    const serverDate = serverMap[k] ? new Date(serverMap[k]) : null;
+    const localDate = localMap[k] ? new Date(localMap[k]) : null;
 
-  // If server has newer data => fetch
-  return serverDate > localDate;
+    if (!localDate) return true;
+
+    return !!serverDate && serverDate > localDate;
+  });
 };


### PR DESCRIPTION
## Summary
- ensure mobile app refreshes markings when marking tables update only once
- allow shouldFetch to accept multiple keys
- group fetch config keys by action

## Testing
- `npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_e_685ea7b974f083308e0d83c33a63c7b0