### PR TITLE
Add shared package and integrate

### DIFF
--- a/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json
+++ b/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json
@@ -213,7 +213,8 @@
 		"short-unique-id": "^5.2.2",
 		"spark-md5": "^3.0.2",
 		"ts-morph": "^25.0.1",
-		"undici": "5.22.1",
-		"uuid": "^11.1.0"
-	}
+                "undici": "5.22.1",
+                "uuid": "^11.1.0",
+                "@rocket-meals/shared": "file:../../../../shared"
+        }
 }

--- a/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TimerHelper.ts
+++ b/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TimerHelper.ts
@@ -1,4 +1,6 @@
 
+import { MathUtil } from '@rocket-meals/shared';
+
 export class TimerHelper {
 
     private name: string;
@@ -30,7 +32,7 @@ export class TimerHelper {
 
     calcEstimatedFinishedDate(current_count: number) {
         //console.log("calcEstimatedFinishedDate: current_count: "+current_count)
-        let timeSpent = (this.private_getNow() - this.startTime) / 1000; // Time spent in seconds
+        let timeSpent = MathUtil.divide(MathUtil.subtract(this.private_getNow(), this.startTime), 1000); // Time spent in seconds
         //console.log("timeSpent: "+timeSpent);
         let averageTimePerTransaction = timeSpent / current_count;
         //console.log("averageTimePerTransaction: "+averageTimePerTransaction)

--- a/frontend/app/helper/CardDimensionHelper.ts
+++ b/frontend/app/helper/CardDimensionHelper.ts
@@ -1,3 +1,5 @@
+import { MathUtil } from '@rocket-meals/shared';
+
 export default class CardDimensionHelper {
   static getCardDimension(screenWidth: number): number {
     const dimensionMap = [
@@ -27,7 +29,7 @@ export default class CardDimensionHelper {
 
   static getCardWidth(screenWidth: number, columns: number): number {
     const offset = screenWidth < 500 ? 10 : screenWidth < 900 ? 25 : 35;
-    return screenWidth / columns - offset;
+    return MathUtil.subtract(screenWidth / columns, offset);
   }
 
   static getNumColumns(screenWidth: number, columnsSetting: number): number {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -110,7 +110,8 @@
     "redux-thunk": "^3.1.0",
     "reselect": "^5.1.1",
     "setimmediate": "^1.0.5",
-    "tinycolor2": "^1.6.0"
+    "tinycolor2": "^1.6.0",
+    "@rocket-meals/shared": "file:../../shared"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/shared/dist/MathUtil.d.ts
+++ b/shared/dist/MathUtil.d.ts
@@ -1,0 +1,6 @@
+export default class MathUtil {
+    static add(a: number, b: number): number;
+    static subtract(a: number, b: number): number;
+    static multiply(a: number, b: number): number;
+    static divide(a: number, b: number): number;
+}

--- a/shared/dist/MathUtil.js
+++ b/shared/dist/MathUtil.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class MathUtil {
+    static add(a, b) {
+        return a + b;
+    }
+    static subtract(a, b) {
+        return a - b;
+    }
+    static multiply(a, b) {
+        return a * b;
+    }
+    static divide(a, b) {
+        return a / b;
+    }
+}
+exports.default = MathUtil;

--- a/shared/dist/index.d.ts
+++ b/shared/dist/index.d.ts
@@ -1,0 +1,1 @@
+export { default as MathUtil } from './MathUtil';

--- a/shared/dist/index.js
+++ b/shared/dist/index.js
@@ -1,0 +1,8 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MathUtil = void 0;
+var MathUtil_1 = require("./MathUtil");
+Object.defineProperty(exports, "MathUtil", { enumerable: true, get: function () { return __importDefault(MathUtil_1).default; } });

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@rocket-meals/shared",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/shared/src/MathUtil.ts
+++ b/shared/src/MathUtil.ts
@@ -1,0 +1,17 @@
+export default class MathUtil {
+  static add(a: number, b: number): number {
+    return a + b;
+  }
+
+  static subtract(a: number, b: number): number {
+    return a - b;
+  }
+
+  static multiply(a: number, b: number): number {
+    return a * b;
+  }
+
+  static divide(a: number, b: number): number {
+    return a / b;
+  }
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,1 @@
+export { default as MathUtil } from './MathUtil';

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- create `shared` TypeScript library with simple `MathUtil`
- consume `MathUtil` from frontend and backend
- link the shared library via local file dependency

## Testing
- `npm run build` in `shared`
- `npx tsc` in `backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle` *(fails: cannot find modules)*
- `npx tsc` in `frontend/app` *(fails: expo tsconfig missing)*

------
https://chatgpt.com/codex/tasks/task_e_686cf8bf33548330a3a5016961c675a7