### PR TITLE
Add experimentell index screen and update menu

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -651,15 +651,15 @@ export default function Layout() {
           }}
         />
         <Drawer.Screen
-          name='experimentell/LeafletMap/index'
+          name='experimentell/index'
           options={{
             header: () => (
               <CustomMenuHeader
-                label={translate(TranslationKeys.leaflet_map)}
-                key={'LeafletMap'}
+                label={translate(TranslationKeys.experimentell)}
+                key={'Experimentell'}
               />
             ),
-            title: translate(TranslationKeys.leaflet_map),
+            title: translate(TranslationKeys.experimentell),
           }}
         />
 

--- a/frontend/app/app/(app)/experimentell/index.tsx
+++ b/frontend/app/app/(app)/experimentell/index.tsx
@@ -1,0 +1,45 @@
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import React from 'react';
+import styles from './styles';
+import { useTheme } from '@/hooks/useTheme';
+import { Entypo, MaterialCommunityIcons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+
+const index = () => {
+  useSetPageTitle(TranslationKeys.experimentell);
+  const { translate } = useLanguage();
+  const { theme } = useTheme();
+
+  return (
+    <ScrollView
+      style={{ ...styles.container, backgroundColor: theme.screen.background }}
+      contentContainerStyle={{
+        ...styles.contentContainer,
+        backgroundColor: theme.screen.background,
+      }}
+    >
+      <View style={{ ...styles.content }}>
+        <Text style={{ ...styles.heading, color: theme.screen.text }}>
+          {translate(TranslationKeys.experimentell)}
+        </Text>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.navigate('/experimentell/LeafletMap')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='map' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.leaflet_map)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+};
+
+export default index;

--- a/frontend/app/app/(app)/experimentell/styles.ts
+++ b/frontend/app/app/(app)/experimentell/styles.ts
@@ -1,0 +1,37 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {},
+  content: {
+    width: '100%',
+    height: '100%',
+    padding: 20,
+  },
+  heading: {
+    fontSize: 24,
+    fontFamily: 'Poppins_700Bold',
+    marginVertical: 10,
+  },
+  listItem: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 10,
+    padding: 10,
+    marginVertical: 10,
+  },
+  col: {
+    maxWidth: '70%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  body: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+  },
+});

--- a/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -290,11 +290,11 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
         position: 9,
       });
       menuItems.push({
-        label: translate(TranslationKeys.leaflet_map),
+        label: translate(TranslationKeys.experimentell),
         iconName: 'bag',
         iconLibName: Ionicons,
-        activeKey: 'experimentell/LeafletMap/index',
-        route: 'experimentell/LeafletMap/index',
+        activeKey: 'experimentell/index',
+        route: 'experimentell/index',
         position: 9.5,
       });
     }


### PR DESCRIPTION
## Summary
- add index and styles for experimentell section
- route Drawer entry to new index
- list LeafletMap screen inside experimentell index

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ff89108908330a43b95272369dda3