### PR TITLE
Add most popular foods image scroll screen

### DIFF
--- a/frontend/app/app/(app)/_layout.tsx
+++ b/frontend/app/app/(app)/_layout.tsx
@@ -689,6 +689,23 @@ export default function Layout() {
           }}
         />
 
+        <Drawer.Screen
+          name='most-popular-foods-vertical-image-scroll/index'
+          options={{
+            header: () => (
+              <CustomStackHeader
+                label={translate(
+                  TranslationKeys.most_popular_foods_vertical_image_scroll
+                )}
+                key={'most_popular_foods_vertical_image_scroll'}
+              />
+            ),
+            title: translate(
+              TranslationKeys.most_popular_foods_vertical_image_scroll
+            ),
+          }}
+        />
+
 
         <Drawer.Screen
           name='notification/index'

--- a/frontend/app/app/(app)/experimentell/index.tsx
+++ b/frontend/app/app/(app)/experimentell/index.tsx
@@ -80,6 +80,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/most-popular-foods-vertical-image-scroll')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='star' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.most_popular_foods_vertical_image_scroll)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/frontend/app/app/(app)/most-popular-foods-vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/most-popular-foods-vertical-image-scroll/index.tsx
@@ -1,0 +1,80 @@
+import { View, Dimensions, TouchableOpacity, Text } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import styles from './styles';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import CardDimensionHelper from '@/helper/CardDimensionHelper';
+import AutoImageScroller from '@/components/AutoImageScroller';
+import FoodImage from '@/components/FoodImage';
+import { loadMostPopularFoodsWithImages } from '@/helper/FoodHelper';
+import { Ionicons } from '@expo/vector-icons';
+import { Foods } from '@/constants/types';
+
+const MostPopularFoodsVerticalImageScroll = () => {
+  useSetPageTitle(TranslationKeys.most_popular_foods_vertical_image_scroll);
+  const { theme } = useTheme();
+  const { amountColumnsForcard } = useSelector((state: RootState) => state.settings);
+  const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
+
+  const numColumns = CardDimensionHelper.getNumColumns(screenWidth, amountColumnsForcard);
+
+  useEffect(() => {
+    const sub = Dimensions.addEventListener('change', ({ window }) => {
+      setScreenWidth(window.width);
+    });
+    return () => sub?.remove();
+  }, []);
+
+  const size =
+    amountColumnsForcard === 0
+      ? CardDimensionHelper.getCardDimension(screenWidth)
+      : CardDimensionHelper.getCardWidth(screenWidth, numColumns);
+
+  const [foods, setFoods] = useState<Foods[]>([]);
+
+  useEffect(() => {
+    const fetchFoods = async () => {
+      try {
+        const data = await loadMostPopularFoodsWithImages(100);
+        setFoods(data);
+      } catch (e) {
+        console.error('Error fetching foods', e);
+      }
+    };
+    fetchFoods();
+  }, []);
+
+  const [speedPercent, setSpeedPercent] = useState(5);
+
+  return (
+    <View
+      key={amountColumnsForcard}
+      style={[styles.container, { backgroundColor: theme.screen.background }]}
+    >
+      <View style={styles.controls}>
+        <TouchableOpacity onPress={() => setSpeedPercent((s) => Math.max(1, s - 1))}>
+          <Ionicons name='remove' size={24} color={theme.primary} />
+        </TouchableOpacity>
+        <Text style={{ color: theme.primary }}>{Math.round(speedPercent)}%/s</Text>
+        <TouchableOpacity onPress={() => setSpeedPercent((s) => s + 1)}>
+          <Ionicons name='add' size={24} color={theme.primary} />
+        </TouchableOpacity>
+      </View>
+      <AutoImageScroller
+        images={foods}
+        numColumns={numColumns}
+        size={size}
+        speedPercent={speedPercent}
+        loadMore={() => {}}
+        renderItem={(item) => (
+          <FoodImage image={item.image} imageRemoteUrl={item.image_remote_url} size={size} />
+        )}
+      />
+    </View>
+  );
+};
+
+export default MostPopularFoodsVerticalImageScroll;

