### PR TITLE
Add popup events listing screen

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -702,6 +702,18 @@ export default function Layout() {
           }}
         />
         <Drawer.Screen
+          name='events/index'
+          options={{
+            header: () => (
+              <CustomStackHeader
+                label={translate(TranslationKeys.events)}
+                key={'events'}
+              />
+            ),
+            title: translate(TranslationKeys.events),
+          }}
+        />
+        <Drawer.Screen
           name='support-FAQ/index'
           options={{
             title: translate(TranslationKeys.feedback_support_faq),

--- a/frontend/app/app/(app)/events/index.tsx
+++ b/frontend/app/app/(app)/events/index.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { SafeAreaView, ScrollView } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import SupportFAQ from '@/components/SupportFAQ/SupportFAQ';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import { useDispatch, useSelector } from 'react-redux';
+import { SET_POPUP_EVENTS } from '@/redux/Types/types';
+import { useFocusEffect } from 'expo-router';
+import { useLanguage } from '@/hooks/useLanguage';
+import { getTitleFromTranslation } from '@/helper/resourceHelper';
+import styles from './styles';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { RootState } from '@/redux/reducer';
+
+const EventsScreen = () => {
+  useSetPageTitle(TranslationKeys.events);
+  const { theme } = useTheme();
+  const { translate, language } = useLanguage();
+  const dispatch = useDispatch();
+  const { popupEvents } = useSelector((state: RootState) => state.food);
+  const [selectedEvent, setSelectedEvent] = useState<any | null>(null);
+  const bottomSheetRef = useRef<BottomSheet>(null);
+  const [isActive, setIsActive] = useState(false);
+
+  const openSheet = useCallback((event: any) => {
+    setSelectedEvent(event);
+    bottomSheetRef.current?.expand();
+  }, []);
+
+  const closeSheet = useCallback(() => {
+    bottomSheetRef.current?.close();
+    setSelectedEvent(null);
+  }, []);
+
+  const resetSeenEvents = () => {
+    const resetEvents = popupEvents.map((e: any, idx: number) => ({
+      ...e,
+      isOpen: false,
+      isCurrent: idx === 0,
+    }));
+    dispatch({ type: SET_POPUP_EVENTS, payload: resetEvents });
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsActive(true);
+      return () => setIsActive(false);
+    }, [])
+  );
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.background }}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <SupportFAQ
+          icon='refresh'
+          label={translate(TranslationKeys.reset_seen_popup_events)}
+          onPress={resetSeenEvents}
+          redirectIcon={false}
+        />
+        {popupEvents.map((event: any) => (
+          <SupportFAQ
+            key={event.id}
+            label={
+              event.translations
+                ? getTitleFromTranslation(event.translations, language)
+                : event.alias
+            }
+            onPress={() => openSheet(event)}
+          />
+        ))}
+      </ScrollView>
+      {isActive && (
+        <BaseBottomSheet
+          ref={bottomSheetRef}
+          index={-1}
+          backgroundStyle={{
+            ...styles.sheetBackground,
+            backgroundColor: theme.sheet.sheetBg,
+          }}
+          enablePanDownToClose
+          handleComponent={null}
+          onClose={closeSheet}
+        >
+          <PopupEventSheet closeSheet={closeSheet} eventData={selectedEvent || {}} />
+        </BaseBottomSheet>
+      )}
+    </SafeAreaView>
+  );
+};
+
+export default EventsScreen;

--- a/frontend/app/app/(app)/events/styles.ts
+++ b/frontend/app/app/(app)/events/styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    width: '100%',
+    padding: 20,
+    gap: 10,
+  },
+  sheetBackground: {
+    borderTopLeftRadius: 30,
+    borderTopRightRadius: 30,
+  },
+});

--- a/frontend/app/app/(app)/settings/index.tsx
+++ b/frontend/app/app/(app)/settings/index.tsx
@@ -612,13 +612,23 @@ const Settings = () => {
                 color={theme.screen.icon}
               />
             }
-            handleFunction={() => router.navigate('/data-access')}
-          />
-          <SettingList
-            leftIcon={
-              <MaterialIcons
-                name='support-agent'
-                size={24}
+          handleFunction={() => router.navigate('/data-access')}
+        />
+        <SettingList
+          leftIcon={
+            <MaterialIcons name='event' size={24} color={theme.screen.icon} />
+          }
+          label={translate(TranslationKeys.events)}
+          rightIcon={
+            <Octicons name='chevron-right' size={24} color={theme.screen.icon} />
+          }
+          handleFunction={() => router.navigate('/events')}
+        />
+        <SettingList
+          leftIcon={
+            <MaterialIcons
+              name='support-agent'
+              size={24}
                 color={theme.screen.icon}
               />
             }

--- a/frontend/app/locales/keys.ts
+++ b/frontend/app/locales/keys.ts
@@ -306,6 +306,8 @@ export enum TranslationKeys {
   cookies = 'cookies',
   feedback = 'feedback',
   feedback_support_faq = 'feedback_support_faq',
+  events = 'events',
+  reset_seen_popup_events = 'reset_seen_popup_events',
   optional = 'optional',
   date_created = 'date_created',
   date_updated = 'date_updated',

--- a/frontend/app/locales/translations.json
+++ b/frontend/app/locales/translations.json
@@ -3063,6 +3063,26 @@
     "tr": "Destek ve SSS",
     "zh": "支持和常见问题解答"
   },
+  "events": {
+    "de": "Events",
+    "en": "Events",
+    "ar": "الأحداث",
+    "es": "Eventos",
+    "fr": "Événements",
+    "ru": "События",
+    "tr": "Etkinlikler",
+    "zh": "活动"
+  },
+  "reset_seen_popup_events": {
+    "de": "Gesehene Pop-up Events zurücksetzen",
+    "en": "Reset seen pop-up events",
+    "ar": "إعادة تعيين أحداث النوافذ المنبثقة المُشاهدة",
+    "es": "Restablecer eventos emergentes vistos",
+    "fr": "Réinitialiser les pop-up événements vus",
+    "ru": "Сбросить просмотренные всплывающие события",
+    "tr": "Görülen açılır etkinlikleri sıfırla",
+    "zh": "重置已查看的弹窗事件"
+  },
   "optional": {
     "de": "Optional",
     "en": "Optional",


### PR DESCRIPTION
## Summary
- add new screen to list popup events
- allow resetting seen popup events
- add Events option in settings
- wire up events screen in app layout
- update translations

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624f4c63a08330a7c380574f99bc8f