### PR TITLE
Fix vertical image scroll

### DIFF
--- a/frontend/app/app/(app)/vertical-image-scroll/_layout.tsx
+++ b/frontend/app/app/(app)/vertical-image-scroll/_layout.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+import { useTheme } from '@/hooks/useTheme';
+import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+
+export default function Layout() {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.header.background },
+        headerTintColor: theme.header.text,
+      }}
+    >
+      <Stack.Screen
+        name='index'
+        options={{
+          title: 'Vertical Image Scroll',
+          header: () => (
+            <CustomStackHeader
+              label={translate(TranslationKeys.vertical_image_scroll)}
+              key={'vertical_image_scroll'}
+            />
+          ),
+        }}
+      />
+    </Stack>
+  );
+}

--- a/frontend/app/app/(app)/vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/vertical-image-scroll/index.tsx
@@ -4,7 +4,7 @@ import {
   Dimensions,
   TouchableOpacity,
 } from 'react-native';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
@@ -16,7 +16,7 @@ import AutoImageScroller from '@/components/AutoImageScroller';
 import { Ionicons } from '@expo/vector-icons';
 
 // Placeholder images which will be replaced with food images in the future
-const PLACEHOLDER_IMAGE_URLS = Array.from({ length: 20 }).map(
+const IMAGE_POOL = Array.from({ length: 50 }).map(
   (_, i) => `https://picsum.photos/id/${i + 10}/600/600`
 );
 
@@ -48,10 +48,23 @@ const VerticalImageScroll = () => {
       : CardDimensionHelper.getCardWidth(screenWidth, numColumns);
 
   const [images, setImages] = useState<string[]>([]);
+  const nextIndex = useRef(0);
+
+  const loadMoreImages = () => {
+    setImages((prev) => {
+      const newImages: string[] = [];
+      for (let i = 0; i < 20; i++) {
+        newImages.push(
+          IMAGE_POOL[nextIndex.current % IMAGE_POOL.length]
+        );
+        nextIndex.current += 1;
+      }
+      return [...prev, ...newImages];
+    });
+  };
 
   useEffect(() => {
-    // In future this will load real food image URLs instead of placeholders
-    setImages(PLACEHOLDER_IMAGE_URLS);
+    loadMoreImages();
   }, []);
 
 
@@ -79,6 +92,7 @@ const VerticalImageScroll = () => {
         numColumns={numColumns}
         size={size}
         speedPercent={speedPercent}
+        loadMore={loadMoreImages}
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- add custom stack header to vertical image scroll screen
- change auto image scroller to append data instead of looping
- use infinite scroll logic in vertical-image-scroll screen

## Testing
- `npm --prefix frontend/app run lint` *(fails: expo not found)*
- `npm --prefix frontend/app run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626452dda48330a0f961c4ba6f8ddf