### PR TITLE
Add Leaflet map WebView

### DIFF
--- a/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
+++ b/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
+import { WebView } from 'react-native-webview';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
-import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 
 const LeafletMap = () => {
   useSetPageTitle(TranslationKeys.leaflet_map);
   const { theme } = useTheme();
-  const { translate } = useLanguage();
+
+  const html = require('@/assets/leaflet/index.html');
 
   return (
     <View style={[styles.container, { backgroundColor: theme.screen.background }]}>
-      <Text style={[styles.text, { color: theme.screen.text }]}>\n        {translate(TranslationKeys.leaflet_map)} Placeholder\n      </Text>
+      <WebView
+        originWhitelist={['*']}
+        source={html}
+        style={styles.webview}
+      />
     </View>
   );
 };

--- a/frontend/app/app/(app)/experimentell/LeafletMap/styles.ts
+++ b/frontend/app/app/(app)/experimentell/LeafletMap/styles.ts
@@ -6,8 +6,8 @@ export default StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  text: {
-    fontSize: 18,
-    fontFamily: 'Poppins_400Regular',
+  webview: {
+    flex: 1,
+    width: '100%',
   },
 });

--- a/frontend/app/app/(app)/experimentell/_layout.tsx
+++ b/frontend/app/app/(app)/experimentell/_layout.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTheme } from '@/hooks/useTheme';
+import { Stack } from 'expo-router';
+import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+
+export default function ExperimentellLayout() {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.header.background },
+        headerTintColor: theme.header.text,
+      }}
+    >
+      <Stack.Screen
+        name='index'
+        options={{
+          title: 'experimentell',
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name='LeafletMap/index'
+        options={{
+          header: () => (
+            <CustomStackHeader
+              label={translate(TranslationKeys.leaflet_map)}
+              key={'LeafletMap'}
+            />
+          ),
+        }}
+      />
+    </Stack>
+  );
+}

--- a/frontend/app/declarations.d.ts
+++ b/frontend/app/declarations.d.ts
@@ -4,3 +4,8 @@ declare module "*.svg" {
   const content: React.FC<SvgProps>;
   export default content;
 }
+
+declare module '*.html' {
+  const content: number;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- add HTML module declaration
- show a header for experimental screens
- load local Leaflet map HTML in WebView
- add style for the WebView

## Testing
- `npx jest --runInBand` *(fails: Need to install jest)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860002c61a4833082be46a09ca2b039