### PR TITLE
Fix forecast auto scroll on native

### DIFF
--- a/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  Platform,
 } from 'react-native';
 import { AntDesign } from '@expo/vector-icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -162,10 +163,14 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({
         }
 
         if (targetIndex !== -1 && targetIndex !== undefined) {
-          scrollViewRef.current?.scrollTo({
-            x: Math.max(0, targetIndex * 101 + 100),
-            animated: true,
-          });
+          const offsetX = Math.max(0, targetIndex * 101 + 100);
+          if (Platform.OS === 'web') {
+            scrollViewRef.current?.scrollTo({ x: offsetX, animated: true });
+          } else {
+            setTimeout(() => {
+              scrollViewRef.current?.scrollTo({ x: offsetX, animated: true });
+            }, 300);
+          }
         }
       }
     }, [chartData])


### PR DESCRIPTION
## Summary
- fix import for Platform in ForecastSheet
- delay scroll offset on native platforms so the forecast sheet autoscroll works

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624e1228a88330b5f1cb6b1820bcb9