### PR TITLE
Replace frontend types import with repo-depkit-common

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -5,26 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useDispatch, useSelector } from 'react-redux';
 import { Redirect, useGlobalSearchParams } from 'expo-router';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
-import {
-  AppElements,
-  AppSettings,
-  Businesshours,
-  BusinesshoursGroups,
-  CanteensFeedbacksLabelsEntries,
-  CollectionsDatesLastUpdate,
-  FoodoffersCategories,
-  FoodsAttributes,
-  FoodsAttributesGroups,
-  FoodsCategories,
-  FoodsFeedbacks,
-  FoodsFeedbacksLabels,
-  FoodsFeedbacksLabelsEntries,
-  Markings,
-  MarkingsGroups,
-  PopupEvents,
-  Profiles,
-  Wikis,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   SET_APP_ELEMENTS,
   SET_APP_SETTINGS,
@@ -144,7 +125,7 @@ export default function Layout() {
       const foodFeedbackLabels =
         (await foodfeedbackLabelHelper.fetchFoodFeedbackLabels(
           {}
-        )) as FoodsFeedbacksLabels[];
+        )) as DatabaseTypes.FoodsFeedbacksLabels[];
       if (foodFeedbackLabels) {
         dispatch({
           type: UPDATE_FOOD_FEEDBACK_LABELS,
@@ -163,7 +144,7 @@ export default function Layout() {
       const profile = (await profileHelper.fetchProfileById(
         user?.profile,
         {}
-      )) as Profiles;
+      )) as DatabaseTypes.Profiles;
       if (profile?.id) {
         getOwnFeedback(profile?.id);
         getFeedbackEntries(profile?.id);
@@ -180,7 +161,7 @@ export default function Layout() {
       // Fetch own feedback
       const result = (await foodFeedbackHelper.fetchFoodFeedbackByProfileId(
         id
-      )) as FoodsFeedbacks[];
+      )) as DatabaseTypes.FoodsFeedbacks[];
       if (result) {
         dispatch({ type: UPDATE_OWN_FOOD_FEEDBACK, payload: result });
       }
@@ -194,7 +175,7 @@ export default function Layout() {
       const result =
         (await foodFeedbackLabelEntryHelper.fetchFoodFeedbackLabelEntriesByProfile(
           id
-        )) as FoodsFeedbacksLabelsEntries[];
+        )) as DatabaseTypes.FoodsFeedbacksLabelsEntries[];
       if (result) {
         dispatch({
           type: UPDATE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES,
@@ -211,7 +192,7 @@ export default function Layout() {
       const result =
         (await canteenFeedbackLabelEntryHelper.fetchCanteenFeedbackLabelEntriesByProfile(
           id
-        )) as CanteensFeedbacksLabelsEntries[];
+        )) as DatabaseTypes.CanteensFeedbacksLabelsEntries[];
       if (result) {
         dispatch({
           type: SET_OWN_CANTEEN_FEEDBACK_LABEL_ENTRIES,
@@ -227,10 +208,10 @@ export default function Layout() {
     try {
       const markingResult = (await markingHelper.fetchMarkings(
         {}
-      )) as Markings[];
+      )) as DatabaseTypes.Markings[];
       const markingGroupResult = (await markingGroupsHelper.fetchMarkingGroups(
         {}
-      )) as MarkingsGroups[];
+      )) as DatabaseTypes.MarkingsGroups[];
 
       // Use the sortMarkingsByGroup function to sort markings
       const sortedMarkings = sortMarkingsByGroup(markingResult, markingGroupResult);
@@ -243,7 +224,7 @@ export default function Layout() {
 
   const getNews = async () => {
     try {
-      const result = (await newsHelper.fetchNews({})) as News[];
+      const result = (await newsHelper.fetchNews({})) as DatabaseTypes.News[];
       if (result) {
         const today = new Date().toISOString().split('T')[0];
         const sortedNews = [...result].sort((a, b) => {
@@ -273,7 +254,7 @@ export default function Layout() {
     try {
       const result = (await foodCategoriesHelper.fetchFoodCategories(
         {}
-      )) as FoodsCategories[];
+      )) as DatabaseTypes.FoodsCategories[];
       if (result) {
         dispatch({ type: SET_FOOD_CATEGORIES, payload: sortBySortField(result) });
       }
@@ -287,7 +268,7 @@ export default function Layout() {
       const result =
         (await foodOffersCategoriesHelper.fetchFoodOffersCategories(
           {}
-        )) as FoodoffersCategories[];
+        )) as DatabaseTypes.FoodoffersCategories[];
       if (result) {
         dispatch({
           type: SET_FOOD_OFFERS_CATEGORIES,
@@ -302,14 +283,14 @@ export default function Layout() {
   const getAllFoodAttributes = async () => {
     try {
       const result =
-        (await foodAttributesHelper.fetchAllFoodAttributes()) as FoodsAttributes[];
+        (await foodAttributesHelper.fetchAllFoodAttributes()) as DatabaseTypes.FoodsAttributes[];
       if (result) {
         const attributesDict = result.reduce((acc, attr) => {
           if (attr.id) {
             acc[attr.id] = attr;
           }
           return acc;
-        }, {} as Record<string, FoodsAttributes>);
+        }, {} as Record<string, DatabaseTypes.FoodsAttributes>);
         dispatch({ type: SET_FOOD_ATTRIBUTES, payload: result });
         dispatch({ type: SET_FOOD_ATTRIBUTES_DICT, payload: attributesDict });
       }
@@ -323,7 +304,7 @@ export default function Layout() {
       const result =
         (await foodAttributeGroupHelper.fetchAllFoodAttributeGroups(
           {}
-        )) as FoodsAttributesGroups[];
+        )) as DatabaseTypes.FoodsAttributesGroups[];
       if (result) {
         dispatch({ type: SET_FOOD_ATTRIBUTE_GROUPS, payload: result });
       }
@@ -336,7 +317,7 @@ export default function Layout() {
     try {
       const result = (await businessHoursGroupsHelper.fetchBusinessHoursGroups(
         {}
-      )) as BusinesshoursGroups[];
+      )) as DatabaseTypes.BusinesshoursGroups[];
       if (result) {
         dispatch({ type: SET_BUSINESS_HOURS_GROUPS, payload: result });
       }
@@ -349,7 +330,7 @@ export default function Layout() {
     try {
       const businessHours = (await businessHoursHelper.fetchBusinessHours(
         {}
-      )) as Businesshours[];
+      )) as DatabaseTypes.Businesshours[];
       dispatch({ type: SET_BUSINESS_HOURS, payload: businessHours });
     } catch (error) {
       console.error('Error fetching business hours:', error);
@@ -358,7 +339,7 @@ export default function Layout() {
 
   const getWikis = async () => {
     try {
-      const response = (await wikisHelper.fetchWikis()) as Wikis[];
+      const response = (await wikisHelper.fetchWikis()) as DatabaseTypes.Wikis[];
       if (response) {
         dispatch({ type: SET_WIKIS, payload: response });
       }
@@ -371,7 +352,7 @@ export default function Layout() {
     try {
       const result = (await appSettingsHelper.fetchAppSettings(
         {}
-      )) as AppSettings;
+      )) as DatabaseTypes.AppSettings;
       if (result) {
         dispatch({ type: SET_APP_SETTINGS, payload: result });
       }
@@ -383,7 +364,7 @@ export default function Layout() {
   const getAllEvents = async () => {
     try {
       const response =
-        (await popupEventsHelper.fetchAllPopupEvents()) as PopupEvents[];
+        (await popupEventsHelper.fetchAllPopupEvents()) as DatabaseTypes.PopupEvents[];
       if (response) {
         const currentDate = new Date();
 
@@ -395,7 +376,7 @@ export default function Layout() {
             : 'show_on_web';
 
         const filteredEvents = response
-          .filter((event: PopupEvents) => {
+          .filter((event: DatabaseTypes.PopupEvents) => {
             const start = event.date_start ? new Date(event.date_start) : null;
             const end = event.date_end ? new Date(event.date_end) : null;
 
@@ -428,7 +409,7 @@ export default function Layout() {
     try {
       const result = (await appElementsHelper.fetchAllAppElements(
         {}
-      )) as AppElements[];
+      )) as DatabaseTypes.AppElements[];
       if (result) {
         dispatch({ type: SET_APP_ELEMENTS, payload: result });
       }
@@ -486,7 +467,7 @@ export default function Layout() {
       const result =
         (await collectionLastUpdateHelper.fetchCollectionDatesLastUpdate(
           {}
-        )) as CollectionsDatesLastUpdate[];
+        )) as DatabaseTypes.CollectionsDatesLastUpdate[];
       if (result) {
         const serverMap = transformUpdateDatesToMap(result);
         if (

--- a/apps/frontend/app/app/(app)/campus/details/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/index.tsx
@@ -18,7 +18,7 @@ import Information from '@/components/Information';
 import BuildingDescription from '@/components/BuildingDescription';
 import { useLocalSearchParams } from 'expo-router';
 import { useSelector } from 'react-redux';
-import { Buildings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -38,7 +38,7 @@ const details = () => {
   const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
   const [activeTab, setActiveTab] = useState('information');
   const [loading, setLoading] = useState(false);
-  const [campusDetails, setCampusDetails] = useState<Buildings | null>(null);
+  const [campusDetails, setCampusDetails] = useState<DatabaseTypes.Buildings | null>(null);
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
   );

--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -30,7 +30,7 @@ import { useFocusEffect, useNavigation } from 'expo-router';
 import BuildingItem from '@/components/BuildingItem/BuildingItem';
 import { useDispatch, useSelector } from 'react-redux';
 import { CampusHelper } from '@/redux/actions/Campus/Campus';
-import { Buildings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   SET_CAMPUSES,
   SET_CAMPUSES_DICT,
@@ -63,7 +63,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [campusesDispatched, setCampusesDispatched] = useState(false);
-  const [selectedBuilding, setSelectedBuilding] = useState<Buildings | null>();
+  const [selectedBuilding, setSelectedBuilding] = useState<DatabaseTypes.Buildings | null>();
   const [isActive, setIsActive] = useState(false);
   const [distanceAdded, setDistanceAdded] = useState(false);
   const [selectedApartmentId, setSelectedApartementId] = useState<string>('');
@@ -119,7 +119,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
   const fetchAllCampuses = async () => {
     setLoading(true);
-    const campusData = (await campusHelper.fetchCampus({})) as Buildings[];
+    const campusData = (await campusHelper.fetchCampus({})) as DatabaseTypes.Buildings[];
     const campuses = campusData || [];
     if (campuses) {
       const attributesDict = campuses.reduce((acc, campus) => {
@@ -127,14 +127,14 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           acc[campus.id] = campus;
         }
         return acc;
-      }, {} as Record<string, Buildings>);
+      }, {} as Record<string, DatabaseTypes.Buildings>);
       dispatch({ type: SET_CAMPUSES, payload: campuses });
       dispatch({ type: SET_CAMPUSES_DICT, payload: attributesDict });
       setCampusesDispatched(true);
     }
   };
 
-  const updateSort = (id: CampusSortOption, campuses: Buildings[]) => {
+  const updateSort = (id: CampusSortOption, campuses: DatabaseTypes.Buildings[]) => {
     setLoading(true);
     let copiedCampuses = [...campuses];
 
@@ -181,8 +181,8 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   }, [selectedBuilding, campusesDispatched]);
 
-  const addDistance = (campuses: Buildings[]) => {
-    let campusWithDistance: Array<Buildings> = [];
+  const addDistance = (campuses: DatabaseTypes.Buildings[]) => {
+    let campusWithDistance: Array<DatabaseTypes.Buildings> = [];
     if (campuses) {
       campuses?.forEach((campus: any) => {
         const distance = calculateDistanceInMeter(
@@ -198,7 +198,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   };
 
-  const sortCampusesWithDistance = (campuses: Buildings[]) => {
+  const sortCampusesWithDistance = (campuses: DatabaseTypes.Buildings[]) => {
     if (campuses) {
       return campuses?.sort((a: any, b: any) => a.distance - b.distance);
     } else {
@@ -206,7 +206,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   };
 
-  const sortCampusesAlphabetically = (campuses: Buildings[]) => {
+  const sortCampusesAlphabetically = (campuses: DatabaseTypes.Buildings[]) => {
     if (campuses) {
       return campuses?.sort((a: any, b: any) => a.alias.localeCompare(b.alias));
     } else {
@@ -218,7 +218,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     if (selectedCanteen?.building) {
       const buildingData = (await buildingsHelper.fetchBuildingById(
         String(selectedCanteen.building)
-      )) as Buildings;
+      )) as DatabaseTypes.Buildings;
       const building = buildingData || [];
       if (building) {
         setSelectedBuilding(building);

--- a/apps/frontend/app/app/(app)/data-access/types.ts
+++ b/apps/frontend/app/app/(app)/data-access/types.ts
@@ -1,4 +1,4 @@
-import { FoodoffersMarkings } from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface DataAccessScreenProps {
   closeSheet: () => void;

--- a/apps/frontend/app/app/(app)/eating-habits/index.tsx
+++ b/apps/frontend/app/app/(app)/eating-habits/index.tsx
@@ -19,7 +19,7 @@ import { isWeb } from '@/constants/Constants';
 import FoodLabelingInfo from '@/components/FoodLabelingInfo';
 import { useSelector } from 'react-redux';
 import MarkingLabels from '@/components/MarkingLabels/MarkingLabels';
-import { FoodoffersMarkings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { useLanguage } from '@/hooks/useLanguage';
 import { excerpt } from '@/constants/HelperFunctions';
 import animation from '@/assets/animations/allergist.json';

--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -30,7 +30,7 @@ import { FeedbackResponse } from './types';
 import useToast from '@/hooks/useToast';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { AppFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/colorHelper';
 
@@ -68,7 +68,7 @@ const FeedbackScreen = () => {
   const fetchFeedbackById = async () => {
     const response = (await appFeedback.fetchAppFeedbackById(
       String(app_feedbacks_id)
-    )) as AppFeedbacks;
+    )) as DatabaseTypes.AppFeedbacks;
     if (response) {
       setInputValues({
         title: response?.title,

--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -15,12 +15,7 @@ import {
   getpreviousFeedback,
   numToOneDecimal,
 } from '@/constants/HelperFunctions';
-import {
-  Foods,
-  FoodsFeedbacks,
-  FoodsTranslations,
-  Profiles,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -213,7 +208,7 @@ export default function FoodDetailsScreen() {
   }, [foodAttributes, foodAttributeGroups, foodDetails, foodCategories, foodOfferCategories]);
 
   const renderContent = useCallback(
-    (foodDetails: Foods) => {
+    (foodDetails: DatabaseTypes.Foods) => {
       switch (activeTab) {
         case 'feedbacks':
           return (
@@ -272,7 +267,7 @@ export default function FoodDetailsScreen() {
         foodDetails?.id,
         profile?.id,
         payload
-      )) as FoodsFeedbacks;
+      )) as DatabaseTypes.FoodsFeedbacks;
       if (updateFeedbackResult?.id) {
         dispatch({
           type: UPDATE_FOOD_FEEDBACK_LOCAL,
@@ -385,7 +380,7 @@ export default function FoodDetailsScreen() {
       const result = (await profileHelper.updateProfile({
         ...profile,
         devices: newDevices,
-      })) as Profiles;
+      })) as DatabaseTypes.Profiles;
       if (result) {
         dispatch({
           type: UPDATE_PROFILE,

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -37,11 +37,7 @@ import {
   SET_SELECTED_DATE,
   UPDATE_PROFILE,
 } from '@/redux/Types/types';
-import {
-  Businesshours,
-  CanteensFeedbacksLabels,
-  Foodoffers,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   Entypo,
   FontAwesome6,
@@ -149,7 +145,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const { appElements } = useSelector((state: RootState) => state.appElements);
   const { selectedCanteen, selectedCanteenFoodOffers, canteenFeedbackLabels } =
     useSelector((state: RootState) => state.canteenReducer);
-  const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, Foodoffers[]>>({});
+  const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : primaryColor;
@@ -319,7 +315,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     try {
       const businessHours = (await businessHoursHelper.fetchBusinessHours(
         {}
-      )) as Businesshours[];
+      )) as DatabaseTypes.Businesshours[];
       dispatch({ type: SET_BUSINESS_HOURS, payload: businessHours });
     } catch (error) {
       console.error('Error fetching business hours:', error);
@@ -383,7 +379,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     return format(day, 'dd.MM.yyyy'); // Return the date if it's not Today, Yesterday, or Tomorrow
   };
 
-  const updateSort = (id: FoodSortOption, foodOffers: Foodoffers[]) => {
+  const updateSort = (id: FoodSortOption, foodOffers: DatabaseTypes.Foodoffers[]) => {
     // Copy food offers to avoid mutation
     let copiedFoodOffers = [...foodOffers];
 
@@ -510,7 +506,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
       setFeedbackLabelsLoading(true);
       // Fetch Canteen Feedback Labels
       const canteenFeedbackLabels =
-        (await canteenFeedbackLabelHelper.fetchCanteenFeedbackLabels()) as CanteensFeedbacksLabels[];
+        (await canteenFeedbackLabelHelper.fetchCanteenFeedbackLabels()) as DatabaseTypes.CanteensFeedbacksLabels[];
       dispatch({
         type: SET_CANTEEN_FEEDBACK_LABELS,
         payload: canteenFeedbackLabels,
@@ -540,7 +536,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const memoizedCanteenFeedbackLabels = useMemo(
     () =>
       canteenFeedbackLabels?.map(
-        (label: CanteensFeedbacksLabels, index: number) => (
+        (label: DatabaseTypes.CanteensFeedbacksLabels, index: number) => (
           <CanteenFeedbackLabels
             key={label?.id || `feedback-label-${index}`}
             label={label}
@@ -962,7 +958,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 </View>
               ) : selectedCanteenFoodOffers &&
                 selectedCanteenFoodOffers?.length > 0 ? (
-                selectedCanteenFoodOffers?.map((item: Foodoffers) => (
+                selectedCanteenFoodOffers?.map((item: DatabaseTypes.Foodoffers) => (
                   <FoodItem
                     canteen={selectedCanteen}
                     item={item}

--- a/apps/frontend/app/app/(app)/form-categories/index.tsx
+++ b/apps/frontend/app/app/(app)/form-categories/index.tsx
@@ -11,7 +11,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { Entypo } from '@expo/vector-icons';
 import { FormCategoriesHelper } from '@/redux/actions/Forms/FormCategories';
-import { FormCategories } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { router, useFocusEffect } from 'expo-router';
 import { useSelector } from 'react-redux';
 import { getFromCategoryTranslation } from '@/helper/resourceHelper';
@@ -25,7 +25,7 @@ const index = () => {
   const { theme } = useTheme();
   const [loading, setLoading] = useState(false);
   const { language } = useSelector((state: RootState) => state.settings);
-  const [formCategories, setFormCategories] = useState<FormCategories[]>([]);
+  const [formCategories, setFormCategories] = useState<DatabaseTypes.FormCategories[]>([]);
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
   );
@@ -35,7 +35,7 @@ const index = () => {
     setLoading(true);
     const result = (await formCategoriesHelper.fetchFormCategories({
       filter: { status: { _eq: 'published' } },
-    })) as FormCategories[];
+    })) as DatabaseTypes.FormCategories[];
 
     if (result) {
       setLoading(false);

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -31,7 +31,7 @@ import useToast from '@/hooks/useToast';
 import { FormAnswersHelper } from '@/redux/actions/Forms/FormAnswers';
 import SubmissionWarningModal from '@/components/SubmissionWarningModal/SubmissionWarningModal';
 import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
-import { Buildings, FormAnswers, FormSubmissions } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import SingleLineInput from '@/components/SingleLineInput/SingleLineInput';
 import MultiLineInput from '@/components/MultiLineInput/MultiLineInput';
 import IBANInput from '@/components/IBANInput/IBANInput';
@@ -88,7 +88,7 @@ const index = () => {
   const [loading, setLoading] = useState(false);
   const [isActive, setIsActive] = useState(false);
   const [isWarning, setIsWarning] = useState(false);
-  const [formAnswers, setFormAnswers] = useState<FormAnswers[]>([]);
+  const [formAnswers, setFormAnswers] = useState<DatabaseTypes.FormAnswers[]>([]);
   const [loadingCollection, setLoadingCollection] = useState(false);
   const [collectionData, setCollectionData] = useState<any>([]);
   const [selectedState, setSelectedState] = useState('');
@@ -209,7 +209,7 @@ const index = () => {
   const checkValidity = async () => {
     const result = (await formsSubmissionsHelper.fetchFormubmissionById(
       String(form_submission_id)
-    )) as FormSubmissions;
+    )) as DatabaseTypes.FormSubmissions;
     if (result) {
       dispatch({ type: SET_FORM_SUBMISSION, payload: result });
       if (result?.user_locked_by && result?.user_locked_by !== user?.id) {
@@ -225,7 +225,7 @@ const index = () => {
             user_locked_by: String(user?.id),
             date_started: new Date().toISOString(),
           }
-        )) as FormSubmissions;
+        )) as DatabaseTypes.FormSubmissions;
       }
     } else {
       toast('Please reload the page', 'error');
@@ -243,7 +243,7 @@ const index = () => {
 
     const result = (await formAnswersHelper.fetchFormAnswers({
       filter: { form_submission: { _eq: form_submission_id } },
-    })) as FormAnswers[];
+    })) as DatabaseTypes.FormAnswers[];
 
     if (result) {
       const sortedResult = result.sort((a, b) => {
@@ -321,7 +321,7 @@ const index = () => {
               data.map(async (apartment: any) => {
                 const buildingData = (await buildingsHelper.fetchBuildingById(
                   apartment?.building
-                )) as Buildings;
+                )) as DatabaseTypes.Buildings;
 
                 return {
                   ...apartment,

--- a/apps/frontend/app/app/(app)/form-submissions/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submissions/index.tsx
@@ -18,7 +18,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { Entypo, FontAwesome, Ionicons } from '@expo/vector-icons';
 import { useLanguage } from '@/hooks/useLanguage';
-import { FormSubmissions } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useSelector } from 'react-redux';
 import { isWeb } from '@/constants/Constants';
@@ -45,7 +45,7 @@ const index = () => {
     Dimensions.get('window').width
   );
   const formsSubmissionsHelper = new FormsSubmissionsHelper();
-  const [formSubmissions, setFormSubmissions] = useState<FormSubmissions[]>([]);
+  const [formSubmissions, setFormSubmissions] = useState<DatabaseTypes.FormSubmissions[]>([]);
   const [selectedOption, setSelectedOption] = useState<string>('draft');
   const { drawerPosition } = useSelector((state: RootState) => state.settings);
 
@@ -69,7 +69,7 @@ const index = () => {
         state: selectedOption || 'draft',
         form: form_id,
         alias: query ? query?.trim() : '',
-      })) as FormSubmissions[];
+      })) as DatabaseTypes.FormSubmissions[];
 
       if (result) {
         if (append) {
@@ -121,7 +121,7 @@ const index = () => {
     return () => subscription?.remove();
   }, []);
 
-  const renderItem = ({ item }: { item: FormSubmissions }) => {
+  const renderItem = ({ item }: { item: DatabaseTypes.FormSubmissions }) => {
     return (
       <TouchableOpacity
         style={{

--- a/apps/frontend/app/app/(app)/forms/index.tsx
+++ b/apps/frontend/app/app/(app)/forms/index.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { Entypo } from '@expo/vector-icons';
-import { Forms } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useSelector } from 'react-redux';
 import { getFromCategoryTranslation } from '@/helper/resourceHelper';
@@ -26,7 +26,7 @@ const index = () => {
   const [loading, setLoading] = useState(false);
   const { category_id } = useLocalSearchParams();
   const { language } = useSelector((state: RootState) => state.settings);
-  const [forms, setForms] = useState<Forms[]>([]);
+  const [forms, setForms] = useState<DatabaseTypes.Forms[]>([]);
   const formsHelper = new FormsHelper();
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
@@ -36,7 +36,7 @@ const index = () => {
     setLoading(true);
     const result = (await formsHelper.fetchForms({
       filter: { category: { _eq: category_id }, status: { _eq: 'published' } },
-    })) as Forms[];
+    })) as DatabaseTypes.Forms[];
     if (result) {
       setLoading(false);
       setForms(result);

--- a/apps/frontend/app/app/(app)/housing/details/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/details/index.tsx
@@ -18,7 +18,7 @@ import Information from '@/components/Information';
 import BuildingDescription from '@/components/BuildingDescription';
 import { useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useSelector } from 'react-redux';
-import { Apartments } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import WashingMachines from '@/components/WashingMachines';
 import { myContrastColor } from '@/helper/colorHelper';
@@ -51,7 +51,7 @@ const details = () => {
   );
   const [activeTab, setActiveTab] = useState('information');
   const [loading, setLoading] = useState(false);
-  const [apartmentDetails, setApartmentDetails] = useState<Apartments | null>(
+  const [apartmentDetails, setApartmentDetails] = useState<DatabaseTypes.Apartments | null>(
     null
   );
   const [screenWidth, setScreenWidth] = useState(

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -28,7 +28,7 @@ import {
 import { RootDrawerParamList } from './types';
 import { useFocusEffect, useNavigation } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
-import { Apartments, Buildings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   SET_APARTMENTS,
   SET_APARTMENTS_DICT,
@@ -68,7 +68,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const [apartmentsDispatched, setApartmentsDispatched] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [distanceAdded, setDistanceAdded] = useState(false);
-  const [selectedBuilding, setSelectedBuilding] = useState<Buildings | null>();
+  const [selectedBuilding, setSelectedBuilding] = useState<DatabaseTypes.Buildings | null>();
   const [selectedApartmentId, setSelectedApartementId] = useState<string>('');
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
@@ -132,7 +132,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
       // Fetch all apartments
       const apartmentData = (await apartmentsHelper.fetchApartments(
         {}
-      )) as Apartments[];
+      )) as DatabaseTypes.Apartments[];
       const apartments = apartmentData || [];
 
       if (apartments && apartments?.length > 0) {
@@ -140,7 +140,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
           apartments.map(async (apartment) => {
             const buildingData = (await buildingsHelper.fetchBuildingById(
               String(apartment?.building)
-            )) as Buildings;
+            )) as DatabaseTypes.Buildings;
 
             return {
               ...apartment,
@@ -190,8 +190,8 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   }, [selectedBuilding, apartmentsDispatched]);
 
-  const addDistance = (apartments: Apartments[]) => {
-    let campusWithDistance: Array<Buildings> = [];
+  const addDistance = (apartments: DatabaseTypes.Apartments[]) => {
+    let campusWithDistance: Array<DatabaseTypes.Buildings> = [];
     if (apartments) {
       apartments?.forEach((apartment: any) => {
         const distance = Number(
@@ -213,7 +213,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     if (selectedCanteen?.building) {
       const buildingData = (await buildingsHelper.fetchBuildingById(
         selectedCanteen.building
-      )) as Buildings;
+      )) as DatabaseTypes.Buildings;
       const building = buildingData || [];
       if (building) {
         setSelectedBuilding(building);
@@ -228,7 +228,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     fetchAllApartments();
   }, []);
 
-  const updateSort = (id: ApartmentSortOption, apartments: Apartments[]) => {
+  const updateSort = (id: ApartmentSortOption, apartments: DatabaseTypes.Apartments[]) => {
     // Copy food offers to avoid mutation
     setLoading(true);
     let copiedApartments = [...apartments];
@@ -269,7 +269,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     if (!apartments) return apartments;
 
     return apartments.sort((a, b) => {
-      // Priority 1: Apartments marked as free (no `available_from`)
+      // Priority 1: DatabaseTypes.Apartments marked as free (no `available_from`)
       const isFreeA = !a.available_from;
       const isFreeB = !b.available_from;
 
@@ -281,7 +281,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     });
   };
 
-  const sortApartmentsWithDistance = (apartments: Apartments[]) => {
+  const sortApartmentsWithDistance = (apartments: DatabaseTypes.Apartments[]) => {
     if (apartments) {
       return apartments?.sort((a: any, b: any) => a.distance - b.distance);
     } else {
@@ -289,7 +289,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   };
 
-  const sortApartmentsAlphabetically = (apartments: Apartments[]) => {
+  const sortApartmentsAlphabetically = (apartments: DatabaseTypes.Apartments[]) => {
     if (apartments) {
       return apartments?.sort((a: any, b: any) =>
         a.alias.localeCompare(b.alias)
@@ -299,7 +299,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     }
   };
 
-  const sortApartmentsByAvailableDate = (apartments: Apartments[]) => {
+  const sortApartmentsByAvailableDate = (apartments: DatabaseTypes.Apartments[]) => {
     if (!apartments) return apartments;
 
     return apartments.sort((a, b) => {

--- a/apps/frontend/app/app/(app)/index.tsx
+++ b/apps/frontend/app/app/(app)/index.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/redux/Types/types';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
-import { Buildings, Canteens } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { RootState } from '@/redux/reducer';
 
@@ -47,7 +47,7 @@ const Home = () => {
     }
   };
 
-  const handleSelectCanteen = (canteen: Canteens) => {
+  const handleSelectCanteen = (canteen: DatabaseTypes.Canteens) => {
     dispatch({ type: SET_SELECTED_CANTEEN, payload: canteen });
     router.push('/(app)/foodoffers');
   };
@@ -57,7 +57,7 @@ const Home = () => {
       setLoading(true);
       const buildingsData = (await buildingsHelper.fetchBuildings(
         {}
-      )) as Buildings[];
+      )) as DatabaseTypes.Buildings[];
       const buildings = buildingsData || [];
 
       const buildingsDict = buildings.reduce(
@@ -72,7 +72,7 @@ const Home = () => {
 
       const canteensData = (await canteenHelper.fetchCanteens(
         {}
-      )) as Canteens[];
+      )) as DatabaseTypes.Canteens[];
 
       const filteredCanteens = canteensData.filter((canteen) => {
         const status = canteen.status || '';

--- a/apps/frontend/app/app/(app)/news/index.tsx
+++ b/apps/frontend/app/app/(app)/news/index.tsx
@@ -11,7 +11,7 @@ import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import NewsItem from '@/components/NewsItem/NewsItem';
 import { NewsHelper } from '@/redux/actions/News/News';
-import { News } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import { SET_NEWS } from '@/redux/Types/types';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -34,7 +34,7 @@ const index = () => {
 
   const fetchAllNews = async () => {
   setLoading(true);
-  const newsData = (await newsHelper.fetchNews({})) as News[];
+  const newsData = (await newsHelper.fetchNews({})) as DatabaseTypes.News[];
 
   const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 
@@ -94,7 +94,7 @@ const index = () => {
             </View>
           ) : (
             news &&
-            news?.map((item: News, index: number) => {
+            news?.map((item: DatabaseTypes.News, index: number) => {
               if (item?.translations?.length > 1) {
                 return <NewsItem key={item?.id} news={item} />;
               }

--- a/apps/frontend/app/app/(app)/notification/index.tsx
+++ b/apps/frontend/app/app/(app)/notification/index.tsx
@@ -22,7 +22,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchFoodDetailsById } from '@/redux/actions/FoodOffers/FoodOffers';
 import { excerpt } from '@/constants/HelperFunctions';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
-import { FoodsFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   DELETE_FOOD_FEEDBACK_LOCAL,
   UPDATE_FOOD_FEEDBACK_LOCAL,
@@ -117,7 +117,7 @@ const NotificationScreen = () => {
 
   // Update notification status
   const updateFoodFeedbackNotification = async (
-    feedbackData: FoodsFeedbacks
+    feedbackData: DatabaseTypes.FoodsFeedbacks
   ) => {
     try {
       const payload = {
@@ -128,7 +128,7 @@ const NotificationScreen = () => {
         String(feedbackData?.food),
         profile?.id,
         payload
-      )) as FoodsFeedbacks;
+      )) as DatabaseTypes.FoodsFeedbacks;
       if (updateFeedbackResult?.id) {
         dispatch({
           type: UPDATE_FOOD_FEEDBACK_LOCAL,

--- a/apps/frontend/app/app/(app)/price-group/index.tsx
+++ b/apps/frontend/app/app/(app)/price-group/index.tsx
@@ -22,7 +22,7 @@ import { useFocusEffect } from 'expo-router';
 import { replaceLottieColors } from '@/helper/animationHelper';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { Profiles } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/colorHelper';
 
@@ -106,7 +106,7 @@ const index = () => {
       setSelectedOption(option);
       const payload = { ...profile, price_group: option };
       if (profile.id) {
-        const result = (await profileHelper.updateProfile(payload)) as Profiles;
+        const result = (await profileHelper.updateProfile(payload)) as DatabaseTypes.Profiles;
         if (result) {
           dispatch({ type: UPDATE_PROFILE, payload });
         }

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -80,7 +80,7 @@ import {
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { Profiles } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 
 const Settings = () => {
@@ -135,7 +135,7 @@ const Settings = () => {
       const result = (await profileHelper.updateProfile({
         ...profile,
         nickname: nickname?.trim(),
-      })) as Profiles;
+      })) as DatabaseTypes.Profiles;
       if (result) {
         dispatch({
           type: UPDATE_PROFILE,

--- a/apps/frontend/app/app/(app)/support-ticket/index.tsx
+++ b/apps/frontend/app/app/(app)/support-ticket/index.tsx
@@ -15,21 +15,21 @@ import { format } from 'date-fns';
 import { router, useFocusEffect } from 'expo-router';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { AppFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 const index = () => {
   useSetPageTitle(TranslationKeys.my_support_tickets);
   const { theme } = useTheme();
   const appFeedback = new AppFeedback();
   const [loading, setLoading] = useState(false);
-  const [allTickets, setAllTickets] = useState<AppFeedbacks[] | null>(null);
+  const [allTickets, setAllTickets] = useState<DatabaseTypes.AppFeedbacks[] | null>(null);
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
 
   const getAllTickets = async () => {
     setLoading(true);
-    const allTickets = (await appFeedback.fetchAppFeedback()) as AppFeedbacks[];
+    const allTickets = (await appFeedback.fetchAppFeedback()) as DatabaseTypes.AppFeedbacks[];
     if (allTickets) {
       setAllTickets(allTickets);
       setLoading(false);

--- a/apps/frontend/app/app/(auth)/login.tsx
+++ b/apps/frontend/app/app/(auth)/login.tsx
@@ -22,7 +22,7 @@ import {
 import AttentionSheet from '@/components/Login/AttentionSheet';
 import useToast from '@/hooks/useToast';
 import { updateLoginStatus } from '@/constants/HelperFunctions';
-import { AppSettings, DirectusUsers, Wikis } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { format } from 'date-fns';
 import { WikisHelper } from '@/redux/actions/Wikis/Wikis';
 import { AppSettingsHelper } from '@/redux/actions/AppSettings/AppSettings';
@@ -80,7 +80,7 @@ export default function Login() {
     try {
       const result = (await appSettingsHelper.fetchAppSettings(
         {}
-      )) as AppSettings;
+      )) as DatabaseTypes.AppSettings;
       if (result) {
         dispatch({ type: SET_APP_SETTINGS, payload: result });
       }
@@ -148,7 +148,7 @@ export default function Login() {
       }
       dispatch({ type: UPDATE_MANAGEMENT, payload: isManagement });
 
-      updateLoginStatus(dispatch, user as DirectusUsers);
+      updateLoginStatus(dispatch, user as DatabaseTypes.DirectusUsers);
       const currentDate = getCurrentDate();
 
       dispatch({
@@ -205,7 +205,7 @@ export default function Login() {
 
   const getWikis = async () => {
     try {
-      const response = (await wikisHelper.fetchWikis()) as Wikis[];
+      const response = (await wikisHelper.fetchWikis()) as DatabaseTypes.Wikis[];
       if (response) {
         dispatch({ type: SET_WIKIS, payload: response });
       }

--- a/apps/frontend/app/app/(monitor)/_layout.tsx
+++ b/apps/frontend/app/app/(monitor)/_layout.tsx
@@ -4,7 +4,7 @@ import { Stack } from 'expo-router';
 import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
-import { AppSettings, Markings, MarkingsGroups } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups';
 import { MarkingHelper } from '@/redux/actions/Markings/Markings';
 import { useDispatch, useSelector } from 'react-redux';
@@ -26,10 +26,10 @@ export default function MonitorLayout() {
   const { appSettings } = useSelector((state: RootState) => state.settings);
 
   const getMarkings = async () => {
-    const markingResult = (await markingHelper.fetchMarkings({})) as Markings[];
+    const markingResult = (await markingHelper.fetchMarkings({})) as DatabaseTypes.Markings[];
     const markingGroupResult = (await markingGroupsHelper.fetchMarkingGroups(
       {}
-    )) as MarkingsGroups[];
+    )) as DatabaseTypes.MarkingsGroups[];
 
     // Use the sortMarkingsByGroup function to sort markings
     const sortedMarkings = sortMarkingsByGroup(markingResult, markingGroupResult);
@@ -40,7 +40,7 @@ export default function MonitorLayout() {
   const getAppSettings = async () => {
     const result = (await appSettingsHelper.fetchAppSettings(
       {}
-    )) as AppSettings;
+    )) as DatabaseTypes.AppSettings;
     if (result) {
       dispatch({ type: SET_APP_SETTINGS, payload: result });
     }

--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -28,7 +28,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import { FoodCategoriesHelper } from '@/redux/actions/FoodCategories/FoodCategories';
-import { FoodoffersCategories, FoodsCategories } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   SET_FOOD_CATEGORIES,
   SET_FOOD_OFFERS_CATEGORIES,
@@ -96,7 +96,7 @@ const Index = () => {
     try {
       const result = (await foodCategoriesHelper.fetchFoodCategories(
         {}
-      )) as FoodsCategories[];
+      )) as DatabaseTypes.FoodsCategories[];
       if (result) {
         dispatch({ type: SET_FOOD_CATEGORIES, payload: result });
       }
@@ -110,7 +110,7 @@ const Index = () => {
       const result =
         (await foodOffersCategoriesHelper.fetchFoodOffersCategories(
           {}
-        )) as FoodoffersCategories[];
+        )) as DatabaseTypes.FoodoffersCategories[];
       if (result) {
         dispatch({ type: SET_FOOD_OFFERS_CATEGORIES, payload: result });
       }

--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -41,7 +41,7 @@ import { myContrastColor } from '@/helper/colorHelper';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
-import { FoodsAttributes } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodAttributesHelper } from '@/redux/actions/FoodAttributes/FoodAttributes';
 
 type FoodAttribute = {
@@ -93,14 +93,14 @@ const Index = () => {
   const getAllFoodAttributes = async () => {
     try {
       const result =
-        (await foodAttributesHelper.fetchAllFoodAttributes()) as FoodsAttributes[];
+        (await foodAttributesHelper.fetchAllFoodAttributes()) as DatabaseTypes.FoodsAttributes[];
       if (result) {
         const attributesDict = result.reduce((acc, attr) => {
           if (attr.id) {
             acc[attr.id] = attr;
           }
           return acc;
-        }, {} as Record<string, FoodsAttributes>);
+        }, {} as Record<string, DatabaseTypes.FoodsAttributes>);
         dispatch({ type: SET_FOOD_ATTRIBUTES, payload: result });
         dispatch({ type: SET_FOOD_ATTRIBUTES_DICT, payload: attributesDict });
       }

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -30,12 +30,7 @@ import MarkingIcon from '@/components/MarkingIcon';
 import { FoodAttributesHelper } from '@/redux/actions/FoodAttributes/FoodAttributes';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import {
-  Buildings,
-  Canteens,
-  FoodsAttributes,
-  FoodsCategories,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { ColumnPercentages } from './types';
 import { RootState } from '@/redux/reducer';
 import { CanteenHelper } from '@/redux/actions';
@@ -67,7 +62,7 @@ const index = () => {
   const [foods, setFoods] = useState([]);
   const [optionalFoods, setOptionalFoods] = useState([]);
   const [foodMarkings, setFoodMarkings] = useState<any>({});
-  const [foodCategories, setFoodCategories] = useState<FoodsCategories[]>([]);
+  const [foodCategories, setFoodCategories] = useState<DatabaseTypes.FoodsCategories[]>([]);
   const [optionalFoodMarkings, setOptionalFoodMarkings] = useState<any>({});
   const [mainFoodCategories, setMainFoodCategories] = useState<any>({});
   const [optionalFoodCategories, setOptionalFoodCategories] = useState<any>({});
@@ -144,7 +139,7 @@ const index = () => {
     try {
       const result = (await foodCategoriesHelper.fetchFoodCategories(
         {}
-      )) as FoodsCategories[];
+      )) as DatabaseTypes.FoodsCategories[];
       if (result) {
         dispatch({ type: SET_FOOD_CATEGORIES, payload: result });
       }
@@ -199,7 +194,7 @@ const index = () => {
             attributeIds.map(async (id: string) => {
               const attr = (await foodAttributesHelper.fetchFoodAttributeById(
                 id
-              )) as FoodsAttributes;
+              )) as DatabaseTypes.FoodsAttributes;
               const title = attr?.translations
                 ? getFoodAttributesTranslation(attr.translations, language)
                 : '';
@@ -228,7 +223,7 @@ const index = () => {
     try {
       const buildingsData = (await buildingsHelper.fetchBuildings(
         {}
-      )) as Buildings[];
+      )) as DatabaseTypes.Buildings[];
       const buildings = buildingsData || [];
 
       const buildingsDict = buildings.reduce(
@@ -241,7 +236,7 @@ const index = () => {
 
       const canteensData = (await canteenHelper.fetchCanteens(
         {}
-      )) as Canteens[];
+      )) as DatabaseTypes.Canteens[];
 
       const filteredCanteens = canteensData.filter((canteen) => {
         const status = canteen.status || '';
@@ -286,7 +281,7 @@ const index = () => {
 
   const fetchSelectedCanteen = useCallback(async () => {
     if (!canteens_id) return;
-    let canteensData: Canteens[] = [];
+    let canteensData: DatabaseTypes.Canteens[] = [];
     if (!canteens || canteens.length === 0) {
       canteensData = await getCanteensWithBuildings();
     } else {
@@ -487,7 +482,7 @@ const index = () => {
   const fetchCurrentFoodCategory = async (
     foodList: any,
     setCategoryState: any,
-    foodCategories: FoodsCategories[]
+    foodCategories: DatabaseTypes.FoodsCategories[]
   ) => {
     if (!foodList) return;
 
@@ -496,7 +491,7 @@ const index = () => {
     for (const food of foodList) {
       if (food?.food?.food_category) {
         const category = foodCategories.find(
-          (cat: FoodsCategories) => cat.id === food?.food?.food_category
+          (cat: DatabaseTypes.FoodsCategories) => cat.id === food?.food?.food_category
         );
         if (category) {
           newCategories[food.id] = category;

--- a/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -26,7 +26,7 @@ import { useLocalSearchParams } from 'expo-router';
 import moment from 'moment';
 import { useLanguage } from '@/hooks/useLanguage';
 import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
-import { FoodsCategories, Markings, MarkingsGroups } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups';
 import { MarkingHelper } from '@/redux/actions/Markings/Markings';
 import { UPDATE_MARKINGS } from '@/redux/Types/types';
@@ -140,7 +140,7 @@ const index = () => {
           if (!newCategories[categoryId]) {
             const result = (await foodCategoriesHelper.fetchFoodCategoriesById(
               categoryId
-            )) as FoodsCategories;
+            )) as DatabaseTypes.FoodsCategories;
             if (result) {
               newCategories[categoryId] = {
                 alias: result?.alias,
@@ -260,10 +260,10 @@ const index = () => {
     try {
       const markingResult = (await markingHelper.fetchMarkings(
         {}
-      )) as Markings[];
+      )) as DatabaseTypes.Markings[];
       const markingGroupResult = (await markingGroupsHelper.fetchMarkingGroups(
         {}
-      )) as MarkingsGroups[];
+      )) as DatabaseTypes.MarkingsGroups[];
 
       // Use the sortMarkingsByGroup function to sort markings
       const sortedMarkings = sortMarkingsByGroup(markingResult, markingGroupResult);

--- a/apps/frontend/app/app/(monitor)/statistics/index.tsx
+++ b/apps/frontend/app/app/(monitor)/statistics/index.tsx
@@ -15,7 +15,7 @@ import {
   SET_MOST_DISLIKED_FOODS,
   SET_MOST_LIKED_FOODS,
 } from '@/redux/Types/types';
-import { Foods } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
@@ -116,7 +116,7 @@ const index = () => {
           </Text>
           <ScrollView>
             {mostLikedFoods &&
-              mostLikedFoods?.map((item: Foods) => (
+              mostLikedFoods?.map((item: DatabaseTypes.Foods) => (
                 <StatisticsCard
                   key={item.id}
                   food={item}
@@ -133,7 +133,7 @@ const index = () => {
           </Text>
           <ScrollView>
             {mostDislikedFoods &&
-              mostDislikedFoods?.map((item: Foods) => (
+              mostDislikedFoods?.map((item: DatabaseTypes.Foods) => (
                 <StatisticsCard
                   key={item.id}
                   food={item}

--- a/apps/frontend/app/app/(wikis)/_layout.tsx
+++ b/apps/frontend/app/app/(wikis)/_layout.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { Stack } from 'expo-router';
-import { Wikis } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { SET_WIKIS } from '@/redux/Types/types';
 import { useDispatch, useSelector } from 'react-redux';
 import { WikisHelper } from '@/redux/actions/Wikis/Wikis';
@@ -15,7 +15,7 @@ export default function FoodOfferLayout() {
 
   const getWikis = async () => {
     try {
-      const response = (await wikisHelper.fetchWikis()) as Wikis[];
+      const response = (await wikisHelper.fetchWikis()) as DatabaseTypes.Wikis[];
       if (response) {
         dispatch({ type: SET_WIKIS, payload: response });
       }

--- a/apps/frontend/app/app/(wikis)/wikis/index.tsx
+++ b/apps/frontend/app/app/(wikis)/wikis/index.tsx
@@ -22,7 +22,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { isWeb } from '@/constants/Constants';
 import DeviceMock from '@/components/DeviceMock/DeviceMock';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { Wikis } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { RootState } from '@/redux/reducer';
 import { TranslationKeys } from '@/locales/keys';
@@ -31,7 +31,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 const index = () => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
-  const [wiki, setWiki] = useState<Wikis>();
+  const [wiki, setWiki] = useState<DatabaseTypes.Wikis>();
   const [loading, setLoading] = useState(true);
   const { wikis, language, primaryColor } = useSelector(
     (state: RootState) => state.settings

--- a/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -12,10 +12,7 @@ import {
   getIconComponent,
   getTextFromTranslation,
 } from '@/helper/resourceHelper';
-import {
-  CanteensFeedbacksLabelsEntries,
-  FoodsFeedbacksLabelsEntries,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   DELETE_OWN_CANTEEN_FEEDBACK_LABEL_ENTRIES,
@@ -67,11 +64,11 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
   const labelData = useMemo(() => {
     return (
       ownCanteenFeedBackLabelEntries?.find(
-        (entry: CanteensFeedbacksLabelsEntries) =>
+        (entry: DatabaseTypes.CanteensFeedbacksLabelsEntries) =>
           entry.label === label?.id &&
           entry.canteen === selectedCanteen?.id &&
           isSameDay(entry.date, date)
-      ) || ({} as FoodsFeedbacksLabelsEntries)
+      ) || ({} as DatabaseTypes.FoodsFeedbacksLabelsEntries)
     );
   }, [ownCanteenFeedBackLabelEntries, date]);
 
@@ -98,7 +95,7 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
         likeStats,
         selectedCanteen.id,
         date
-      )) as CanteensFeedbacksLabelsEntries;
+      )) as DatabaseTypes.CanteensFeedbacksLabelsEntries;
     getLabelEntries(label?.id);
     dispatch({
       type: result

--- a/apps/frontend/app/components/CanteenFeedbackLabels/types.ts
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/types.ts
@@ -1,7 +1,7 @@
-import { CanteensFeedbacksLabels, CanteensFeedbacksLabelsTranslations, FoodsFeedbacksLabelsTranslations } from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface CanteenFeedbackLabelProps {
-  label: CanteensFeedbacksLabels;
+  label: DatabaseTypes.CanteensFeedbacksLabels;
   date: string;
 }
 

--- a/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
+++ b/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
@@ -14,7 +14,7 @@ import {
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
-import { Buildings, Canteens } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CanteenHelper } from '@/redux/actions';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { TranslationKeys } from '@/locales/keys';
@@ -36,7 +36,7 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
   );
   const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
 
-  const handleSelectCanteen = (canteen: Canteens) => {
+  const handleSelectCanteen = (canteen: DatabaseTypes.Canteens) => {
     dispatch({ type: SET_SELECTED_CANTEEN, payload: canteen });
     closeSheet();
   };
@@ -45,7 +45,7 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
     try {
       const buildingsData = (await buildingsHelper.fetchBuildings(
         {}
-      )) as Buildings[];
+      )) as DatabaseTypes.Buildings[];
       const buildings = buildingsData || [];
 
       const buildingsDict = buildings.reduce(
@@ -60,7 +60,7 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
 
       const canteensData = (await canteenHelper.fetchCanteens(
         {}
-      )) as Canteens[];
+      )) as DatabaseTypes.Canteens[];
 
       const filteredCanteens = canteensData.filter((canteen) => {
         const status = canteen.status || '';

--- a/apps/frontend/app/components/CanteenSelectionSheet/types.ts
+++ b/apps/frontend/app/components/CanteenSelectionSheet/types.ts
@@ -1,10 +1,10 @@
-import { Canteens } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface CanteenSelectionSheetProps {
   closeSheet: () => void;
 }
 
-export interface CanteenProps extends Canteens {
+export interface CanteenProps extends DatabaseTypes.Canteens {
   imageAssetId: string;
   image_url: string;
 }

--- a/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -29,7 +29,7 @@ import { isBefore, isEqual, parse } from 'date-fns';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/colorHelper';
 import { TranslationKeys } from '@/locales/keys';
-import { Profiles } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 
 const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({
@@ -209,7 +209,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({
       const result = (await profileHelper.updateProfile({
         ...profile,
         course_timetable: updatedTimetableString,
-      })) as Profiles;
+      })) as DatabaseTypes.Profiles;
       if (result) {
         dispatch({
           type: UPDATE_PROFILE,
@@ -237,7 +237,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({
         const result = (await profileHelper.updateProfile({
           ...profile,
           course_timetable: courseTimetable,
-        })) as Profiles;
+        })) as DatabaseTypes.Profiles;
         if (result) {
           dispatch({
             type: UPDATE_PROFILE,
@@ -304,7 +304,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({
           const result = (await profileHelper.updateProfile({
             ...profile,
             course_timetable: courseTimetable,
-          })) as Profiles;
+          })) as DatabaseTypes.Profiles;
           if (result) {
             dispatch({
               type: UPDATE_PROFILE,

--- a/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -39,7 +39,7 @@ import * as Linking from 'expo-linking';
 import useToast from '@/hooks/useToast';
 import { getTitleFromTranslation } from '@/helper/resourceHelper';
 import { WikisHelper } from '@/redux/actions/Wikis/Wikis';
-import { Wikis } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { IconProps } from '@expo/vector-icons/build/createIconSet';
 import { AntDesign } from '@expo/vector-icons';
 import { Feather } from '@expo/vector-icons';
@@ -221,7 +221,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
 
   const getWikis = async () => {
     try {
-      const response = (await wikisHelper.fetchWikis()) as Wikis[];
+      const response = (await wikisHelper.fetchWikis()) as DatabaseTypes.Wikis[];
       if (response) {
         dispatch({ type: SET_WIKIS, payload: response });
       }
@@ -324,7 +324,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
       });
     }
 
-    // Add Wikis dynamically with position sorting
+    // Add DatabaseTypes.Wikis dynamically with position sorting
     if (wikis) {
       const wikiMenuItems = wikis
         .filter((wiki: any) => wiki.show_in_drawer) // Only show relevant wikis

--- a/apps/frontend/app/components/EatingHabitsSheet/types.ts
+++ b/apps/frontend/app/components/EatingHabitsSheet/types.ts
@@ -1,4 +1,4 @@
-import { FoodoffersMarkings } from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface EatingHabitsSheetProps {
   closeSheet: () => void;

--- a/apps/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
+++ b/apps/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
@@ -14,7 +14,7 @@ import { sheetProps } from './types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
-import { FormSubmissions } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { SET_FORM_SUBMISSION } from '@/redux/Types/types';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
@@ -39,7 +39,7 @@ const EditFormSubmissionSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
         {
           alias: alias,
         }
-      )) as FormSubmissions;
+      )) as DatabaseTypes.FormSubmissions;
       if (update) {
         dispatch({ type: SET_FORM_SUBMISSION, payload: update });
         setLoading(false);

--- a/apps/frontend/app/components/FeedbackLabel/index.tsx
+++ b/apps/frontend/app/components/FeedbackLabel/index.tsx
@@ -9,7 +9,7 @@ import {
   getIconComponent,
   getTextFromTranslation,
 } from '@/helper/resourceHelper';
-import { FoodsFeedbacksLabelsEntries } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackLabelEntryHelper } from '@/redux/actions/FoodFeeedbackLabelEntries/FoodFeedbackLabelEntries';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -61,10 +61,10 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
   const labelData = useMemo(() => {
     return (
       labelEntries?.find(
-        (entry: FoodsFeedbacksLabelsEntries) =>
+        (entry: DatabaseTypes.FoodsFeedbacksLabelsEntries) =>
           entry.label === label[0]?.foods_feedbacks_labels_id &&
           entry.food === foodId
-      ) || ({} as FoodsFeedbacksLabelsEntries)
+      ) || ({} as DatabaseTypes.FoodsFeedbacksLabelsEntries)
     );
   }, [label, labelEntries]);
 
@@ -92,7 +92,7 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
         likeStats,
         selectedCanteen?.id,
         offerId
-      )) as FoodsFeedbacksLabelsEntries;
+      )) as DatabaseTypes.FoodsFeedbacksLabelsEntries;
     dispatch({
       type: result
         ? UPDATE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL

--- a/apps/frontend/app/components/FeedbackLabel/types.ts
+++ b/apps/frontend/app/components/FeedbackLabel/types.ts
@@ -1,7 +1,7 @@
-import { FoodsFeedbacksLabelsTranslations } from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface FeedbackLabelProps {
-  label: Array<FoodsFeedbacksLabelsTranslations>;
+  label: Array<DatabaseTypes.FoodsFeedbacksLabelsTranslations>;
   imageUrl?: string | null | undefined;
   icon?: string;
   labelEntries: any;

--- a/apps/frontend/app/components/Feedbacks/index.tsx
+++ b/apps/frontend/app/components/Feedbacks/index.tsx
@@ -18,7 +18,7 @@ import {
   getpreviousFeedback,
   numToOneDecimal,
 } from '@/constants/HelperFunctions';
-import { FoodsFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
 import useToast from '@/hooks/useToast';
 import { DateHelper } from 'repo-depkit-common';
@@ -111,7 +111,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({
         foodDetails?.id,
         profile?.id,
         { ...previousFeedback, comment: string, canteen: foodOfferCanteenId }
-      )) as FoodsFeedbacks;
+      )) as DatabaseTypes.FoodsFeedbacks;
       // Dispatch the correct action
       dispatch({
         type: result?.id

--- a/apps/frontend/app/components/Feedbacks/types.ts
+++ b/apps/frontend/app/components/Feedbacks/types.ts
@@ -1,7 +1,7 @@
-import { Foods } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface FeedbacksProps {
-  foodDetails: Foods;
+  foodDetails: DatabaseTypes.Foods;
   canteenId?: string;
   offerId: string;
 }

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -27,7 +27,7 @@ import {
   getDescriptionFromTranslation,
   getTextFromTranslation,
 } from '@/helper/resourceHelper';
-import { Foods, Markings, ProfilesMarkings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   SET_MARKING_DETAILS,
@@ -74,7 +74,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
     const { theme } = useTheme();
     const { translate } = useLanguage();
     const { food } = item;
-    const foodItem = food as Foods;
+    const foodItem = food as DatabaseTypes.Foods;
     const markings = useSelector(selectMarkings);
     const { user, profile, isManagement } = useSelector(
       (state: RootState) => state.authReducer
@@ -133,7 +133,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       () =>
         item?.markings?.filter((marking) =>
           profile?.markings?.some(
-            (profileMarking: ProfilesMarkings) =>
+            (profileMarking: DatabaseTypes.ProfilesMarkings) =>
               profileMarking?.markings_id === marking?.markings_id &&
               profileMarking?.like === false
           )
@@ -165,7 +165,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
     const markingsData = useMemo(
       () =>
         markings
-          ?.filter((m: Markings) =>
+          ?.filter((m: DatabaseTypes.Markings) =>
             item?.markings.some((mark) => mark.markings_id === m.id)
           )
           .slice(0, 2),
@@ -178,7 +178,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       return () => subscription?.remove();
     }, []);
 
-    const openMarkingLabel = (marking: Markings) => {
+    const openMarkingLabel = (marking: DatabaseTypes.Markings) => {
       dispatch({
         type: SET_MARKING_DETAILS,
         payload: marking,

--- a/apps/frontend/app/components/FoodItem/types.ts
+++ b/apps/frontend/app/components/FoodItem/types.ts
@@ -1,13 +1,13 @@
 import { SHEET_COMPONENTS } from '@/app/(app)/foodoffers';
-import {Foodoffers, Foods, FoodoffersMarkings, Canteens} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface FoodItemProps {
-  item: Foodoffers;
-  canteen: Canteens;
+  item: DatabaseTypes.Foodoffers;
+  canteen: DatabaseTypes.Canteens;
   // handleNavigation: (id: string, foodId: string) => void;
   handleMenuSheet: (sheet: keyof typeof SHEET_COMPONENTS) => void;
   handleImageSheet: (id: string) => void;
   handleEatingHabitsSheet: (sheet: keyof typeof SHEET_COMPONENTS) => void;
-  // setItemMarkings: React.Dispatch<React.SetStateAction<FoodoffersMarkings[]>>;
+  // setItemMarkings: React.Dispatch<React.SetStateAction<DatabaseTypes.FoodoffersMarkings[]>>;
   setSelectedFoodId: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -21,7 +21,7 @@ import { useSelector } from 'react-redux';
 import { useFocusEffect } from 'expo-router';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
-import { UtilizationsEntries } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 
 const ForecastSheet: React.FC<ForecastSheetProps> = ({
@@ -108,7 +108,7 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({
           {},
           selectedCanteen?.utilization_group,
           forDate
-        )) as UtilizationsEntries[];
+        )) as DatabaseTypes.UtilizationsEntries[];
       if (utilizationData) {
         const processedData = processData(utilizationData);
         setChartData(processedData);

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -13,7 +13,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
 import { useLanguage } from '@/hooks/useLanguage';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
-import { Buildings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { BusinessHoursHelper } from '@/redux/actions/BusinessHours/BusinessHours';
 import { BusinessHour, HourSheetProps } from './types';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
@@ -96,7 +96,7 @@ const HourSheet: React.FC<HourSheetProps> = ({ closeSheet }) => {
       setLoading(true);
       const buildingData = (await buildingsHelper.fetchBuildingById(
         selectedCanteen.building as string
-      )) as Buildings;
+      )) as DatabaseTypes.Buildings;
 
       if (!buildingData?.businesshours?.length) {
         setHours(null);

--- a/apps/frontend/app/components/ImageUpload/ImageUpload.tsx
+++ b/apps/frontend/app/components/ImageUpload/ImageUpload.tsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { isWeb } from '@/constants/Constants';
 import { FormAnswersHelper } from '@/redux/actions/Forms/FormAnswers';
-import { FormAnswers } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { deleteDirectusFile } from '@/constants/HelperFunctions';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
@@ -88,7 +88,7 @@ const ImageUpload = ({
       if (!value?.name) {
         const formAnswer = (await formAnswersHelper.fetchFormsById(id, {
           fields: ['id', 'value_image'],
-        })) as FormAnswers;
+        })) as DatabaseTypes.FormAnswers;
 
         if (formAnswer && formAnswer?.value_image) {
           const isFileDeleted = await deleteDirectusFile(
@@ -100,7 +100,7 @@ const ImageUpload = ({
               {
                 value_image: null,
               }
-            )) as FormAnswers;
+            )) as DatabaseTypes.FormAnswers;
 
             if (deleteResponse) {
               onChange(id, null, custom_type);

--- a/apps/frontend/app/components/Labels/index.tsx
+++ b/apps/frontend/app/components/Labels/index.tsx
@@ -7,7 +7,7 @@ import FoodLabelingInfo from '../FoodLabelingInfo';
 import MarkingLabels from '../MarkingLabels/MarkingLabels';
 import { getFoodOffer } from '@/constants/HelperFunctions';
 import { studentUnionUrl } from '@/constants/Constants';
-import { FoodoffersMarkings, Markings, MarkingsGroups } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { createSelector } from 'reselect';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -57,7 +57,7 @@ const Labels: React.FC<LabelsProps> = ({
   const foodOffer = useSelector(selectFoodOffer(offerId));
 
   // State for marking groups
-  const [markingGroups, setMarkingGroups] = useState<MarkingsGroups[]>([]);
+  const [markingGroups, setMarkingGroups] = useState<DatabaseTypes.MarkingsGroups[]>([]);
 
   // Fetch marking groups
   useEffect(() => {
@@ -81,10 +81,10 @@ const Labels: React.FC<LabelsProps> = ({
 
     // First, map food offer markings to actual marking objects
     const mappedMarkings = foodOffer.markings
-      ?.map((marking: FoodoffersMarkings) =>
-        markings.find((mark: Markings) => mark.id === marking?.markings_id)
+      ?.map((marking: DatabaseTypes.FoodoffersMarkings) =>
+        markings.find((mark: DatabaseTypes.Markings) => mark.id === marking?.markings_id)
       )
-      .filter((mark: any): mark is Markings => Boolean(mark));
+      .filter((mark: any): mark is DatabaseTypes.Markings => Boolean(mark));
 
     // Then sort them using the sortMarkingsByGroup function
     return sortMarkingsByGroup(mappedMarkings, markingGroups);
@@ -96,7 +96,7 @@ const Labels: React.FC<LabelsProps> = ({
         {translate(TranslationKeys.markings)}
       </Text>
 
-      {foodMarkings?.map((marking: Markings) => (
+      {foodMarkings?.map((marking: DatabaseTypes.Markings) => (
         <MarkingLabels
           key={marking.id}
           markingId={marking.id}

--- a/apps/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
+++ b/apps/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
@@ -11,7 +11,7 @@ import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CanteenHelper } from '@/redux/actions';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
-import { Buildings, Canteens } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { SET_BUILDINGS, SET_CANTEENS } from '@/redux/Types/types';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
@@ -37,7 +37,7 @@ const ManagementCanteensSheet: React.FC<ManagementCanteensSheetProps> = ({
     try {
       const buildingsData = (await buildingsHelper.fetchBuildings(
         {}
-      )) as Buildings[];
+      )) as DatabaseTypes.Buildings[];
       const buildings = buildingsData || [];
 
       const buildingsDict = buildings.reduce(
@@ -52,7 +52,7 @@ const ManagementCanteensSheet: React.FC<ManagementCanteensSheetProps> = ({
 
       const canteensData = (await canteenHelper.fetchCanteens(
         {}
-      )) as Canteens[];
+      )) as DatabaseTypes.Canteens[];
 
       const filteredCanteens = canteensData.filter((canteen) => {
         const status = canteen.status || '';

--- a/apps/frontend/app/components/ManagementCanteensSheet/types.ts
+++ b/apps/frontend/app/components/ManagementCanteensSheet/types.ts
@@ -1,11 +1,11 @@
-import { Canteens } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface ManagementCanteensSheetProps {
   closeSheet: () => void;
   handleSelectCanteen: (canteen: any) => void;
 }
 
-export interface CanteenProps extends Canteens {
+export interface CanteenProps extends DatabaseTypes.Canteens {
   imageAssetId: string;
   image_url: string;
 }

--- a/apps/frontend/app/components/ManagementFoodCategorySheet/ManagementFoodCategorySheet.tsx
+++ b/apps/frontend/app/components/ManagementFoodCategorySheet/ManagementFoodCategorySheet.tsx
@@ -16,7 +16,7 @@ import { isWeb } from '@/constants/Constants';
 import { SET_DAY_PLAN } from '@/redux/Types/types';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { RootState } from '@/redux/reducer';
-import { FoodoffersCategories, FoodsCategories } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 const ManagementFoodCategorySheet: React.FC<
   ManagementFoodCategorySheetProps
@@ -24,7 +24,7 @@ const ManagementFoodCategorySheet: React.FC<
   const { theme } = useTheme();
   const dispatch = useDispatch();
   const [isCustom, setIsCustom] = useState(false);
-  const [list, setList] = useState<FoodsCategories[] | FoodoffersCategories[]>(
+  const [list, setList] = useState<DatabaseTypes.FoodsCategories[] | DatabaseTypes.FoodoffersCategories[]>(
     []
   );
   const { dayPlan } = useSelector((state: RootState) => state.management);

--- a/apps/frontend/app/components/MarkingIcon/index.tsx
+++ b/apps/frontend/app/components/MarkingIcon/index.tsx
@@ -6,11 +6,11 @@ import { useMyContrastColor } from '@/helper/colorHelper';
 import { iconLibraries } from '../Drawer/CustomDrawerContent';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import styles from './styles';
-import { Markings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 
 interface MarkingIconProps {
-  marking: Markings;
+  marking: DatabaseTypes.Markings;
   size?: number;
   color?: string;
   compact?: boolean;

--- a/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -19,7 +19,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
 import styles from './styles';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
-import { Markings, Profiles } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { useMyContrastColor } from '@/helper/colorHelper';
 import { iconLibraries } from '../Drawer/CustomDrawerContent';
 import MarkingIcon from '../MarkingIcon';
@@ -59,7 +59,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
     (mark: any) => mark.markings_id === markingId
   );
 
-  const openMarkingLabel = (marking: Markings) => {
+  const openMarkingLabel = (marking: DatabaseTypes.Markings) => {
     if (handleMenuSheet) {
       dispatch({
         type: SET_MARKING_DETAILS,
@@ -75,7 +75,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
       const profile = (await profileHelper.fetchProfileById(
         user?.profile,
         {}
-      )) as Profiles;
+      )) as DatabaseTypes.Profiles;
       if (profile) {
         dispatch({ type: UPDATE_PROFILE, payload: profile });
       }
@@ -165,7 +165,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({
         // Update profile on the server
         const result = (await profileHelper.updateProfile(
           profileData
-        )) as Profiles;
+        )) as DatabaseTypes.Profiles;
         if (result) {
           fetchProfile();
           if (like) {

--- a/apps/frontend/app/components/NotificationSheet/NotificationSheet.tsx
+++ b/apps/frontend/app/components/NotificationSheet/NotificationSheet.tsx
@@ -24,7 +24,7 @@ import { useFocusEffect } from 'expo-router';
 import { replaceLottieColors } from '@/helper/animationHelper';
 import { myContrastColor } from '@/helper/colorHelper';
 import { TranslationKeys } from '@/locales/keys';
-import { FoodsFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 
 const NotificationSheet: React.FC<NotificationSheetProps> = ({
@@ -108,7 +108,7 @@ const NotificationSheet: React.FC<NotificationSheetProps> = ({
         foodDetails?.id,
         profile?.id,
         payload
-      )) as FoodsFeedbacks;
+      )) as DatabaseTypes.FoodsFeedbacks;
       if (updateFeedbackResult?.id) {
         dispatch({
           type: UPDATE_FOOD_FEEDBACK_LOCAL,

--- a/apps/frontend/app/components/NotificationSheet/types.ts
+++ b/apps/frontend/app/components/NotificationSheet/types.ts
@@ -1,7 +1,7 @@
-import { Foods, FoodsFeedbacks } from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface NotificationSheetProps {
   closeSheet: () => void;
-  previousFeedback: FoodsFeedbacks;
-  foodDetails: Foods;
+  previousFeedback: DatabaseTypes.FoodsFeedbacks;
+  foodDetails: DatabaseTypes.Foods;
 }

--- a/apps/frontend/app/components/StatisticsCard/types.ts
+++ b/apps/frontend/app/components/StatisticsCard/types.ts
@@ -1,7 +1,7 @@
-import { Foods } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface StatisticsCardProps {
-  food: Foods;
+  food: DatabaseTypes.Foods;
   handleImageSheet: () => void;
   setSelectedFoodId: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/apps/frontend/app/components/SubmissionWarningModal/SubmissionWarningModal.tsx
+++ b/apps/frontend/app/components/SubmissionWarningModal/SubmissionWarningModal.tsx
@@ -15,7 +15,7 @@ import { useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
 import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
-import { FormSubmissions } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 
@@ -43,7 +43,7 @@ const SubmissionWarningModal: React.FC<SubmissionWarningModalProps> = ({
         user_locked_by: String(user?.id),
         date_started: new Date().toISOString(),
       }
-    )) as FormSubmissions;
+    )) as DatabaseTypes.FormSubmissions;
     if (update) {
       setIsVisible(false);
       setLoading(false);

--- a/apps/frontend/app/components/SubmissionWarningSheet/SubmissionWarningSheet.tsx
+++ b/apps/frontend/app/components/SubmissionWarningSheet/SubmissionWarningSheet.tsx
@@ -15,7 +15,7 @@ import { useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { router } from 'expo-router';
 import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
-import { FormSubmissions } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 
@@ -35,7 +35,7 @@ const SubmissionWarningSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
         user_locked_by: String(user?.id),
         date_started: new Date().toISOString(),
       }
-    )) as FormSubmissions;
+    )) as DatabaseTypes.FormSubmissions;
     if (update) {
       closeSheet();
       setLoading(false);

--- a/apps/frontend/app/components/WashingMachines/index.tsx
+++ b/apps/frontend/app/components/WashingMachines/index.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
-import { Apartments, Washingmachines } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { differenceInSeconds, format, isAfter, isBefore } from 'date-fns';
 import washingmachine from '@/assets/animations/washingmachine/washingmachine.json';
 import washingmachineEmpty from '@/assets/animations/washingmachine/washingmachineEmpty.json';
@@ -21,7 +21,7 @@ const WashingMachines: React.FC<any> = ({ campusDetails }) => {
   const { theme } = useTheme();
   const apartmentsHelper = new ApartmentsHelper();
   const [washingMachines, setWashingMachines] = useState<
-    Washingmachines[] | any[]
+    DatabaseTypes.Washingmachines[] | any[]
   >();
   const [loading, setLoading] = useState(false);
   const { primaryColor, appSettings } = useSelector(
@@ -64,7 +64,7 @@ const WashingMachines: React.FC<any> = ({ campusDetails }) => {
 
     const response = (await apartmentsHelper.fetchApartmentWithWashingMachines(
       apartmentId
-    )) as Apartments;
+    )) as DatabaseTypes.Apartments;
     if (response.washingmachines) {
       setWashingMachines(response?.washingmachines);
     }

--- a/apps/frontend/app/helper/DeviceHelper.ts
+++ b/apps/frontend/app/helper/DeviceHelper.ts
@@ -1,6 +1,6 @@
 import {Dimensions, PixelRatio, useWindowDimensions} from 'react-native';
 import {EdgeInsets, useSafeAreaInsets} from 'react-native-safe-area-context';
-import {Devices} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import * as DeviceInfo from 'expo-device';
 import {DeviceType} from 'expo-device';
 import usePlatformHelper from '@/helper/platformHelper';
@@ -122,8 +122,8 @@ export function getIsLandScape(): boolean {
 	return isLandscape;
 }
 
-export function getCurrentDevice(deviceInformationsId: string | undefined, devices: any): Devices | undefined {
-	let foundDevice: undefined | Devices = undefined;
+export function getCurrentDevice(deviceInformationsId: string | undefined, devices: any): DatabaseTypes.Devices | undefined {
+	let foundDevice: undefined | DatabaseTypes.Devices = undefined;
 	if (deviceInformationsId) {
 		for (const device of devices) {
 			if (getDeviceIdentifier(device) === deviceInformationsId) {
@@ -135,11 +135,11 @@ export function getCurrentDevice(deviceInformationsId: string | undefined, devic
 	return foundDevice;
 }
 
-export function getDeviceIdentifier(device: Partial<Devices>) {
+export function getDeviceIdentifier(device: Partial<DatabaseTypes.Devices>) {
 	return device.platform+'_'+device.brand+'_'+device.system_version;
 }
 
-export function getDeviceInformationWithoutPushToken(): Partial<Devices> { // Promise<DeviceInformationType>
+export function getDeviceInformationWithoutPushToken(): Partial<DatabaseTypes.Devices> { // Promise<DeviceInformationType>
 	const { getPlatformDisplayName, isIOS, isAndroid, isWeb } = usePlatformHelper();
     const windowWidth = Dimensions.get('screen').width;
 	const windowHeight = Dimensions.get('screen').height;

--- a/apps/frontend/app/helper/FoodHelper.ts
+++ b/apps/frontend/app/helper/FoodHelper.ts
@@ -1,4 +1,4 @@
-import { Foods } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from './collectionHelper';
 
 export async function loadMostLikedOrDislikedFoods(
@@ -7,7 +7,7 @@ export async function loadMostLikedOrDislikedFoods(
   minRatingAmount: number | undefined,
   bestFirst: boolean
 ) {
-  const collectionHelper = new CollectionHelper<Foods>('foods');
+  const collectionHelper = new CollectionHelper<DatabaseTypes.Foods>('foods');
   if (!minRatingAmount) {
     minRatingAmount = 1;
   }

--- a/apps/frontend/app/helper/MarkingHelper.ts
+++ b/apps/frontend/app/helper/MarkingHelper.ts
@@ -1,12 +1,12 @@
-import {Foodoffers, FoodoffersMarkings, ProfilesMarkings} from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export class MarkingHelper {
 
-	static getDislikedMarkingIds(foodOffer: Foodoffers, profileMarkingsDict: Record<string, ProfilesMarkings>) {
+	static getDislikedMarkingIds(foodOffer: DatabaseTypes.Foodoffers, profileMarkingsDict: Record<string, DatabaseTypes.ProfilesMarkings>) {
 		const aMarkingsIds = MarkingHelper.getFoodOfferMarkingIds(foodOffer);
 		let dislikedMarkingIds: string[] = [];
 		for(const marking_id of aMarkingsIds){
-			const profilesMarking: ProfilesMarkings = profileMarkingsDict[marking_id];
+			const profilesMarking: DatabaseTypes.ProfilesMarkings = profileMarkingsDict[marking_id];
 			if(profilesMarking){
 				const like = profilesMarking.like;
 				if(like !== null && like !== undefined && like===false){
@@ -17,11 +17,11 @@ export class MarkingHelper {
 		return dislikedMarkingIds;
 	}
 
-	static getLikedMarkingIds(foodOffer: Foodoffers, profileMarkingsDict: Record<string, ProfilesMarkings>) {
+	static getLikedMarkingIds(foodOffer: DatabaseTypes.Foodoffers, profileMarkingsDict: Record<string, DatabaseTypes.ProfilesMarkings>) {
 		const aMarkingsIds = MarkingHelper.getFoodOfferMarkingIds(foodOffer);
 		let likedMarkingIds: string[] = [];
 		for(const marking_id of aMarkingsIds){
-			const profilesMarking: ProfilesMarkings = profileMarkingsDict[marking_id];
+			const profilesMarking: DatabaseTypes.ProfilesMarkings = profileMarkingsDict[marking_id];
 			if(profilesMarking){
 				const like = profilesMarking.like;
 				if(like !== null && like !== undefined && like===true){
@@ -32,19 +32,19 @@ export class MarkingHelper {
 		return likedMarkingIds;
 	}
 
-	static areLikedEatingHabitsFoundInFoodOffer(foodOffer: Foodoffers, profileMarkingsDict: Record<string, ProfilesMarkings>) {
+	static areLikedEatingHabitsFoundInFoodOffer(foodOffer: DatabaseTypes.Foodoffers, profileMarkingsDict: Record<string, DatabaseTypes.ProfilesMarkings>) {
 		const likedMarkingIds = MarkingHelper.getLikedMarkingIds(foodOffer, profileMarkingsDict);
 		return likedMarkingIds.length > 0;
 	}
 
-	static areDislikedEatingHabitsFoundInFoodOffer(foodOffer: Foodoffers, profileMarkingsDict: Record<string, ProfilesMarkings>) {
+	static areDislikedEatingHabitsFoundInFoodOffer(foodOffer: DatabaseTypes.Foodoffers, profileMarkingsDict: Record<string, DatabaseTypes.ProfilesMarkings>) {
 		const dislikedMarkingIds = MarkingHelper.getDislikedMarkingIds(foodOffer, profileMarkingsDict);
 		return dislikedMarkingIds.length > 0;
 	}
 
 
-	static getFoodOfferMarkingIds(foodOffer: Foodoffers | null | undefined) {
-		const aMarkingsRelation = foodOffer?.markings as FoodoffersMarkings[]
+	static getFoodOfferMarkingIds(foodOffer: DatabaseTypes.Foodoffers | null | undefined) {
+		const aMarkingsRelation = foodOffer?.markings as DatabaseTypes.FoodoffersMarkings[]
 		let aMarkingsIds: string[] = [];
 		if(aMarkingsRelation){
 			for(const marking of aMarkingsRelation){
@@ -58,5 +58,4 @@ export class MarkingHelper {
 			}
 		}
 		return aMarkingsIds;
-	}
-}
+	}}

--- a/apps/frontend/app/helper/NotificationHelper.ts
+++ b/apps/frontend/app/helper/NotificationHelper.ts
@@ -5,7 +5,7 @@ import Constants from 'expo-constants';
 import usePlatformHelper from '@/helper/platformHelper';
 import {IosAuthorizationStatus} from 'expo-notifications/src/NotificationPermissions.types';
 import { getDeviceInformationWithoutPushToken } from './DeviceHelper';
-import { Devices, Profiles } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 // import {useSynchedDevices} from "@/states/SynchedDevices";
 
 export type NotificationObjType = {
@@ -20,19 +20,19 @@ export class NotificationHelper {
 		return Constants.expoConfig?.extra?.eas?.projectId;
 	}
 
-	static useNotificationPermission(profile: Profiles): [boolean, NotificationObjType, (timestamp?: string) => void, () => void] {
+	static useNotificationPermission(profile: DatabaseTypes.Profiles): [boolean, NotificationObjType, (timestamp?: string) => void, () => void] {
         const devices = profile?.devices || [];
-        let deviceInformationsWithoutPushToken: Partial<Devices> = getDeviceInformationWithoutPushToken();
+        let deviceInformationsWithoutPushToken: Partial<DatabaseTypes.Devices> = getDeviceInformationWithoutPushToken();
         let deviceInformationsId = getDeviceIdentifier(deviceInformationsWithoutPushToken);
         let currentDevice = getCurrentDevice(deviceInformationsId);
 
 
-	function getDeviceIdentifier(device: Partial<Devices>) {
+	function getDeviceIdentifier(device: Partial<DatabaseTypes.Devices>) {
 		return device.platform+'_'+device.brand+'_'+device.system_version;
 	}
     
-        function getCurrentDevice(deviceInformationsId: string | undefined): Devices | undefined {
-            let foundDevice: undefined | Devices = undefined;
+        function getCurrentDevice(deviceInformationsId: string | undefined): DatabaseTypes.Devices | undefined {
+            let foundDevice: undefined | DatabaseTypes.Devices = undefined;
             if (deviceInformationsId) {
                 for (const device of devices) {
                     if (getDeviceIdentifier(device) === deviceInformationsId) {

--- a/apps/frontend/app/helper/collectionHelper.ts
+++ b/apps/frontend/app/helper/collectionHelper.ts
@@ -12,7 +12,7 @@ import {
   aggregate,
   withToken,
 } from '@directus/sdk';
-import { CustomDirectusTypes } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
 // Define types for queries and filters
@@ -62,11 +62,11 @@ export type AggregateQuery<CollectionScheme> = {
 
 export class CollectionHelper<CollectionScheme> {
   private collection: string;
-  private client: DirectusClient<CustomDirectusTypes> & RestClient<any>;
+  private client: DirectusClient<DatabaseTypes.CustomDirectusTypes> & RestClient<any>;
 
   constructor(
     collection: string,
-    client?: DirectusClient<CustomDirectusTypes> & RestClient<any>
+    client?: DirectusClient<DatabaseTypes.CustomDirectusTypes> & RestClient<any>
   ) {
     this.collection = collection;
     this.client = client ?? ServerAPI.getClient();

--- a/apps/frontend/app/helper/dateMap.ts
+++ b/apps/frontend/app/helper/dateMap.ts
@@ -1,7 +1,7 @@
-import { CollectionsDatesLastUpdate } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export const transformUpdateDatesToMap = (
-  array: CollectionsDatesLastUpdate[]
+  array: DatabaseTypes.CollectionsDatesLastUpdate[]
 ): Record<string, string> => {
   const map: Record<string, string> = {};
   array.forEach((item) => {

--- a/apps/frontend/app/helper/feedback.ts
+++ b/apps/frontend/app/helper/feedback.ts
@@ -1,4 +1,4 @@
-import { FoodsFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
 import {
   DELETE_FOOD_FEEDBACK_LOCAL,
@@ -39,7 +39,7 @@ export const handleFoodRating = async ({
       foodId,
       profileId || '',
       { ...previousFeedback, rating, canteen: canteenId }
-    )) as FoodsFeedbacks;
+    )) as DatabaseTypes.FoodsFeedbacks;
 
     dispatch({
       type: updateFeedbackResult?.id

--- a/apps/frontend/app/helper/resourceHelper.tsx
+++ b/apps/frontend/app/helper/resourceHelper.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
 import { MaterialCommunityIcons, MaterialIcons, FontAwesome } from '@expo/vector-icons';
-import {
-  BuildingsTranslations,
-  Foodoffers,
-  Foods,
-  FoodsCategories,
-  FoodoffersCategories,
-  FormCategoriesTranslations,
-  FormFieldsTranslations,
-  FormsTranslations,
-  MarkingsTranslations,
-  NewsTranslations,
-  WikisTranslations,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { StringHelper } from 'repo-depkit-common';
 
 export type TranslationEntry = {
@@ -110,8 +98,8 @@ export const getFoodAttributesTranslation = (
 };
 
 const getFoodCategoryName = (
-  categories: FoodsCategories[],
-  category: string | FoodsCategories | null | undefined,
+  categories: DatabaseTypes.FoodsCategories[],
+  category: string | DatabaseTypes.FoodsCategories | null | undefined,
   languageCode: string
 ): string => {
   if (!category) return '';
@@ -128,8 +116,8 @@ const getFoodCategoryName = (
 };
 
 const getFoodOfferCategoryName = (
-  categories: FoodoffersCategories[],
-  category: string | FoodoffersCategories | null | undefined,
+  categories: DatabaseTypes.FoodoffersCategories[],
+  category: string | DatabaseTypes.FoodoffersCategories | null | undefined,
   languageCode: string
 ): string => {
   if (!category) return '';
@@ -188,7 +176,7 @@ const getDescriptionFromTranslation = (
   return translation?.description || '';
 };
 
-const extractFoodDetails = (food: Foodoffers) => {
+const extractFoodDetails = (food: DatabaseTypes.Foodoffers) => {
   const {
     fat_g,
     protein_g,
@@ -298,7 +286,7 @@ export function isRatingNegative(rating: number | null | undefined): boolean {
 }
 
 export function getFoodName(
-  food: string | Foods | null | undefined,
+  food: string | DatabaseTypes.Foods | null | undefined,
   languageCode: string
 ) {
   if (typeof food === 'object' && food !== null) {

--- a/apps/frontend/app/helper/sortingHelper.ts
+++ b/apps/frontend/app/helper/sortingHelper.ts
@@ -1,11 +1,4 @@
-import {
-  Foodoffers,
-  Foods,
-  Markings,
-  MarkingsGroups,
-  FoodsCategories,
-  FoodoffersCategories,
-} from "@/constants/types";
+import { DatabaseTypes } from 'repo-depkit-common';
 
 export const normalizeSort = (value: any): number => {
   return value === undefined || value === null || value === "" ? Infinity : value;
@@ -32,7 +25,7 @@ export const sortBySortField = <T extends { sort?: number | null }>(
 
 import { getFoodName, isRatingNegative, isRatingPositive } from "./resourceHelper";
 
-export function sortByFoodName(foodOffers: Foodoffers[], languageCode: string) {
+export function sortByFoodName(foodOffers: DatabaseTypes.Foodoffers[], languageCode: string) {
     foodOffers.sort((a, b) => {
       let nameA = getFoodName(a.food, languageCode);
       let nameB = getFoodName(b.food, languageCode);
@@ -48,8 +41,8 @@ export function sortByFoodName(foodOffers: Foodoffers[], languageCode: string) {
 }
 
 export function sortByFoodCategory(
-  foodOffers: Foodoffers[],
-  categories: FoodsCategories[],
+  foodOffers: DatabaseTypes.Foodoffers[],
+  categories: DatabaseTypes.FoodsCategories[],
     languageCode: string
 ) {
   // 1) Alphabetisch (am wenigsten wichtig)
@@ -62,8 +55,8 @@ export function sortByFoodCategory(
 }
 
 function sortByFoodCategoryOnly(
-    foodOffers: Foodoffers[],
-    categories: FoodsCategories[]
+    foodOffers: DatabaseTypes.Foodoffers[],
+    categories: DatabaseTypes.FoodsCategories[]
 ) {
   const sortMap = new Map<string, number>();
   categories.forEach((cat) => {
@@ -93,8 +86,8 @@ function sortByFoodCategoryOnly(
 }
 
 export function sortByFoodOfferCategory(
-  foodOffers: Foodoffers[],
-  categories: FoodoffersCategories[],
+  foodOffers: DatabaseTypes.Foodoffers[],
+  categories: DatabaseTypes.FoodoffersCategories[],
     languageCode: string
 ) {
     // 1) Alphabetisch (am wenigsten wichtig)
@@ -107,8 +100,8 @@ export function sortByFoodOfferCategory(
 }
 
 function sortByFoodOfferCategoryOnly(
-    foodOffers: Foodoffers[],
-    categories: FoodoffersCategories[]
+    foodOffers: DatabaseTypes.Foodoffers[],
+    categories: DatabaseTypes.FoodoffersCategories[]
 ) {
   const sortMap = new Map<string, number>();
   categories.forEach((cat) => {
@@ -138,7 +131,7 @@ function sortByFoodOfferCategoryOnly(
 }
 
   // Working Own Favorite Sorting
-export function sortByOwnFavorite(foodOffers: Foodoffers[], ownFeedBacks: any) {
+export function sortByOwnFavorite(foodOffers: DatabaseTypes.Foodoffers[], ownFeedBacks: any) {
     const feedbackMap = new Map(
       ownFeedBacks.map((feedback: any) => [feedback.food, feedback.rating])
     );
@@ -161,10 +154,10 @@ export function sortByOwnFavorite(foodOffers: Foodoffers[], ownFeedBacks: any) {
   }
 
   // Working Public Favorite Sorting
-export function sortByPublicFavorite(foodOffers: Foodoffers[]) {
+export function sortByPublicFavorite(foodOffers: DatabaseTypes.Foodoffers[]) {
     foodOffers.sort((a, b) => {
-      const aFood: Foods = a.food || {};
-      const bFood: Foods = b.food || {};
+      const aFood: DatabaseTypes.Foods = a.food || {};
+      const bFood: DatabaseTypes.Foods = b.food || {};
       const getRatingCategory = (rating: number | null | undefined) => {
         if (isRatingNegative(rating)) return "negative";
         if (rating === null || rating === undefined) return "null";
@@ -187,12 +180,12 @@ export function sortByPublicFavorite(foodOffers: Foodoffers[]) {
   }
 
 
-export function sortByEatingHabits(foodOffers: Foodoffers[], profileMarkingsData: any) {
+export function sortByEatingHabits(foodOffers: DatabaseTypes.Foodoffers[], profileMarkingsData: any) {
     const profileMarkingsMap = new Map(
       profileMarkingsData?.map((marking: any) => [marking.markings_id, marking])
     );
     foodOffers.sort((a, b) => {
-      const calculateSortValue = (foodOffer: Foodoffers) => {
+      const calculateSortValue = (foodOffer: DatabaseTypes.Foodoffers) => {
         let sortValue = 0;
         const likeSortWeight = 1;
         const dislikeSortWeight = likeSortWeight * 2;
@@ -225,7 +218,7 @@ export function sortByEatingHabits(foodOffers: Foodoffers[], profileMarkingsData
   }
 
 
-export function sortMarkingsByGroup(markings: Markings[], markingGroups: MarkingsGroups[]): Markings[] {
+export function sortMarkingsByGroup(markings: DatabaseTypes.Markings[], markingGroups: DatabaseTypes.MarkingsGroups[]): DatabaseTypes.Markings[] {
   if (!markings || !markingGroups) {
     return markings || [];
   }
@@ -233,7 +226,7 @@ export function sortMarkingsByGroup(markings: Markings[], markingGroups: Marking
   const sortedGroups = sortBySortField(markingGroups);
 
   // Create a map for quick lookup of each marking's group
-  const markingToGroupMap = new Map<string, MarkingsGroups>();
+  const markingToGroupMap = new Map<string, DatabaseTypes.MarkingsGroups>();
   sortedGroups.forEach((group) => {
     group.markings.forEach((markingId) => {
       if (typeof markingId === 'string') {
@@ -245,13 +238,13 @@ export function sortMarkingsByGroup(markings: Markings[], markingGroups: Marking
   });
 
   // Helper function to get group sort value
-  const getGroupSort = (marking: Markings): number => {
+  const getGroupSort = (marking: DatabaseTypes.Markings): number => {
     const group = markingToGroupMap.get(marking.id);
     return normalizeSort(group?.sort);
   };
 
   // Helper function to get marking's own sort value
-  const getMarkingSort = (marking: Markings): number => {
+  const getMarkingSort = (marking: DatabaseTypes.Markings): number => {
     return normalizeSort(marking.sort);
   };
 
@@ -279,12 +272,12 @@ export function sortMarkingsByGroup(markings: Markings[], markingGroups: Marking
 }
 
 export function intelligentSort(
-    foodOffers: Foodoffers[],
+    foodOffers: DatabaseTypes.Foodoffers[],
     ownFeedbacks: any[],
     profileMarkings: any[],
     languageCode: string,
-    foodCategories: FoodsCategories[] = [],
-    foodOfferCategories: FoodoffersCategories[] = []
+    foodCategories: DatabaseTypes.FoodsCategories[] = [],
+    foodOfferCategories: DatabaseTypes.FoodoffersCategories[] = []
 ) {
   // 1) Alphabetisch (am wenigsten wichtig)
   sortByFoodName(foodOffers, languageCode);

--- a/apps/frontend/app/redux/Types/stateTypes.ts
+++ b/apps/frontend/app/redux/Types/stateTypes.ts
@@ -1,29 +1,4 @@
-import {
-  Apartments,
-  AppElements,
-  AppSettings,
-  Buildings,
-  Businesshours,
-  BusinesshoursGroups,
-  Canteens,
-  CanteensFeedbacksLabels,
-  CanteensFeedbacksLabelsEntries,
-  DirectusUsers,
-  Foodoffers,
-  FoodoffersCategories,
-  FoodsAttributes,
-  FoodsAttributesGroups,
-  FoodsCategories,
-  FoodsFeedbacks,
-  FoodsFeedbacksLabels,
-  FoodsFeedbacksLabelsEntries,
-  FormSubmissions,
-  Markings,
-  News,
-  PopupEvents,
-  Profiles,
-  Wikis,
-} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {
   FoodSortOption,
   CampusSortOption,
@@ -31,8 +6,8 @@ import {
 } from '@/constants/SortingEnums';
 
 export interface AuthState {
-  user: DirectusUsers | Record<string, any> | null;
-  profile: Profiles;
+  user: DatabaseTypes.DirectusUsers | Record<string, any> | null;
+  profile: DatabaseTypes.Profiles;
   loggedIn: boolean;
   isManagement: boolean;
   isDevMode: boolean;
@@ -40,26 +15,26 @@ export interface AuthState {
 }
 
 export interface AppElementState {
-  appElements: AppElements[];
+  appElements: DatabaseTypes.AppElements[];
 }
 
 export interface ApartmentsState {
-  apartments: Apartments[];
-  apartmentsLocal: Apartments[];
-  unSortedApartments: Apartments[];
-  apartmentsDict: Record<string, Apartments>;
+  apartments: DatabaseTypes.Apartments[];
+  apartmentsLocal: DatabaseTypes.Apartments[];
+  unSortedApartments: DatabaseTypes.Apartments[];
+  apartmentsDict: Record<string, DatabaseTypes.Apartments>;
 }
 
 export interface CanteensState {
-  canteens: Canteens[];
-  buildings: Buildings[];
-  selectedCanteen: Canteens | null;
+  canteens: DatabaseTypes.Canteens[];
+  buildings: DatabaseTypes.Buildings[];
+  selectedCanteen: DatabaseTypes.Canteens | null;
   selectedCanteenFoodOffers: any[];
-  canteenFoodOffers: Foodoffers[];
-  businessHours: Businesshours[];
-  businessHoursGroups: BusinesshoursGroups[];
-  canteenFeedbackLabels: CanteensFeedbacksLabels[];
-  ownCanteenFeedBackLabelEntries: CanteensFeedbacksLabelsEntries[];
+  canteenFoodOffers: DatabaseTypes.Foodoffers[];
+  businessHours: DatabaseTypes.Businesshours[];
+  businessHoursGroups: DatabaseTypes.BusinesshoursGroups[];
+  canteenFeedbackLabels: DatabaseTypes.CanteensFeedbacksLabels[];
+  ownCanteenFeedBackLabelEntries: DatabaseTypes.CanteensFeedbacksLabelsEntries[];
 }
 
 export interface SettingsState {
@@ -70,25 +45,25 @@ export interface SettingsState {
   apartmentsSortBy: ApartmentSortOption;
   serverInfo: Record<string, any>;
   primaryColor: string;
-  appSettings: AppSettings;
+  appSettings: DatabaseTypes.AppSettings;
   language: string;
   firstDayOfTheWeek: { id: string; name: string };
   drawerPosition: 'left' | 'right';
   wikisPages: any[];
-  wikis: Wikis[];
+  wikis: DatabaseTypes.Wikis[];
   nickNameLocal: string;
   amountColumnsForcard: number;
 }
 
 export interface FoodState {
-  foodFeedbackLabels: FoodsFeedbacksLabels[];
-  ownFoodFeedbacks: FoodsFeedbacks[];
-  ownfoodFeedbackLabelEntries: FoodsFeedbacksLabelsEntries[];
-  markings: Markings[];
+  foodFeedbackLabels: DatabaseTypes.FoodsFeedbacksLabels[];
+  ownFoodFeedbacks: DatabaseTypes.FoodsFeedbacks[];
+  ownfoodFeedbackLabelEntries: DatabaseTypes.FoodsFeedbacksLabelsEntries[];
+  markings: DatabaseTypes.Markings[];
   selectedFoodMarkings: any[];
-  foodCategories: FoodsCategories[];
-  foodOfferCategories: FoodoffersCategories[];
-  markingDetails: Markings;
+  foodCategories: DatabaseTypes.FoodsCategories[];
+  foodOfferCategories: DatabaseTypes.FoodoffersCategories[];
+  markingDetails: DatabaseTypes.Markings;
   mostLikedFoods: any[];
   mostDislikedFoods: any[];
   foodCollection: Record<string, any>;
@@ -96,31 +71,31 @@ export interface FoodState {
   selectedDate: string;
 }
 
-interface ExtendedPopUpEvents extends PopupEvents {
+interface ExtendedPopUpEvents extends DatabaseTypes.PopupEvents {
   isOpen: boolean;
   isCurrent: number;
 }
 
 export interface FoodAttributesState {
-  foodAttributeGroups: FoodsAttributesGroups[];
-  foodAttributes: FoodsAttributes[];
-  foodAttributesDict: Record<string, FoodsAttributes>;
+  foodAttributeGroups: DatabaseTypes.FoodsAttributesGroups[];
+  foodAttributes: DatabaseTypes.FoodsAttributes[];
+  foodAttributesDict: Record<string, DatabaseTypes.FoodsAttributes>;
 }
 
 export interface FormState {
   filterBy: string;
-  formSubmission: FormSubmissions;
+  formSubmission: DatabaseTypes.FormSubmissions;
 }
 
 export interface CampusState {
-  campuses: Buildings[];
-  campusesLocal: Buildings[];
-  unSortedCampuses: Buildings[];
-  campusesDict: Record<string, Buildings>;
+  campuses: DatabaseTypes.Buildings[];
+  campusesLocal: DatabaseTypes.Buildings[];
+  unSortedCampuses: DatabaseTypes.Buildings[];
+  campusesDict: Record<string, DatabaseTypes.Buildings>;
 }
 
 export interface NewsState {
-  news: News[];
+  news: DatabaseTypes.News[];
 }
 
 export interface LastUpdatedState {
@@ -128,7 +103,7 @@ export interface LastUpdatedState {
 }
 
 interface DayPlan {
-  selectedCanteen: Canteens;
+  selectedCanteen: DatabaseTypes.Canteens;
   mealOfferCategory: { id: string; alias: string };
   isMenuCategory: boolean;
   nextFoodInterval: number;
@@ -139,14 +114,14 @@ interface DayPlan {
 }
 
 interface FoodPlan {
-  selectedCanteen: Canteens;
-  additionalSelectedCanteen: Canteens;
+  selectedCanteen: DatabaseTypes.Canteens;
+  additionalSelectedCanteen: DatabaseTypes.Canteens;
   nextFoodInterval: number;
   refreshInterval: number;
 }
 
 interface WeekPlan {
-  selectedCanteen: Canteens;
+  selectedCanteen: DatabaseTypes.Canteens;
   isAllergene: boolean;
   selectedWeek: {
     week: number;

--- a/apps/frontend/app/redux/actions/Apartments/Apartments.ts
+++ b/apps/frontend/app/redux/actions/Apartments/Apartments.ts
@@ -1,8 +1,8 @@
-import { Apartments } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class ApartmentsHelper extends CollectionHelper<Apartments> {
+export class ApartmentsHelper extends CollectionHelper<DatabaseTypes.Apartments> {
   constructor(client?: any) {
     super('apartments', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/AppElements/AppElements.ts
+++ b/apps/frontend/app/redux/actions/AppElements/AppElements.ts
@@ -1,8 +1,8 @@
-import { AppElements } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class AppElementsHelper extends CollectionHelper<AppElements> {
+export class AppElementsHelper extends CollectionHelper<DatabaseTypes.AppElements> {
   constructor(client?: any) {
     super('app_elements', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/AppFeedback/AppFeedback.ts
+++ b/apps/frontend/app/redux/actions/AppFeedback/AppFeedback.ts
@@ -1,8 +1,8 @@
-import { AppFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class AppFeedback extends CollectionHelper<AppFeedbacks> {
+export class AppFeedback extends CollectionHelper<DatabaseTypes.AppFeedbacks> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('app_feedbacks', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/AppSettings/AppSettings.ts
+++ b/apps/frontend/app/redux/actions/AppSettings/AppSettings.ts
@@ -1,8 +1,8 @@
-import { AppSettings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class AppSettingsHelper extends CollectionHelper<AppSettings> {
+export class AppSettingsHelper extends CollectionHelper<DatabaseTypes.AppSettings> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('app_settings', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/Auth/Auth.ts
+++ b/apps/frontend/app/redux/actions/Auth/Auth.ts
@@ -21,11 +21,7 @@ import {
 	ServerInfoOutput
   } from '@directus/sdk';
   
-  import {
-	CustomDirectusTypes,
-	DirectusPolicies,
-	DirectusRoles
-  } from '@/constants/types';
+  import { DatabaseTypes } from 'repo-depkit-common';
   
   import { UrlHelper } from '@/constants/UrlHelper';
   import ServerConfiguration from '@/constants/ServerUrl';
@@ -78,7 +74,7 @@ import {
   
 	// Creates a public Directus client
 	static getPublicClient() {
-	  return createDirectus<CustomDirectusTypes>(this.getServerUrl()).with(rest());
+	  return createDirectus<DatabaseTypes.CustomDirectusTypes>(this.getServerUrl()).with(rest());
 	}
   
 	// Initializes authentication storage
@@ -160,7 +156,7 @@ import {
 	}
   
 	static async readRemoteRoles() {
-	  return this.getClient().request<DirectusRoles[]>(readRoles({
+	  return this.getClient().request<DatabaseTypes.DirectusRoles[]>(readRoles({
 		fields: ['*'],
 		deep: { users: { _limit: 0 }, policies: { _limit: 0 } },
 		limit: -1

--- a/apps/frontend/app/redux/actions/Buildings/Buildings.ts
+++ b/apps/frontend/app/redux/actions/Buildings/Buildings.ts
@@ -1,8 +1,8 @@
-import { Buildings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class BuildingsHelper extends CollectionHelper<Buildings> {
+export class BuildingsHelper extends CollectionHelper<DatabaseTypes.Buildings> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('buildings', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/BusinessHours/BusinessHours.ts
+++ b/apps/frontend/app/redux/actions/BusinessHours/BusinessHours.ts
@@ -1,8 +1,8 @@
-import { Businesshours } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class BusinessHoursHelper extends CollectionHelper<Businesshours> {
+export class BusinessHoursHelper extends CollectionHelper<DatabaseTypes.Businesshours> {
   constructor(client?: any) {
     super('businesshours', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/BusinessHours/BusinessHoursGroups.ts
+++ b/apps/frontend/app/redux/actions/BusinessHours/BusinessHoursGroups.ts
@@ -1,8 +1,8 @@
-import { BusinesshoursGroups } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class BusinessHoursGroupsHelper extends CollectionHelper<BusinesshoursGroups> {
+export class BusinessHoursGroupsHelper extends CollectionHelper<DatabaseTypes.BusinesshoursGroups> {
   constructor(client?: any) {
     super('businesshours_groups', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/Campus/Campus.ts
+++ b/apps/frontend/app/redux/actions/Campus/Campus.ts
@@ -1,8 +1,8 @@
-import { Buildings } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class CampusHelper extends CollectionHelper<Buildings> {
+export class CampusHelper extends CollectionHelper<DatabaseTypes.Buildings> {
   constructor(client?: any) {
     super('buildings', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/CanteenFeedbackLabelEntries/CanteenFeedbackLabelEntries.ts
+++ b/apps/frontend/app/redux/actions/CanteenFeedbackLabelEntries/CanteenFeedbackLabelEntries.ts
@@ -1,9 +1,9 @@
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
-import { CanteensFeedbacksLabelsEntries } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { itemStatus } from '@/constants/Constants';
 
-export class CanteenFeedbackLabelEntryHelper extends CollectionHelper<CanteensFeedbacksLabelsEntries> {
+export class CanteenFeedbackLabelEntryHelper extends CollectionHelper<DatabaseTypes.CanteensFeedbacksLabelsEntries> {
   constructor(client?: any) {
     super('canteens_feedbacks_labels_entries', client || ServerAPI.getClient());
   }
@@ -71,7 +71,7 @@ export class CanteenFeedbackLabelEntryHelper extends CollectionHelper<CanteensFe
   async updateCanteenFeedbackLabelEntry(
     profile_id: string,
     canteenFeedbackLabelEntriesData:
-      | CanteensFeedbacksLabelsEntries[]
+      | DatabaseTypes.CanteensFeedbacksLabelsEntries[]
       | null
       | undefined,
     canteenFeedbackLabelId: string,
@@ -93,7 +93,7 @@ export class CanteenFeedbackLabelEntryHelper extends CollectionHelper<CanteensFe
     let isNewEntry = !existingEntry;
 
     // Prepare new entry data
-    const newFoodFeedbackLabelEntry: Partial<CanteensFeedbacksLabelsEntries> = {
+    const newFoodFeedbackLabelEntry: Partial<DatabaseTypes.CanteensFeedbacksLabelsEntries> = {
       canteen: canteen_id,
       label: canteenFeedbackLabelId,
       status: itemStatus,
@@ -106,7 +106,7 @@ export class CanteenFeedbackLabelEntryHelper extends CollectionHelper<CanteensFe
     if (isNewEntry) {
       existingEntry = (await this.createItem(
         newFoodFeedbackLabelEntry
-      )) as CanteensFeedbacksLabelsEntries;
+      )) as DatabaseTypes.CanteensFeedbacksLabelsEntries;
     }
 
     // Handle missing entry

--- a/apps/frontend/app/redux/actions/CanteenFeedbacksLabel/CanteenFeedbacksLabel.ts
+++ b/apps/frontend/app/redux/actions/CanteenFeedbacksLabel/CanteenFeedbacksLabel.ts
@@ -1,9 +1,9 @@
 import { itemStatus } from '@/constants/Constants';
-import { CanteensFeedbacksLabels } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class CanteenFeedbackLabelHelper extends CollectionHelper<CanteensFeedbacksLabels> {
+export class CanteenFeedbackLabelHelper extends CollectionHelper<DatabaseTypes.CanteensFeedbacksLabels> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('canteens_feedbacks_labels', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/Canteens/Canteens.ts
+++ b/apps/frontend/app/redux/actions/Canteens/Canteens.ts
@@ -1,8 +1,8 @@
-import { Canteens } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class CanteenHelper extends CollectionHelper<Canteens> {
+export class CanteenHelper extends CollectionHelper<DatabaseTypes.Canteens> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('canteens', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/CollectionLastUpdate/CollectionLastUpdate.ts
+++ b/apps/frontend/app/redux/actions/CollectionLastUpdate/CollectionLastUpdate.ts
@@ -1,8 +1,8 @@
-import { CollectionsDatesLastUpdate } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class CollectionLastUpdateHelper extends CollectionHelper<CollectionsDatesLastUpdate> {
+export class CollectionLastUpdateHelper extends CollectionHelper<DatabaseTypes.CollectionsDatesLastUpdate> {
   constructor(client?: any) {
     super('collections_dates_last_update', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/FoodAttributes/FoodAttributeGroup.ts
+++ b/apps/frontend/app/redux/actions/FoodAttributes/FoodAttributeGroup.ts
@@ -1,8 +1,8 @@
-import { FoodsAttributesGroups } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FoodAttributeGroupHelper extends CollectionHelper<FoodsAttributesGroups> {
+export class FoodAttributeGroupHelper extends CollectionHelper<DatabaseTypes.FoodsAttributesGroups> {
   constructor(client?: any) {
     super('foods_attributes_groups', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/FoodAttributes/FoodAttributes.ts
+++ b/apps/frontend/app/redux/actions/FoodAttributes/FoodAttributes.ts
@@ -1,8 +1,8 @@
-import { FoodsAttributes } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FoodAttributesHelper extends CollectionHelper<FoodsAttributes> {
+export class FoodAttributesHelper extends CollectionHelper<DatabaseTypes.FoodsAttributes> {
   constructor(client?: any) {
     super('foods_attributes', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/FoodAttributes/FoodAttributesValues.ts
+++ b/apps/frontend/app/redux/actions/FoodAttributes/FoodAttributesValues.ts
@@ -1,8 +1,8 @@
-import { FoodsAttributesValues } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FoodAttributesValuesHelper extends CollectionHelper<FoodsAttributesValues> {
+export class FoodAttributesValuesHelper extends CollectionHelper<DatabaseTypes.FoodsAttributesValues> {
   constructor(client?: any) {
     super('foods_attributes_values', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/FoodCategories/FoodCategories.ts
+++ b/apps/frontend/app/redux/actions/FoodCategories/FoodCategories.ts
@@ -1,9 +1,9 @@
 import { itemStatus } from '@/constants/Constants';
-import { FoodsCategories } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class FoodCategoriesHelper extends CollectionHelper<FoodsCategories> {
+export class FoodCategoriesHelper extends CollectionHelper<DatabaseTypes.FoodsCategories> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('foods_categories', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/FoodFeedbacks/FoodFeedbacks.ts
+++ b/apps/frontend/app/redux/actions/FoodFeedbacks/FoodFeedbacks.ts
@@ -1,8 +1,8 @@
-import { FoodsFeedbacks } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class FoodFeedbackHelper extends CollectionHelper<FoodsFeedbacks> {
+export class FoodFeedbackHelper extends CollectionHelper<DatabaseTypes.FoodsFeedbacks> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('foods_feedbacks', client || ServerAPI.getClient());
@@ -88,10 +88,10 @@ export class FoodFeedbackHelper extends CollectionHelper<FoodsFeedbacks> {
   async updateFoodFeedback(
     foodId: string,
     profileId: string,
-    // ownFeedback: FoodsFeedbacks | null | undefined,
-    feedback: FoodsFeedbacks
+    // ownFeedback: DatabaseTypes.FoodsFeedbacks | null | undefined,
+    feedback: DatabaseTypes.FoodsFeedbacks
   ) {
-    // const resourceCollectionHelper = new CollectionHelper<FoodsFeedbacks>(TABLE_NAME_FOODS_FEEDBACKS);
+    // const resourceCollectionHelper = new CollectionHelper<DatabaseTypes.FoodsFeedbacks>(TABLE_NAME_FOODS_FEEDBACKS);
 
     let foodFeedback = Object.values(feedback)?.length > 2 ? feedback : null;
     // Create a new feedback if it doesn't exist
@@ -99,7 +99,7 @@ export class FoodFeedbackHelper extends CollectionHelper<FoodsFeedbacks> {
       foodFeedback = (await this.createItem({
         food: foodId,
         profile: profileId,
-      })) as FoodsFeedbacks;
+      })) as DatabaseTypes.FoodsFeedbacks;
       foodFeedback = { ...foodFeedback, ...feedback };
     }
 

--- a/apps/frontend/app/redux/actions/FoodFeedbacksLabel/FoodFeedbacksLabel.ts
+++ b/apps/frontend/app/redux/actions/FoodFeedbacksLabel/FoodFeedbacksLabel.ts
@@ -1,9 +1,9 @@
 import { itemStatus } from '@/constants/Constants';
-import { FoodsFeedbacksLabels } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class FoodFeedbackLabelHelper extends CollectionHelper<FoodsFeedbacksLabels> {
+export class FoodFeedbackLabelHelper extends CollectionHelper<DatabaseTypes.FoodsFeedbacksLabels> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('foods_feedbacks_labels', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/FoodFeeedbackLabelEntries/FoodFeedbackLabelEntries.ts
+++ b/apps/frontend/app/redux/actions/FoodFeeedbackLabelEntries/FoodFeedbackLabelEntries.ts
@@ -1,8 +1,8 @@
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
-import { FoodsFeedbacksLabelsEntries } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
-export class FoodFeedbackLabelEntryHelper extends CollectionHelper<FoodsFeedbacksLabelsEntries> {
+export class FoodFeedbackLabelEntryHelper extends CollectionHelper<DatabaseTypes.FoodsFeedbacksLabelsEntries> {
   constructor(client?: any) {
     super('foods_feedbacks_labels_entries', client || ServerAPI.getClient());
   }
@@ -58,7 +58,7 @@ export class FoodFeedbackLabelEntryHelper extends CollectionHelper<FoodsFeedback
     foodId: string,
     profile_id: string,
     foodFeedbackLabelEntriesData:
-      | FoodsFeedbacksLabelsEntries[]
+      | DatabaseTypes.FoodsFeedbacksLabelsEntries[]
       | null
       | undefined,
     foodFeedbackLabelId: string,
@@ -76,7 +76,7 @@ export class FoodFeedbackLabelEntryHelper extends CollectionHelper<FoodsFeedback
     let isNewEntry = !existingEntry;
 
     // Prepare new entry data
-    const newFoodFeedbackLabelEntry: Partial<FoodsFeedbacksLabelsEntries> = {
+    const newFoodFeedbackLabelEntry: Partial<DatabaseTypes.FoodsFeedbacksLabelsEntries> = {
       food: foodId,
       label: foodFeedbackLabelId,
       like,
@@ -87,7 +87,7 @@ export class FoodFeedbackLabelEntryHelper extends CollectionHelper<FoodsFeedback
     if (isNewEntry) {
       existingEntry = (await this.createItem(
         newFoodFeedbackLabelEntry
-      )) as FoodsFeedbacksLabelsEntries;
+      )) as DatabaseTypes.FoodsFeedbacksLabelsEntries;
     }
 
     // Handle missing entry

--- a/apps/frontend/app/redux/actions/FoodOffersCategories/FoodOffersCategories.ts
+++ b/apps/frontend/app/redux/actions/FoodOffersCategories/FoodOffersCategories.ts
@@ -1,9 +1,9 @@
 import { itemStatus } from '@/constants/Constants';
-import { FoodoffersCategories } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class FoodOffersCategoriesHelper extends CollectionHelper<FoodoffersCategories> {
+export class FoodOffersCategoriesHelper extends CollectionHelper<DatabaseTypes.FoodoffersCategories> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('foodoffers_categories', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/Forms/FormAnswers.ts
+++ b/apps/frontend/app/redux/actions/Forms/FormAnswers.ts
@@ -1,8 +1,8 @@
-import { FormAnswers } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FormAnswersHelper extends CollectionHelper<FormAnswers> {
+export class FormAnswersHelper extends CollectionHelper<DatabaseTypes.FormAnswers> {
   constructor(client?: any) {
     super('form_answers', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/Forms/FormCategories.ts
+++ b/apps/frontend/app/redux/actions/Forms/FormCategories.ts
@@ -1,8 +1,8 @@
-import { FormCategories } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FormCategoriesHelper extends CollectionHelper<FormCategories> {
+export class FormCategoriesHelper extends CollectionHelper<DatabaseTypes.FormCategories> {
   constructor(client?: any) {
     super('form_categories', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/Forms/FormSubmitions.ts
+++ b/apps/frontend/app/redux/actions/Forms/FormSubmitions.ts
@@ -1,8 +1,8 @@
-import { FormSubmissions } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FormsSubmissionsHelper extends CollectionHelper<FormSubmissions> {
+export class FormsSubmissionsHelper extends CollectionHelper<DatabaseTypes.FormSubmissions> {
   constructor(client?: any) {
     super('form_submissions', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/Forms/Forms.ts
+++ b/apps/frontend/app/redux/actions/Forms/Forms.ts
@@ -1,8 +1,8 @@
-import { Forms } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class FormsHelper extends CollectionHelper<Forms> {
+export class FormsHelper extends CollectionHelper<DatabaseTypes.Forms> {
   constructor(client?: any) {
     super('forms', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/MarkingGroups/MarkingGroups.ts
+++ b/apps/frontend/app/redux/actions/MarkingGroups/MarkingGroups.ts
@@ -1,8 +1,8 @@
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
-import { Markings, MarkingsGroups } from '@/constants/types'; // Assuming Markings is the required type
+import { DatabaseTypes } from 'repo-depkit-common'; // Assuming DatabaseTypes.Markings is the required type
 
-export class MarkingGroupsHelper extends CollectionHelper<MarkingsGroups> {
+export class MarkingGroupsHelper extends CollectionHelper<DatabaseTypes.MarkingsGroups> {
   constructor(client?: any) {
     // Pass the collection name 'markings' and an optional API client
     super('markings_groups', client || ServerAPI.getClient());
@@ -47,12 +47,12 @@ export class MarkingGroupsHelper extends CollectionHelper<MarkingsGroups> {
   }
 
   // Create a new marking groups entry
-  async createMarkingGroups(entryData: Markings) {
+  async createMarkingGroups(entryData: DatabaseTypes.Markings) {
     return await this.createItem(entryData);
   }
 
   // Update an existing marking groups entry by ID
-  async updateMarkingGroupsById(id: string, updatedData: Markings) {
+  async updateMarkingGroupsById(id: string, updatedData: DatabaseTypes.Markings) {
     return await this.updateItem(id, updatedData);
   }
 

--- a/apps/frontend/app/redux/actions/Markings/Markings.ts
+++ b/apps/frontend/app/redux/actions/Markings/Markings.ts
@@ -1,8 +1,8 @@
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
-import { Markings } from '@/constants/types'; // Assuming Markings is the required type
+import { DatabaseTypes } from 'repo-depkit-common'; // Assuming DatabaseTypes.Markings is the required type
 
-export class MarkingHelper extends CollectionHelper<Markings> {
+export class MarkingHelper extends CollectionHelper<DatabaseTypes.Markings> {
   constructor(client?: any) {
     // Pass the collection name 'markings' and an optional API client
     super('markings', client || ServerAPI.getClient());
@@ -47,12 +47,12 @@ export class MarkingHelper extends CollectionHelper<Markings> {
   }
 
   // Create a new marking entry
-  async createMarking(entryData: Markings) {
+  async createMarking(entryData: DatabaseTypes.Markings) {
     return await this.createItem(entryData);
   }
 
   // Update an existing marking entry by ID
-  async updateMarkingById(id: string, updatedData: Markings) {
+  async updateMarkingById(id: string, updatedData: DatabaseTypes.Markings) {
     return await this.updateItem(id, updatedData);
   }
 

--- a/apps/frontend/app/redux/actions/News/News.ts
+++ b/apps/frontend/app/redux/actions/News/News.ts
@@ -1,8 +1,8 @@
-import { News } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class NewsHelper extends CollectionHelper<News> {
+export class NewsHelper extends CollectionHelper<DatabaseTypes.News> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('news', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/PopupEvents/PopupEvents.ts
+++ b/apps/frontend/app/redux/actions/PopupEvents/PopupEvents.ts
@@ -1,9 +1,9 @@
 import { itemStatus } from '@/constants/Constants';
-import { PopupEvents } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
-export class PopupEventsHelper extends CollectionHelper<PopupEvents> {
+export class PopupEventsHelper extends CollectionHelper<DatabaseTypes.PopupEvents> {
   constructor(client?: any) {
     super('popup_events', client || ServerAPI.getClient());
   }

--- a/apps/frontend/app/redux/actions/Profile/Profile.ts
+++ b/apps/frontend/app/redux/actions/Profile/Profile.ts
@@ -1,8 +1,8 @@
-import { Profiles } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Your helper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // Your API client
 
-export class ProfileHelper extends CollectionHelper<Profiles> {
+export class ProfileHelper extends CollectionHelper<DatabaseTypes.Profiles> {
   constructor(client?: any) {
     super('profiles', client || ServerAPI.getClient());
   }
@@ -62,6 +62,6 @@ export class ProfileHelper extends CollectionHelper<Profiles> {
 }
 
 export async function deleteProfileRemote(id: string | number) {
-  const profileCollectionHelper = new CollectionHelper<Profiles>('profiles');
+  const profileCollectionHelper = new CollectionHelper<DatabaseTypes.Profiles>('profiles');
   await profileCollectionHelper.deleteItem(id);
 }

--- a/apps/frontend/app/redux/actions/User/User.ts
+++ b/apps/frontend/app/redux/actions/User/User.ts
@@ -4,14 +4,14 @@
 import {AuthenticationData} from '@directus/sdk';
 import {configureStore} from '@/redux/store';
 // import {PersistentSecureStore} from '@/helper/syncState/PersistentSecureStore';
-import {DirectusRoles, DirectusUsers} from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import {ServerAPI} from '@/redux/actions/Auth/Auth';
 // import {useSynchedRolesDict} from "@/states/SynchedRoles";
 // import {useIsDemo} from "@/states/SynchedDemo";
 // import {RoleHelper} from "@/helper/role/RoleHelper";
 // import {PermissionHelper, PermissionHelperObject} from "@/helper/permission/PermissionHelper";
 
-export type CachedUserInformation = DirectusUsers | undefined;
+export type CachedUserInformation = DatabaseTypes.DirectusUsers | undefined;
 
 export function useLogoutCallback(): () => void {
 	return async () => {
@@ -46,7 +46,7 @@ export function useLogoutCallback(): () => void {
 // 	return [currentUser, setUserWithCache]
 // }
 
-function isDirectusUserAnonymous(user: DirectusUsers | undefined) {
+function isDirectusUserAnonymous(user: DatabaseTypes.DirectusUsers | undefined) {
 	if (!user) return true
 	return user?.id === undefined || user?.id === null
 }
@@ -71,7 +71,7 @@ export function getAnonymousUser(): any {
 	}
 }
 
-// export function useCurrentUser(): [DirectusUsers | undefined, (newValue: any) => void] {
+// export function useCurrentUser(): [DatabaseTypes.DirectusUsers | undefined, (newValue: any) => void] {
 // 	const [currentUserRaw, setCurrentUserRaw] = useCurrentUserRaw()
 // 	// TODO: Update cached user
 // 	const setUserWithCache = (newValue: any) => {
@@ -87,7 +87,7 @@ export function getAnonymousUser(): any {
 // 	return [currentUser, setUserWithCache]
 // }
 
-// export function useCurrentRole(): DirectusRoles | null {
+// export function useCurrentRole(): DatabaseTypes.DirectusRoles | null {
 // 	const [currentUser, setCurrentUser] = useCurrentUser()
 // 	const [rolesDict, setRolesDict] = useSynchedRolesDict()
 // 	const role_id = currentUser?.role

--- a/apps/frontend/app/redux/actions/UtilizationEntries/UtilizationEntries.ts
+++ b/apps/frontend/app/redux/actions/UtilizationEntries/UtilizationEntries.ts
@@ -1,9 +1,9 @@
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { DateHelper } from 'repo-depkit-common';
-import { UtilizationsEntries } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 
-export class UtilizationEntryHelper extends CollectionHelper<UtilizationsEntries> {
+export class UtilizationEntryHelper extends CollectionHelper<DatabaseTypes.UtilizationsEntries> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('utilizations_entries', client || ServerAPI.getClient());

--- a/apps/frontend/app/redux/actions/Wikis/Wikis.ts
+++ b/apps/frontend/app/redux/actions/Wikis/Wikis.ts
@@ -1,8 +1,8 @@
-import { Wikis } from '@/constants/types';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { CollectionHelper } from '@/helper/collectionHelper'; // Reusing the CollectionHelper
 import { ServerAPI } from '@/redux/actions/Auth/Auth'; // API client
 
-export class WikisHelper extends CollectionHelper<Wikis> {
+export class WikisHelper extends CollectionHelper<DatabaseTypes.Wikis> {
   constructor(client?: any) {
     // Pass the collection name and API client
     super('wikis', client || ServerAPI.getClient());


### PR DESCRIPTION
## Summary
- switch frontend type imports from `@/constants/types` to `repo-depkit-common`
- prefix all referenced types with `DatabaseTypes.`

## Testing
- `yarn install`
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686ea7f091408330a279fb4a56b35766