### PR TITLE
Implement foodoffer prefetch and next-date navigation

### DIFF
--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -80,6 +80,7 @@ import { getAppElementTranslation } from '@/helper/resourceHelper';
 import noFoodOffersFound from '@/assets/animations/noFoodOffersFound.json';
 import LottieView from 'lottie-react-native';
 import { replaceLottieColors } from '@/helper/animationHelper';
+import { myContrastColor } from '@/helper/colorHelper';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
@@ -129,6 +130,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     drawerPosition,
     appSettings,
     primaryColor,
+    selectedTheme: mode,
   } = useSelector((state: RootState) => state.settings);
   const {
     ownFoodFeedbacks,
@@ -150,6 +152,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : primaryColor;
+  const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
 
   // Set Page Title
   useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);
@@ -988,13 +991,13 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                       }
                       style={[
                         styles.jumpButton,
-                        { backgroundColor: theme.activeBackground },
+                        { backgroundColor: foods_area_color },
                       ]}
                     >
                       <Text
                         style={[
                           styles.jumpButtonText,
-                          { color: theme.activeText },
+                          { color: contrastColor },
                         ]}
                       >
                         {`${translate(TranslationKeys.show_offers_on)} ${translate(

--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -73,7 +73,7 @@ import {
   sortByFoodCategory,
   sortByFoodOfferCategory,
 } from '@/helper/sortingHelper';
-import { format } from 'date-fns';
+import { format, addDays } from 'date-fns';
 import { BusinessHoursHelper } from '@/redux/actions/BusinessHours/BusinessHours';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';
 import { getAppElementTranslation } from '@/helper/resourceHelper';
@@ -146,6 +146,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const { appElements } = useSelector((state: RootState) => state.appElements);
   const { selectedCanteen, selectedCanteenFoodOffers, canteenFeedbackLabels } =
     useSelector((state: RootState) => state.canteenReducer);
+  const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, Foodoffers[]>>({});
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : primaryColor;
@@ -456,11 +457,35 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const fetchFoods = async () => {
     try {
       setLoading(true);
-      const foodData = await fetchFoodOffersByCanteen(
-        selectedCanteen?.id,
-        selectedDate
-      );
-      const foodOffers = foodData?.data || [];
+      let foodOffers = prefetchedFoodOffers[selectedDate];
+
+      if (!foodOffers) {
+        const foodData = await fetchFoodOffersByCanteen(
+          selectedCanteen?.id,
+          selectedDate
+        );
+        foodOffers = foodData?.data || [];
+      }
+
+      setPrefetchedFoodOffers((prev) => ({
+        ...prev,
+        [selectedDate]: foodOffers,
+      }));
+
+      // Prefetch next two days
+      for (let i = 1; i <= 2; i++) {
+        const date = addDays(new Date(selectedDate), i)
+          .toISOString()
+          .split('T')[0];
+        if (!prefetchedFoodOffers[date]) {
+          fetchFoodOffersByCanteen(selectedCanteen?.id, date)
+            .then((res) => {
+              const offers = res?.data || [];
+              setPrefetchedFoodOffers((p) => ({ ...p, [date]: offers }));
+            })
+            .catch((e) => console.error('Error prefetching Food Offers:', e));
+        }
+      }
 
       updateSort(sortBy, foodOffers);
 
@@ -521,6 +546,24 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     [canteenFeedbackLabels, selectedDate]
   );
   const canteenFeedbackLabelsExist = canteenFeedbackLabels?.length > 0;
+
+  const nextAvailableDate = useMemo(() => {
+    for (let i = 1; i <= 2; i++) {
+      const date = addDays(new Date(selectedDate), i)
+        .toISOString()
+        .split('T')[0];
+      const offers = prefetchedFoodOffers[date];
+      if (offers && offers.length > 0) {
+        return date;
+      }
+    }
+    return null;
+  }, [prefetchedFoodOffers, selectedDate]);
+
+  const getWeekdayKey = (date: string) => {
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    return days[new Date(date).getDay()];
+  };
 
   const SheetComponent =
     selectedSheet && selectedSheet !== 'menu'
@@ -935,6 +978,31 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                     )}
                   </Text>
                   <View style={styles.animationContainer}>{renderLottie}</View>
+                  {nextAvailableDate && (
+                    <TouchableOpacity
+                      onPress={() =>
+                        dispatch({
+                          type: SET_SELECTED_DATE,
+                          payload: nextAvailableDate,
+                        })
+                      }
+                      style={[
+                        styles.jumpButton,
+                        { backgroundColor: theme.activeBackground },
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.jumpButtonText,
+                          { color: theme.activeText },
+                        ]}
+                      >
+                        {`${translate(TranslationKeys.show_offers_on)} ${translate(
+                          TranslationKeys[getWeekdayKey(nextAvailableDate)]
+                        )}`}
+                      </Text>
+                    </TouchableOpacity>
+                  )}
                 </View>
               )}
             </View>

--- a/frontend/app/app/(app)/foodoffers/styles.ts
+++ b/frontend/app/app/(app)/foodoffers/styles.ts
@@ -76,4 +76,15 @@ export default StyleSheet.create({
     fontSize: 18,
     fontFamily: 'Poppins_400Regular',
   },
+  jumpButton: {
+    marginTop: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  jumpButtonText: {
+    fontSize: 16,
+    fontFamily: 'Poppins_500Medium',
+  },
 });

--- a/frontend/app/locales/keys.ts
+++ b/frontend/app/locales/keys.ts
@@ -94,6 +94,7 @@ export enum TranslationKeys {
   without_account_limitations = 'without_account_limitations',
   not_useable = 'not_useable',
   no_foodoffers_found_for_selection = 'no_foodoffers_found_for_selection',
+  show_offers_on = 'show_offers_on',
   error = 'error',
   description = 'description',
   information = 'information',

--- a/frontend/app/locales/translations.json
+++ b/frontend/app/locales/translations.json
@@ -1009,6 +1009,16 @@
     "tr": "Teklif bulunamadı veya yemekhane kapalı.",
     "zh": "未找到优惠或食堂已关闭。"
   },
+  "show_offers_on": {
+    "de": "Zeige Angebote am",
+    "en": "Show offers on",
+    "ar": "اعرض العروض في",
+    "es": "Mostrar ofertas el",
+    "fr": "Afficher les offres le",
+    "ru": "Показать предложения на",
+    "tr": "Teklifleri g\u00f6ster",
+    "zh": "\u663e\u793a\u4f18\u60e0 \u5728"
+  },
   "error": {
     "de": "Fehler",
     "en": "Error",


### PR DESCRIPTION
## Summary
- prefetch food offers for the next two days and cache them
- add button to skip to the next day with available offers
- introduce translation key `show_offers_on`
- style button in foodoffers screen

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a2bb440108330a6e57f4fe1eb674c