### PR TITLE
Fix vertical scroll jump

### DIFF
--- a/frontend/app/components/AutoImageScroller/index.tsx
+++ b/frontend/app/components/AutoImageScroller/index.tsx
@@ -21,12 +21,22 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({
   const screenHeight = Dimensions.get('window').height;
   const frameRef = useRef<number>();
 
-  const extendedImages = React.useMemo(() => [...images, ...images], [images]);
+  const extendedImages = React.useMemo(
+    () => [...images, ...images, ...images],
+    [images]
+  );
 
   useEffect(() => {
     let lastTime: number | null = null;
     const pxPerSecond = (speedPercent / 100) * screenHeight;
     const listHeight = Math.ceil(images.length / numColumns) * size;
+
+    // Start scrolling from the middle set to allow seamless looping
+    scrollOffset.current = listHeight;
+    flatListRef.current?.scrollToOffset({
+      offset: scrollOffset.current,
+      animated: false,
+    });
 
     const step = (time: number) => {
       if (lastTime === null) {
@@ -36,7 +46,7 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({
       lastTime = time;
       const distance = (pxPerSecond * delta) / 1000;
       scrollOffset.current += distance;
-      if (scrollOffset.current >= listHeight) {
+      if (scrollOffset.current >= listHeight * 2) {
         scrollOffset.current -= listHeight;
       }
       flatListRef.current?.scrollToOffset({


### PR DESCRIPTION
## Summary
- improve AutoImageScroller looping by starting from middle of repeated data
- extend images threefold and adjust loop logic for seamless scroll

## Testing
- `npm test -- -w=1 --passWithNoTests`
- `npm run lint` *(fails: Couldn't find a script named "eslint")*

------
https://chatgpt.com/codex/tasks/task_e_68625e7a49448330a640250c7c03f88c