### PR TITLE
Fix workflow path triggers

### DIFF
--- a/.github/workflows/backend_directus_extension_build.yml
+++ b/.github/workflows/backend_directus_extension_build.yml
@@ -5,8 +5,7 @@ on:
     branches: [master]
     paths:
       - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+      - '!apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   build:

--- a/.github/workflows/frontend_expo_update.yml
+++ b/.github/workflows/frontend_expo_update.yml
@@ -7,8 +7,7 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+      - '!apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   update:

--- a/.github/workflows/frontend_native_android.yml
+++ b/.github/workflows/frontend_native_android.yml
@@ -7,8 +7,7 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+      - '!apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_native_android_preview.yml
+++ b/.github/workflows/frontend_native_android_preview.yml
@@ -7,8 +7,7 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+      - '!apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_native_ios.yml
+++ b/.github/workflows/frontend_native_ios.yml
@@ -7,8 +7,7 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+      - '!apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_web_ghpages_production.yml
+++ b/.github/workflows/frontend_web_ghpages_production.yml
@@ -7,8 +7,7 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
+      - '!apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   deploy-gh-pages:


### PR DESCRIPTION
## Summary
- fix invalid GitHub Actions path filters by combining paths and negated paths

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle workspace missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6872100b38ac833087794aa41508469a