### PR TITLE
Improve campus color contrast

### DIFF
--- a/apps/frontend/app/app/(app)/campus/details/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/index.tsx
@@ -18,6 +18,7 @@ import Information from '@/components/Information';
 import BuildingDescription from '@/components/BuildingDescription';
 import { useLocalSearchParams } from 'expo-router';
 import { useSelector } from 'react-redux';
+import { myContrastColor } from '@/helper/colorHelper';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -31,9 +32,12 @@ const details = () => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
   const { id } = useLocalSearchParams();
-  const { serverInfo, appSettings, primaryColor } = useSelector(
-    (state: RootState) => state.settings
-  );
+  const {
+    serverInfo,
+    appSettings,
+    primaryColor,
+    selectedTheme: mode,
+  } = useSelector((state: RootState) => state.settings);
   const { campusesDict } = useSelector((state: RootState) => state.campus);
   const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
   const [activeTab, setActiveTab] = useState('information');
@@ -45,6 +49,7 @@ const details = () => {
   const campus_area_color = appSettings?.campus_area_color
     ? appSettings?.campus_area_color
     : primaryColor;
+  const contrastColor = myContrastColor(campus_area_color, theme, mode === 'dark');
 
   const fetchCampusById = async () => {
     setLoading(true);
@@ -113,7 +118,7 @@ const details = () => {
   const themeStyles = {
     backgroundColor: campus_area_color,
     borderColor: campus_area_color,
-    color: theme.light,
+    color: contrastColor,
   };
 
   return (
@@ -254,7 +259,7 @@ const details = () => {
                           size={26}
                           color={
                             activeTab === 'information'
-                              ? theme.light
+                              ? contrastColor
                               : theme.screen.icon
                           }
                         />
@@ -290,7 +295,7 @@ const details = () => {
                           size={26}
                           color={
                             activeTab === 'description'
-                              ? theme.light
+                              ? contrastColor
                               : theme.screen.icon
                           }
                         />

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -5,6 +5,7 @@ import { isWeb } from '@/constants/Constants';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
+import { myContrastColor } from '@/helper/colorHelper';
 import styles from './styles';
 import { BuildingItemProps } from './types';
 import { router } from 'expo-router';
@@ -21,10 +22,18 @@ const BuildingItem: React.FC<BuildingItemProps> = ({
 }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
-  const { amountColumnsForcard, primaryColor, serverInfo } = useSelector(
-    (state: RootState) => state.settings
-  );
+  const {
+    amountColumnsForcard,
+    primaryColor,
+    serverInfo,
+    appSettings,
+    selectedTheme: mode,
+  } = useSelector((state: RootState) => state.settings);
   const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
+  const campus_area_color = appSettings?.campus_area_color
+    ? appSettings?.campus_area_color
+    : primaryColor;
+  const contrastColor = myContrastColor(campus_area_color, theme, mode === 'dark');
   const { isManagement } = useSelector((state: RootState) => state.authReducer);
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
@@ -153,15 +162,15 @@ const BuildingItem: React.FC<BuildingItemProps> = ({
               <TouchableOpacity
                 style={{
                   ...styles.directionButton,
-                  backgroundColor: primaryColor,
+                  backgroundColor: campus_area_color,
                 }}
               >
                 <MaterialCommunityIcons
                   name='map-marker-distance'
                   size={20}
-                  color={theme.activeText}
+                  color={contrastColor}
                 />
-                <Text style={{ ...styles.distance, color: theme.activeText }}>
+                <Text style={{ ...styles.distance, color: contrastColor }}>
                   {getDistanceUnit(campus?.distance)}
                 </Text>
               </TouchableOpacity>


### PR DESCRIPTION
## Summary
- compute contrast color in campus BuildingItem
- compute contrast color for campus details tabs

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn workspace rocket-meals-dev lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6872b3433774833090006ba47be2a86b