### PR TITLE
Apply BaseBottomSheet to calendar picker

### DIFF
--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -964,34 +964,37 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           </ScrollView>
         </View>
         {isActive && (
-          <BaseBottomSheet
-            key={selectedSheet}
-            ref={bottomSheetRef}
-            // snapPoints={['40%']}
-            backgroundStyle={{
-              ...styles.sheetBackground,
-              backgroundColor: theme.sheet.sheetBg,
-            }}
-            enablePanDownToClose={selectedSheet === 'forecast' ? false : true}
-            enableContentPanningGesture={
-              selectedSheet === 'forecast' ? false : true
-            }
-            enableHandlePanningGesture={
-              selectedSheet === 'forecast' ? false : true
-            }
-            enableDynamicSizing={selectedSheet === 'forecast' ? false : true}
-            onChange={(index) => {
-              if (index === -1) {
-                closeSheet();
+          selectedSheet === 'calendar' ? (
+            <CalendarSheet sheetRef={bottomSheetRef} closeSheet={closeSheet} />
+          ) : (
+            <BaseBottomSheet
+              key={selectedSheet}
+              ref={bottomSheetRef}
+              backgroundStyle={{
+                ...styles.sheetBackground,
+                backgroundColor: theme.sheet.sheetBg,
+              }}
+              enablePanDownToClose={selectedSheet === 'forecast' ? false : true}
+              enableContentPanningGesture={
+                selectedSheet === 'forecast' ? false : true
               }
-            }}
-            onClose={closeSheet}
-            handleComponent={null}
-          >
-            {SheetComponent && (
-              <SheetComponent closeSheet={closeSheet} {...sheetProps} />
-            )}
-          </BaseBottomSheet>
+              enableHandlePanningGesture={
+                selectedSheet === 'forecast' ? false : true
+              }
+              enableDynamicSizing={selectedSheet === 'forecast' ? false : true}
+              onChange={(index) => {
+                if (index === -1) {
+                  closeSheet();
+                }
+              }}
+              onClose={closeSheet}
+              handleComponent={null}
+            >
+              {SheetComponent && (
+                <SheetComponent closeSheet={closeSheet} {...sheetProps} />
+              )}
+            </BaseBottomSheet>
+          )
         )}
 
         {isActive && (

--- a/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -3,7 +3,8 @@ import React, { useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { CalendarSheetProps, Direction } from './types';
-import { BottomSheetView } from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { isWeb } from '@/constants/Constants';
 import { AntDesign } from '@expo/vector-icons';
 import { Calendar, LocaleConfig } from 'react-native-calendars';
@@ -14,7 +15,7 @@ import { SET_SELECTED_DATE } from '@/redux/Types/types';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 
-const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
+const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, sheetRef }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
   const dispatch = useDispatch();
@@ -95,8 +96,15 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
   LocaleConfig.defaultLocale = 'custom';
 
   return (
-    <BottomSheetView
-      style={{ ...styles.container, backgroundColor: theme.sheet.sheetBg }}
+    <BaseBottomSheet
+      ref={sheetRef}
+      index={-1}
+      onClose={closeSheet}
+      handleComponent={null}
+      backgroundStyle={{
+        ...styles.container,
+        backgroundColor: theme.sheet.sheetBg,
+      }}
     >
       <View
         style={{
@@ -176,16 +184,16 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
             textDisabledColor: 'gray',
             arrowColor: foods_area_color,
             disabledArrowColor: 'gray',
-            textDayFontFamily: 'Poppins_400Regular',
-            textMonthFontFamily: 'Poppins_400Regular',
-            textDayHeaderFontFamily: 'Poppins_400Regular',
-            textDayFontSize: 16,
-            textMonthFontSize: 18,
-            textDayHeaderFontSize: 14,
-          }}
+          textDayFontFamily: 'Poppins_400Regular',
+          textMonthFontFamily: 'Poppins_400Regular',
+          textDayHeaderFontFamily: 'Poppins_400Regular',
+          textDayFontSize: 16,
+          textMonthFontSize: 18,
+          textDayHeaderFontSize: 14,
+        }}
         />
       </View>
-    </BottomSheetView>
+    </BaseBottomSheet>
   );
 };
 

--- a/frontend/app/components/CalendarSheet/types.ts
+++ b/frontend/app/components/CalendarSheet/types.ts
@@ -1,5 +1,8 @@
+import type BottomSheet from '@gorhom/bottom-sheet';
+
 export interface CalendarSheetProps {
   closeSheet: () => void;
+  sheetRef: React.RefObject<BottomSheet>;
 }
 
 export type Direction = 'left' | 'right';


### PR DESCRIPTION
## Summary
- use `BaseBottomSheet` inside `CalendarSheet`
- allow passing a bottom sheet ref to `CalendarSheet`
- open `CalendarSheet` directly instead of wrapping it in another sheet

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f905e54bc83308de3300220d590e6