### PR TITLE
Make canteen heading clickable

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -661,12 +661,17 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 </Tooltip>
 
                 {/* Canteen Heading */}
-                <Text style={{ ...styles.heading, color: theme.header.text }}>
-                  {excerpt(
-                    String(selectedCanteen?.alias),
-                    screenWidth > 800 ? 30 : 10
-                  ) || 'Food Offers'}
-                </Text>
+                <TouchableOpacity
+                  onPress={() => openSheet('canteen')}
+                  activeOpacity={0.7}
+                >
+                  <Text style={{ ...styles.heading, color: theme.header.text }}>
+                    {excerpt(
+                      String(selectedCanteen?.alias),
+                      screenWidth > 800 ? 30 : 10
+                    ) || 'Food Offers'}
+                  </Text>
+                </TouchableOpacity>
               </View>
               <View
                 style={{


### PR DESCRIPTION
## Summary
- open the canteen selection sheet when clicking the current canteen name in Foodoffers

## Testing
- `yarn test` *(fails: monorepo not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6874281b06888330bf726d9973ec55a1