### PR TITLE
Add backend dist ignore

### DIFF
--- a/.github/workflows/backend_directus_extension_build.yml
+++ b/.github/workflows/backend_directus_extension_build.yml
@@ -1,0 +1,55 @@
+name: Backend Directus Extension Build
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/**'
+    paths-ignore:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 🧰 Setup Node.js, Yarn & Dependencies
+        uses: ./.github/actions/setup-and-install
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 🚀 Build the extension
+        run: yarn run build
+
+      - name: 🔍 Check if dist has changed
+        id: check_changes
+        run: |
+          if [[ -n $(git status --porcelain ./dist) ]]; then
+            echo "dist_changed=true" >> $GITHUB_ENV
+          else
+            echo "dist_changed=false" >> $GITHUB_ENV
+          fi
+
+      - name: ✅ Commit and push changes if dist changed
+        if: env.dist_changed == 'true'
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git pull --rebase
+          git add -f ./dist
+          git commit -m "Update dist after backend build"
+          git push
+
+      - name: ☁️ Upload Dist Artifact
+        if: env.dist_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./dist
+          name: backend-dist

--- a/.github/workflows/frontend_expo_update.yml
+++ b/.github/workflows/frontend_expo_update.yml
@@ -7,6 +7,8 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
+    paths-ignore:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   update:

--- a/.github/workflows/frontend_native_android.yml
+++ b/.github/workflows/frontend_native_android.yml
@@ -7,6 +7,8 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
+    paths-ignore:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_native_android_preview.yml
+++ b/.github/workflows/frontend_native_android_preview.yml
@@ -7,6 +7,8 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
+    paths-ignore:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_native_ios.yml
+++ b/.github/workflows/frontend_native_ios.yml
@@ -7,6 +7,8 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
+    paths-ignore:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_web_ghpages_production.yml
+++ b/.github/workflows/frontend_web_ghpages_production.yml
@@ -7,6 +7,8 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
+    paths-ignore:
+      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   deploy-gh-pages:

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ apps/frontend/app/android
 tools/screenshotGenerator/dist/
 secrets/
 
+# Ignore built Directus extension
+apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/
+
 # Virtual environment folder
 **/venv/


### PR DESCRIPTION
## Summary
- ignore built backend dist folder in git
- update backend build workflow to force-add dist artifacts
- use the shared setup-and-install action

## Testing
- `node --version`
- `yarn --version`
- `yarn test` *(fails: package not in lockfile)*
- `yarn test` in extension *(fails: ENETUNREACH during news tests)*

------
https://chatgpt.com/codex/tasks/task_e_6871f3a2ce9083308214737564a1cf19