### PR TITLE
Fix long marking names overlapping

### DIFF
--- a/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -245,6 +245,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
               {...triggerProps}
               onHoverIn={() => setShowTooltip(true)}
               onHoverOut={() => setShowTooltip(false)}
+              style={styles.labelContainer}
             >
               <Text
                 style={{

--- a/frontend/app/components/MarkingLabels/styles.ts
+++ b/frontend/app/components/MarkingLabels/styles.ts
@@ -30,6 +30,10 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_400Regular',
     flexShrink: 1,
     flexWrap: 'wrap',
+    flex: 1,
+  },
+  labelContainer: {
+    flexShrink: 1,
   },
   likeButton: {
     padding: 12,


### PR DESCRIPTION
## Summary
- ensure long text wraps beside like/dislike buttons

## Testing
- `yarn lint` *(fails: couldn't find eslint script)*
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6863ee47c53c8330a89a1315d2852486