### PR TITLE
Fix big screen image import crash

### DIFF
--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -2,6 +2,7 @@ import {
   Animated,
   Dimensions,
   Easing,
+  Image,
   ScrollView,
   Text,
   View,


### PR DESCRIPTION
## Summary
- add missing `Image` import for monitor big screen

## Testing
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6870cb9d985c8330b78fb75ac4dea757