### PR TITLE
Fix backend workflow trigger

### DIFF
--- a/.github/workflows/backend_directus_extension_build.yml
+++ b/.github/workflows/backend_directus_extension_build.yml
@@ -6,6 +6,7 @@ on:
     branches: [master]
     paths:
       - 'apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/**'
+      - '.github/workflows/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- trigger the backend build when workflows change

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68725c6a91c4833093d6c8a1bb63268a