### PR TITLE
Implement WebView map coordinate messaging

### DIFF
--- a/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
+++ b/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
@@ -1,20 +1,41 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { useLocalSearchParams } from 'expo-router';
 
 const LeafletMap = () => {
   useSetPageTitle(TranslationKeys.leaflet_map);
   const { theme } = useTheme();
+  const params = useLocalSearchParams();
+  const webViewRef = useRef<WebView>(null);
 
   const html = require('@/assets/leaflet/index.html');
+
+  const sendCoordinates = useCallback(() => {
+    if (webViewRef.current && params.lat && params.lng) {
+      const lat = Array.isArray(params.lat) ? params.lat[0] : params.lat;
+      const lng = Array.isArray(params.lng) ? params.lng[0] : params.lng;
+      const zoomParam = params.zoom ? (Array.isArray(params.zoom) ? params.zoom[0] : params.zoom) : undefined;
+      const message = {
+        mapCenterPosition: { lat: parseFloat(String(lat)), lng: parseFloat(String(lng)) },
+        zoom: zoomParam ? parseInt(String(zoomParam), 10) : 13,
+      };
+      webViewRef.current.postMessage(JSON.stringify(message));
+    }
+  }, [params.lat, params.lng, params.zoom]);
+
+  useEffect(() => {
+    sendCoordinates();
+  }, [sendCoordinates]);
 
   return (
     <View style={[styles.container, { backgroundColor: theme.screen.background }]}>
       <WebView
+        ref={webViewRef}
         originWhitelist={['*']}
         source={html}
         style={styles.webview}
@@ -24,6 +45,7 @@ const LeafletMap = () => {
         domStorageEnabled
         javaScriptEnabled
         containerStyle={{ height: '100%', width: '100%' }}
+        onLoadEnd={sendCoordinates}
       />
     </View>
   );

--- a/frontend/app/app/(app)/experimentell/index.tsx
+++ b/frontend/app/app/(app)/experimentell/index.tsx
@@ -27,7 +27,12 @@ const index = () => {
         </Text>
         <TouchableOpacity
           style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-          onPress={() => router.navigate('/experimentell/LeafletMap')}
+          onPress={() =>
+            router.push({
+              pathname: '/experimentell/LeafletMap',
+              params: { lat: '52.275', lng: '7.4584', zoom: '16' },
+            })
+          }
         >
           <View style={styles.col}>
             <MaterialCommunityIcons name='map' color={theme.screen.icon} size={24} />


### PR DESCRIPTION
## Summary
- allow passing lat/lng via params to the Leaflet map
- pass example coordinates from the experimentell overview

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609efd727483309564c2e35acf5e96