### PR TITLE
Fix Leaflet initial map center

### DIFF
--- a/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
+++ b/frontend/app/app/(app)/experimentell/LeafletMap/index.tsx
@@ -5,7 +5,10 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import MyMap from '@/components/MyMap/MyMap';
 
-const DEFAULT_POSITION = { lat: 52.52, lng: 13.405 };
+const POSITION_BUNDESTAG = {
+  lat: 52.518594247456804,
+  lng: 13.376281624711964,
+};
 
 const LeafletMap = () => {
   useSetPageTitle(TranslationKeys.leaflet_map);
@@ -14,7 +17,7 @@ const LeafletMap = () => {
     (state: RootState) => state.canteenReducer
   );
 
-  const position = useMemo(() => {
+  const centerPosition = useMemo(() => {
     if (selectedCanteen?.building) {
       const building = buildings.find((b) => b.id === selectedCanteen.building);
       const coords = (building as any)?.coordinates?.coordinates;
@@ -22,10 +25,14 @@ const LeafletMap = () => {
         return { lat: Number(coords[1]), lng: Number(coords[0]) };
       }
     }
-    return DEFAULT_POSITION;
+    return undefined;
   }, [selectedCanteen, buildings]);
 
-  return <MyMap latitude={position.lat} longitude={position.lng} />;
+  return (
+    <MyMap
+      mapCenterPosition={centerPosition || POSITION_BUNDESTAG}
+    />
+  );
 };
 
 export default LeafletMap;

--- a/frontend/app/components/MyMap/MyMap.tsx
+++ b/frontend/app/components/MyMap/MyMap.tsx
@@ -4,13 +4,17 @@ import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 
+export interface Position {
+  lat: number;
+  lng: number;
+}
+
 export interface MyMapProps {
-  latitude: number;
-  longitude: number;
+  mapCenterPosition: Position;
   zoom?: number;
 }
 
-const MyMap: React.FC<MyMapProps> = ({ latitude, longitude, zoom }) => {
+const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom }) => {
   const { theme } = useTheme();
   const webViewRef = useRef<WebView>(null);
   const html = require('@/assets/leaflet/index.html');
@@ -39,14 +43,14 @@ const MyMap: React.FC<MyMapProps> = ({ latitude, longitude, zoom }) => {
   const sendCoordinates = useCallback(() => {
     if (webViewRef.current) {
       const message = {
-        mapCenterPosition: { lat: latitude, lng: longitude },
+        mapCenterPosition,
         zoom: zoom ?? 13,
         mapLayers: [defaultLayer],
       };
       const js = `window.postMessage(${JSON.stringify(message)}, '*');`;
       webViewRef.current.injectJavaScript(js);
     }
-  }, [latitude, longitude, zoom]);
+  }, [mapCenterPosition, zoom]);
 
   useEffect(() => {
     sendCoordinates();


### PR DESCRIPTION
## Summary
- default MyMap to accept a centerPosition object
- fallback to Bundestag coordinates when no location is available

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686163e00204833082349c37e3942a68