### PR TITLE
Show missing food message in monitor week plan

### DIFF
--- a/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -511,8 +511,11 @@ const index = () => {
                 const dayName = weekDayNames[index];
                 const shortDayName = dayName?.concat('_S');
 
+                const columns = getColumns();
+                const totalFlex = columns.reduce((sum, c) => sum + c.flex, 0);
+
                 // Check if any column for this day has food items
-                const hasAnyFood = getColumns().some((col) => {
+                const hasAnyFood = columns.some((col) => {
                   if (col.key === 'day') return false;
                   return (
                     foods[dayName]?.some(
@@ -520,8 +523,6 @@ const index = () => {
                     ) || false
                   );
                 });
-
-                if (!hasAnyFood) return null;
 
                 return (
                   <View
@@ -540,8 +541,9 @@ const index = () => {
                         pageBreakInside: 'avoid', // Avoid the page break
                       }}
                     >
-                      {getColumns().map((col, colIndex) => {
-                        const foodItems = foods[dayName]
+                      {hasAnyFood ? (
+                        columns.map((col, colIndex) => {
+                          const foodItems = foods[dayName]
                           ?.filter(
                             (food: any) => food.food.food_category === col.key
                           )
@@ -660,20 +662,20 @@ const index = () => {
                             );
                           });
 
-                        return (
-                          <View
-                            key={col.key}
-                            style={[
-                              styles.cell,
-                              {
-                                flex: col.flex,
-                                borderRightWidth: 1,
-                                borderBottomWidth: 1,
-                                borderLeftWidth: colIndex === 0 ? 1 : 0,
-                                borderColor: foods_area_color,
-                              },
-                            ]}
-                          >
+                          return (
+                            <View
+                              key={col.key}
+                              style={[
+                                styles.cell,
+                                {
+                                  flex: col.flex,
+                                  borderRightWidth: 1,
+                                  borderBottomWidth: 1,
+                                  borderLeftWidth: colIndex === 0 ? 1 : 0,
+                                  borderColor: foods_area_color,
+                                },
+                              ]}
+                            >
                             {col.key === 'day' ? (
                               <View style={{ flexDirection: 'column' }}>
                                 <Text
@@ -718,9 +720,80 @@ const index = () => {
                                 )}
                               </View>
                             )}
+                            </View>
+                          );
+                        })
+                      ) : (
+                        <>
+                          <View
+                            style={[
+                              styles.cell,
+                              {
+                                flex: columns[0].flex,
+                                borderLeftWidth: 1,
+                                borderRightWidth: 1,
+                                borderBottomWidth: 1,
+                                borderColor: foods_area_color,
+                              },
+                            ]}
+                          >
+                            <View style={{ flexDirection: 'column' }}>
+                              <Text
+                                style={[
+                                  styles.itemText,
+                                  {
+                                    fontSize: isMobile ? fontSize : fontSize,
+                                    fontFamily: isMobile
+                                      ? 'Poppins_400Regular'
+                                      : 'Poppins_700Bold',
+                                    textAlign: 'center',
+                                    color: theme.screen.text,
+                                  },
+                                ]}
+                              >
+                                {translate(shortDayName)}
+                              </Text>
+                              <Text
+                                style={[
+                                  styles.itemText,
+                                  {
+                                    fontSize: isMobile ? fontSize : fontSize,
+                                    fontFamily: isMobile
+                                      ? 'Poppins_400Regular'
+                                      : 'Poppins_700Bold',
+                                    textAlign: 'center',
+                                    color: theme.screen.text,
+                                  },
+                                ]}
+                              >
+                                {formatDate(date)}
+                              </Text>
+                            </View>
                           </View>
-                        );
-                      })}
+                          <View
+                            style={[
+                              styles.cell,
+                              {
+                                flex: totalFlex - columns[0].flex,
+                                borderRightWidth: 1,
+                                borderBottomWidth: 1,
+                                borderColor: foods_area_color,
+                              },
+                            ]}
+                          >
+                            <Text
+                              style={{
+                                ...styles.noOffersText,
+                                color: theme.screen.text,
+                              }}
+                            >
+                              {translate(
+                                TranslationKeys.no_foodoffers_found_for_selection
+                              )}
+                            </Text>
+                          </View>
+                        </>
+                      )}
                     </View>
                   </View>
                 );

--- a/frontend/app/app/(monitor)/list-week-screen/details/styles.ts
+++ b/frontend/app/app/(monitor)/list-week-screen/details/styles.ts
@@ -53,4 +53,9 @@ export default StyleSheet.create({
     fontSize: 16,
     fontFamily: 'Poppins_400Regular',
   },
+  noOffersText: {
+    fontSize: 10,
+    fontFamily: 'Poppins_400Regular',
+    textAlign: 'center',
+  },
 });


### PR DESCRIPTION
## Summary
- add style for empty day message
- show translation text for days without offers in monitor week screen

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `npx -y tsc -p frontend/app/tsconfig.json --noEmit` *(fails: File 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c411da5b083309d9eeb628e74f3c3