### PR TITLE
Add map marker utils and example usage

### DIFF
--- a/frontend/app/app/(app)/leaflet-map/index.tsx
+++ b/frontend/app/app/(app)/leaflet-map/index.tsx
@@ -4,6 +4,11 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import MyMap from '@/components/MyMap/MyMap';
+import {
+  MARKER_DEFAULT_SIZE,
+  MyMapMarkerIcons,
+  getDefaultIconAnchor,
+} from '@/components/MyMap/markerUtils';
 
 const POSITION_BUNDESTAG = {
   lat: 52.518594247456804,
@@ -28,8 +33,24 @@ const LeafletMap = () => {
     return undefined;
   }, [selectedCanteen, buildings]);
 
+  const markers = [
+    {
+      id: 'example',
+      position: POSITION_BUNDESTAG,
+      icon: MyMapMarkerIcons.DEBUG_ICON,
+      size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
+      iconAnchor: getDefaultIconAnchor(
+        MARKER_DEFAULT_SIZE,
+        MARKER_DEFAULT_SIZE,
+      ),
+    },
+  ];
+
   return (
-    <MyMap mapCenterPosition={centerPosition || POSITION_BUNDESTAG} />
+    <MyMap
+      mapCenterPosition={centerPosition || POSITION_BUNDESTAG}
+      mapMarkers={markers}
+    />
   );
 };
 

--- a/frontend/app/components/MyMap/MyMap.tsx
+++ b/frontend/app/components/MyMap/MyMap.tsx
@@ -3,6 +3,8 @@ import { View } from 'react-native';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
+import DEFAULT_TILE_LAYER from './defaultTileLayer';
+import type { MapMarker } from './model';
 
 export interface Position {
   lat: number;
@@ -12,7 +14,7 @@ export interface Position {
 export interface MyMapProps {
   mapCenterPosition: Position;
   zoom?: number;
-  mapMarkers?: { id: string; position: Position; title?: string; icon?: string; }[];
+  mapMarkers?: MapMarker[];
 }
 
 const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom, mapMarkers }) => {
@@ -20,12 +22,6 @@ const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom, mapMarkers }) =>
   const webViewRef = useRef<WebView>(null);
   const html = require('@/assets/leaflet/index.html');
 
-  const defaultLayer = {
-    layerType: 'TileLayer',
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    baseLayerName: 'OpenStreetMap',
-    baseLayerIsChecked: true,
-  };
 
 
   const sendCoordinates = useCallback(() => {
@@ -33,7 +29,7 @@ const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom, mapMarkers }) =>
       const message = {
         mapCenterPosition,
         zoom: zoom ?? 13,
-        mapLayers: [defaultLayer],
+        mapLayers: [DEFAULT_TILE_LAYER],
         mapMarkers: mapMarkers ?? [],
       };
       const js = `window.postMessage(${JSON.stringify(message)}, '*');`;