--- a/frontend/app/app/(app)/most-popular-foods-vertical-image-scroll/index.tsx
+++ b/frontend/app/app/(app)/most-popular-foods-vertical-image-scroll/index.tsx
@@ -70,7 +70,12 @@ const MostPopularFoodsVerticalImageScroll = () => {
         speedPercent={speedPercent}
         loadMore={() => {}}
         renderItem={(item) => (
-          <FoodImage image={item.image} imageRemoteUrl={item.image_remote_url} size={size} />
+          <FoodImage
+            image={item.image}
+            imageRemoteUrl={item.image_remote_url}
+            size={size}
+            style={styles.image}
+          />
         )}
       />
     </View>

--- a/frontend/app/app/(app)/most-popular-foods-vertical-image-scroll/styles.ts
+++ b/frontend/app/app/(app)/most-popular-foods-vertical-image-scroll/styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 8,
+    gap: 10,
+  },
+  image: {
+    margin: 5,
+    borderRadius: 8,
+  },
+});

--- a/frontend/app/components/AutoImageScroller/index.tsx
+++ b/frontend/app/components/AutoImageScroller/index.tsx
@@ -3,22 +3,24 @@ import { FlatList, View, Dimensions } from 'react-native';
 import { Image } from 'expo-image';
 import styles from './styles';
 
-interface AutoImageScrollerProps {
-  images: string[];
+interface AutoImageScrollerProps<T = any> {
+  images: T[];
   numColumns: number;
   size: number;
   speedPercent: number; // percent of screen height per second
   loadMore: () => void;
+  renderItem?: (item: T, size: number, index: number) => React.ReactNode;
 }
 
-const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({
+const AutoImageScroller = <T,>({
   images,
   numColumns,
   size,
   speedPercent,
   loadMore,
-}) => {
-  const flatListRef = useRef<FlatList<string>>(null);
+  renderItem,
+}: AutoImageScrollerProps<T>) => {
+  const flatListRef = useRef<FlatList<T>>(null);
   const scrollOffset = useRef(0);
   const screenHeight = Dimensions.get('window').height;
   const frameRef = useRef<number>();
@@ -71,16 +73,26 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({
     };
   }, [images, numColumns, size, speedPercent, screenHeight]);
 
-  const renderItem = ({ item, index }: { item: string; index: number }) => {
+  const defaultRenderItem = ({ item, index }: { item: any; index: number }) => {
     const columnIndex = index % numColumns;
     const offset = (columnIndex % 3) * (size / 3);
     return (
       <View style={{ transform: [{ translateY: offset }] }}>
         <Image
-          source={{ uri: item }}
+          source={{ uri: String(item) }}
           style={[styles.image, { width: size, height: size }]}
           contentFit='cover'
         />
+      </View>
+    );
+  };
+
+  const renderItemWrapper = ({ item, index }: { item: T; index: number }) => {
+    const columnIndex = index % numColumns;
+    const offset = (columnIndex % 3) * (size / 3);
+    return (
+      <View style={{ transform: [{ translateY: offset }] }}>
+        {renderItem ? renderItem(item, size, index) : defaultRenderItem({ item, index })}
       </View>
     );
   };
@@ -90,7 +102,7 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({
       ref={flatListRef}
       key={numColumns}
       data={extendedImages}
-      renderItem={renderItem}
+      renderItem={renderItemWrapper}
       keyExtractor={(_, idx) => idx.toString()}
       numColumns={numColumns}
       showsVerticalScrollIndicator={false}

--- a/frontend/app/components/FoodImage/FoodImage.tsx
+++ b/frontend/app/components/FoodImage/FoodImage.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { useSelector } from 'react-redux';
+import styles from './styles';
+import { getImageUrl } from '@/constants/HelperFunctions';
+import { RootState } from '@/redux/reducer';
+import { DirectusFiles } from '@/constants/types';
+
+type FoodImageProps = {
+  image?: string | DirectusFiles | null;
+  imageRemoteUrl?: string | null;
+  size: number;
+};
+
+const FoodImage: React.FC<FoodImageProps> = ({ image, imageRemoteUrl, size }) => {
+  const { appSettings, serverInfo, primaryColor } = useSelector(
+    (state: RootState) => state.settings
+  );
+
+  const foods_area_color = appSettings?.foods_area_color
+    ? appSettings?.foods_area_color
+    : primaryColor;
+
+  const defaultImage =
+    getImageUrl(String(appSettings.foods_placeholder_image)) ||
+    appSettings.foods_placeholder_image_remote_url ||
+    getImageUrl((serverInfo as any)?.info?.project?.project_logo);
+
+  const imageId = typeof image === 'string' ? image : image?.id || '';
+
+  return (
+    <Image
+      source={{ uri: imageRemoteUrl || getImageUrl(imageId) || defaultImage }}
+      style={[
+        styles.image,
+        { width: size, height: size, borderColor: foods_area_color },
+      ]}
+    />
+  );
+};
+
+export default FoodImage;

--- a/frontend/app/components/FoodImage/FoodImage.tsx
+++ b/frontend/app/components/FoodImage/FoodImage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Image } from 'expo-image';
 import { useSelector } from 'react-redux';
+import { StyleProp, ImageStyle } from 'react-native';
 import styles from './styles';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { RootState } from '@/redux/reducer';
@@ -9,17 +10,19 @@ import { DirectusFiles } from '@/constants/types';
 type FoodImageProps = {
   image?: string | DirectusFiles | null;
   imageRemoteUrl?: string | null;
-  size: number;
+  size?: number;
+  style?: StyleProp<ImageStyle>;
 };
 
-const FoodImage: React.FC<FoodImageProps> = ({ image, imageRemoteUrl, size }) => {
-  const { appSettings, serverInfo, primaryColor } = useSelector(
+const FoodImage: React.FC<FoodImageProps> = ({
+  image,
+  imageRemoteUrl,
+  size,
+  style,
+}) => {
+  const { appSettings, serverInfo } = useSelector(
     (state: RootState) => state.settings
   );
-
-  const foods_area_color = appSettings?.foods_area_color
-    ? appSettings?.foods_area_color
-    : primaryColor;
 
   const defaultImage =
     getImageUrl(String(appSettings.foods_placeholder_image)) ||
@@ -33,7 +36,8 @@ const FoodImage: React.FC<FoodImageProps> = ({ image, imageRemoteUrl, size }) =>
       source={{ uri: imageRemoteUrl || getImageUrl(imageId) || defaultImage }}
       style={[
         styles.image,
-        { width: size, height: size, borderColor: foods_area_color },
+        style,
+        size ? { width: size, height: size } : null,
       ]}
       contentFit='cover'
     />

--- a/frontend/app/components/FoodImage/FoodImage.tsx
+++ b/frontend/app/components/FoodImage/FoodImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image } from 'react-native';
+import { Image } from 'expo-image';
 import { useSelector } from 'react-redux';
 import styles from './styles';
 import { getImageUrl } from '@/constants/HelperFunctions';
@@ -35,6 +35,7 @@ const FoodImage: React.FC<FoodImageProps> = ({ image, imageRemoteUrl, size }) =>
         styles.image,
         { width: size, height: size, borderColor: foods_area_color },
       ]}
+      contentFit='cover'
     />
   );
 };

--- a/frontend/app/components/FoodImage/index.ts
+++ b/frontend/app/components/FoodImage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FoodImage';

--- a/frontend/app/components/FoodImage/styles.ts
+++ b/frontend/app/components/FoodImage/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  image: {
+    margin: 5,
+    borderRadius: 8,
+    borderWidth: 2,
+  },
+});

