### PR TITLE
Fix backend extension build workflow

### DIFF
--- a/.github/workflows/backend_directus_extension_build.yml
+++ b/.github/workflows/backend_directus_extension_build.yml
@@ -6,9 +6,9 @@ on:
     paths:
       - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/**'
 
-  jobs:
-    build:
-      runs-on: ubuntu-latest
+jobs:
+  build:
+    runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- fix indentation in backend extension build workflow

## Testing
- `yarn install` *(fails: lockfile would have been modified)*
- `yarn install` *(succeeds with warnings)*
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687242036fb08330a1ea1f4e560c97ec