### PR TITLE
Refactor card size logic

### DIFF
--- a/frontend/app/app/(app)/vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/vertical-image-scroll/index.tsx
@@ -7,6 +7,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
+import CardDimensionHelper from '@/helper/CardDimensionHelper';
 
 const IMAGE_URLS = Array.from({ length: 20 }).map(
   (_, i) => `https://picsum.photos/id/${i + 10}/600/600`
@@ -30,30 +31,10 @@ const VerticalImageScroll = () => {
     return () => sub?.remove();
   }, []);
 
-  const getCardDimension = () => {
-    if (screenWidth < 1110 && screenWidth > 960) return 300;
-    else if (screenWidth < 840 && screenWidth > 750) return 350;
-    else if (screenWidth < 750 && screenWidth > 710) return 330;
-    else if (screenWidth < 709 && screenWidth > 650) return 300;
-    else if (screenWidth > 570) return 260;
-    else if (screenWidth > 530) return 240;
-    else if (screenWidth > 500) return 220;
-    else if (screenWidth > 450) return 210;
-    else if (screenWidth > 380) return 180;
-    else if (screenWidth > 360) return 170;
-    else if (screenWidth > 340) return 160;
-    else if (screenWidth > 320) return 150;
-    else if (screenWidth > 300) return 140;
-    else if (screenWidth > 280) return 130;
-    else return 120;
-  };
-
-  const getCardWidth = () => {
-    const offset = screenWidth < 500 ? 10 : screenWidth < 900 ? 25 : 35;
-    return screenWidth / numColumns - offset;
-  };
-
-  const size = amountColumnsForcard === 0 ? getCardDimension() : getCardWidth();
+  const size =
+    amountColumnsForcard === 0
+      ? CardDimensionHelper.getCardDimension(screenWidth)
+      : CardDimensionHelper.getCardWidth(screenWidth, numColumns);
 
   const [images, setImages] = useState<string[]>([]);
   const flatListRef = useRef<FlatList<string>>(null);

--- a/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/frontend/app/components/FoodItem/FoodItem.tsx
@@ -42,6 +42,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useToast from '@/hooks/useToast';
 import { handleFoodRating } from '@/helper/feedback';
 import { RootState } from '@/redux/reducer';
+import CardDimensionHelper from '@/helper/CardDimensionHelper';
 
 const selectFoodState = (state: RootState) => state.food;
 
@@ -189,38 +190,8 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       router.navigate('/price-group');
     };
 
-    const getCardDimension = () => {
-      const dimensionMap = [
-        { min: 960, max: 1110, value: 300 },
-        { min: 750, max: 840, value: 350 },
-        { min: 710, max: 750, value: 330 },
-        { min: 650, max: 709, value: 300 },
-        { min: 570, max: Infinity, value: 260 },
-        { min: 530, max: Infinity, value: 240 },
-        { min: 500, max: Infinity, value: 220 },
-        { min: 450, max: Infinity, value: 210 },
-        { min: 380, max: Infinity, value: 180 },
-        { min: 360, max: Infinity, value: 170 },
-        { min: 340, max: Infinity, value: 160 },
-        { min: 320, max: Infinity, value: 150 },
-        { min: 300, max: Infinity, value: 140 },
-        { min: 280, max: Infinity, value: 130 },
-      ];
-
-      for (const { min, max, value } of dimensionMap) {
-        if (screenWidth > min && screenWidth < max) return value;
-      }
-
-      return 120; // Default value
-    };
-
-    const getCardWidth = () => {
-      const offset = screenWidth < 500 ? 10 : screenWidth < 900 ? 25 : 35;
-      return screenWidth / amountColumnsForcard - offset;
-    };
-
     useEffect(() => {
-      getCardWidth();
+      CardDimensionHelper.getCardWidth(screenWidth, amountColumnsForcard);
     }, [amountColumnsForcard, screenWidth]);
 
     return (
@@ -234,8 +205,11 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                 ...styles.card,
                 width:
                   amountColumnsForcard === 0
-                    ? getCardDimension()
-                    : getCardWidth(),
+                    ? CardDimensionHelper.getCardDimension(screenWidth)
+                    : CardDimensionHelper.getCardWidth(
+                        screenWidth,
+                        amountColumnsForcard
+                      ),
                 backgroundColor: theme.card.background,
                 borderWidth: dislikedMarkings.length > 0 ? 3 : 0,
                 borderColor: '#FF000095',
@@ -258,8 +232,11 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                   ...styles.imageContainer,
                   height:
                     amountColumnsForcard === 0
-                      ? getCardDimension()
-                      : getCardWidth(),
+                      ? CardDimensionHelper.getCardDimension(screenWidth)
+                      : CardDimensionHelper.getCardWidth(
+                          screenWidth,
+                          amountColumnsForcard
+                        ),
                 }}
               >
                 <Image

--- a/frontend/app/helper/CardDimensionHelper.ts
+++ b/frontend/app/helper/CardDimensionHelper.ts
@@ -1,0 +1,32 @@
+export default class CardDimensionHelper {
+  static getCardDimension(screenWidth: number): number {
+    const dimensionMap = [
+      { min: 960, max: 1110, value: 300 },
+      { min: 750, max: 840, value: 350 },
+      { min: 710, max: 750, value: 330 },
+      { min: 650, max: 709, value: 300 },
+      { min: 570, max: Infinity, value: 260 },
+      { min: 530, max: Infinity, value: 240 },
+      { min: 500, max: Infinity, value: 220 },
+      { min: 450, max: Infinity, value: 210 },
+      { min: 380, max: Infinity, value: 180 },
+      { min: 360, max: Infinity, value: 170 },
+      { min: 340, max: Infinity, value: 160 },
+      { min: 320, max: Infinity, value: 150 },
+      { min: 300, max: Infinity, value: 140 },
+      { min: 280, max: Infinity, value: 130 },
+    ];
+
+    for (const { min, max, value } of dimensionMap) {
+      if (screenWidth > min && screenWidth < max) {
+        return value;
+      }
+    }
+    return 120;
+  }
+
+  static getCardWidth(screenWidth: number, columns: number): number {
+    const offset = screenWidth < 500 ? 10 : screenWidth < 900 ? 25 : 35;
+    return screenWidth / columns - offset;
+  }
+}


### PR DESCRIPTION
## Summary
- extract common card dimension logic to `CardDimensionHelper`
- reuse helper in `FoodItem` and vertical image scroll screen

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a9c34b4483308cf60d6a0cb60aa3