--- a/frontend/app/components/FoodImage/styles.ts
+++ b/frontend/app/components/FoodImage/styles.ts
@@ -2,6 +2,7 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   image: {
-    borderRadius: 8,
+    // keep default styling minimal so components can control borders/margins
+    borderRadius: 0,
   },
 });

--- a/frontend/app/components/FoodImage/styles.ts
+++ b/frontend/app/components/FoodImage/styles.ts
@@ -2,8 +2,6 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   image: {
-    margin: 5,
     borderRadius: 8,
-    borderWidth: 2,
   },
 });

--- a/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/frontend/app/components/FoodItem/FoodItem.tsx
@@ -5,6 +5,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { Image } from 'expo-image';
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
@@ -242,14 +243,10 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                 <FoodImage
                   image={foodItem?.image}
                   imageRemoteUrl={foodItem?.image_remote_url}
-                  size={
-                    amountColumnsForcard === 0
-                      ? CardDimensionHelper.getCardDimension(screenWidth)
-                      : CardDimensionHelper.getCardWidth(
-                          screenWidth,
-                          amountColumnsForcard
-                        )
-                  }
+                  style={[
+                    styles.image,
+                    { borderColor: foods_area_color },
+                  ]}
                 />
                 {isManagement && (
                   <Tooltip

--- a/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/frontend/app/components/FoodItem/FoodItem.tsx
@@ -1,6 +1,5 @@
 import {
   Dimensions,
-  Image,
   Linking,
   Text,
   TouchableOpacity,
@@ -43,6 +42,7 @@ import useToast from '@/hooks/useToast';
 import { handleFoodRating } from '@/helper/feedback';
 import { RootState } from '@/redux/reducer';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
+import FoodImage from '../FoodImage';
 
 const selectFoodState = (state: RootState) => state.food;
 
@@ -239,19 +239,16 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                         ),
                 }}
               >
