### PR TITLE
Fix Experimental tab navigation

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -614,7 +614,7 @@ export default function Layout() {
           }}
         />
         <Drawer.Screen
-          name='experimental/index'
+          name='experimental'
           options={{
             header: () => (
               <CustomMenuHeader

--- a/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -284,8 +284,8 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
         label: translate(TranslationKeys.experimental),
         iconName: 'flask',
         iconLibName: FontAwesome5,
-        activeKey: 'experimental/index',
-        route: 'experimental/index',
+        activeKey: 'experimental',
+        route: 'experimental',
         position: 8.5,
       });
     }


### PR DESCRIPTION
## Summary
- fix screen name for experimental tab
- update drawer menu item to match new route

## Testing
- `npm test --silent`
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe306448c833080b3f5ef80d79383