### PR TITLE
Fix navigation to experimentell screen

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -651,7 +651,7 @@ export default function Layout() {
           }}
         />
         <Drawer.Screen
-          name='experimentell/index'
+          name='experimentell'
           options={{
             header: () => (
               <CustomMenuHeader

--- a/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -293,8 +293,8 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
         label: translate(TranslationKeys.experimentell),
         iconName: 'bag',
         iconLibName: Ionicons,
-        activeKey: 'experimentell/index',
-        route: 'experimentell/index',
+        activeKey: 'experimentell',
+        route: 'experimentell',
         position: 9.5,
       });
     }


### PR DESCRIPTION
## Summary
- adjust drawer route name for experimentell screen
- update drawer configuration to match new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686005d25c948330b33963ba1ddd6140