### PR TITLE
Introduce domain-specific sorting enums

### DIFF
--- a/frontend/app/app/(app)/campus/index.tsx
+++ b/frontend/app/app/(app)/campus/index.tsx
@@ -16,6 +16,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { CampusSortOption } from '@/constants/SortingEnums';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -133,18 +134,18 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   };
 
-  const updateSort = (id: string, campuses: Buildings[]) => {
+  const updateSort = (id: CampusSortOption, campuses: Buildings[]) => {
     setLoading(true);
     let copiedCampuses = [...campuses];
 
     switch (id) {
-      case 'intelligent':
+      case CampusSortOption.INTELLIGENT:
         copiedCampuses = sortCampusesWithDistance(copiedCampuses) || [];
         break;
-      case 'alphabetical':
+      case CampusSortOption.ALPHABETICAL:
         copiedCampuses = sortCampusesAlphabetically(copiedCampuses) || [];
         break;
-      case 'distance':
+      case CampusSortOption.DISTANCE:
         copiedCampuses = sortCampusesWithDistance(copiedCampuses) || [];
         break;
       default:
@@ -234,7 +235,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
   useEffect(() => {
     if (campuses && distanceAdded) {
-      updateSort(campusesSortBy, campuses);
+      updateSort(campusesSortBy as CampusSortOption, campuses);
     }
   }, [campusesSortBy, distanceAdded]);
 

--- a/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/frontend/app/app/(app)/foodoffers/index.tsx
@@ -16,6 +16,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { FoodSortOption } from '@/constants/SortingEnums';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import {
@@ -382,44 +383,44 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     return format(day, 'dd.MM.yyyy'); // Return the date if it's not Today, Yesterday, or Tomorrow
   };
 
-  const updateSort = (id: string, foodOffers: Foodoffers[]) => {
+  const updateSort = (id: FoodSortOption, foodOffers: Foodoffers[]) => {
     // Copy food offers to avoid mutation
     let copiedFoodOffers = [...foodOffers];
 
     // Sorting logic based on option id
     switch (id) {
-      case 'alphabetical':
+      case FoodSortOption.ALPHABETICAL:
         copiedFoodOffers = sortByFoodName(copiedFoodOffers, languageCode);
         break;
-      case 'favorite':
+      case FoodSortOption.FAVORITE:
         copiedFoodOffers = sortByOwnFavorite(
           copiedFoodOffers,
           ownFoodFeedbacks
         );
         break;
-      case 'eating':
+      case FoodSortOption.EATING:
         copiedFoodOffers = sortByEatingHabits(
           copiedFoodOffers,
           profile.markings
         );
         break;
-      case 'food_category':
+      case FoodSortOption.FOOD_CATEGORY:
         copiedFoodOffers = sortByFoodCategory(
           copiedFoodOffers,
           foodCategories,
             languageCode
         );
         break;
-      case 'foodoffer_category':
+      case FoodSortOption.FOODOFFER_CATEGORY:
         copiedFoodOffers = sortByFoodOfferCategory(
           copiedFoodOffers,
           foodOfferCategories
         );
         break;
-      case 'rating':
+      case FoodSortOption.RATING:
         copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
         break;
-      case 'intelligent':
+      case FoodSortOption.INTELLIGENT:
         copiedFoodOffers = intelligentSort(
           copiedFoodOffers,
           ownFoodFeedbacks,
@@ -491,7 +492,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         }
       }
 
-      updateSort(sortBy, foodOffers);
+      updateSort(sortBy as FoodSortOption, foodOffers);
 
       dispatch({
         type: SET_SELECTED_CANTEEN_FOOD_OFFERS_LOCAL,

--- a/frontend/app/app/(app)/housing/index.tsx
+++ b/frontend/app/app/(app)/housing/index.tsx
@@ -16,6 +16,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { ApartmentSortOption } from '@/constants/SortingEnums';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -227,23 +228,23 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     fetchAllApartments();
   }, []);
 
-  const updateSort = (id: string, apartments: Apartments[]) => {
+  const updateSort = (id: ApartmentSortOption, apartments: Apartments[]) => {
     // Copy food offers to avoid mutation
     setLoading(true);
     let copiedApartments = [...apartments];
 
     // Sorting logic based on option id
     switch (id) {
-      case 'intelligent':
+      case ApartmentSortOption.INTELLIGENT:
         copiedApartments = sortApartmentsIntelligently(copiedApartments) || [];
         break;
-      case 'alphabetical':
+      case ApartmentSortOption.ALPHABETICAL:
         copiedApartments = sortApartmentsAlphabetically(copiedApartments) || [];
         break;
-      case 'distance':
+      case ApartmentSortOption.DISTANCE:
         copiedApartments = sortApartmentsWithDistance(copiedApartments) || [];
         break;
-      case 'free rooms':
+      case ApartmentSortOption.FREE_ROOMS:
         copiedApartments =
           sortApartmentsByAvailableDate(copiedApartments) || [];
         break;
@@ -322,7 +323,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
   useEffect(() => {
     if (apartments && distanceAdded) {
-      updateSort(apartmentsSortBy, apartments);
+      updateSort(apartmentsSortBy as ApartmentSortOption, apartments);
     }
   }, [apartmentsSortBy, distanceAdded]);
 

--- a/frontend/app/components/BuildingSortSheet/BuildingSortSheet.tsx
+++ b/frontend/app/components/BuildingSortSheet/BuildingSortSheet.tsx
@@ -15,6 +15,11 @@ import {
   SET_APARTMENTS_SORTING,
   SET_CAMPUSES_SORTING,
 } from '@/redux/Types/types';
+import {
+  CampusSortOption,
+  ApartmentSortOption,
+  BuildingSortOption,
+} from '@/constants/SortingEnums';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/colorHelper';
@@ -35,7 +40,7 @@ const BuildingSortSheet: React.FC<BuildingSortSheetProps> = ({
     appSettings,
     selectedTheme: mode,
   } = useSelector((state: RootState) => state.settings);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [selectedOption, setSelectedOption] = useState<BuildingSortOption | null>(null);
   const housing_area_color = appSettings?.housing_area_color
     ? appSettings?.housing_area_color
     : projectColor;
@@ -50,28 +55,34 @@ const BuildingSortSheet: React.FC<BuildingSortSheetProps> = ({
 
   const sortingOptions = [
     {
-      id: 'intelligent',
+      id: freeRooms
+        ? ApartmentSortOption.INTELLIGENT
+        : CampusSortOption.INTELLIGENT,
       label: 'sort_option_intelligent',
       icon: <MaterialCommunityIcons name='brain' size={24} />,
     },
     {
-      id: 'free rooms',
+      id: ApartmentSortOption.FREE_ROOMS,
       label: 'free_rooms',
       icon: <MaterialCommunityIcons name='door-open' size={24} />,
     },
     {
-      id: 'distance',
+      id: freeRooms
+        ? ApartmentSortOption.DISTANCE
+        : CampusSortOption.DISTANCE,
       label: 'sort_option_distance',
       icon: <MaterialCommunityIcons name='map-marker-distance' size={24} />,
     },
 
     {
-      id: 'alphabetical',
+      id: freeRooms
+        ? ApartmentSortOption.ALPHABETICAL
+        : CampusSortOption.ALPHABETICAL,
       label: 'sort_option_alphabetical',
       icon: <FontAwesome5 name='sort-alpha-down' size={24} />,
     },
     {
-      id: 'none',
+      id: freeRooms ? ApartmentSortOption.NONE : CampusSortOption.NONE,
       label: 'sort_option_none',
       icon: <MaterialCommunityIcons name='sort-variant-remove' size={24} />,
     },
@@ -79,9 +90,9 @@ const BuildingSortSheet: React.FC<BuildingSortSheetProps> = ({
 
   const filteredSortingOptions = freeRooms
     ? sortingOptions
-    : sortingOptions.filter((option) => option.id !== 'free rooms');
+    : sortingOptions.filter((option) => option.id !== ApartmentSortOption.FREE_ROOMS);
 
-  const updateSort = (option: { id: string }) => {
+  const updateSort = (option: { id: BuildingSortOption }) => {
     setSelectedOption(option.id);
     if (freeRooms) {
       dispatch({ type: SET_APARTMENTS_SORTING, payload: option.id });
@@ -93,9 +104,9 @@ const BuildingSortSheet: React.FC<BuildingSortSheetProps> = ({
 
   useEffect(() => {
     if (freeRooms) {
-      setSelectedOption(apartmentsSortBy);
+      setSelectedOption(apartmentsSortBy as BuildingSortOption);
     } else {
-      setSelectedOption(campusesSortBy);
+      setSelectedOption(campusesSortBy as BuildingSortOption);
     }
   }, [campusesSortBy, apartmentsSortBy]);
 

--- a/frontend/app/components/SortSheet/SortSheet.tsx
+++ b/frontend/app/components/SortSheet/SortSheet.tsx
@@ -13,6 +13,7 @@ import {
 
 import { SortSheetProps } from './types';
 import Checkbox from 'expo-checkbox';
+import { FoodSortOption } from '@/constants/SortingEnums';
 import { SET_SELECTED_CANTEEN_FOOD_OFFERS, SET_SORTING } from '@/redux/Types/types';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -48,7 +49,7 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
     (state: RootState) => state.food
   );
   const { profile } = useSelector((state: RootState) => state.authReducer);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [selectedOption, setSelectedOption] = useState<FoodSortOption | null>(null);
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : primaryColor;
@@ -60,48 +61,48 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
 
   const sortingOptions = [
     {
-      id: 'intelligent',
+      id: FoodSortOption.INTELLIGENT,
       label: 'sort_option_intelligent',
       icon: <MaterialCommunityIcons name='brain' size={24} />,
     },
     {
-      id: 'favorite',
+      id: FoodSortOption.FAVORITE,
       label: 'sort_option_favorite',
       icon: <AntDesign name='heart' size={24} />,
     },
     {
-      id: 'eating',
+      id: FoodSortOption.EATING,
       label: 'eating_habits',
       icon: <Ionicons name='bag-add' size={24} />,
     },
     {
-      id: 'food_category',
+      id: FoodSortOption.FOOD_CATEGORY,
       label: 'sort_option_food_category',
       icon: <MaterialCommunityIcons name='food' size={24} />,
     },
     {
-      id: 'foodoffer_category',
+      id: FoodSortOption.FOODOFFER_CATEGORY,
       label: 'sort_option_foodoffer_category',
       icon: <MaterialCommunityIcons name='food-variant' size={24} />,
     },
     {
-      id: 'rating',
+      id: FoodSortOption.RATING,
       label: 'sort_option_public_rating',
       icon: <AntDesign name='star' size={24} />,
     },
     {
-      id: 'alphabetical',
+      id: FoodSortOption.ALPHABETICAL,
       label: 'sort_option_alphabetical',
       icon: <FontAwesome5 name='sort-alpha-down' size={24} />,
     },
     {
-      id: 'none',
+      id: FoodSortOption.NONE,
       label: 'sort_option_none',
       icon: <MaterialCommunityIcons name='sort-variant-remove' size={24} />,
     },
   ];
 
-  const updateSort = (option: { id: string }) => {
+  const updateSort = (option: { id: FoodSortOption }) => {
     setSelectedOption(option.id);
     dispatch({ type: SET_SORTING, payload: option.id });
 
@@ -110,38 +111,38 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
 
     // Sorting logic based on option id
     switch (option.id) {
-      case 'alphabetical':
+      case FoodSortOption.ALPHABETICAL:
         copiedFoodOffers = sortByFoodName(copiedFoodOffers, languageCode);
         break;
-      case 'favorite':
+      case FoodSortOption.FAVORITE:
         copiedFoodOffers = sortByOwnFavorite(
           copiedFoodOffers,
           ownFoodFeedbacks
         );
         break;
-      case 'eating':
+      case FoodSortOption.EATING:
         copiedFoodOffers = sortByEatingHabits(
           copiedFoodOffers,
           profile.markings
         );
         break;
-      case 'food_category':
+      case FoodSortOption.FOOD_CATEGORY:
         copiedFoodOffers = sortByFoodCategory(
           copiedFoodOffers,
           foodCategories,
             languageCode
         );
         break;
-      case 'foodoffer_category':
+      case FoodSortOption.FOODOFFER_CATEGORY:
         copiedFoodOffers = sortByFoodOfferCategory(
           copiedFoodOffers,
           foodOfferCategories
         );
         break;
-      case 'rating':
+      case FoodSortOption.RATING:
         copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
         break;
-      case 'intelligent':
+      case FoodSortOption.INTELLIGENT:
         copiedFoodOffers = intelligentSort(
           copiedFoodOffers,
           ownFoodFeedbacks,
@@ -165,7 +166,7 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
   };
 
   useEffect(() => {
-    setSelectedOption(sortBy);
+    setSelectedOption(sortBy as FoodSortOption);
   }, []);
 
   return (

--- a/frontend/app/constants/SortingEnums.ts
+++ b/frontend/app/constants/SortingEnums.ts
@@ -1,0 +1,27 @@
+export enum FoodSortOption {
+  INTELLIGENT = 'intelligent',
+  FAVORITE = 'favorite',
+  EATING = 'eating',
+  FOOD_CATEGORY = 'food_category',
+  FOODOFFER_CATEGORY = 'foodoffer_category',
+  RATING = 'rating',
+  ALPHABETICAL = 'alphabetical',
+  NONE = 'none',
+}
+
+export enum CampusSortOption {
+  INTELLIGENT = 'intelligent',
+  ALPHABETICAL = 'alphabetical',
+  DISTANCE = 'distance',
+  NONE = 'none',
+}
+
+export enum ApartmentSortOption {
+  INTELLIGENT = 'intelligent',
+  ALPHABETICAL = 'alphabetical',
+  DISTANCE = 'distance',
+  FREE_ROOMS = 'free rooms',
+  NONE = 'none',
+}
+
+export type BuildingSortOption = CampusSortOption | ApartmentSortOption;

--- a/frontend/app/redux/Types/stateTypes.ts
+++ b/frontend/app/redux/Types/stateTypes.ts
@@ -24,6 +24,11 @@ import {
   Profiles,
   Wikis,
 } from '@/constants/types';
+import {
+  FoodSortOption,
+  CampusSortOption,
+  ApartmentSortOption,
+} from '@/constants/SortingEnums';
 
 export interface AuthState {
   user: DirectusUsers | Record<string, any> | null;
@@ -60,9 +65,9 @@ export interface CanteensState {
 export interface SettingsState {
   selectedTheme: string;
   isWarning: boolean;
-  sortBy: string;
-  campusesSortBy: string;
-  apartmentsSortBy: string;
+  sortBy: FoodSortOption;
+  campusesSortBy: CampusSortOption;
+  apartmentsSortBy: ApartmentSortOption;
   serverInfo: Record<string, any>;
   primaryColor: string;
   appSettings: AppSettings;

--- a/frontend/app/redux/reducer/settingsReducer.ts
+++ b/frontend/app/redux/reducer/settingsReducer.ts
@@ -16,13 +16,18 @@ import {
   SET_WIKIS,
   SET_WIKIS_PAGES,
 } from '@/redux/Types/types';
+import {
+  FoodSortOption,
+  CampusSortOption,
+  ApartmentSortOption,
+} from '@/constants/SortingEnums';
 
 const initialState = {
   selectedTheme: 'systematic',
   isWarning: false,
-  sortBy: 'intelligent',
-  campusesSortBy: 'intelligent',
-  apartmentsSortBy: 'intelligent',
+  sortBy: FoodSortOption.INTELLIGENT,
+  campusesSortBy: CampusSortOption.INTELLIGENT,
+  apartmentsSortBy: ApartmentSortOption.INTELLIGENT,
   serverInfo: {},
   primaryColor: '#FCDE31',
   appSettings: {},


### PR DESCRIPTION
## Summary
- split SortOption into domain-specific enums
- refactor SortSheet to use FoodSortOption
- update BuildingSortSheet with CampusSortOption and ApartmentSortOption
- adapt campus and housing screens and redux state

## Testing
- `yarn lint` *(fails: No project found in repo)*
- `npx tsc --noEmit` *(shows help output)*

------
https://chatgpt.com/codex/tasks/task_e_686baedd73c08330a9b34ba813acfc85