### PR TITLE
Add vertical image scroll feature and map markers

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -677,6 +677,19 @@ export default function Layout() {
         />
 
         <Drawer.Screen
+          name='vertical-image-scroll/index'
+          options={{
+            header: () => (
+              <CustomStackHeader
+                label={translate(TranslationKeys.vertical_image_scroll)}
+                key={'VerticalImageScroll'}
+              />
+            ),
+            title: translate(TranslationKeys.vertical_image_scroll),
+          }}
+        />
+
+        <Drawer.Screen
           name='notification/index'
           options={{
             header: () => (

--- a/frontend/app/app/(app)/experimentell/index.tsx
+++ b/frontend/app/app/(app)/experimentell/index.tsx
@@ -68,6 +68,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/vertical-image-scroll')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='image-multiple' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.vertical_image_scroll)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/frontend/app/app/(app)/leaflet-map/index.tsx
+++ b/frontend/app/app/(app)/leaflet-map/index.tsx
@@ -5,6 +5,29 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import MyMap from '@/components/MyMap/MyMap';
 
+const MARKERS = [
+  { id: '1', position: { lat: 53.7554, lng: 12.0636 }, title: 'Marker 1' },
+  { id: '2', position: { lat: 50.3646, lng: 8.0713 }, title: 'Marker 2' },
+  { id: '3', position: { lat: 51.0902, lng: 9.2395 }, title: 'Marker 3' },
+  { id: '4', position: { lat: 53.2704, lng: 8.4265 }, title: 'Marker 4' },
+  { id: '5', position: { lat: 50.8128, lng: 10.6671 }, title: 'Marker 5' },
+  { id: '6', position: { lat: 54.2649, lng: 10.0375 }, title: 'Marker 6' },
+  { id: '7', position: { lat: 49.2547, lng: 12.0464 }, title: 'Marker 7' },
+  { id: '8', position: { lat: 51.947, lng: 8.0041 }, title: 'Marker 8' },
+  { id: '9', position: { lat: 54.278, lng: 13.8623 }, title: 'Marker 9' },
+  { id: '10', position: { lat: 53.4817, lng: 13.2173 }, title: 'Marker 10' },
+  { id: '11', position: { lat: 49.4812, lng: 11.8387 }, title: 'Marker 11' },
+  { id: '12', position: { lat: 54.1907, lng: 11.4719 }, title: 'Marker 12' },
+  { id: '13', position: { lat: 50.7771, lng: 6.8056 }, title: 'Marker 13' },
+  { id: '14', position: { lat: 50.4734, lng: 10.8871 }, title: 'Marker 14' },
+  { id: '15', position: { lat: 54.3041, lng: 13.7329 }, title: 'Marker 15' },
+  { id: '16', position: { lat: 50.8161, lng: 12.9225 }, title: 'Marker 16' },
+  { id: '17', position: { lat: 49.0839, lng: 12.4402 }, title: 'Marker 17' },
+  { id: '18', position: { lat: 51.3896, lng: 6.1123 }, title: 'Marker 18' },
+  { id: '19', position: { lat: 52.7576, lng: 9.1906 }, title: 'Marker 19' },
+  { id: '20', position: { lat: 53.5988, lng: 11.3452 }, title: 'Marker 20' },
+];
+
 const POSITION_BUNDESTAG = {
   lat: 52.518594247456804,
   lng: 13.376281624711964,
@@ -31,6 +54,7 @@ const LeafletMap = () => {
   return (
     <MyMap
       mapCenterPosition={centerPosition || POSITION_BUNDESTAG}
+      mapMarkers={MARKERS}
     />
   );
 };

--- a/frontend/app/app/(app)/vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/vertical-image-scroll/index.tsx
@@ -1,0 +1,35 @@
+import { ScrollView } from 'react-native';
+import React from 'react';
+import styles from './styles';
+import { useTheme } from '@/hooks/useTheme';
+import { Image } from 'expo-image';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+
+const images = [
+  require('@/assets/images/react-logo.png'),
+  require('@/assets/images/react-logo@2x.png'),
+  require('@/assets/images/react-logo@3x.png'),
+  require('@/assets/images/splash.png'),
+  require('@/assets/images/splash-icon.png'),
+];
+
+const VerticalImageScroll = () => {
+  useSetPageTitle(TranslationKeys.vertical_image_scroll);
+  const { theme } = useTheme();
+
+  return (
+    <ScrollView style={{ ...styles.container, backgroundColor: theme.screen.background }}>
+      {images.map((img, index) => (
+        <Image
+          key={index}
+          source={img}
+          style={styles.image}
+          contentFit='contain'
+        />
+      ))}
+    </ScrollView>
+  );
+};
+
+export default VerticalImageScroll;

--- a/frontend/app/app/(app)/vertical-image-scroll/styles.ts
+++ b/frontend/app/app/(app)/vertical-image-scroll/styles.ts
@@ -1,0 +1,12 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  image: {
+    width: '100%',
+    height: 200,
+    marginVertical: 10,
+  },
+});

--- a/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -291,11 +291,19 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
       });
       menuItems.push({
         label: translate(TranslationKeys.experimentell),
-        iconName: 'bottle-soda',
+        iconName: 'flask',
         iconLibName: MaterialCommunityIcons,
         activeKey: 'experimentell/index',
         route: 'experimentell/index',
         position: 9.5,
+      });
+      menuItems.push({
+        label: translate(TranslationKeys.vertical_image_scroll),
+        iconName: 'image-multiple',
+        iconLibName: MaterialCommunityIcons,
+        activeKey: 'vertical-image-scroll/index',
+        route: 'vertical-image-scroll/index',
+        position: 9.6,
       });
     }
 

