### PR TITLE
Update canteen selection logic

### DIFF
--- a/apps/frontend/app/hooks/useSelectedCanteen.ts
+++ b/apps/frontend/app/hooks/useSelectedCanteen.ts
@@ -12,19 +12,31 @@ export default function useSelectedCanteen() {
   );
 
   return useMemo(() => {
-    if (kioskMode) {
-      if (canteens_id) {
-        const found = canteens.find(
-          (c) => String(c.id) === String(canteens_id),
-        );
-        if (found) {
-          return found;
-        }
-      }
-      if (selectedCanteen) {
-        return selectedCanteen;
+    if (canteens_id) {
+      const found = canteens.find(
+        (c) => String(c.id) === String(canteens_id),
+      );
+      if (found) {
+        return found;
       }
     }
-    return selectedCanteen;
+
+    if (kioskMode) {
+      const firstPublished = canteens.find((c) => c.status === 'published');
+      if (firstPublished) {
+        return firstPublished;
+      }
+    }
+
+    if (selectedCanteen) {
+      const exists = canteens.find(
+        (c) => String(c.id) === String(selectedCanteen.id),
+      );
+      if (exists) {
+        return exists;
+      }
+    }
+
+    return null;
   }, [kioskMode, canteens_id, canteens, selectedCanteen]);
 }


### PR DESCRIPTION
## Summary
- prioritize URL param when selecting canteen
- fall back to first published canteen in kiosk mode
- verify redux canteen exists

## Testing
- `yarn install`
- `yarn workspace directus-extension-rocket-meals-bundle install`
- `yarn test` *(fails: NewsTestHannover due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687188b5f41c8330825db98f1254eef2