### PR TITLE
Fix vertical image scroll columns

### DIFF
--- a/frontend/app/app/(app)/vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/vertical-image-scroll/index.tsx
@@ -19,9 +19,13 @@ const VerticalImageScroll = () => {
   const { amountColumnsForcard } = useSelector(
     (state: RootState) => state.settings
   );
-  const numColumns = amountColumnsForcard || 1;
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
+  );
+
+  const numColumns = CardDimensionHelper.getNumColumns(
+    screenWidth,
+    amountColumnsForcard
   );
 
   useEffect(() => {

--- a/frontend/app/helper/CardDimensionHelper.ts
+++ b/frontend/app/helper/CardDimensionHelper.ts
@@ -29,4 +29,12 @@ export default class CardDimensionHelper {
     const offset = screenWidth < 500 ? 10 : screenWidth < 900 ? 25 : 35;
     return screenWidth / columns - offset;
   }
+
+  static getNumColumns(screenWidth: number, columnsSetting: number): number {
+    if (columnsSetting === 0) {
+      const size = this.getCardDimension(screenWidth);
+      return Math.max(1, Math.floor(screenWidth / size));
+    }
+    return columnsSetting;
+  }
 }


### PR DESCRIPTION
## Summary
- support automatic column count in CardDimensionHelper
- use new helper to compute columns in vertical image scroll view

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b12cf8c4833093c5eab72131f6f5