-                <Image
-                  style={{
-                    ...styles.image,
-                    borderColor: foods_area_color,
-                  }}
-                  source={
-                    foodItem?.image_remote_url || foodItem?.image
-                      ? {
-                          uri:
-                            foodItem?.image_remote_url ||
-                            getImageUrl(foodItem?.image),
-                        }
-                      : { uri: defaultImage }
+                <FoodImage
+                  image={foodItem?.image}
+                  imageRemoteUrl={foodItem?.image_remote_url}
+                  size={
+                    amountColumnsForcard === 0
+                      ? CardDimensionHelper.getCardDimension(screenWidth)
+                      : CardDimensionHelper.getCardWidth(
+                          screenWidth,
+                          amountColumnsForcard
+                        )
                   }
                 />
                 {isManagement && (

--- a/frontend/app/components/FoodItem/styles.ts
+++ b/frontend/app/components/FoodItem/styles.ts
@@ -68,8 +68,8 @@ export default StyleSheet.create({
   image: {
     width: '100%',
     height: '100%',
-    borderTopRightRadius: 18,
-    borderTopLeftRadius: 18,
+    borderTopRightRadius: 8,
+    borderTopLeftRadius: 8,
     resizeMode: 'cover',
   },
   foodName: {

--- a/frontend/app/helper/FoodHelper.ts
+++ b/frontend/app/helper/FoodHelper.ts
@@ -39,3 +39,20 @@ export async function loadMostLikedOrDislikedFoods(
 
   return await collectionHelper.readItems(query);
 }
+
+export async function loadMostPopularFoodsWithImages(limit = 100) {
+  const collectionHelper = new CollectionHelper<Foods>('foods');
+  const query = {
+    limit,
+    sort: ['-rating_average'],
+    filter: {
+      _or: [
+        { image_remote_url: { _nnull: true } },
+        { image: { _nnull: true } },
+      ],
+    },
+    fields: ['id', 'image', 'image_remote_url', 'rating_average'],
+  };
+
+  return await collectionHelper.readItems(query);
+}

--- a/frontend/app/locales/keys.ts
+++ b/frontend/app/locales/keys.ts
@@ -237,6 +237,7 @@ export enum TranslationKeys {
   course_timetable = 'course_timetable',
   experimentell = "experimentell",
   vertical_image_scroll = 'vertical_image_scroll',
+  most_popular_foods_vertical_image_scroll = 'most_popular_foods_vertical_image_scroll',
   eating_habits = 'eating_habits',
   markings = 'markings',
   category = 'category',

--- a/frontend/app/locales/translations.json
+++ b/frontend/app/locales/translations.json
@@ -2393,6 +2393,16 @@
     "tr": "Dikey Resim Kaydırma",
     "zh": "垂直图片滚动"
   },
+  "most_popular_foods_vertical_image_scroll": {
+    "de": "Beliebteste Gerichte Bildlauf",
+    "en": "Most Popular Foods Vertical Image Scroll",
+    "ar": "الاطعمة الأكثر شعبية بتمرير عمودي",
+    "es": "Desplazamiento vertical de las comidas más populares",
+    "fr": "Défilement vertical des plats les plus populaires",
+    "ru": "Вертикальная прокрутка самых популярных блюд",
+    "tr": "En Popüler Yemekler Dikey Kaydırma",
+    "zh": "最受欢迎食物的垂直滚动"
+  },
   "markings": {
     "de": "Kennzeichnungen",
     "en": "Labels",


### PR DESCRIPTION
## Summary
- add `FoodImage` component for reusable food images
- refactor `AutoImageScroller` to accept custom renderers
- support fetching most popular foods in `FoodHelper`
- implement `most-popular-foods-vertical-image-scroll` screen
- register screen in experiment menu and drawer
- update translations
- use `FoodImage` in `FoodItem`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68646c7066a483309fa77a58ad2548c1