### PR TITLE
Refactor common card component

### DIFF
--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -1,4 +1,4 @@
-import { Dimensions, Image, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import React, { memo, useEffect, useState } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { isWeb } from '@/constants/Constants';
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import CardWithText from '../CardWithText/CardWithText';
 
 const BuildingItem: React.FC<BuildingItemProps> = ({
   campus,
@@ -96,37 +97,31 @@ const BuildingItem: React.FC<BuildingItemProps> = ({
     <Tooltip
       placement='top'
       trigger={(triggerProps) => (
-        <TouchableOpacity
+        <CardWithText
           {...triggerProps}
-          style={{
-            ...styles.card,
+          onPress={() => handleNavigation(campus?.id)}
+          imageSource={
+            campus?.image || campus?.image_remote_url
+              ? {
+                  uri: campus?.image_remote_url || getImageUrl(campus?.image),
+                }
+              : { uri: defaultImage }
+          }
+          containerStyle={{
             width:
               amountColumnsForcard === 0 ? getCardDimension() : getCardWidth(),
             backgroundColor: theme.card.background,
           }}
-          onPress={() => handleNavigation(campus?.id)}
-        >
-          <View
-            style={{
-              ...styles.imageContainer,
-              height:
-                amountColumnsForcard === 0
-                  ? getCardDimension()
-                  : getCardWidth(),
-            }}
-          >
-            <Image
-              style={styles.image}
-              source={
-                campus?.image || campus?.image_remote_url
-                  ? {
-                      uri:
-                        campus?.image_remote_url || getImageUrl(campus?.image),
-                    }
-                  : { uri: defaultImage }
-              }
-            />
-
+          imageContainerStyle={{
+            height:
+              amountColumnsForcard === 0
+                ? getCardDimension()
+                : getCardWidth(),
+          }}
+          contentStyle={{
+            paddingHorizontal: 5,
+          }}
+          imageChildren={
             <View style={styles.imageActionContainer}>
               {isManagement ? (
                 <Tooltip
@@ -175,18 +170,12 @@ const BuildingItem: React.FC<BuildingItemProps> = ({
                 </Text>
               </TouchableOpacity>
             </View>
-          </View>
-          <View
-            style={{
-              ...styles.cardContent,
-              paddingHorizontal: 5,
-            }}
-          >
-            <Text style={{ ...styles.campusName, color: theme.screen.text }}>
-              {isWeb ? excerpt(campus?.alias, 70) : excerpt(campus?.alias, 40)}
-            </Text>
-          </View>
-        </TouchableOpacity>
+          }
+        >
+          <Text style={{ ...styles.campusName, color: theme.screen.text }}>
+            {isWeb ? excerpt(campus?.alias, 70) : excerpt(campus?.alias, 40)}
+          </Text>
+        </CardWithText>
       )}
     >
       <TooltipContent bg={theme.tooltip.background} py='$1' px='$2'>

--- a/apps/frontend/app/components/BuildingItem/styles.ts
+++ b/apps/frontend/app/components/BuildingItem/styles.ts
@@ -1,16 +1,6 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  card: {
-    borderRadius: 18,
-    justifyContent: 'space-between',
-    paddingBottom: 10,
-  },
-  imageContainer: {
-    width: '100%',
-    borderRadius: 18,
-    position: 'relative',
-  },
   overlay: {
     width: '100%',
     height: '100%',
@@ -20,13 +10,6 @@ export default StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.2)',
     borderTopRightRadius: 18,
     borderTopLeftRadius: 18,
-  },
-  image: {
-    width: '100%',
-    height: '100%',
-    borderTopRightRadius: 18,
-    borderTopLeftRadius: 18,
-    resizeMode: 'cover',
   },
   imageActionContainer: {
     width: '100%',
@@ -56,11 +39,6 @@ export default StyleSheet.create({
   distance: {
     fontSize: 16,
     fontFamily: 'Poppins_400Regular',
-  },
-  cardContent: {
-    alignItems: 'stretch',
-    justifyContent: 'center',
-    flex: 1,
   },
   campusName: {
     fontSize: 16,

--- a/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
+++ b/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
@@ -1,4 +1,4 @@
-import { Dimensions, Image, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
@@ -19,6 +19,7 @@ import { CanteenHelper } from '@/redux/actions';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import CardWithText from '../CardWithText/CardWithText';
 
 const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
   closeSheet,
@@ -159,36 +160,29 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
             selectedCanteen &&
             String(selectedCanteen.id) === String(canteen.id);
           return (
-            <TouchableOpacity
-              style={{
-                ...styles.card,
+            <CardWithText
+              key={canteen.id + canteen.alias}
+              onPress={() => {
+                handleSelectCanteen(canteen);
+              }}
+              imageSource={
+                canteen?.image_url || canteensData[index]?.image
+                  ? {
+                      uri: canteen?.image_url || canteensData[index]?.image,
+                    }
+                  : { uri: defaultImage }
+              }
+              containerStyle={{
                 width: screenWidth > 800 ? 210 : 160,
                 backgroundColor: theme.card.background,
                 marginBottom: 10,
                 borderColor: isSelected ? foods_area_color : 'transparent',
                 borderWidth: isSelected ? 3 : 0,
               }}
-              key={canteen.id + canteen.alias}
-              onPress={() => {
-                handleSelectCanteen(canteen);
-              }}
-            >
-            <View
-              style={{
-                ...styles.imageContainer,
+              imageContainerStyle={{
                 height: screenWidth > 800 ? 210 : 160,
               }}
             >
-              <Image
-                style={styles.image}
-                source={
-                  canteen?.image_url || canteensData[index]?.image
-                    ? {
-                        uri: canteen?.image_url || canteensData[index]?.image,
-                      }
-                    : { uri: defaultImage }
-                }
-              />
               {canteen.status === 'archived' && (
                 <View style={styles.archiveContainer}>
                   <MaterialCommunityIcons
@@ -198,16 +192,15 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({
                   />
                 </View>
               )}
-            </View>
-            <Text
-              style={{ ...styles.foodName, color: theme.screen.text }}
-              numberOfLines={3}
-              ellipsizeMode='tail'
-            >
-              {excerpt(String(canteen.alias), 20)}
-            </Text>
-          </TouchableOpacity>
-        );
+              <Text
+                style={{ ...styles.foodName, color: theme.screen.text }}
+                numberOfLines={3}
+                ellipsizeMode='tail'
+              >
+                {excerpt(String(canteen.alias), 20)}
+              </Text>
+            </CardWithText>
+          );
         })}
       </View>
     </BottomSheetScrollView>

--- a/apps/frontend/app/components/CanteenSelectionSheet/styles.ts
+++ b/apps/frontend/app/components/CanteenSelectionSheet/styles.ts
@@ -36,22 +36,6 @@ export default StyleSheet.create({
     rowGap: 10,
     paddingBottom: 20,
   },
-  card: {
-    borderRadius: 18,
-    paddingBottom: 10,
-  },
-  imageContainer: {
-    width: '100%',
-    height: '75%',
-    borderRadius: 18,
-  },
-  image: {
-    width: '100%',
-    height: '100%',
-    borderTopRightRadius: 18,
-    borderTopLeftRadius: 18,
-    resizeMode: 'cover',
-  },
   foodName: {
     fontSize: 16,
     fontFamily: 'Poppins_400Regular',

--- a/apps/frontend/app/components/CardWithText/CardWithText.tsx
+++ b/apps/frontend/app/components/CardWithText/CardWithText.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Image, TouchableOpacity, View } from 'react-native';
+import styles from './styles';
+import { CardWithTextProps } from './types';
+
+const CardWithText: React.FC<CardWithTextProps> = ({
+  imageSource,
+  containerStyle,
+  imageContainerStyle,
+  imageStyle,
+  contentStyle,
+  borderColor,
+  imageChildren,
+  children,
+  ...rest
+}) => {
+  const contentBorder = borderColor
+    ? { borderTopColor: borderColor, borderTopWidth: 3 }
+    : null;
+
+  return (
+    <TouchableOpacity style={[styles.card, containerStyle]} {...rest}>
+      <View style={[styles.imageContainer, imageContainerStyle]}>
+        <Image style={[styles.image, imageStyle]} source={imageSource} />
+        {imageChildren}
+      </View>
+      <View style={[styles.cardContent, contentBorder, contentStyle]}>
+        {children}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default CardWithText;

--- a/apps/frontend/app/components/CardWithText/styles.ts
+++ b/apps/frontend/app/components/CardWithText/styles.ts
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  card: {
+    borderRadius: 18,
+    paddingBottom: 10,
+  },
+  imageContainer: {
+    width: '100%',
+    borderRadius: 18,
+    position: 'relative',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    borderTopRightRadius: 18,
+    borderTopLeftRadius: 18,
+    resizeMode: 'cover',
+  },
+  cardContent: {
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    flex: 1,
+  },
+});

--- a/apps/frontend/app/components/CardWithText/types.ts
+++ b/apps/frontend/app/components/CardWithText/types.ts
@@ -1,0 +1,17 @@
+import { ImageSourcePropType, StyleProp, ViewStyle, ImageStyle, TouchableOpacityProps } from 'react-native';
+import React from 'react';
+
+export interface CardWithTextProps extends TouchableOpacityProps {
+  imageSource: ImageSourcePropType;
+  containerStyle?: StyleProp<ViewStyle>;
+  imageContainerStyle?: StyleProp<ViewStyle>;
+  imageStyle?: StyleProp<ImageStyle>;
+  contentStyle?: StyleProp<ViewStyle>;
+  /**
+   * Optional border color for the content section. If provided the component
+   * will automatically apply a border with a default width.
+   */
+  borderColor?: string;
+  imageChildren?: React.ReactNode;
+  children?: React.ReactNode;
+}

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -43,6 +43,7 @@ import useToast from '@/hooks/useToast';
 import { handleFoodRating } from '@/helper/feedback';
 import { RootState } from '@/redux/reducer';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
+import CardWithText from '../CardWithText/CardWithText';
 
 const selectFoodState = (state: RootState) => state.food;
 
@@ -199,21 +200,8 @@ const FoodItem: React.FC<FoodItemProps> = memo(
         <Tooltip
           placement='top'
           trigger={(triggerProps) => (
-            <TouchableOpacity
+            <CardWithText
               {...triggerProps}
-              style={{
-                ...styles.card,
-                width:
-                  amountColumnsForcard === 0
-                    ? CardDimensionHelper.getCardDimension(screenWidth)
-                    : CardDimensionHelper.getCardWidth(
-                        screenWidth,
-                        amountColumnsForcard
-                      ),
-                backgroundColor: theme.card.background,
-                borderWidth: dislikedMarkings.length > 0 ? 3 : 0,
-                borderColor: '#FF000095',
-              }}
               onPress={() => {
                 if (item.redirect_url) {
                   openInBrowser(item.redirect_url);
@@ -226,78 +214,145 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                   handleNavigation(item?.id, foodId);
                 }
               }}
-            >
-              <View
-                style={{
-                  ...styles.imageContainer,
-                  height:
-                    amountColumnsForcard === 0
-                      ? CardDimensionHelper.getCardDimension(screenWidth)
-                      : CardDimensionHelper.getCardWidth(
-                          screenWidth,
-                          amountColumnsForcard
-                        ),
-                }}
-              >
-                <Image
-                  style={{
-                    ...styles.image,
-                    borderColor: foods_area_color,
-                  }}
-                  source={
-                    foodItem?.image_remote_url || foodItem?.image
-                      ? {
-                          uri:
-                            foodItem?.image_remote_url ||
-                            getImageUrl(foodItem?.image),
-                        }
-                      : { uri: defaultImage }
-                  }
-                />
-                {isManagement && (
-                  <Tooltip
-                    placement='top'
-                    trigger={(triggerProps) => (
-                      <TouchableOpacity
-                        {...triggerProps}
-                        style={styles.editImageButton}
-                        onPress={() => {
-                          setSelectedFoodId(item?.food?.id);
-                          handleImageSheet(item?.food?.id);
-                        }}
-                      >
-                        <MaterialCommunityIcons
-                          name='image-edit'
-                          size={20}
-                          color={'white'}
-                        />
-                      </TouchableOpacity>
-                    )}
-                  >
-                    <TooltipContent
-                      bg={theme.tooltip.background}
-                      py='$1'
-                      px='$2'
-                    >
-                      <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                        {`${translate(TranslationKeys.edit)}: ${translate(
-                          TranslationKeys.image
-                        )}`}
-                      </TooltipText>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-                <TouchableOpacity style={styles.favContainer}>
-                  {previousFeedback?.rating === 5 ? (
+              imageSource={
+                foodItem?.image_remote_url || foodItem?.image
+                  ? {
+                      uri:
+                        foodItem?.image_remote_url || getImageUrl(foodItem?.image),
+                    }
+                  : { uri: defaultImage }
+              }
+              containerStyle={{
+                width:
+                  amountColumnsForcard === 0
+                    ? CardDimensionHelper.getCardDimension(screenWidth)
+                    : CardDimensionHelper.getCardWidth(
+                        screenWidth,
+                        amountColumnsForcard
+                      ),
+                backgroundColor: theme.card.background,
+                borderWidth: dislikedMarkings.length > 0 ? 3 : 0,
+                borderColor: '#FF000095',
+              }}
+              imageContainerStyle={{
+                height:
+                  amountColumnsForcard === 0
+                    ? CardDimensionHelper.getCardDimension(screenWidth)
+                    : CardDimensionHelper.getCardWidth(
+                        screenWidth,
+                        amountColumnsForcard
+                      ),
+              }}
+              contentStyle={{
+                gap: isWeb ? 15 : 5,
+                paddingHorizontal: isWeb
+                  ? screenWidth > 550
+                    ? 5
+                    : screenWidth > 360
+                    ? 5
+                    : 5
+                  : 5,
+              }}
+              borderColor={foods_area_color}
+              imageChildren={
+                <>
+                  {isManagement && (
                     <Tooltip
                       placement='top'
                       trigger={(triggerProps) => (
                         <TouchableOpacity
                           {...triggerProps}
-                          onPress={() => updateRating(null)}
+                          style={styles.editImageButton}
+                          onPress={() => {
+                            setSelectedFoodId(item?.food?.id);
+                            handleImageSheet(item?.food?.id);
+                          }}
                         >
-                          <AntDesign
-                            name='star'
+                          <MaterialCommunityIcons
+                            name='image-edit'
+                            size={20}
+                            color={'white'}
+                          />
+                        </TouchableOpacity>
+                      )}
+                    >
+                      <TooltipContent
+                        bg={theme.tooltip.background}
+                        py='$1'
+                        px='$2'
+                      >
+                        <TooltipText fontSize='$sm' color={theme.tooltip.text}>
+                          {`${translate(TranslationKeys.edit)}: ${translate(
+                            TranslationKeys.image
+                          )}`}
+                        </TooltipText>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  <TouchableOpacity style={styles.favContainer}>
+                    {previousFeedback?.rating === 5 ? (
+                      <Tooltip
+                        placement='top'
+                        trigger={(triggerProps) => (
+                          <TouchableOpacity
+                            {...triggerProps}
+                            onPress={() => updateRating(null)}
+                          >
+                            <AntDesign
+                              name='star'
+                              size={20}
+                              color={foods_area_color}
+                            />
+                          </TouchableOpacity>
+                        )}
+                      >
+                        <TooltipContent
+                          bg={theme.tooltip.background}
+                          py='$1'
+                          px='$2'
+                        >
+                          <TooltipText fontSize='$sm' color={theme.tooltip.text}>
+                            {translate(TranslationKeys.set_rate_as_not_favorite)}
+                          </TooltipText>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip
+                        placement='top'
+                        trigger={(triggerProps) => (
+                          <TouchableOpacity
+                            {...triggerProps}
+                            onPress={() => updateRating(5)}
+                          >
+                            <AntDesign name='staro' size={20} color={'white'} />
+                          </TouchableOpacity>
+                        )}
+                      >
+                        <TooltipContent
+                          bg={theme.tooltip.background}
+                          py='$1'
+                          px='$2'
+                        >
+                          <TooltipText fontSize='$sm' color={theme.tooltip.text}>
+                            {translate(TranslationKeys.set_rate_as_favorite)}
+                          </TooltipText>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </TouchableOpacity>
+                  {dislikedMarkings.length > 0 && (
+                    <Tooltip
+                      placement='top'
+                      trigger={(triggerProps) => (
+                        <TouchableOpacity
+                          style={{
+                            ...styles.favContainerWarn,
+                          }}
+                          {...triggerProps}
+                          onPress={handleOpenSheet}
+                        >
+                          <MaterialIcons
+                            name='warning'
                             size={20}
                             color={foods_area_color}
                           />
@@ -310,183 +365,113 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                         px='$2'
                       >
                         <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                          {translate(TranslationKeys.set_rate_as_not_favorite)}
-                        </TooltipText>
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <Tooltip
-                      placement='top'
-                      trigger={(triggerProps) => (
-                        <TouchableOpacity
-                          {...triggerProps}
-                          onPress={() => updateRating(5)}
-                        >
-                          <AntDesign name='staro' size={20} color={'white'} />
-                        </TouchableOpacity>
-                      )}
-                    >
-                      <TooltipContent
-                        bg={theme.tooltip.background}
-                        py='$1'
-                        px='$2'
-                      >
-                        <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                          {translate(TranslationKeys.set_rate_as_favorite)}
+                          {`${translate(TranslationKeys.attention)} ${translate(
+                            TranslationKeys.eating_habits
+                          )}`}
                         </TooltipText>
                       </TooltipContent>
                     </Tooltip>
                   )}
-                </TouchableOpacity>
-                {dislikedMarkings.length > 0 && (
+                  <View style={styles.categoriesContainer}>
+                    {markingsData?.map((mark: any) => {
+                      const description = getDescriptionFromTranslation(
+                        mark?.translations,
+                        language
+                      );
+                      if ((mark?.image_remote_url || mark?.image) && description)
+                        return (
+                          <TouchableOpacity
+                            key={mark.id}
+                            onPress={() => openMarkingLabel(mark)}
+                          >
+                            <Image
+                              source={
+                                mark?.image_remote_url || mark?.image
+                                  ? {
+                                      uri:
+                                        mark?.image_remote_url ||
+                                        getImageUrl(mark?.image),
+                                    }
+                                  : { uri: defaultImage }
+                              }
+                              style={{
+                                ...styles.categoryLogo,
+                                backgroundColor:
+                                  mark?.background_color && mark?.background_color,
+                                borderRadius: mark?.background_color
+                                  ? 8
+                                  : mark.hide_border
+                                  ? 5
+                                  : 0,
+                              }}
+                            />
+                          </TouchableOpacity>
+                        );
+                    })}
+                  </View>
                   <Tooltip
                     placement='top'
                     trigger={(triggerProps) => (
                       <TouchableOpacity
-                        style={{
-                          ...styles.favContainerWarn,
-                        }}
+                        style={styles.priceTag}
                         {...triggerProps}
-                        onPress={handleOpenSheet}
+                        onPress={handlePriceChange}
                       >
-                        <MaterialIcons
-                          name='warning'
-                          size={20}
-                          color={foods_area_color}
-                        />
+                        <Text style={styles.priceText}>
+                          {showFormatedPrice(showPrice(item, profile))}
+                        </Text>
                       </TouchableOpacity>
                     )}
                   >
-                    <TooltipContent
-                      bg={theme.tooltip.background}
-                      py='$1'
-                      px='$2'
-                    >
+                    <TooltipContent bg={theme.tooltip.background} py='$1' px='$2'>
                       <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                        {`${translate(TranslationKeys.attention)} ${translate(
-                          TranslationKeys.eating_habits
+                        {`${showFormatedPrice(
+                          showPrice(item, profile)
+                        )} - ${translate(TranslationKeys.edit)}: ${translate(
+                          TranslationKeys.price_group
+                        )} ${translate(
+                          profile?.price_group ? getPriceGroup(profile?.price_group) : ''
                         )}`}
                       </TooltipText>
                     </TooltipContent>
                   </Tooltip>
-                )}
-                <View style={styles.categoriesContainer}>
-                  {markingsData?.map((mark: any) => {
-                    const description = getDescriptionFromTranslation(
-                      mark?.translations,
-                      language
-                    );
-                    if ((mark?.image_remote_url || mark?.image) && description)
-                      return (
-                        <TouchableOpacity
-                          key={mark.id}
-                          onPress={() => openMarkingLabel(mark)}
-                        >
-                          <Image
-                            source={
-                              mark?.image_remote_url || mark?.image
-                                ? {
-                                    uri:
-                                      mark?.image_remote_url ||
-                                      getImageUrl(mark?.image),
-                                  }
-                                : { uri: defaultImage }
-                            }
-                            style={{
-                              ...styles.categoryLogo,
-                              backgroundColor:
-                                mark?.background_color &&
-                                mark?.background_color,
-                              borderRadius: mark?.background_color
-                                ? 8
-                                : mark.hide_border
-                                ? 5
-                                : 0,
-                            }}
-                          />
-                        </TouchableOpacity>
-                      );
-                  })}
-                </View>
-                <Tooltip
-                  placement='top'
-                  trigger={(triggerProps) => (
-                    <TouchableOpacity
-                      style={styles.priceTag}
-                      {...triggerProps}
-                      onPress={handlePriceChange}
-                    >
-                      <Text style={styles.priceText}>
-                        {showFormatedPrice(showPrice(item, profile))}
-                      </Text>
-                    </TouchableOpacity>
-                  )}
-                >
-                  <TooltipContent bg={theme.tooltip.background} py='$1' px='$2'>
-                    <TooltipText fontSize='$sm' color={theme.tooltip.text}>
-                      {`${showFormatedPrice(
-                        showPrice(item, profile)
-                      )} - ${translate(TranslationKeys.edit)}: ${translate(
-                        TranslationKeys.price_group
-                      )} ${translate(
-                        profile?.price_group
-                          ? getPriceGroup(profile?.price_group)
-                          : ''
-                      )}`}
-                    </TooltipText>
-                  </TooltipContent>
-                </Tooltip>
-              </View>
-
-              <View
-                style={{
-                  ...styles.cardContent,
-                  gap: isWeb ? 15 : 5,
-                  borderColor: foods_area_color,
-                  paddingHorizontal: isWeb
-                    ? screenWidth > 550
-                      ? 5
-                      : screenWidth > 360
-                      ? 5
-                      : 5
-                    : 5,
-                }}
-              >
-                <Text style={{ ...styles.foodName, color: theme.screen.text }}>
-                  {screenWidth > 1000
-                    ? excerpt(
-                        getTextFromTranslation(
-                          foodItem?.translations,
-                          language
-                        ),
-                        120
-                      )
-                    : screenWidth > 700
-                    ? excerpt(
-                        getTextFromTranslation(
-                          foodItem?.translations,
-                          language
-                        ),
-                        80
-                      )
-                    : screenWidth > 460
-                    ? excerpt(
-                        getTextFromTranslation(
-                          foodItem?.translations,
-                          language
-                        ),
-                        60
-                      )
-                    : excerpt(
-                        getTextFromTranslation(
-                          foodItem?.translations,
-                          language
-                        ),
-                        40
-                      )}
-                </Text>
-              </View>
-            </TouchableOpacity>
+                </>
+              }
+            >
+              <Text style={{ ...styles.foodName, color: theme.screen.text }}>
+                {screenWidth > 1000
+                  ? excerpt(
+                      getTextFromTranslation(
+                        foodItem?.translations,
+                        language
+                      ),
+                      120
+                    )
+                  : screenWidth > 700
+                  ? excerpt(
+                      getTextFromTranslation(
+                        foodItem?.translations,
+                        language
+                      ),
+                      80
+                    )
+                  : screenWidth > 460
+                  ? excerpt(
+                      getTextFromTranslation(
+                        foodItem?.translations,
+                        language
+                      ),
+                      60
+                    )
+                  : excerpt(
+                      getTextFromTranslation(
+                        foodItem?.translations,
+                        language
+                      ),
+                      40
+                    )}
+              </Text>
+            </CardWithText>
           )}
         >
           <TooltipContent bg={theme.tooltip.background} py='$1' px='$2'>

--- a/apps/frontend/app/components/FoodItem/styles.ts
+++ b/apps/frontend/app/components/FoodItem/styles.ts
@@ -1,21 +1,6 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  card: {
-    borderRadius: 21,
-    justifyContent: 'space-between',
-    paddingBottom: 10,
-  },
-  cardContent: {
-    alignItems: 'stretch',
-    borderTopWidth: 3,
-    flex: 1,
-  },
-  imageContainer: {
-    width: '100%',
-    borderRadius: 18,
-    position: 'relative',
-  },
   editImageButton: {
     position: 'absolute',
     bottom: 10,
@@ -63,13 +48,6 @@ export default StyleSheet.create({
   categoryLogo: {
     width: 40,
     height: 40,
-    resizeMode: 'cover',
-  },
-  image: {
-    width: '100%',
-    height: '100%',
-    borderTopRightRadius: 18,
-    borderTopLeftRadius: 18,
     resizeMode: 'cover',
   },
   foodName: {


### PR DESCRIPTION
## Summary
- add border color prop to `CardWithText`
- remove redundant style objects from card users
- streamline `BuildingItem`, `FoodItem` and `CanteenSelectionSheet` to use new prop

## Testing
- `yarn test` *(fails: monorepo not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6876ba4eb2088330a95802165f7724e6