### PR TITLE
Add close button to forecast sheet

### DIFF
--- a/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { AntDesign } from '@expo/vector-icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
@@ -176,12 +177,23 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({
     >
       <View
         style={{
-          ...styles.sheetHeader,
+          ...styles.header,
           paddingRight: isWeb ? 10 : 0,
           paddingTop: isWeb ? 10 : 0,
         }}
       >
-        <View />
+        <View style={styles.placeholder} />
+        <View
+          style={[styles.handle, { backgroundColor: theme.sheet.closeBg }]}
+        />
+        <TouchableOpacity
+          style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
+          onPress={closeSheet}
+        >
+          <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
+        </TouchableOpacity>
+      </View>
+      <View style={styles.titleContainer}>
         <Text
           style={{
             ...styles.sheetHeading,

--- a/frontend/app/components/ForecastSheet/styles.ts
+++ b/frontend/app/components/ForecastSheet/styles.ts
@@ -10,7 +10,16 @@ export default StyleSheet.create({
     paddingBottom: 0,
     alignItems: 'center',
   },
-  sheetHeader: {
+  header: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+  },
+  titleContainer: {
     width: '100%',
     flexDirection: 'row',
     justifyContent: 'center',
@@ -18,16 +27,26 @@ export default StyleSheet.create({
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
   },
-  sheetcloseButton: {
+  closeButton: {
     width: 45,
     height: 45,
     borderRadius: 50,
     justifyContent: 'center',
     alignItems: 'center',
   },
+  handle: {
+    width: '30%',
+    height: 6,
+    borderRadius: 3,
+    marginHorizontal: 10,
+    alignSelf: 'center',
+  },
+  placeholder: {
+    width: 45,
+    height: 45,
+  },
   sheetHeading: {
     fontFamily: 'Poppins_700Bold',
-    
   },
   forecastContainer: {
     width: '100%',


### PR DESCRIPTION
## Summary
- add AntDesign icon to `ForecastSheet`
- add top header row with handle and close button
- move title to separate row below

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f9d0ce9b48330a67d5f7cff499e81