### PR TITLE
Fix vertical centering for marking labels

### DIFF
--- a/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -252,7 +252,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
                   ...styles.label,
                   color: theme.screen.text,
                   fontSize: isWeb ? 18 : 14,
-                  marginTop: 2,
+                  textAlignVertical: 'center',
                 }}
               >
                 {markingText}

--- a/frontend/app/components/MarkingLabels/styles.ts
+++ b/frontend/app/components/MarkingLabels/styles.ts
@@ -31,6 +31,7 @@ export default StyleSheet.create({
     flexShrink: 1,
     flexWrap: 'wrap',
     flex: 1,
+    textAlignVertical: 'center',
   },
   labelContainer: {
     flexShrink: 1,


### PR DESCRIPTION
## Summary
- make text inside marking labels vertically centered

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6865b1a516a48330950002b6093584e3