### PR TITLE
Update vertical scroll to use online placeholders

### DIFF
--- a/frontend/app/app/(app)/vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/vertical-image-scroll/index.tsx
@@ -6,13 +6,9 @@ import { Image } from 'expo-image';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 
-const images = [
-  require('@/assets/images/react-logo.png'),
-  require('@/assets/images/react-logo@2x.png'),
-  require('@/assets/images/react-logo@3x.png'),
-  require('@/assets/images/splash.png'),
-  require('@/assets/images/splash-icon.png'),
-];
+const images = Array.from({ length: 5 }).map((_, index) => ({
+  uri: `https://placehold.co/600x400.png?text=Image+${index + 1}`,
+}));
 
 const VerticalImageScroll = () => {
   useSetPageTitle(TranslationKeys.vertical_image_scroll);


### PR DESCRIPTION
## Summary
- use remote placeholder images instead of local assets for the vertical image scroll screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686180d2068c8330a51a67b3ebdb29dd