### PR TITLE
Unify marking icons

### DIFF
--- a/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -23,6 +23,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { useLocalSearchParams } from 'expo-router';
 import NetInfo from '@react-native-community/netinfo';
 import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
+import MarkingIcon from '@/components/MarkingIcon';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
@@ -581,59 +582,22 @@ const Index = () => {
                 </Text>
                 <View style={styles.labelsContainer}>
                   {currentMarking &&
-                    currentMarking?.map((item: any) => {
-                      const iconParts = item?.icon?.split(':') || [];
-                      const [library, name] = iconParts;
-                      const Icon = library && iconLibraries[library];
-                      if (item?.shortCode && !item?.image?.uri && !item?.icon) {
-                        return (
-                          <View
-                            style={{
-                              ...styles.shortCode,
-                              backgroundColor: item?.bgColor,
-                            }}
-                          >
-                            <Text style={{ color: item.color, fontSize: 18 }}>
-                              {item?.shortCode}
-                            </Text>
-                          </View>
-                        );
-                      }
-                      if (!item?.image?.uri && item?.icon) {
-                        return (
-                          <View
-                            style={{
-                              ...styles.shortCode,
-                              backgroundColor: item?.bgColor,
-                            }}
-                          >
-                            <Icon name={name} size={20} color={item.color} />
-                          </View>
-                        );
-                      }
-                      if (item?.image?.uri) {
-                        return (
-                          <View
-                            style={{
-                              width: 30,
-                              height: 30,
-                            }}
-                          >
-                            <Image
-                              source={item?.image?.uri}
-                              style={{
-                                ...styles.icon,
-                                backgroundColor: item?.bgColor && item?.bgColor,
-                                borderRadius: item?.bgColor
-                                  ? 8
-                                  : item.hide_border
-                                  ? 5
-                                  : 0,
-                              }}
-                            />
-                          </View>
-                        );
-                      }
+                    currentMarking?.map((item: any, idx: number) => {
+                      const marking = {
+                        icon: item.icon,
+                        short_code: item.shortCode,
+                        image_remote_url: item.image?.uri,
+                        background_color: item.bgColor,
+                        hide_border: item.hide_border,
+                      } as any;
+                      return (
+                        <MarkingIcon
+                          key={idx}
+                          marking={marking}
+                          size={20}
+                          color={item.color}
+                        />
+                      );
                     })}
                 </View>
               </View>

--- a/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -594,7 +594,7 @@ const Index = () => {
                         <MarkingIcon
                           key={idx}
                           marking={marking}
-                          size={20}
+                          size={30}
                           color={item.color}
                         />
                       );

--- a/frontend/app/app/(monitor)/labels/index.tsx
+++ b/frontend/app/app/(monitor)/labels/index.tsx
@@ -78,7 +78,7 @@ const index = () => {
                         background_color: marking?.background_color,
                         hide_border: marking?.hide_border,
                       } as any}
-                      size={22}
+                      size={30}
                       color={MarkingColor}
                     />
                     <Text

--- a/frontend/app/app/(monitor)/labels/index.tsx
+++ b/frontend/app/app/(monitor)/labels/index.tsx
@@ -8,7 +8,7 @@ import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { useMyContrastColor } from '@/helper/colorHelper';
 import { useTheme } from '@/hooks/useTheme';
 import LabelHeader from '@/components/LabelHeader/LabelHeader';
-import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
+import MarkingIcon from '@/components/MarkingIcon';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
@@ -54,9 +54,6 @@ const index = () => {
                   theme,
                   mode === 'dark'
                 );
-                const iconParts = marking?.icon?.split(':') || [];
-                const [library, name] = iconParts;
-                const Icon = library && iconLibraries[library];
                 return (
                   <View key={index} style={styles.iconText}>
                     {markingImage?.uri && (
@@ -73,42 +70,17 @@ const index = () => {
                         ]}
                       />
                     )}
-                    {marking?.short_code &&
-                      !marking?.icon &&
-                      !markingImage?.uri && (
-                        <View
-                          style={{
-                            ...styles.shortCode,
-                            backgroundColor:
-                              MarkingBackgroundColor || 'transparent',
-                            borderWidth: marking?.hide_border ? 0 : 1,
-                            borderColor: MarkingColor,
-                          }}
-                        >
-                          <Text
-                            style={{
-                              color: MarkingColor,
-                              fontSize: 16,
-                              lineHeight: 18,
-                            }}
-                          >
-                            {marking?.short_code}
-                          </Text>
-                        </View>
-                      )}
-                    {marking?.icon && !markingImage?.uri && (
-                      <View
-                        style={{
-                          ...styles.iconMarking,
-                          backgroundColor:
-                            MarkingBackgroundColor || 'transparent',
-                          borderWidth: marking?.hide_border ? 0 : 1,
-                          borderColor: MarkingColor,
-                        }}
-                      >
-                        <Icon name={name} size={22} color={MarkingColor} />
-                      </View>
-                    )}
+                    <MarkingIcon
+                      marking={{
+                        icon: marking?.icon,
+                        short_code: marking?.short_code,
+                        image_remote_url: marking?.image_remote_url,
+                        background_color: marking?.background_color,
+                        hide_border: marking?.hide_border,
+                      } as any}
+                      size={22}
+                      color={MarkingColor}
+                    />
                     <Text
                       style={{
                         ...styles.title,

--- a/frontend/app/app/(monitor)/labels/index.tsx
+++ b/frontend/app/app/(monitor)/labels/index.tsx
@@ -1,9 +1,7 @@
-import { Image } from 'expo-image';
 import React from 'react';
 import { View, Text, ScrollView } from 'react-native';
 import styles from './styles';
 import { useSelector } from 'react-redux';
-import { getImageUrl } from '@/constants/HelperFunctions';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { useMyContrastColor } from '@/helper/colorHelper';
 import { useTheme } from '@/hooks/useTheme';
@@ -41,9 +39,6 @@ const index = () => {
           chunkedMarkings?.map((chunk, chunkIndex) => (
             <View key={chunkIndex} style={styles.mainContainer}>
               {chunk.map((marking, index) => {
-                const markingImage = marking?.image_remote_url
-                  ? { uri: marking?.image_remote_url }
-                  : { uri: getImageUrl(String(marking?.image)) };
                 const markingText = getTextFromTranslation(
                   marking?.translations,
                   language
@@ -56,24 +51,11 @@ const index = () => {
                 );
                 return (
                   <View key={index} style={styles.iconText}>
-                    {markingImage?.uri && (
-                      <Image
-                        source={markingImage}
-                        style={[
-                          styles.logoImage,
-                          markingImage?.uri && {
-                            backgroundColor: marking?.background_color
-                              ? marking?.background_color
-                              : 'transparent',
-                            borderRadius: marking?.background_color ? 8 : 0,
-                          },
-                        ]}
-                      />
-                    )}
                     <MarkingIcon
                       marking={{
                         icon: marking?.icon,
                         short_code: marking?.short_code,
+                        image: marking?.image,
                         image_remote_url: marking?.image_remote_url,
                         background_color: marking?.background_color,
                         hide_border: marking?.hide_border,

--- a/frontend/app/app/(monitor)/labels/styles.ts
+++ b/frontend/app/app/(monitor)/labels/styles.ts
@@ -12,21 +12,6 @@ export default StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: '#ddd',
   },
-  shortCode: {
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#2E2E2E',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 5,
-  },
-  iconMarking: {
-    borderRadius: 8,
-    borderWidth: 1,
-    padding: 2,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   mainContainer: {
     margin: 10,
   },
@@ -34,12 +19,6 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 10,
-  },
-  logoImage: {
-    width: 30,
-    height: 30,
-    marginRight: 5,
-    borderRadius: 25,
   },
   title: {
     marginLeft: 5,

--- a/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -28,6 +28,7 @@ import { useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useLanguage } from '@/hooks/useLanguage';
 import NetInfo from '@react-native-community/netinfo';
 import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
+import MarkingIcon from '@/components/MarkingIcon';
 import { FoodAttributesHelper } from '@/redux/actions/FoodAttributes/FoodAttributes';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -791,65 +792,22 @@ const index = () => {
                           ]}
                         >
                           {foodMarkings[item.id] &&
-                            foodMarkings[item.id]?.map((item: any) => {
-                              if (item?.icon) {
-                                const iconParts = item?.icon?.split(':') || [];
-                                const [library, name] = iconParts;
-                                const Icon = library && iconLibraries[library];
-                                return (
-                                  <View
-                                    style={{
-                                      ...styles.iconMarking,
-                                      backgroundColor: item?.bgColor,
-                                      borderWidth: item?.hide_border ? 0 : 1,
-                                      borderColor: item.color,
-                                    }}
-                                  >
-                                    <Icon
-                                      name={name}
-                                      size={14}
-                                      color={item.color}
-                                    />
-                                  </View>
-                                );
-                              }
-                              if (item?.shortCode && !item?.image?.uri) {
-                                return (
-                                  <View
-                                    style={{
-                                      ...styles.shortCode,
-                                      backgroundColor: item?.bgColor,
-                                      borderWidth: item?.hide_border ? 0 : 1,
-                                      borderColor: item.color,
-                                    }}
-                                  >
-                                    <Text
-                                      style={{
-                                        color: item.color,
-                                        fontSize: 12,
-                                        lineHeight: 18,
-                                      }}
-                                    >
-                                      {item?.shortCode}
-                                    </Text>
-                                  </View>
-                                );
-                              }
-                              if (item?.image?.uri) {
-                                return (
-                                  <Image
-                                    source={item?.image?.uri}
-                                    style={[
-                                      styles.icon,
-                                      item?.image?.uri && {
-                                        backgroundColor:
-                                          item?.bgColor && item?.bgColor,
-                                        borderRadius: item?.bgColor ? 8 : 0,
-                                      },
-                                    ]}
-                                  />
-                                );
-                              }
+                            foodMarkings[item.id]?.map((m: any, idx: number) => {
+                              const marking = {
+                                icon: m.icon,
+                                short_code: m.shortCode,
+                                image_remote_url: m.image?.uri,
+                                background_color: m.bgColor,
+                                hide_border: m.hide_border,
+                              } as any;
+                              return (
+                                <MarkingIcon
+                                  key={idx}
+                                  marking={marking}
+                                  size={14}
+                                  color={m.color}
+                                />
+                              );
                             })}
                         </View>
                         {foodAttributes[item?.id] &&
@@ -1038,38 +996,33 @@ const index = () => {
                               );
                             }
                             if (item?.shortCode && !item?.image?.uri) {
+                              const marking = {
+                                icon: item.icon,
+                                short_code: item.shortCode,
+                                image_remote_url: undefined,
+                                background_color: item.bgColor,
+                                hide_border: item.hide_border,
+                              } as any;
                               return (
-                                <View
-                                  style={{
-                                    ...styles.shortCode,
-                                    backgroundColor: item?.bgColor,
-                                    borderWidth: item?.hide_border ? 0 : 1,
-                                    borderColor: item.color,
-                                  }}
-                                >
-                                  <Text
-                                    style={{
-                                      color: item.color,
-                                      fontSize: 12,
-                                      lineHeight: 18,
-                                    }}
-                                  >
-                                    {item?.shortCode}
-                                  </Text>
-                                </View>
+                                <MarkingIcon
+                                  marking={marking}
+                                  size={14}
+                                  color={item.color}
+                                />
                               );
                             } else if (item?.image?.uri) {
+                              const marking = {
+                                icon: item.icon,
+                                short_code: item.shortCode,
+                                image_remote_url: item.image?.uri,
+                                background_color: item.bgColor,
+                                hide_border: item.hide_border,
+                              } as any;
                               return (
-                                <Image
-                                  source={item?.image?.uri}
-                                  style={[
-                                    styles.icon,
-                                    item?.image?.uri && {
-                                      backgroundColor:
-                                        item?.bgColor && item?.bgColor,
-                                      borderRadius: item?.bgColor ? 8 : 0,
-                                    },
-                                  ]}
+                                <MarkingIcon
+                                  marking={marking}
+                                  size={14}
+                                  color={item.color}
                                 />
                               );
                             }

--- a/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -804,7 +804,7 @@ const index = () => {
                                 <MarkingIcon
                                   key={idx}
                                   marking={marking}
-                                  size={14}
+                                  size={24}
                                   color={m.color}
                                 />
                               );
@@ -1006,7 +1006,7 @@ const index = () => {
                               return (
                                 <MarkingIcon
                                   marking={marking}
-                                  size={14}
+                                  size={24}
                                   color={item.color}
                                 />
                               );
@@ -1021,7 +1021,7 @@ const index = () => {
                               return (
                                 <MarkingIcon
                                   marking={marking}
-                                  size={14}
+                                  size={24}
                                   color={item.color}
                                 />
                               );

--- a/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -806,6 +806,7 @@ const index = () => {
                                   marking={marking}
                                   size={24}
                                   color={m.color}
+                                  compact
                                 />
                               );
                             })}
@@ -1008,6 +1009,7 @@ const index = () => {
                                   marking={marking}
                                   size={24}
                                   color={item.color}
+                                  compact
                                 />
                               );
                             } else if (item?.image?.uri) {
@@ -1023,6 +1025,7 @@ const index = () => {
                                   marking={marking}
                                   size={24}
                                   color={item.color}
+                                  compact
                                 />
                               );
                             }

--- a/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -21,13 +21,11 @@ import {
   getTextFromTranslation,
 } from '@/helper/resourceHelper';
 import { myContrastColor, useMyContrastColor } from '@/helper/colorHelper';
-import { Image } from 'expo-image';
 import styles from './styles';
 import { fetchFoodsByCanteen } from '@/redux/actions/FoodOffers/FoodOffers';
 import { useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useLanguage } from '@/hooks/useLanguage';
 import NetInfo from '@react-native-community/netinfo';
-import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
 import MarkingIcon from '@/components/MarkingIcon';
 import { FoodAttributesHelper } from '@/redux/actions/FoodAttributes/FoodAttributes';
 import { TranslationKeys } from '@/locales/keys';
@@ -974,61 +972,23 @@ const index = () => {
                         ]}
                       >
                         {optionalFoodMarkings[item.id] &&
-                          optionalFoodMarkings[item.id]?.map((item: any) => {
-                            if (item?.icon) {
-                              const iconParts = item?.icon?.split(':') || [];
-                              const [library, name] = iconParts;
-                              const Icon = library && iconLibraries[library];
-                              return (
-                                <View
-                                  style={{
-                                    ...styles.iconMarking,
-                                    backgroundColor: item?.bgColor,
-                                    borderWidth: item?.hide_border ? 0 : 1,
-                                    borderColor: item.color,
-                                  }}
-                                >
-                                  <Icon
-                                    name={name}
-                                    size={14}
-                                    color={item.color}
-                                  />
-                                </View>
-                              );
-                            }
-                            if (item?.shortCode && !item?.image?.uri) {
-                              const marking = {
-                                icon: item.icon,
-                                short_code: item.shortCode,
-                                image_remote_url: undefined,
-                                background_color: item.bgColor,
-                                hide_border: item.hide_border,
-                              } as any;
-                              return (
-                                <MarkingIcon
-                                  marking={marking}
-                                  size={24}
-                                  color={item.color}
-                                  compact
-                                />
-                              );
-                            } else if (item?.image?.uri) {
-                              const marking = {
-                                icon: item.icon,
-                                short_code: item.shortCode,
-                                image_remote_url: item.image?.uri,
-                                background_color: item.bgColor,
-                                hide_border: item.hide_border,
-                              } as any;
-                              return (
-                                <MarkingIcon
-                                  marking={marking}
-                                  size={24}
-                                  color={item.color}
-                                  compact
-                                />
-                              );
-                            }
+                          optionalFoodMarkings[item.id]?.map((mark: any, idx: number) => {
+                            const marking = {
+                              icon: mark.icon,
+                              short_code: mark.shortCode,
+                              image_remote_url: mark.image?.uri,
+                              background_color: mark.bgColor,
+                              hide_border: mark.hide_border,
+                            } as any;
+                            return (
+                              <MarkingIcon
+                                key={idx}
+                                marking={marking}
+                                size={24}
+                                color={mark.color}
+                                compact
+                              />
+                            );
                           })}
                       </View>
                       {optionalFoodAttributes[item?.id] &&
@@ -1157,60 +1117,20 @@ const index = () => {
                       theme,
                       mode === 'dark'
                     );
-                    const iconParts = marking?.icon?.split(':') || [];
-                    const [library, name] = iconParts;
-                    const Icon = library && iconLibraries[library];
                     return (
                       <View key={index} style={styles.iconText}>
-                        {markingImage?.uri && (
-                          <Image
-                            source={markingImage}
-                            style={[
-                              styles.logoImage,
-                              markingImage.uri && {
-                                backgroundColor:
-                                  marking?.background_color &&
-                                  marking?.background_color,
-                                borderRadius: marking?.background_color && 8,
-                              },
-                            ]}
-                          />
-                        )}
-
-                        {!markingImage?.uri &&
-                          !marking?.icon &&
-                          marking?.short_code && (
-                            <View
-                              style={{
-                                ...styles.shortCode,
-                                backgroundColor: MarkingBackgroundColor,
-                                borderWidth: marking?.hide_border ? 0 : 1,
-                                borderColor: MarkingColor,
-                              }}
-                            >
-                              <Text
-                                style={{
-                                  color: MarkingColor,
-                                  fontSize: 10,
-                                  lineHeight: 14,
-                                }}
-                              >
-                                {marking?.short_code}
-                              </Text>
-                            </View>
-                          )}
-                        {marking?.icon && !markingImage?.uri && (
-                          <View
-                            style={{
-                              ...styles.iconMarking,
-                              backgroundColor: MarkingBackgroundColor,
-                              borderWidth: marking?.hide_border ? 0 : 1,
-                              borderColor: MarkingColor,
-                            }}
-                          >
-                            <Icon name={name} size={14} color={MarkingColor} />
-                          </View>
-                        )}
+                        <MarkingIcon
+                          marking={{
+                            icon: marking?.icon,
+                            short_code: marking?.short_code,
+                            image: marking?.image,
+                            image_remote_url: marking?.image_remote_url,
+                            background_color: marking?.background_color,
+                            hide_border: marking?.hide_border,
+                          } as any}
+                          size={30}
+                          color={MarkingColor}
+                        />
                         <Text
                           style={{ ...styles.title, color: theme.screen.text }}
                         >

--- a/frontend/app/app/(monitor)/list-day-screen/styles.ts
+++ b/frontend/app/app/(monitor)/list-day-screen/styles.ts
@@ -61,12 +61,6 @@ export default StyleSheet.create({
     alignItems: 'center',
     marginBottom: 5,
   },
-  logoImage: {
-    width: 20,
-    height: 20,
-    resizeMode: 'contain',
-    marginRight: 5,
-  },
   title: {
     marginLeft: 5,
     fontSize: 10,
@@ -80,24 +74,6 @@ export default StyleSheet.create({
     marginLeft: 10,
   },
   footer: {},
-  shortCode: {
-    height: 24,
-    // width:24,
-    borderRadius: 8,
-    borderWidth: 1,
-    paddingHorizontal: 4,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  iconMarking: {
-    height: 24,
-    width: 24,
-    borderRadius: 8,
-    borderWidth: 1,
-    padding: 2,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   icon: {
     width: 20,
     height: 20,

--- a/frontend/app/components/MarkingIcon/index.tsx
+++ b/frontend/app/components/MarkingIcon/index.tsx
@@ -13,9 +13,15 @@ interface MarkingIconProps {
   marking: Markings;
   size?: number;
   color?: string;
+  compact?: boolean;
 }
 
-const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color }) => {
+const MarkingIcon: React.FC<MarkingIconProps> = ({
+  marking,
+  size = 24,
+  color,
+  compact = false,
+}) => {
   const { theme } = useTheme();
   const { selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 
@@ -52,12 +58,22 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color }) 
     },
   ];
 
+  const iconScale = compact ? 0.6 : 0.8;
+  const textScale = compact ? 0.5 : 0.65;
+  const lineHeightScale = compact ? 0.75 : 0.8;
+  const imageScale = compact ? 0.8 : 1;
+
   if (markingImage?.uri) {
     return (
       <View style={containerStyle}>
         <Image
           source={markingImage}
-          style={{ width: size, height: size, resizeMode: 'contain', borderRadius: bgColor ? 8 : 0 }}
+          style={{
+            width: size * imageScale,
+            height: size * imageScale,
+            resizeMode: 'contain',
+            borderRadius: bgColor ? 8 : 0,
+          }}
         />
       </View>
     );
@@ -66,7 +82,7 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color }) 
   if (Icon) {
     return (
       <View style={containerStyle}>
-        <Icon name={iconName} size={size * 0.8} color={textColor} />
+        <Icon name={iconName} size={size * iconScale} color={textColor} />
       </View>
     );
   }
@@ -74,7 +90,13 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color }) 
   if (marking.short_code) {
     return (
       <View style={containerStyle}>
-        <Text style={{ color: textColor, fontSize: size * 0.65, lineHeight: size * 0.8 }}>
+        <Text
+          style={{
+            color: textColor,
+            fontSize: size * textScale,
+            lineHeight: size * lineHeightScale,
+          }}
+        >
           {marking.short_code}
         </Text>
       </View>

--- a/frontend/app/components/MarkingIcon/index.tsx
+++ b/frontend/app/components/MarkingIcon/index.tsx
@@ -44,6 +44,9 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({
   const isTextOnly =
     !!marking.short_code && !markingImage?.uri && !Icon;
 
+  const hasImage = !!markingImage?.uri;
+  const showBorder = !hasImage && !marking.hide_border;
+
   const containerStyle = [
     styles.container,
     {
@@ -51,8 +54,8 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({
       minWidth: size,
       height: size,
       backgroundColor: bgColor || 'transparent',
-      borderWidth: marking.hide_border ? 0 : 1,
-      borderColor: textColor,
+      borderWidth: showBorder ? 1 : 0,
+      borderColor: showBorder ? textColor : 'transparent',
       borderRadius: bgColor ? 8 : 0,
       paddingHorizontal: isTextOnly ? 4 : undefined,
     },

--- a/frontend/app/components/MarkingIcon/index.tsx
+++ b/frontend/app/components/MarkingIcon/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, Text, Image } from 'react-native';
+import { useSelector } from 'react-redux';
+import { useTheme } from '@/hooks/useTheme';
+import { useMyContrastColor } from '@/helper/colorHelper';
+import { iconLibraries } from '../Drawer/CustomDrawerContent';
+import { getImageUrl } from '@/constants/HelperFunctions';
+import styles from './styles';
+import { Markings } from '@/constants/types';
+import { RootState } from '@/redux/reducer';
+
+interface MarkingIconProps {
+  marking: Markings;
+  size?: number;
+  color?: string;
+}
+
+const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color }) => {
+  const { theme } = useTheme();
+  const { selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+
+  if (!marking) return null;
+
+  const markingImage = marking.image_remote_url
+    ? { uri: marking.image_remote_url }
+    : marking.image
+    ? { uri: getImageUrl(String(marking.image)) }
+    : null;
+
+  const bgColor = marking.background_color;
+  const contrast = useMyContrastColor(bgColor, theme, mode === 'dark');
+  const textColor = color || contrast;
+
+  const iconParts = marking.icon?.split(':') || [];
+  const [library, iconName] = iconParts;
+  const Icon = library && iconLibraries[library];
+
+  const containerStyle = [
+    styles.container,
+    {
+      width: size,
+      height: size,
+      backgroundColor: bgColor || 'transparent',
+      borderWidth: marking.hide_border ? 0 : 1,
+      borderColor: textColor,
+      borderRadius: bgColor ? 8 : 0,
+    },
+  ];
+
+  if (markingImage?.uri) {
+    return (
+      <View style={containerStyle}>
+        <Image
+          source={markingImage}
+          style={{ width: size, height: size, resizeMode: 'contain', borderRadius: bgColor ? 8 : 0 }}
+        />
+      </View>
+    );
+  }
+
+  if (Icon) {
+    return (
+      <View style={containerStyle}>
+        <Icon name={iconName} size={size * 0.8} color={textColor} />
+      </View>
+    );
+  }
+
+  if (marking.short_code) {
+    return (
+      <View style={containerStyle}>
+        <Text style={{ color: textColor, fontSize: size * 0.65, lineHeight: size * 0.8 }}>
+          {marking.short_code}
+        </Text>
+      </View>
+    );
+  }
+
+  return null;
+};
+
+export default MarkingIcon;

--- a/frontend/app/components/MarkingIcon/index.tsx
+++ b/frontend/app/components/MarkingIcon/index.tsx
@@ -35,15 +35,20 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color }) 
   const [library, iconName] = iconParts;
   const Icon = library && iconLibraries[library];
 
+  const isTextOnly =
+    !!marking.short_code && !markingImage?.uri && !Icon;
+
   const containerStyle = [
     styles.container,
     {
-      width: size,
+      width: isTextOnly ? undefined : size,
+      minWidth: size,
       height: size,
       backgroundColor: bgColor || 'transparent',
       borderWidth: marking.hide_border ? 0 : 1,
       borderColor: textColor,
       borderRadius: bgColor ? 8 : 0,
+      paddingHorizontal: isTextOnly ? 4 : undefined,
     },
   ];
 

--- a/frontend/app/components/MarkingIcon/styles.ts
+++ b/frontend/app/components/MarkingIcon/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 2,
+  },
+});

--- a/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -22,6 +22,7 @@ import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { Markings, Profiles } from '@/constants/types';
 import { useMyContrastColor } from '@/helper/colorHelper';
 import { iconLibraries } from '../Drawer/CustomDrawerContent';
+import MarkingIcon from '../MarkingIcon';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -209,110 +210,10 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
     mode === 'dark'
   );
 
-  const iconParts = marking?.icon?.split(':') || [];
-  const [library, name] = iconParts;
-
-  const Icon = library && iconLibraries[library];
   return (
     <View style={styles.row}>
       <View style={styles.col}>
-        {marking?.icon && !markingImage?.uri ? (
-          handleMenuSheet ? (
-            <Tooltip
-              placement='top'
-              trigger={(triggerProps) => (
-                <Pressable
-                  {...triggerProps}
-                  onPress={() => openMarkingLabel(marking)}
-                  onHoverIn={() => setShowTooltip(true)}
-                  onHoverOut={() => setShowTooltip(false)}
-                >
-                  <View
-                    style={{
-                      ...styles.shortCode,
-                      backgroundColor: MarkingBackgroundColor || 'transparent',
-                      borderWidth: marking?.hide_border ? 0 : 1,
-                      borderColor: MarkingColor,
-                    }}
-                  >
-                    <Icon name={name} size={20} color={MarkingColor} />
-                  </View>
-                </Pressable>
-              )}
-            >
-              <TooltipContent bg={theme.tooltip.background} py='$1' px='$2'>
-                <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                  {`${markingText}`}
-                </TooltipText>
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <View
-              style={{
-                ...styles.shortCode,
-                backgroundColor: MarkingBackgroundColor || 'transparent',
-                borderWidth: marking?.hide_border ? 0 : 1,
-                borderColor: MarkingColor,
-              }}
-            >
-              <Icon name={name} size={20} color={MarkingColor} />
-            </View>
-          )
-        ) : marking?.short_code && !markingImage?.uri ? (
-          handleMenuSheet ? (
-            <Tooltip
-              placement='top'
-              trigger={(triggerProps) => (
-                <Pressable
-                  {...triggerProps}
-                  onPress={() => openMarkingLabel(marking)}
-                  onHoverIn={() => setShowTooltip(true)}
-                  onHoverOut={() => setShowTooltip(false)}
-                >
-                  <View
-                    style={{
-                      ...styles.shortCode,
-                      backgroundColor: MarkingBackgroundColor || 'transparent',
-                      borderWidth: marking?.hide_border ? 0 : 1,
-                      borderColor: MarkingColor,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        color: MarkingColor,
-                        fontSize: 16,
-                        lineHeight: 18,
-                      }}
-                    >
-                      {marking?.short_code}
-                    </Text>
-                  </View>
-                </Pressable>
-              )}
-            >
-              <TooltipContent bg={theme.tooltip.background} py='$1' px='$2'>
-                <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                  {`${markingText}`}
-                </TooltipText>
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <View
-              style={{
-                ...styles.shortCode,
-                backgroundColor: MarkingBackgroundColor || 'transparent',
-                borderWidth: marking?.hide_border ? 0 : 1,
-                borderColor: MarkingColor,
-              }}
-            >
-              <Text
-                style={{ color: MarkingColor, fontSize: 16, lineHeight: 18 }}
-              >
-                {marking?.short_code}
-              </Text>
-            </View>
-          )
-        ) : handleMenuSheet ? (
+        {handleMenuSheet ? (
           <Tooltip
             placement='top'
             trigger={(triggerProps) => (
@@ -322,18 +223,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
                 onHoverIn={() => setShowTooltip(true)}
                 onHoverOut={() => setShowTooltip(false)}
               >
-                <Image
-                  source={markingImage}
-                  style={[
-                    styles.icon,
-                    markingImage.uri && {
-                      backgroundColor: marking?.background_color
-                        ? marking?.background_color
-                        : 'transparent',
-                      borderRadius: marking?.background_color ? 8 : 0,
-                    },
-                  ]}
-                />
+                <MarkingIcon marking={marking} size={20} />
               </Pressable>
             )}
           >
@@ -344,17 +234,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
             </TooltipContent>
           </Tooltip>
         ) : (
-          <Image
-            source={markingImage}
-            style={[
-              styles.icon,
-              markingImage.uri && {
-                backgroundColor:
-                  marking?.background_color && marking?.background_color,
-                borderRadius: marking?.background_color ? 8 : 0,
-              },
-            ]}
-          />
+          <MarkingIcon marking={marking} size={20} />
         )}
         <Tooltip
           placement='top'

--- a/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -30,6 +30,7 @@ import { RootState } from '@/redux/reducer';
 const MarkingLabels: React.FC<MarkingLabelProps> = ({
   markingId,
   handleMenuSheet,
+  size = 30,
 }) => {
   const { theme } = useTheme();
   const dispatch = useDispatch();
@@ -223,7 +224,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
                 onHoverIn={() => setShowTooltip(true)}
                 onHoverOut={() => setShowTooltip(false)}
               >
-                <MarkingIcon marking={marking} size={20} />
+                <MarkingIcon marking={marking} size={size} />
               </Pressable>
             )}
           >
@@ -234,7 +235,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
             </TooltipContent>
           </Tooltip>
         ) : (
-          <MarkingIcon marking={marking} size={20} />
+          <MarkingIcon marking={marking} size={size} />
         )}
         <Tooltip
           placement='top'

--- a/frontend/app/components/MarkingLabels/types.ts
+++ b/frontend/app/components/MarkingLabels/types.ts
@@ -1,5 +1,6 @@
 export interface MarkingLabelProps {
   markingId: string;
   handleMenuSheet?: () => void;
+  size?: number;
   // id: number;
 }


### PR DESCRIPTION
## Summary
- add reusable `MarkingIcon` component
- render marking icons with new component in MarkingLabels and monitor screens

## Testing
- `npm test -- -w=off` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639255a63c8330a106f5c3660ef41a