### PR TITLE
Fix MyMarkdown font size

### DIFF
--- a/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -74,12 +74,10 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content }) => {
   const customHTMLElementModels = {
     sub: HTMLElementModel.fromCustomModel({
       tagName: 'sub',
-      mixedUAStyles: { fontSize: '75%' },
       contentModel: HTMLContentModel.textual,
     }),
     sup: HTMLElementModel.fromCustomModel({
       tagName: 'sup',
-      mixedUAStyles: { fontSize: '75%' },
       contentModel: HTMLContentModel.textual,
     }),
   };
@@ -131,7 +129,7 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content }) => {
       const { data } = props.tnode;
       const text = data || props.children[0]?.data;
       return (
-        <Text style={{ fontSize: fontSize * 0.75, verticalAlign: 'sub', color: textColor }}>
+        <Text style={{ fontSize, verticalAlign: 'sub', color: textColor }}>
           {text}
         </Text>
       );
@@ -140,7 +138,7 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content }) => {
       const { data } = props.tnode;
       const text = data || props.children[0]?.data;
       return (
-        <Text style={{ fontSize: fontSize * 0.75, verticalAlign: 'super', color: textColor }}>
+        <Text style={{ fontSize, verticalAlign: 'super', color: textColor }}>
           {text}
         </Text>
       );


### PR DESCRIPTION
## Summary
- ensure sub- and superscript text in MyMarkdown uses the same font size as normal text

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eccdf1a788330a06e6f76b127a199