### PR TITLE
Fix GitHub Actions path filters

### DIFF
--- a/.github/workflows/backend_directus_extension_build.yml
+++ b/.github/workflows/backend_directus_extension_build.yml
@@ -5,8 +5,6 @@ on:
     branches: [master]
     paths:
       - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   build:

--- a/.github/workflows/frontend_expo_update.yml
+++ b/.github/workflows/frontend_expo_update.yml
@@ -7,8 +7,6 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   update:

--- a/.github/workflows/frontend_native_android.yml
+++ b/.github/workflows/frontend_native_android.yml
@@ -7,8 +7,6 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_native_android_preview.yml
+++ b/.github/workflows/frontend_native_android_preview.yml
@@ -7,8 +7,6 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_native_ios.yml
+++ b/.github/workflows/frontend_native_ios.yml
@@ -7,8 +7,6 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   check-build:

--- a/.github/workflows/frontend_web_ghpages_production.yml
+++ b/.github/workflows/frontend_web_ghpages_production.yml
@@ -7,8 +7,6 @@ on:
       - 'apps/frontend/app/**'
       - 'packages/common/**'
       - '.github/workflows/**'
-    paths-ignore:
-      - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist/**'
 
 jobs:
   deploy-gh-pages:


### PR DESCRIPTION
## Summary
- remove `paths-ignore` from push triggers in frontend and backend workflows

## Testing
- `yarn test` *(fails: connect ENETUNREACH 185.232.0.200:443)*

------
https://chatgpt.com/codex/tasks/task_e_68721bed35888330b9b72d6c8400471f