### PR TITLE
Adjust canteen selection for kiosk mode

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -3,6 +3,7 @@ import { Drawer } from 'expo-router/drawer';
 import CustomDrawerContent from '@/components/Drawer/CustomDrawerContent';
 import { useTheme } from '@/hooks/useTheme';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { Redirect, useGlobalSearchParams } from 'expo-router';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { DatabaseTypes } from 'repo-depkit-common';
@@ -103,9 +104,10 @@ export default function Layout() {
   const { loggedIn, user } = useSelector(
     (state: RootState) => state.authReducer
   );
-  const { canteens, selectedCanteen } = useSelector(
+  const { canteens } = useSelector(
     (state: RootState) => state.canteenReducer
   );
+  const selectedCanteen = useSelectedCanteen();
 
   useEffect(() => {
     const autoLogin = async () => {

--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -29,6 +29,7 @@ import { RootDrawerParamList } from './types';
 import { useFocusEffect, useNavigation } from 'expo-router';
 import BuildingItem from '@/components/BuildingItem/BuildingItem';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { CampusHelper } from '@/redux/actions/Campus/Campus';
 import { DatabaseTypes } from 'repo-depkit-common';
 import {
@@ -76,9 +77,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const { campuses, campusesLocal, unSortedCampuses } = useSelector(
     (state: RootState) => state.campus
   );
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
   const drawerNavigation =
     useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
 

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -8,15 +8,17 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { RootState } from '@/redux/reducer';
 
 const index = () => {
   useSetPageTitle(TranslationKeys.experimentell);
   const { translate } = useLanguage();
   const { theme } = useTheme();
-  const { selectedCanteen, buildings } = useSelector(
+  const { buildings } = useSelector(
     (state: RootState) => state.canteenReducer
   );
+  const selectedCanteen = useSelectedCanteen();
 
   const buildingPosition = useMemo(() => {
     if (selectedCanteen?.building) {

--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -18,6 +18,7 @@ import {
 import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import {
   DELETE_FOOD_FEEDBACK_LOCAL,
   UPDATE_FOOD_FEEDBACK_LOCAL,
@@ -104,9 +105,7 @@ export default function FoodDetailsScreen() {
     getImageUrl(serverInfo?.info?.project?.project_logo);
 
   const [warning, setWarning] = useState(false);
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
   const foodOfferCanteenId = selectedCanteen?.id as string | undefined;
   const [foodDetails, setFoodDetails] = useState<any>(null);
 

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -27,6 +27,7 @@ import { isWeb } from '@/constants/Constants';
 import FoodItem from '@/components/FoodItem/FoodItem';
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { fetchFoodOffersByCanteen } from '@/redux/actions/FoodOffers/FoodOffers';
 import {
   SET_BUSINESS_HOURS,
@@ -143,8 +144,10 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     (state: RootState) => state.authReducer
   );
   const { appElements } = useSelector((state: RootState) => state.appElements);
-  const { selectedCanteen, selectedCanteenFoodOffers, canteenFeedbackLabels } =
-    useSelector((state: RootState) => state.canteenReducer);
+  const { selectedCanteenFoodOffers, canteenFeedbackLabels } = useSelector(
+    (state: RootState) => state.canteenReducer,
+  );
+  const selectedCanteen = useSelectedCanteen();
   const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<
     Record<string, Record<string, DatabaseTypes.Foodoffers[]>>
   >({});

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -28,6 +28,7 @@ import {
 import { RootDrawerParamList } from './types';
 import { useFocusEffect, useNavigation } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { DatabaseTypes } from 'repo-depkit-common';
 import {
   SET_APARTMENTS,
@@ -73,9 +74,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
   );
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
   const {
     drawerPosition,
     apartmentsSortBy,

--- a/apps/frontend/app/app/(app)/index.tsx
+++ b/apps/frontend/app/app/(app)/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { CanteenHelper } from '@/redux/actions/Canteens/Canteens';
@@ -33,9 +34,10 @@ const Home = () => {
   const { serverInfo } = useSelector((state: RootState) => state.settings);
   const { isManagement } = useSelector((state: RootState) => state.authReducer);
   const [loading, setLoading] = useState(false);
-  const { canteens, selectedCanteen } = useSelector(
+  const { canteens } = useSelector(
     (state: RootState) => state.canteenReducer
   );
+  const selectedCanteen = useSelectedCanteen();
   const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width

--- a/apps/frontend/app/app/(app)/leaflet-map/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-map/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { Text, Platform } from 'react-native';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -21,9 +22,10 @@ const POSITION_BUNDESTAG = {
 const LeafletMap = () => {
   useSetPageTitle(TranslationKeys.leaflet_map);
 
-  const { selectedCanteen, buildings } = useSelector(
+  const { buildings } = useSelector(
       (state: RootState) => state.canteenReducer
   );
+  const selectedCanteen = useSelectedCanteen();
 
   const [markerIconSrc, setMarkerIconSrc] = useState<string | null>(null);
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(null);

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -41,6 +41,7 @@ import {
   days,
 } from '../../../constants/SettingData';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import AmountColumns from '@/components/AmountColumn/AmountColumns';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
@@ -118,9 +119,7 @@ const Settings = () => {
     amountColumnsForcard,
     serverInfo,
   } = useSelector((state: RootState) => state.settings);
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );

--- a/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/helper/resourceHelper';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import {
   DELETE_OWN_CANTEEN_FEEDBACK_LABEL_ENTRIES,
   UPDATE_OWN_CANTEEN_FEEDBACK_LABEL_ENTRIES,
@@ -48,9 +49,10 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
   const { user, profile } = useSelector(
     (state: RootState) => state.authReducer
   );
-  const { selectedCanteen, ownCanteenFeedBackLabelEntries } = useSelector(
+  const { ownCanteenFeedBackLabelEntries } = useSelector(
     (state: RootState) => state.canteenReducer
   );
+  const selectedCanteen = useSelectedCanteen();
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color
     : primaryColor;

--- a/apps/frontend/app/components/FeedbackLabel/index.tsx
+++ b/apps/frontend/app/components/FeedbackLabel/index.tsx
@@ -12,6 +12,7 @@ import {
 import { DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackLabelEntryHelper } from '@/redux/actions/FoodFeeedbackLabelEntries/FoodFeedbackLabelEntries';
 import { useDispatch, useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import {
   DELETE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL,
   UPDATE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL,
@@ -44,9 +45,7 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
   const { user, profile } = useSelector(
     (state: RootState) => state.authReducer
   );
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
   const foodFeedbackLabelEntryHelper = new FoodFeedbackLabelEntryHelper();
   const foods_area_color = appSettings?.foods_area_color
     ? appSettings?.foods_area_color

--- a/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -18,6 +18,7 @@ import { BarChart } from 'react-native-chart-kit';
 import { format, parseISO } from 'date-fns';
 import { UtilizationEntryHelper } from '@/redux/actions/UtilizationEntries/UtilizationEntries';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { useFocusEffect } from 'expo-router';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -32,9 +33,7 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({
   const { translate } = useLanguage();
   const utilizationEntryHelper = new UtilizationEntryHelper();
   const [loading, setLoading] = useState(false);
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
   const scrollViewRef = useRef<ScrollView>(null);
   const [chartData, setChartData] = useState<any>({
     labels: [],

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -62,9 +63,10 @@ const HourSheet: React.FC<HourSheetProps> = ({ closeSheet }) => {
   const { language, firstDayOfTheWeek } = useSelector(
     (state: RootState) => state.settings
   );
-  const { selectedCanteen, businessHoursGroups } = useSelector(
+  const { businessHoursGroups } = useSelector(
     (state: RootState) => state.canteenReducer
   );
+  const selectedCanteen = useSelectedCanteen();
   const ScreenWidth = Dimensions.get('window').width;
   const buildingsHelper = new BuildingsHelper();
   const businessHoursHelper = new BusinessHoursHelper();

--- a/apps/frontend/app/components/ManagmentFoodPlan/FoodPlan.tsx
+++ b/apps/frontend/app/components/ManagmentFoodPlan/FoodPlan.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import styles from './styles';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { RootState } from '@/redux/reducer';
 
 const FoodPlan = ({
@@ -59,9 +60,7 @@ const FoodPlan = ({
     setToggleStates(updatedStates);
   };
 
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
 
   return (
     <View

--- a/apps/frontend/app/components/ManagmentFoodPlan/FoodPlanList.tsx
+++ b/apps/frontend/app/components/ManagmentFoodPlan/FoodPlanList.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
 import styles from './styles';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { router, useFocusEffect } from 'expo-router';
 import { RootState } from '@/redux/reducer';
 
@@ -61,9 +62,7 @@ const FoodPlanList = ({
     setToggleStates(updatedStates);
   };
 
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
 
   return (
     <View

--- a/apps/frontend/app/components/ManagmentFoodPlan/FoodPlanWeek.tsx
+++ b/apps/frontend/app/components/ManagmentFoodPlan/FoodPlanWeek.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
 import styles from './styles';
 import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { router } from 'expo-router';
 import { RootState } from '@/redux/reducer';
 
@@ -49,9 +50,7 @@ const FoodPlanWeek = ({
     setToggleStates(updatedStates);
   };
 
-  const { selectedCanteen } = useSelector(
-    (state: RootState) => state.canteenReducer
-  );
+  const selectedCanteen = useSelectedCanteen();
 
   return (
     <View

--- a/apps/frontend/app/hooks/useSelectedCanteen.ts
+++ b/apps/frontend/app/hooks/useSelectedCanteen.ts
@@ -1,0 +1,31 @@
+import { useGlobalSearchParams } from 'expo-router';
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { RootState } from '@/redux/reducer';
+
+export default function useSelectedCanteen() {
+  const { kioskMode, canteens_id } = useGlobalSearchParams<{
+    kioskMode?: string;
+    canteens_id?: string;
+  }>();
+  const { canteens, selectedCanteen } = useSelector(
+    (state: RootState) => state.canteenReducer,
+  );
+
+  return useMemo(() => {
+    if (kioskMode === 'true') {
+      if (canteens_id) {
+        const found = canteens.find(
+          (c) => String(c.id) === String(canteens_id),
+        );
+        if (found) {
+          return found;
+        }
+      }
+      if (selectedCanteen) {
+        return selectedCanteen;
+      }
+    }
+    return selectedCanteen;
+  }, [kioskMode, canteens_id, canteens, selectedCanteen]);
+}


### PR DESCRIPTION
## Summary
- add a `useSelectedCanteen` hook to prefer the kiosk canteen if provided
- use the new hook across several frontend screens and sheets

## Testing
- `yarn install` *(fails: some dependencies require build or network)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68717542e218833086510571987480eb