### PR TITLE
Add CompanyImage component

### DIFF
--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -2,7 +2,6 @@ import {
   Animated,
   Dimensions,
   Easing,
-  Image,
   ScrollView,
   Text,
   View,
@@ -24,6 +23,7 @@ import { useLocalSearchParams } from 'expo-router';
 import NetInfo from '@react-native-community/netinfo';
 import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
 import MarkingIcon from '@/components/MarkingIcon';
+import CompanyImage from '@/components/CompanyImage';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
@@ -72,9 +72,6 @@ const Index = () => {
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const { canteens } = useSelector((state: RootState) => state.canteenReducer);
   const [selectedCanteen, setSelectedCanteen] = useState<any>(null);
-  const companyImage =
-    appSettings?.company_image &&
-    getImageUrl(String(appSettings?.company_image))?.split('?')[0];
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : projectColor;
@@ -384,7 +381,7 @@ const Index = () => {
         >
           <View style={styles.headerCol1}>
             <View style={styles.logoContainer}>
-              <Image source={{ uri: companyImage }} style={logoStyle} />
+              <CompanyImage appSettings={appSettings} style={logoStyle} />
             </View>
             <View style={styles.labelText}>
               <View style={styles.row}>

--- a/apps/frontend/app/components/CompanyImage/index.tsx
+++ b/apps/frontend/app/components/CompanyImage/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Image, ImageResizeMode, ImageStyle, StyleProp } from 'react-native';
+import { getImageUrl } from '@/constants/HelperFunctions';
+import { DatabaseTypes } from 'repo-depkit-common';
+
+interface CompanyImageProps {
+  appSettings?: DatabaseTypes.AppSettings | null;
+  style?: StyleProp<ImageStyle>;
+  resizeMode?: ImageResizeMode;
+}
+
+const CompanyImage: React.FC<CompanyImageProps> = ({
+  appSettings,
+  style,
+  resizeMode = 'contain',
+}) => {
+  const imageUri =
+    appSettings?.company_image &&
+    getImageUrl(String(appSettings.company_image))?.split('?')[0];
+
+  const source = imageUri
+    ? { uri: imageUri }
+    : require('@/assets/images/company.png');
+
+  return <Image source={source} style={style} resizeMode={resizeMode} />;
+};
+
+export default CompanyImage;

--- a/apps/frontend/app/components/LabelHeader/LabelHeader.tsx
+++ b/apps/frontend/app/components/LabelHeader/LabelHeader.tsx
@@ -1,8 +1,8 @@
-import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
-import { getImageUrl } from '@/constants/HelperFunctions';
+import CompanyImage from '@/components/CompanyImage';
 import { RootState } from '@/redux/reducer';
 
 const LabelHeader: React.FC<{ Label: any; isConnected?: Boolean }> = ({
@@ -14,9 +14,6 @@ const LabelHeader: React.FC<{ Label: any; isConnected?: Boolean }> = ({
   const [logoStyle, setLogoStyle] = useState(styles.logo);
   const { width } = Dimensions.get('window');
   const { appSettings } = useSelector((state: RootState) => state.settings);
-  const companyImage =
-    appSettings?.company_image &&
-    getImageUrl(String(appSettings?.company_image))?.split('?')[0];
   const updateLogoStyle = useCallback(() => {
     setLogoStyle({
       width: width < 600 ? 150 : width > 600 ? 300 : 300,
@@ -55,7 +52,7 @@ const LabelHeader: React.FC<{ Label: any; isConnected?: Boolean }> = ({
       }}
     >
       <View style={styles.logoContainer}>
-        <Image source={{ uri: companyImage }} style={logoStyle} />
+        <CompanyImage appSettings={appSettings} style={logoStyle} />
       </View>
       <View style={{ ...styles.row }}>
         <View style={styles.labelText}>


### PR DESCRIPTION
## Summary
- add reusable `CompanyImage` component with appSettings fallback
- update `LabelHeader` and monitor `bigScreen` to use `CompanyImage`

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686fc10d8d1c8330b3ed248d5286a5f2