### PR TITLE
Add canteen selection hook

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -59,8 +59,8 @@ import { transformUpdateDatesToMap } from '@/helper/dateMap';
 import { shouldFetch } from '@/helper/shouldFetch';
 import { updateLoginStatus } from '@/constants/HelperFunctions';
 import { format } from 'date-fns';
-import { CanteenHelper } from '@/redux/actions/Canteens/Canteens';
-import { SET_CANTEENS, SET_SELECTED_CANTEEN, UPDATE_PRIVACY_POLICY_DATE } from '@/redux/Types/types';
+import { UPDATE_PRIVACY_POLICY_DATE } from '@/redux/Types/types';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 // TODO: replace HashHelper with expo-crypto once packages can be installed
 import { HashHelper } from '@/helper/hashHelper';
 import { CollectionKeys } from '@/constants/collectionKeys';
@@ -103,9 +103,7 @@ export default function Layout() {
   const { loggedIn, user } = useSelector(
     (state: RootState) => state.authReducer
   );
-  const { canteens, selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  useSelectedCanteen();
 
   useEffect(() => {
     const autoLogin = async () => {
@@ -130,24 +128,6 @@ export default function Layout() {
     autoLogin();
   }, [kioskMode, loggedIn]);
 
-  useEffect(() => {
-    const selectCanteen = async () => {
-      if (kioskMode === 'true' && !selectedCanteen) {
-        try {
-          const helper = new CanteenHelper();
-          const result = (await helper.fetchCanteens({})) as DatabaseTypes.Canteens[];
-          const published = result.filter((c) => c.status === 'published');
-          if (published.length > 0) {
-            dispatch({ type: SET_CANTEENS, payload: published });
-            dispatch({ type: SET_SELECTED_CANTEEN, payload: published[0] });
-          }
-        } catch (error) {
-          console.error('Error fetching canteens:', error);
-        }
-      }
-    };
-    selectCanteen();
-  }, [kioskMode, selectedCanteen]);
 
   if (!loggedIn && kioskMode !== 'true') {
     return <Redirect href='/(auth)/login' />;

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -83,6 +83,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { RootState } from '@/redux/reducer';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 
 export const SHEET_COMPONENTS = {
   canteen: CanteenSelectionSheet,
@@ -143,8 +144,10 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     (state: RootState) => state.authReducer
   );
   const { appElements } = useSelector((state: RootState) => state.appElements);
-  const { selectedCanteen, selectedCanteenFoodOffers, canteenFeedbackLabels } =
-    useSelector((state: RootState) => state.canteenReducer);
+  const { selectedCanteenFoodOffers, canteenFeedbackLabels } = useSelector(
+    (state: RootState) => state.canteenReducer,
+  );
+  const selectedCanteen = useSelectedCanteen();
   const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<
     Record<string, Record<string, DatabaseTypes.Foodoffers[]>>
   >({});

--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -21,6 +21,7 @@ import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { myContrastColor } from '@/helper/colorHelper';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useLocalSearchParams } from 'expo-router';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import NetInfo from '@react-native-community/netinfo';
 import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
 import MarkingIcon from '@/components/MarkingIcon';
@@ -71,8 +72,7 @@ const Index = () => {
   const [isConnected, setIsConnected] = useState(true);
   const progressAnim = useRef(new Animated.Value(0)).current;
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  const { canteens } = useSelector((state: RootState) => state.canteenReducer);
-  const [selectedCanteen, setSelectedCanteen] = useState<any>(null);
+  const selectedCanteen = useSelectedCanteen();
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : projectColor;
@@ -126,29 +126,12 @@ const Index = () => {
     }
   }, [foodCategories, foodOfferCategories]);
 
-  const fetchSelectedCanteen = useCallback(() => {
-    if (!params?.canteens_id || !canteens || canteens.length === 0) return;
-
-    const foundCanteen = canteens?.find(
-      (canteen: any) => canteen.id === params?.canteens_id
-    );
-
-    if (foundCanteen) {
-      setSelectedCanteen(foundCanteen);
-    } else {
-      console.warn('Canteen not found for ID:', params?.canteens_id);
-    }
-  }, [params?.canteens_id, canteens]);
-
-  useEffect(() => {
-    fetchSelectedCanteen();
-  }, [params?.canteens_id, canteens]);
 
   const fetchFoods = async () => {
     try {
       const todayDate = new Date().toISOString().split('T')[0];
       const foodData = await fetchFoodsByCanteen(
-        String(params?.canteens_id),
+        String(selectedCanteen?.id),
         todayDate
       );
 
@@ -205,10 +188,10 @@ const Index = () => {
   }, [params?.refreshFoodOffersIntervalInSeconds]);
 
   useEffect(() => {
-    if (params?.canteens_id) {
+    if (selectedCanteen?.id) {
       fetchFoods();
     }
-  }, [params?.foodCategoryIds, params?.canteens_id]);
+  }, [params?.foodCategoryIds, selectedCanteen?.id]);
 
   useEffect(() => {
     if (foods.length > 0 && params?.nextFoodIntervalInSeconds) {

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -33,16 +33,14 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { ColumnPercentages } from './types';
 import { RootState } from '@/redux/reducer';
-import { CanteenHelper } from '@/redux/actions';
-import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { FoodCategoriesHelper } from '@/redux/actions/FoodCategories/FoodCategories';
 import { SET_FOOD_CATEGORIES } from '@/redux/Types/types';
 import { sortMarkingsByGroup } from '@/helper/sortingHelper';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups';
 const index = () => {
   useSetPageTitle('list-day-screen');
   const {
-    canteens_id,
     refreshDataIntervalInSeconds,
     nextPageIntervalInSeconds,
     monitor_additional_canteens_id,
@@ -55,8 +53,6 @@ const index = () => {
   const { markings, foodCategories: localFoodCategories } = useSelector(
     (state: RootState) => state.food
   );
-  const canteenHelper = new CanteenHelper();
-  const buildingsHelper = new BuildingsHelper();
   const foodAttributesHelper = new FoodAttributesHelper();
   const foodCategoriesHelper = new FoodCategoriesHelper();
   const [foods, setFoods] = useState([]);
@@ -66,8 +62,7 @@ const index = () => {
   const [optionalFoodMarkings, setOptionalFoodMarkings] = useState<any>({});
   const [mainFoodCategories, setMainFoodCategories] = useState<any>({});
   const [optionalFoodCategories, setOptionalFoodCategories] = useState<any>({});
-  const [selectedCanteen, setSelectedCanteen] = useState<any>(null);
-  const { canteens } = useSelector((state: RootState) => state.canteenReducer);
+  const selectedCanteen = useSelectedCanteen();
   const { isManagement } = useSelector((state: RootState) => state.authReducer);
   const {
     primaryColor: projectColor,
@@ -219,88 +214,6 @@ const index = () => {
     fetchAliases();
   }, [foodAttributesData, foodAttributesDict, language]);
 
-  const getCanteensWithBuildings = async () => {
-    try {
-      const buildingsData = (await buildingsHelper.fetchBuildings(
-        {}
-      )) as DatabaseTypes.Buildings[];
-      const buildings = buildingsData || [];
-
-      const buildingsDict = buildings.reduce(
-        (acc: Record<string, any>, building: any) => {
-          acc[building.id] = building;
-          return acc;
-        },
-        {}
-      );
-
-      const canteensData = (await canteenHelper.fetchCanteens(
-        {}
-      )) as DatabaseTypes.Canteens[];
-
-      const filteredCanteens = canteensData.filter((canteen) => {
-        const status = canteen.status || '';
-
-        // Normal users: only show published
-        if (!isManagement) {
-          return status === 'published';
-        }
-
-        // Management: show all, but only handle published + archived
-        return status === 'published' || status === 'archived';
-      });
-
-      const sortedCanteens = filteredCanteens.sort((a, b) => {
-        const aPublished = a.status === 'published';
-        const bPublished = b.status === 'published';
-
-        // Move unpublished (archived) to the end
-        if (aPublished !== bPublished) {
-          return aPublished ? -1 : 1;
-        }
-
-        // If both are same status, sort by sort value
-        return (a.sort || 0) - (b.sort || 0);
-      });
-
-      const updatedCanteens = sortedCanteens.map((canteen) => {
-        const building = buildingsDict[canteen?.building as string];
-        return {
-          ...canteen,
-          imageAssetId: building?.image,
-          thumbHash: building?.image_thumb_hash,
-          image_url: building?.image_remote_url || getImageUrl(building?.image),
-        };
-      });
-      return updatedCanteens;
-      // dispatch({ type: SET_CANTEENS, payload: updatedCanteens });
-    } catch (error) {
-      return [];
-    }
-  };
-
-  const fetchSelectedCanteen = useCallback(async () => {
-    if (!canteens_id) return;
-    let canteensData: DatabaseTypes.Canteens[] = [];
-    if (!canteens || canteens.length === 0) {
-      canteensData = await getCanteensWithBuildings();
-    } else {
-      canteensData = canteens;
-    }
-    const foundCanteen = canteensData?.find(
-      (canteen: any) => canteen.id === canteens_id
-    );
-
-    if (foundCanteen) {
-      setSelectedCanteen(foundCanteen);
-    } else {
-      console.warn('Canteen not found for ID:', canteens_id);
-    }
-  }, [canteens_id, canteens]);
-
-  useEffect(() => {
-    fetchSelectedCanteen();
-  }, [canteens_id, canteens]);
 
   const filterFoodAttributes = (foodOffers: any) => {
     if (!foodOffers || !foodAttributesDataFull) return {};
@@ -378,7 +291,7 @@ const index = () => {
     try {
       const todayDate = new Date().toISOString().split('T')[0];
       const foodData = await fetchFoodsByCanteen(
-        String(canteens_id),
+        String(selectedCanteen?.id),
         todayDate
       );
       const foodOffers = foodData?.data || [];
@@ -430,13 +343,13 @@ const index = () => {
   }, [refreshDataIntervalInSeconds]);
 
   useEffect(() => {
-    if (canteens_id) {
+    if (selectedCanteen?.id) {
       fetchFoods();
     }
     if (monitor_additional_canteens_id) {
       fetchOptionalFoods();
     }
-  }, [canteens_id, monitor_additional_canteens_id]);
+  }, [selectedCanteen?.id, monitor_additional_canteens_id]);
 
   const fetchFoodMarkingLabels = useCallback(
     async (foodList: any, setMarkingsState: any) => {

--- a/apps/frontend/app/hooks/useSelectedCanteen.ts
+++ b/apps/frontend/app/hooks/useSelectedCanteen.ts
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useGlobalSearchParams } from 'expo-router';
+import { CanteenHelper } from '@/redux/actions/Canteens/Canteens';
+import { SET_CANTEENS, SET_SELECTED_CANTEEN } from '@/redux/Types/types';
+import { RootState } from '@/redux/reducer';
+import { DatabaseTypes } from 'repo-depkit-common';
+
+/**
+ * Hook to determine the currently selected canteen.
+ * Priority order:
+ *   1. `canteen_id` param from URL
+ *   2. kioskMode -> first public canteen
+ *   3. canteen stored in profile
+ */
+const useSelectedCanteen = () => {
+  const { canteen_id, kioskMode } = useGlobalSearchParams();
+  const dispatch = useDispatch();
+  const { canteens, selectedCanteen } = useSelector(
+    (state: RootState) => state.canteenReducer
+  );
+  const { profile } = useSelector((state: RootState) => state.authReducer);
+
+  useEffect(() => {
+    const selectCanteen = async () => {
+      try {
+        // 1. Param canteen_id has highest priority
+        if (canteen_id) {
+          if (!selectedCanteen || selectedCanteen.id !== canteen_id) {
+            const helper = new CanteenHelper();
+            const canteen = (await helper.fetchCanteenById(
+              String(canteen_id)
+            )) as DatabaseTypes.Canteens;
+            if (canteen) {
+              dispatch({ type: SET_SELECTED_CANTEEN, payload: canteen });
+            }
+          }
+          return;
+        }
+
+        // 2. Kiosk mode -> select first public canteen
+        if (kioskMode === 'true') {
+          if (!selectedCanteen) {
+            const helper = new CanteenHelper();
+            const all = (await helper.fetchCanteens({})) as DatabaseTypes.Canteens[];
+            const published = all.filter((c) => c.status === 'published');
+            if (published.length > 0) {
+              dispatch({ type: SET_CANTEENS, payload: published });
+              dispatch({ type: SET_SELECTED_CANTEEN, payload: published[0] });
+            }
+          }
+          return;
+        }
+
+        // 3. Canteen stored in profile
+        if (profile?.canteen) {
+          if (!selectedCanteen || selectedCanteen.id !== profile.canteen) {
+            const helper = new CanteenHelper();
+            const canteen = (await helper.fetchCanteenById(
+              String(profile.canteen)
+            )) as DatabaseTypes.Canteens;
+            if (canteen) {
+              dispatch({ type: SET_SELECTED_CANTEEN, payload: canteen });
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Error determining selected canteen:', error);
+      }
+    };
+
+    selectCanteen();
+  }, [canteen_id, kioskMode, profile?.canteen]);
+
+  return useSelector((state: RootState) => state.canteenReducer.selectedCanteen);
+};
+
+export default useSelectedCanteen;


### PR DESCRIPTION
## Summary
- add `useSelectedCanteen` hook
- use new hook in app layout and monitor screens to automatically resolve canteen
- use hook in food offers screen to fetch data for the correct canteen

## Testing
- `npm test --silent` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687130d984208330aca608c8e7e07c7a