--- a/frontend/app/components/MyMap/MyMap.web.tsx
+++ b/frontend/app/components/MyMap/MyMap.web.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
+import DEFAULT_TILE_LAYER from './defaultTileLayer';
+import type { MapMarker } from './model';
 
 export interface Position {
   lat: number;
@@ -11,7 +13,7 @@ export interface Position {
 export interface MyMapProps {
   mapCenterPosition: Position;
   zoom?: number;
-  mapMarkers?: { id: string; position: Position; title?: string; icon?: string }[];
+  mapMarkers?: MapMarker[];
 }
 
 const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom, mapMarkers }) => {
@@ -19,19 +21,13 @@ const MyMap: React.FC<MyMapProps> = ({ mapCenterPosition, zoom, mapMarkers }) =>
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const html = require('@/assets/leaflet/index.html');
 
-  const defaultLayer = {
-    layerType: 'TileLayer',
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    baseLayerName: 'OpenStreetMap',
-    baseLayerIsChecked: true,
-  };
 
   const sendCoordinates = useCallback(() => {
     if (iframeRef.current && iframeRef.current.contentWindow) {
       const message = {
         mapCenterPosition,
         zoom: zoom ?? 13,
-        mapLayers: [defaultLayer],
+        mapLayers: [DEFAULT_TILE_LAYER],
         mapMarkers: mapMarkers ?? [],
       };
       iframeRef.current.contentWindow.postMessage(message, '*');

--- a/frontend/app/components/MyMap/defaultTileLayer.ts
+++ b/frontend/app/components/MyMap/defaultTileLayer.ts
@@ -1,0 +1,10 @@
+import { MapLayer } from './model';
+
+export const DEFAULT_TILE_LAYER: MapLayer = {
+  layerType: 'TileLayer',
+  url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  baseLayerName: 'OpenStreetMap',
+  baseLayerIsChecked: true,
+};
+
+export default DEFAULT_TILE_LAYER;

--- a/frontend/app/components/MyMap/markerUtils.ts
+++ b/frontend/app/components/MyMap/markerUtils.ts
@@ -1,0 +1,16 @@
+import type { PointTuple } from 'leaflet';
+
+export const MARKER_DEFAULT_SIZE = 48;
+
+export const getDefaultIconAnchor = (
+  width: number,
+  height: number,
+): PointTuple => [width / 2, height];
+
+export class MyMapMarkerIcons {
+  static DEBUG_ICON = `<div style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; background-color: #FF000066; position: relative;'><div style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; background-color: #00FF0066; border-radius: 50%; position: absolute; top: 0%; left: 0%;'></div></div>`;
+
+  static getIconForWebByUri(iconUri: string): string {
+    return `<img src='${iconUri}' style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; object-fit: contain;'>`;
+  }
+}

--- a/frontend/app/components/MyMap/model.ts
+++ b/frontend/app/components/MyMap/model.ts
@@ -1,0 +1,106 @@
+import type {
+  DivIcon,
+  LatLngBoundsLiteral,
+  LatLngLiteral,
+  PointTuple,
+} from 'leaflet';
+import {
+  CircleMarkerProps,
+  CircleProps,
+  PolygonProps,
+  PolylineProps,
+  RectangleProps,
+} from 'react-leaflet';
+
+export type Dimensions = [width: number, height: number];
+
+type Payload = {
+  bounds: LatLngBoundsLiteral;
+  mapCenter: LatLngLiteral;
+  zoom: number;
+};
+
+export type MapMarkerClickedEvent = {
+  tag: 'onMapMarkerClicked';
+  mapMarkerId: string;
+};
+
+export type LeafletWebViewEvent =
+  | { tag: 'DebugMessage'; message: string }
+  | { tag: 'DocumentEventListenerAdded' }
+  | { tag: 'DocumentEventListenerRemoved' }
+  | { tag: 'Error'; error: any }
+  | { tag: 'WindowEventListenerAdded' }
+  | { tag: 'WindowEventListenerRemoved' }
+  | { tag: 'MapReady'; version: string }
+  | { tag: 'MapComponentMounted'; version: string }
+  | { tag: 'onMapClicked'; location: LatLngLiteral }
+  | MapMarkerClickedEvent
+  | ({ tag: 'onMove' } & Payload)
+  | ({ tag: 'onMoveEnd' } & Payload)
+  | ({ tag: 'onMoveStart' } & Payload)
+  | ({ tag: 'onResize' } & Payload)
+  | ({ tag: 'onUnload' } & Payload)
+  | ({ tag: 'onZoom' } & Payload)
+  | ({ tag: 'onZoomEnd' } & Payload)
+  | ({ tag: 'onZoomLevelsChange' } & Payload)
+  | ({ tag: 'onZoomStart' } & Payload);
+
+export type MapLayerType =
+  | 'ImageOverlay'
+  | 'TileLayer'
+  | 'VectorLayer'
+  | 'VideoOverlay'
+  | 'WMSTileLayer';
+
+export type MapMarker = {
+  icon: string;
+  iconAnchor?: PointTuple;
+  id: string;
+  position: LatLngLiteral;
+  size?: Dimensions;
+  title?: string;
+};
+
+export type MapLayer = {
+  attribution?: string;
+  baseLayer?: boolean;
+  baseLayerIsChecked?: boolean;
+  baseLayerName?: string;
+  bounds?: LatLngBoundsLiteral;
+  id?: string;
+  layerType?: MapLayerType;
+  opacity?: number;
+  pane?: string;
+  subLayer?: string;
+  url?: string;
+  zIndex?: number;
+};
+
+type CircleShape = {
+  shapeType: 'circle';
+} & CircleProps;
+
+type CircleMarkerShape = {
+  shapeType: 'circleMarker';
+} & CircleMarkerProps;
+
+type PolygonShape = {
+  shapeType: 'polygon';
+} & PolygonProps;
+
+type PolylineShape = {
+  shapeType: 'polyline';
+} & PolylineProps;
+
+type RectangleShape = {
+  shapeType: 'rectangle';
+} & RectangleProps;
+
+export type MapShape = { id?: string } & (
+  | CircleShape
+  | CircleMarkerShape
+  | PolygonShape
+  | PolylineShape
+  | RectangleShape
+);


### PR DESCRIPTION
## Summary
- add Leaflet model definitions
- extract default tile layer constant
- add marker utilities for default icon and anchors
- refactor MyMap components to use new helpers
- show example marker on Leaflet page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862984115208330a409b97a87ca00f8