### PR TITLE
Fix language sheet flags and reuse component on login

### DIFF
--- a/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Image } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { Image } from 'expo-image';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
@@ -26,7 +26,7 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({
   const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
   return (
-    <BottomSheetScrollView
+    <ScrollView
       style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
       contentContainerStyle={styles.contentContainer}
     >
@@ -102,7 +102,7 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({
           </TouchableOpacity>
         ))}
       </View>
-    </BottomSheetScrollView>
+    </ScrollView>
   );
 };
 

--- a/frontend/app/components/Login/Header.tsx
+++ b/frontend/app/components/Login/Header.tsx
@@ -10,7 +10,8 @@ import { SET_DRAWER_POSITION } from '@/redux/Types/types';
 import ModalComponent from '../ModalSetting/ModalComponent';
 import { languages } from '../../constants/SettingData';
 import { Image } from 'expo-image';
-import { Entypo, MaterialCommunityIcons } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons';
+import LanguageSheet from '../LanguageSheet/LanguageSheet';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
@@ -139,58 +140,13 @@ const LoginHeader = () => {
         onSave={saveLanguage}
         showButtons={false}
       >
-        <View style={styles.languageContainer}>
-          {languages.map((language, index) => (
-            <TouchableOpacity
-              key={index}
-              style={{
-                ...styles.languageRow,
-                paddingHorizontal: isWeb ? 20 : 10,
-
-                backgroundColor:
-                  selectedLanguage === language.value
-                    ? primaryColor
-                    : theme.screen.iconBg,
-              }}
-              onPress={() => {
-                changeLanguage(language);
-              }}
-            >
-              <Image
-                source={language.flag}
-                style={styles.flagIcon}
-                cachePolicy={'memory-disk'}
-                transition={500}
-                contentFit='cover'
-              />
-              <Text
-                style={{
-                  ...styles.languageText,
-                  color:
-                    selectedLanguage === language.value
-                      ? theme.activeText
-                      : theme.screen.text,
-                }}
-              >
-                {language.label}
-              </Text>
-
-              {/* Radio Button */}
-              <MaterialCommunityIcons
-                name={
-                  selectedLanguage === language.value
-                    ? 'checkbox-marked'
-                    : 'checkbox-blank'
-                }
-                size={24}
-                color={
-                  selectedLanguage === language.value ? '#ffffff' : '#ffffff'
-                }
-                style={styles.radioButton}
-              />
-            </TouchableOpacity>
-          ))}
-        </View>
+        <LanguageSheet
+          closeSheet={closeLanguageModal}
+          selectedLanguage={selectedLanguage}
+          onSelect={(value) => {
+            changeLanguage({ value } as any);
+          }}
+        />
       </ModalComponent>
     </View>
   );


### PR DESCRIPTION
## Summary
- show language flags using expo-image in LanguageSheet
- reuse LanguageSheet inside login modal
- avoid crash by rendering with ScrollView when not inside a bottom sheet

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625fd154948330adb7b15ee7785ee1