### PR TITLE
Add reusable modal component

### DIFF
--- a/frontend/app/components/BaseModal/BaseModal.tsx
+++ b/frontend/app/components/BaseModal/BaseModal.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, Dimensions } from 'react-native';
+import Modal from 'react-native-modal';
+import { AntDesign } from '@expo/vector-icons';
+import { styles } from './styles';
+import { useTheme } from '@/hooks/useTheme';
+
+export interface BaseModalProps {
+  isVisible: boolean;
+  title?: string;
+  onClose: () => void;
+  children?: React.ReactNode;
+}
+
+const BaseModal: React.FC<BaseModalProps> = ({
+  isVisible,
+  title,
+  onClose,
+  children,
+}) => {
+  const { theme } = useTheme();
+
+  const getModalWidth = (windowWidth: number) => {
+    if (windowWidth < 800) return '100%';
+    if (windowWidth >= 800 && windowWidth <= 1200) return 700;
+    return 600;
+  };
+
+  const [modalWidth, setModalWidth] = useState(() =>
+    getModalWidth(Dimensions.get('window').width)
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      const windowWidth = Dimensions.get('window').width;
+      setModalWidth(getModalWidth(windowWidth));
+    };
+
+    const subscription = Dimensions.addEventListener('change', handleResize);
+    return () => subscription.remove();
+  }, []);
+
+  return (
+    <Modal
+      isVisible={isVisible}
+      style={styles.modalContainer}
+      onBackdropPress={onClose}
+    >
+      <View
+        style={[
+          styles.modalView,
+          { backgroundColor: theme.modal.modalBg, width: modalWidth },
+        ]}
+      >
+        <View style={styles.modalHeader}>
+          <TouchableOpacity
+            style={[styles.closeButton, { backgroundColor: theme.modal.closeBg }]}
+            onPress={onClose}
+          >
+            <AntDesign name='close' size={28} color={theme.modal.closeIcon} />
+          </TouchableOpacity>
+        </View>
+        {title && (
+          <Text
+            style={{
+              ...styles.modalHeading,
+              color: theme.modal.text,
+              fontSize: Dimensions.get('window').width < 500 ? 26 : 36,
+            }}
+          >
+            {title}
+          </Text>
+        )}
+        {children}
+      </View>
+    </Modal>
+  );
+};
+
+export default BaseModal;

--- a/frontend/app/components/BaseModal/index.ts
+++ b/frontend/app/components/BaseModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './BaseModal';
+export type { BaseModalProps } from './BaseModal';

--- a/frontend/app/components/BaseModal/styles.ts
+++ b/frontend/app/components/BaseModal/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  modalContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalView: {
+    height: 'auto',
+    borderRadius: 40,
+    padding: 20,
+    alignItems: 'flex-start',
+  },
+  modalHeader: {
+    width: '100%',
+    alignItems: 'flex-end',
+  },
+  closeButton: {
+    width: 50,
+    height: 50,
+    borderRadius: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalHeading: {
+    fontSize: 36,
+    fontFamily: 'Poppins_700Bold',
+    textAlign: 'center',
+    width: '100%',
+  },
+});

--- a/frontend/app/components/PermissionModal/PermissionModal.tsx
+++ b/frontend/app/components/PermissionModal/PermissionModal.tsx
@@ -3,12 +3,10 @@ import {
   Dimensions,
   Text,
   TouchableOpacity,
-  View,
 } from 'react-native';
-import React, { useEffect, useState } from 'react';
-import Modal from 'react-native-modal';
+import React, { useState } from 'react';
+import BaseModal from '@/components/BaseModal';
 import { styles } from './styles';
