### PR TITLE
Disable popup events in kiosk mode

### DIFF
--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -14,12 +14,14 @@ import styles from './styles';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
+import useKioskMode from '@/hooks/useKioskMode';
 
 const EventsScreen = () => {
   useSetPageTitle(TranslationKeys.events);
   const { theme } = useTheme();
   const { translate, language } = useLanguage();
   const dispatch = useDispatch();
+  const kioskMode = useKioskMode();
   const { popupEvents } = useSelector((state: RootState) => state.food);
   const [selectedEvent, setSelectedEvent] = useState<any | null>(null);
   const bottomSheetRef = useRef<BottomSheet>(null);
@@ -60,19 +62,20 @@ const EventsScreen = () => {
           onPress={resetSeenEvents}
           redirectIcon={false}
         />
-        {popupEvents.map((event: any) => (
-          <SupportFAQ
-            key={event.id}
-            label={
-              event.translations
-                ? getTitleFromTranslation(event.translations, language)
-                : event.alias
-            }
-            onPress={() => openSheet(event)}
-          />
-        ))}
+        {!kioskMode &&
+          popupEvents.map((event: any) => (
+            <SupportFAQ
+              key={event.id}
+              label={
+                event.translations
+                  ? getTitleFromTranslation(event.translations, language)
+                  : event.alias
+              }
+              onPress={() => openSheet(event)}
+            />
+          ))}
       </ScrollView>
-      {isActive && (
+      {isActive && !kioskMode && (
         <BaseBottomSheet
           ref={bottomSheetRef}
           index={-1}

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -28,6 +28,7 @@ import FoodItem from '@/components/FoodItem/FoodItem';
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
+import useKioskMode from '@/hooks/useKioskMode';
 import { fetchFoodOffersByCanteen } from '@/redux/actions/FoodOffers/FoodOffers';
 import {
   SET_BUSINESS_HOURS,
@@ -148,6 +149,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     (state: RootState) => state.canteenReducer,
   );
   const selectedCanteen = useSelectedCanteen();
+  const kioskMode = useKioskMode();
   const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<
     Record<string, Record<string, DatabaseTypes.Foodoffers[]>>
   >({});
@@ -250,13 +252,16 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   );
 
   useEffect(() => {
+    if (kioskMode) {
+      return;
+    }
     const currentEvent = popupEvents?.find((e: any) => e.isCurrent);
     if (currentEvent) {
       setTimeout(() => {
         openEventSheet();
       }, 300);
     }
-  }, [popupEvents]);
+  }, [popupEvents, kioskMode]);
 
   const openSheet = useCallback(
     (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
@@ -278,6 +283,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
   };
 
   const openEventSheet = () => {
+    if (kioskMode) return;
     eventSheetRef?.current?.expand();
   };
 
@@ -1051,7 +1057,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
             )}
           </ScrollView>
         </View>
-        {isActive && (
+        {isActive && !kioskMode && popupEvents.length > 0 && (
           selectedSheet === 'menu' ? (
             <MarkingBottomSheet ref={bottomSheetRef} onClose={closeSheet} />
           ) : (

--- a/apps/frontend/app/hooks/useKioskMode.ts
+++ b/apps/frontend/app/hooks/useKioskMode.ts
@@ -1,0 +1,6 @@
+import { useGlobalSearchParams } from 'expo-router';
+
+export default function useKioskMode(): boolean {
+  const { kioskMode } = useGlobalSearchParams<{ kioskMode?: string }>();
+  return kioskMode === 'true';
+}

--- a/apps/frontend/app/hooks/useSelectedCanteen.ts
+++ b/apps/frontend/app/hooks/useSelectedCanteen.ts
@@ -1,19 +1,18 @@
 import { useGlobalSearchParams } from 'expo-router';
+import useKioskMode from './useKioskMode';
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import { RootState } from '@/redux/reducer';
 
 export default function useSelectedCanteen() {
-  const { kioskMode, canteens_id } = useGlobalSearchParams<{
-    kioskMode?: string;
-    canteens_id?: string;
-  }>();
+  const kioskMode = useKioskMode();
+  const { canteens_id } = useGlobalSearchParams<{ canteens_id?: string }>();
   const { canteens, selectedCanteen } = useSelector(
     (state: RootState) => state.canteenReducer,
   );
 
   return useMemo(() => {
-    if (kioskMode === 'true') {
+    if (kioskMode) {
       if (canteens_id) {
         const found = canteens.find(
           (c) => String(c.id) === String(canteens_id),


### PR DESCRIPTION
## Summary
- add `useKioskMode` hook
- use kiosk mode hook in layout and selected canteen logic
- hide popup events when kiosk mode is active

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68717cb726a883308051cb43e5787416