### PR TITLE
Refactor marking sheet

### DIFF
--- a/frontend/app/app/(app)/eating-habits/index.tsx
+++ b/frontend/app/app/(app)/eating-habits/index.tsx
@@ -30,7 +30,7 @@ import { myContrastColor } from '@/helper/colorHelper';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
-import MenuSheet from '@/components/MenuSheet/MenuSheet';
+import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import { RootState } from '@/redux/reducer';
 
@@ -188,21 +188,7 @@ const index = () => {
         </ScrollView>
       </View>
       {isActive && (
-        <BaseBottomSheet
-          ref={menuSheetRef}
-          index={-1}
-          backgroundStyle={{
-            ...styles.sheetBackground,
-            backgroundColor: theme.sheet.sheetBg,
-          }}
-          enablePanDownToClose
-          handleComponent={null}
-          enableHandlePanningGesture={false}
-          enableContentPanningGesture={false}
-          onClose={closeMenuSheet}
-        >
-          <MenuSheet closeSheet={closeMenuSheet} />
-        </BaseBottomSheet>
+        <MarkingBottomSheet ref={menuSheetRef} onClose={closeMenuSheet} />
       )}
     </SafeAreaView>
   );

--- a/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -28,7 +28,7 @@ import {
   UPDATE_FOOD_FEEDBACK_LOCAL,
   UPDATE_PROFILE,
 } from '@/redux/Types/types';
-import MenuSheet from '@/components/MenuSheet/MenuSheet';
+import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import PermissionModal from '@/components/PermissionModal/PermissionModal';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
@@ -942,21 +942,7 @@ export default function FoodDetailsScreen() {
       {/* Menu sheet */}
 
       {isActive && (
-        <BaseBottomSheet
-          ref={menuSheetRef}
-          index={-1}
-          backgroundStyle={{
-            ...styles.sheetBackground,
-            backgroundColor: theme.sheet.sheetBg,
-          }}
-          enablePanDownToClose
-          handleComponent={null}
-          enableHandlePanningGesture={false}
-          enableContentPanningGesture={false}
-          onClose={closeMenuSheet}
-        >
-          <MenuSheet closeSheet={closeMenuSheet} />
-        </BaseBottomSheet>
+        <MarkingBottomSheet ref={menuSheetRef} onClose={closeMenuSheet} />
       )}
     </SafeAreaView>
   );

--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -58,7 +58,6 @@ import CalendarSheet from '@/components/CalendarSheet/CalendarSheet';
 import { excerpt } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
 import ForecastSheet from '@/components/ForecastSheet/ForecastSheet';
-import MenuSheet from '@/components/MenuSheet/MenuSheet';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet';
 import { CanteenFeedbackLabelHelper } from '@/redux/actions/CanteenFeedbacksLabel/CanteenFeedbacksLabel';
