### PR TITLE
Fix Leaflet map WebView

### DIFF
--- a/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
+++ b/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
@@ -18,6 +18,12 @@ const LeafletMap = () => {
         originWhitelist={['*']}
         source={html}
         style={styles.webview}
+        allowFileAccess
+        allowFileAccessFromFileURLs
+        allowUniversalAccessFromFileURLs
+        domStorageEnabled
+        javaScriptEnabled
+        containerStyle={{ height: '100%', width: '100%' }}
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- allow file access in WebView for Leaflet map

## Testing
- `yarn test`
- `yarn lint` *(fails: Couldn't find a script named "eslint")*

------
https://chatgpt.com/codex/tasks/task_e_68600b76cc68833090bdb72e96cf546c