### PR TITLE
Add experimental chat screens

### DIFF
--- a/apps/frontend/app/app/(app)/chats/details/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/details/index.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { View, Text, FlatList } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { useLocalSearchParams } from 'expo-router';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { TranslationKeys } from '@/locales/keys';
+import MyMarkdown from '@/components/MyMarkdown/MyMarkdown';
+import styles from './styles';
+
+interface ChatMessage {
+  id: string;
+  chat_id: string;
+  profile_id: string;
+  text: string;
+  timestamp: string;
+}
+
+const MESSAGES: ChatMessage[] = [
+  {
+    id: 'm1',
+    chat_id: '1',
+    profile_id: '1',
+    text: 'Hallo **Welt**!',
+    timestamp: new Date().toISOString(),
+  },
+  {
+    id: 'm2',
+    chat_id: '1',
+    profile_id: '2',
+    text: 'Willkommen im Chat.',
+    timestamp: new Date(Date.now() - 1000000).toISOString(),
+  },
+];
+
+const ChatDetailsScreen = () => {
+  useSetPageTitle(TranslationKeys.chat);
+  const { theme } = useTheme();
+  const { chat_id } = useLocalSearchParams<{ chat_id?: string }>();
+
+  const chatMessages = MESSAGES.filter((m) => m.chat_id === chat_id);
+  chatMessages.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  const renderItem = ({ item }: { item: ChatMessage }) => (
+    <View style={styles.messageItem}>
+      <Text style={{ ...styles.timestamp, color: theme.screen.text }}>
+        {new Date(item.timestamp).toLocaleString()}
+      </Text>
+      <MyMarkdown content={item.text} />
+    </View>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.screen.background }]}>
+      <FlatList
+        data={chatMessages}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+      />
+    </View>
+  );
+};
+
+export default ChatDetailsScreen;

--- a/apps/frontend/app/app/(app)/chats/details/styles.ts
+++ b/apps/frontend/app/app/(app)/chats/details/styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  list: {
+    padding: 20,
+    gap: 10,
+  },
+  messageItem: {
+    padding: 10,
+    borderRadius: 10,
+  },
+  timestamp: {
+    fontSize: 12,
+    fontFamily: 'Poppins_400Regular',
+    marginBottom: 4,
+  },
+});

--- a/apps/frontend/app/app/(app)/chats/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, Text, FlatList, TouchableOpacity } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { router } from 'expo-router';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { TranslationKeys } from '@/locales/keys';
+import styles from './styles';
+
+interface Chat {
+  id: string;
+  owner: string;
+  title: string;
+}
+
+const CHATS: Chat[] = [
+  { id: '1', owner: '1', title: 'General' },
+  { id: '2', owner: '2', title: 'Project X' },
+];
+
+const ChatsScreen = () => {
+  useSetPageTitle(TranslationKeys.chats);
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+
+  const renderItem = ({ item }: { item: Chat }) => (
+    <TouchableOpacity
+      style={{ ...styles.chatItem, backgroundColor: theme.screen.iconBg }}
+      onPress={() =>
+        router.push({ pathname: '/chats/details', params: { chat_id: item.id } })
+      }
+    >
+      <Text style={{ ...styles.chatTitle, color: theme.screen.text }}>
+        {item.title}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.screen.background }]}>
+      <FlatList
+        data={CHATS}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+      />
+    </View>
+  );
+};
+
+export default ChatsScreen;

--- a/apps/frontend/app/app/(app)/chats/styles.ts
+++ b/apps/frontend/app/app/(app)/chats/styles.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  list: {
+    padding: 20,
+    gap: 10,
+  },
+  chatItem: {
+    padding: 15,
+    borderRadius: 10,
+  },
+  chatTitle: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+  },
+});

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -82,6 +82,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/chats')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='chat' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.chats)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -238,6 +238,8 @@ export enum TranslationKeys {
   course_timetable = 'course_timetable',
   experimentell = "experimentell",
   vertical_image_scroll = 'vertical_image_scroll',
+  chats = 'chats',
+  chat = 'chat',
   rss_feed = 'rss_feed',
   eating_habits = 'eating_habits',
   markings = 'markings',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2403,6 +2403,26 @@
     "tr": "Dikey Resim Kaydırma",
     "zh": "垂直图片滚动"
   },
+  "chats": {
+    "de": "Chats",
+    "en": "Chats",
+    "ar": "الدردشات",
+    "es": "Chats",
+    "fr": "Discussions",
+    "ru": "Чаты",
+    "tr": "Sohbetler",
+    "zh": "聊天"
+  },
+  "chat": {
+    "de": "Chat",
+    "en": "Chat",
+    "ar": "دردشة",
+    "es": "Chat",
+    "fr": "Chat",
+    "ru": "Чат",
+    "tr": "Sohbet",
+    "zh": "聊天"
+  },
   "rss_feed": {
     "de": "RSS Feed",
     "en": "RSS Feed",


### PR DESCRIPTION
## Summary
- add ChatList and ChatDetails screens under experimental area
- extend translations with chat labels
- link new screens from experimental index

## Testing
- `yarn install` *(fails: Some peer dependencies warnings)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687764853cec8330931d686ffdb7bdb8