@@ -85,6 +84,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { RootState } from '@/redux/reducer';
+import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 
 export const SHEET_COMPONENTS = {
   canteen: CanteenSelectionSheet,
@@ -92,7 +92,6 @@ export const SHEET_COMPONENTS = {
   hours: HourSheet,
   calendar: CalendarSheet,
   forecast: ForecastSheet,
-  menu: MenuSheet,
   imageManagement: ImageManagementSheet,
   eatingHabits: EatingHabitsSheet,
 };
@@ -254,7 +253,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   }, [popupEvents]);
 
   const openSheet = useCallback(
-    (sheet: keyof typeof SHEET_COMPONENTS, props = {}) => {
+    (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
       setSelectedSheet(sheet);
       setSheetProps(props);
     },
@@ -523,7 +522,10 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   );
   const canteenFeedbackLabelsExist = canteenFeedbackLabels?.length > 0;
 
-  const SheetComponent = selectedSheet ? SHEET_COMPONENTS[selectedSheet] : null;
+  const SheetComponent =
+    selectedSheet && selectedSheet !== 'menu'
+      ? SHEET_COMPONENTS[selectedSheet]
+      : null;
 
   return (
     <>
@@ -964,34 +966,37 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           </ScrollView>
         </View>
         {isActive && (
-          <BaseBottomSheet
-            key={selectedSheet}
-            ref={bottomSheetRef}
-            // snapPoints={['40%']}
-            backgroundStyle={{
-              ...styles.sheetBackground,
-              backgroundColor: theme.sheet.sheetBg,
-            }}
-            enablePanDownToClose={selectedSheet === 'forecast' ? false : true}
-            enableContentPanningGesture={
-              selectedSheet === 'forecast' ? false : true
-            }
-            enableHandlePanningGesture={
-              selectedSheet === 'forecast' ? false : true
-            }
-            enableDynamicSizing={selectedSheet === 'forecast' ? false : true}
-            onChange={(index) => {
-              if (index === -1) {
-                closeSheet();
+          selectedSheet === 'menu' ? (
+            <MarkingBottomSheet ref={bottomSheetRef} onClose={closeSheet} />
+          ) : (
+            <BaseBottomSheet
+              key={selectedSheet}
+              ref={bottomSheetRef}
+              backgroundStyle={{
+                ...styles.sheetBackground,
+                backgroundColor: theme.sheet.sheetBg,
+              }}
+              enablePanDownToClose={selectedSheet === 'forecast' ? false : true}
+              enableContentPanningGesture={
+                selectedSheet === 'forecast' ? false : true
               }
-            }}
-            onClose={closeSheet}
-            handleComponent={null}
-          >
-            {SheetComponent && (
-              <SheetComponent closeSheet={closeSheet} {...sheetProps} />
-            )}
-          </BaseBottomSheet>
+              enableHandlePanningGesture={
+                selectedSheet === 'forecast' ? false : true
+              }
+              enableDynamicSizing={selectedSheet === 'forecast' ? false : true}
+              onChange={(index) => {
+                if (index === -1) {
+                  closeSheet();
+                }
+              }}
+              onClose={closeSheet}
+              handleComponent={null}
+            >
+              {SheetComponent && (
+                <SheetComponent closeSheet={closeSheet} {...sheetProps} />
+              )}
+            </BaseBottomSheet>
+          )
         )}
 
         {isActive && (

--- a/frontend/app/app/(monitor)/labels/index.tsx
+++ b/frontend/app/app/(monitor)/labels/index.tsx
@@ -1,19 +1,35 @@
-import React from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import React, { useRef } from 'react';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
 import styles from './styles';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { useMyContrastColor } from '@/helper/colorHelper';
 import { useTheme } from '@/hooks/useTheme';
 import LabelHeader from '@/components/LabelHeader/LabelHeader';
 import MarkingIcon from '@/components/MarkingIcon';
+import MarkingBottomSheet from '@/components/MarkingBottomSheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { useLanguage } from '@/hooks/useLanguage';
+import { SET_MARKING_DETAILS } from '@/redux/Types/types';
 import { RootState } from '@/redux/reducer';
 
 const index = () => {
   const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const dispatch = useDispatch();
+  const menuSheetRef = useRef<BottomSheet>(null);
+
   useSetPageTitle(TranslationKeys.markings);
+
+  const openMenuSheet = () => {
+    menuSheetRef.current?.expand();
+  };
+
+  const closeMenuSheet = () => {
+    menuSheetRef.current?.close();
+  };
 
   const { markings } = useSelector((state: RootState) => state.food);
   const { language, selectedTheme: mode } = useSelector(
@@ -32,7 +48,7 @@ const index = () => {
         backgroundColor: theme.screen.background,
       }}
     >
-      <LabelHeader Label={'Labels'} />
+      <LabelHeader Label={translate(TranslationKeys.markings)} />
 
       <View style={styles.gridContainer}>
         {chunkedMarkings &&
@@ -50,7 +66,14 @@ const index = () => {
                   mode === 'dark'
                 );
                 return (
-                  <View key={index} style={styles.iconText}>
+                  <TouchableOpacity
+                    key={index}
+                    style={styles.iconText}
+                    onPress={() => {
+                      dispatch({ type: SET_MARKING_DETAILS, payload: marking });
+                      openMenuSheet();
+                    }}
+                  >
                     <MarkingIcon
                       marking={{
                         icon: marking?.icon,
@@ -72,12 +95,13 @@ const index = () => {
                     >
                       {markingText}
                     </Text>
-                  </View>
+                  </TouchableOpacity>
                 );
               })}
             </View>
           ))}
       </View>
+      <MarkingBottomSheet ref={menuSheetRef} onClose={closeMenuSheet} />
     </ScrollView>
   );
 };

--- a/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
+++ b/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef } from 'react';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import BaseBottomSheet from '../BaseBottomSheet';
+import MenuSheet from '../MenuSheet/MenuSheet';
+import { useTheme } from '@/hooks/useTheme';
+
+export interface MarkingBottomSheetProps {
+  onClose: () => void;
+}
+
+const MarkingBottomSheet = forwardRef<BottomSheet, MarkingBottomSheetProps>(
+  ({ onClose }, ref) => {
+    const { theme } = useTheme();
+
+    return (
+      <BaseBottomSheet
+        ref={ref}
+        index={-1}
+        backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+        enablePanDownToClose
+        handleComponent={null}
+        enableHandlePanningGesture={false}
+        enableContentPanningGesture={false}
+        onClose={onClose}
+      >
+        <MenuSheet closeSheet={onClose} />
+      </BaseBottomSheet>
+    );
+  }
+);
+
+export default MarkingBottomSheet;

--- a/frontend/app/components/MarkingBottomSheet/index.ts
+++ b/frontend/app/components/MarkingBottomSheet/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MarkingBottomSheet';
+export type { MarkingBottomSheetProps } from './MarkingBottomSheet';


### PR DESCRIPTION
## Summary
- create `MarkingBottomSheet` component for displaying label details
- reuse new bottom sheet in food offers, food offer details, eating habits and label management pages
- open `MarkingBottomSheet` instead of plain sheet in food offers
- fix header translation on labels page

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b373e70c8330a671ea736315eea4