### PR TITLE
Run permission script before docker start

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,11 @@
 services:
+  prepare-data:
+    image: alpine:3.18
+    volumes:
+      - ./data:/data
+    working_dir: /data
+    entrypoint: ["/bin/sh", "-c", "./permissionDatabase.sh"]
+
   traefik:
     env_file:
       - .env
@@ -10,6 +17,8 @@ services:
     env_file:
       - .env
     depends_on:
+      prepare-data:
+        condition: service_completed_successfully
       rocket-meals-database:
         condition: service_healthy
       rocket-meals-cache:
@@ -21,6 +30,9 @@ services:
   rocket-meals-database:
     env_file:
       - .env
+    depends_on:
+      prepare-data:
+        condition: service_completed_successfully
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U directus" ]
       interval: 10s
@@ -33,6 +45,9 @@ services:
   rocket-meals-database-backup:
     env_file:
       - .env
+    depends_on:
+      prepare-data:
+        condition: service_completed_successfully
     extends:
       service: rocket-meals-database-backup
       file: apps/backend/docker-compose.yaml


### PR DESCRIPTION
## Summary
- run `permissionDatabase.sh` from a new `prepare-data` service
- ensure backend services depend on `prepare-data`

## Testing
- `yarn test` *(fails: package missing)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687039b10c1c833092a5e9ced2f8a4ec