--- a/frontend/app/components/MyMap/MyMap.tsx
+++ b/frontend/app/components/MyMap/MyMap.tsx
@@ -12,9 +12,10 @@ export interface Position {
 export interface MyMapProps {
   mapCenterPosition: Position;
   zoom?: number;
+  mapMarkers?: { id: string; position: Position; title?: string; icon?: string; }[];
 }
 
-const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom }) => {
+const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom, mapMarkers }) => {
   const { theme } = useTheme();
   const webViewRef = useRef<WebView>(null);
   const html = require('@/assets/leaflet/index.html');
@@ -46,11 +47,12 @@ const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom }) => {
         mapCenterPosition,
         zoom: zoom ?? 13,
         mapLayers: [defaultLayer],
+        mapMarkers: mapMarkers ?? [],
       };
       const js = `window.postMessage(${JSON.stringify(message)}, '*');`;
       webViewRef.current.injectJavaScript(js);
     }
-  }, [mapCenterPosition, zoom]);
+  }, [mapCenterPosition, zoom, mapMarkers]);
 
   useEffect(() => {
     sendCoordinates();

--- a/frontend/app/locales/keys.ts
+++ b/frontend/app/locales/keys.ts
@@ -236,6 +236,7 @@ export enum TranslationKeys {
   show_more_information = 'show_more_information',
   course_timetable = 'course_timetable',
   experimentell = "experimentell",
+  vertical_image_scroll = 'vertical_image_scroll',
   eating_habits = 'eating_habits',
   markings = 'markings',
   category = 'category',

--- a/frontend/app/locales/translations.json
+++ b/frontend/app/locales/translations.json
@@ -2383,6 +2383,16 @@
     "tr": "Experimentell",
     "zh": "Experimentell"
   },
+  "vertical_image_scroll": {
+    "de": "Vertikaler Bildlauf",
+    "en": "Vertical Image Scroll",
+    "ar": "تمرير الصور عمودياً",
+    "es": "Desplazamiento vertical de imágenes",
+    "fr": "Défilement vertical d'images",
+    "ru": "Вертикальная прокрутка изображений",
+    "tr": "Dikey Resim Kaydırma",
+    "zh": "垂直图片滚动"
+  },
   "markings": {
     "de": "Kennzeichnungen",
     "en": "Labels",


### PR DESCRIPTION
## Summary
- change drawer icon to flask and add vertical image scroll entry
- add vertical image scroll screen with some sample images
- wire new screen into navigation
- extend map component with marker support and show 20 markers on Leaflet map

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617bd2dfcc83309d0ce1811858b1b6