### PR TITLE
Improve update loader layout

### DIFF
--- a/frontend/app/components/ExpoUpdateLoader/ExpoUpdateLoader.tsx
+++ b/frontend/app/components/ExpoUpdateLoader/ExpoUpdateLoader.tsx
@@ -99,15 +99,17 @@ const ExpoUpdateLoader: React.FC<ExpoUpdateLoaderProps> = ({ children }) => {
         style={styles.logo}
         resizeMode='contain'
       />
-      <ActivityIndicator size='large' style={styles.spinner} />
-      <Text style={styles.title}>{translate(status)}</Text>
-      {showCancel && (
-        <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
-          <Text style={styles.cancelLabel}>
-            {translate(TranslationKeys.cancel)}
-          </Text>
-        </TouchableOpacity>
-      )}
+      <View style={styles.bottomContainer}>
+        {showCancel && (
+          <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
+            <Text style={styles.cancelLabel}>
+              {translate(TranslationKeys.cancel)}
+            </Text>
+          </TouchableOpacity>
+        )}
+        <Text style={styles.title}>{translate(status)}</Text>
+        <ActivityIndicator size='large' style={styles.spinner} />
+      </View>
     </View>
   );
 };
@@ -123,6 +125,14 @@ const styles = StyleSheet.create({
     width: 200,
     height: 200,
     marginBottom: 20,
+  },
+  bottomContainer: {
+    position: 'absolute',
+    bottom: 40,
+    left: 0,
+    right: 0,
+    flexDirection: 'column-reverse',
+    alignItems: 'center',
   },
   spinner: {
     marginBottom: 15,


### PR DESCRIPTION
## Summary
- keep company logo centered during updates
- anchor update text and cancel button to the bottom using `column-reverse`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863939cc8f08330a22884ade8ec98b9