-import { AntDesign } from '@expo/vector-icons';
 import { PermissionModalProps } from './types';
 import { useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
@@ -35,30 +33,6 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
   const router = useRouter();
   const dispatch = useDispatch();
 
-  const getModalWidth = (windowWidth: number) => {
-    if (windowWidth < 800) return '100%';
-    if (windowWidth >= 800 && windowWidth <= 1200) return 700;
-    return 600;
-  };
-
-  const [modalWidth, setModalWidth] = useState(() => {
-    const windowWidth = Dimensions.get('window').width;
-    return getModalWidth(windowWidth);
-  });
-
-  useEffect(() => {
-    const handleResize = () => {
-      const windowWidth = Dimensions.get('window').width;
-
-      setModalWidth(getModalWidth(windowWidth));
-    };
-
-    const subscription = Dimensions.addEventListener('change', handleResize);
-
-    return () => {
-      subscription.remove();
-    };
-  }, []);
   const handleLogout = async () => {
     try {
       setLoading(true);
@@ -75,67 +49,38 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
   };
 
   return (
-      <Modal
-          isVisible={isVisible}
-          style={styles.modalContainer}
-          onClose={() => setIsVisible(false)}
+    <BaseModal
+      isVisible={isVisible}
+      title={translate(TranslationKeys.access_limited)}
+      onClose={() => setIsVisible(false)}
+    >
+      <Text
+        style={{
+          ...styles.modalSubHeading,
+          color: theme.modal.text,
+          fontSize: Dimensions.get('window').width < 500 ? 14 : 18,
+        }}
       >
-        <View
-            style={{
-              ...styles.modalView,
-              backgroundColor: theme.modal.modalBg,
-              width: modalWidth,
-            }}
-        >
-          <View style={styles.modalHeader}>
-            <TouchableOpacity
-                style={{
-                  ...styles.closeButton,
-                  backgroundColor: theme.modal.closeBg,
-                }}
-                onPress={() => setIsVisible(false)}
-            >
-              <AntDesign name='close' size={28} color={theme.modal.closeIcon} />
-            </TouchableOpacity>
-          </View>
-          <Text
-              style={{
-                ...styles.modalHeading,
-                color: theme.modal.text,
-                fontSize: Dimensions.get('window').width < 500 ? 26 : 36,
-              }}
-          >
-            {translate(TranslationKeys.access_limited)}
+        {translate(TranslationKeys.limited_access_description)}
+      </Text>
+      <TouchableOpacity
+        style={{
+          ...styles.loginButton,
+          backgroundColor: primaryColor,
+          width: Dimensions.get('window').width < 500 ? '100%' : '80%',
+        }}
+        onPress={handleLogout}
+      >
+        {loading ? (
+          <ActivityIndicator size={22} color={theme.background} />
+        ) : (
+          <Text style={{ ...styles.loginLabel, color: contrastColor }}>
+            {translate(TranslationKeys.sign_in)} /{' '}
+            {translate(TranslationKeys.create_account)}
           </Text>
-          <Text
-              style={{
-                ...styles.modalSubHeading,
-                color: theme.modal.text,
-                fontSize: Dimensions.get('window').width < 500 ? 14 : 18,
-              }}
-          >
-            {translate(TranslationKeys.limited_access_description)}
-          </Text>
-          <TouchableOpacity
-              style={{
-                ...styles.loginButton,
-                backgroundColor: primaryColor,
-                width: Dimensions.get('window').width < 500 ? '100%' : '80%',
-              }}
-              onPress={handleLogout}
-          >
-            {loading ? (
-                <ActivityIndicator size={22} color={theme.background} />
-            ) : (
-                <Text style={{ ...styles.loginLabel, color: contrastColor }}>
-                  {/* Sign In / Create Account */}
-                  {translate(TranslationKeys.sign_in)} /{' '}
-                  {translate(TranslationKeys.create_account)}
-                </Text>
-            )}
-          </TouchableOpacity>
-        </View>
-      </Modal>
+        )}
+      </TouchableOpacity>
+    </BaseModal>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `BaseModal` component for consistent modal style
- update `PermissionModal` to use `BaseModal`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b3791204833083961a9e4524e58b