### PR TITLE
Improve experimental chat layout

### DIFF
--- a/apps/frontend/app/app/(app)/chats/details/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/details/index.tsx
@@ -5,6 +5,11 @@ import { useLocalSearchParams } from 'expo-router';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { TranslationKeys } from '@/locales/keys';
 import MyMarkdown from '@/components/MyMarkdown/MyMarkdown';
+import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
+import { CHATS } from '../index';
 import styles from './styles';
 
 interface ChatMessage {
@@ -20,15 +25,43 @@ const MESSAGES: ChatMessage[] = [
     id: 'm1',
     chat_id: '1',
     profile_id: '1',
-    text: 'Hallo **Welt**!',
+    text: 'Hallo **Welt**! Dies ist eine längere Testnachricht, um das neue Layout zu überprüfen.',
     timestamp: new Date().toISOString(),
   },
   {
     id: 'm2',
     chat_id: '1',
     profile_id: '2',
-    text: 'Willkommen im Chat.',
+    text: 'Klingt gut! So können wir sehen, wie längere Texte in den Bubbles wirken.',
     timestamp: new Date(Date.now() - 1000000).toISOString(),
+  },
+  {
+    id: 'm3',
+    chat_id: '1',
+    profile_id: '1',
+    text: 'Super, ich freue mich auf dein Feedback.',
+    timestamp: new Date(Date.now() - 2000000).toISOString(),
+  },
+  {
+    id: 'm4',
+    chat_id: '2',
+    profile_id: '2',
+    text: 'Willkommen im Projekt X Chat. Hast du die neuesten Änderungen gesehen?',
+    timestamp: new Date(Date.now() - 3000000).toISOString(),
+  },
+  {
+    id: 'm5',
+    chat_id: '2',
+    profile_id: '1',
+    text: 'Ja, die Updates sehen vielversprechend aus. Wir sollten sie bald testen.',
+    timestamp: new Date(Date.now() - 3500000).toISOString(),
+  },
+  {
+    id: 'm6',
+    chat_id: '2',
+    profile_id: '2',
+    text: 'Absolut. Ich plane, morgen einen kurzen Build zu erstellen.',
+    timestamp: new Date(Date.now() - 4000000).toISOString(),
   },
 ];
 
@@ -36,23 +69,47 @@ const ChatDetailsScreen = () => {
   useSetPageTitle(TranslationKeys.chat);
   const { theme } = useTheme();
   const { chat_id } = useLocalSearchParams<{ chat_id?: string }>();
+  const { primaryColor: projectColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings
+  );
 
   const chatMessages = MESSAGES.filter((m) => m.chat_id === chat_id);
   chatMessages.sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   );
 
-  const renderItem = ({ item }: { item: ChatMessage }) => (
-    <View style={styles.messageItem}>
-      <Text style={{ ...styles.timestamp, color: theme.screen.text }}>
-        {new Date(item.timestamp).toLocaleString()}
-      </Text>
-      <MyMarkdown content={item.text} />
-    </View>
-  );
+  const chatTitle = CHATS.find((c) => c.id === chat_id)?.title || 'Chat';
+
+  const renderItem = ({ item }: { item: ChatMessage }) => {
+    const isMe = item.profile_id === '1';
+    const bgColor = isMe ? projectColor : theme.card.background;
+    const textColor = myContrastColor(bgColor, theme, mode === 'dark');
+    return (
+      <View
+        style={[
+          styles.messageItem,
+          { alignSelf: isMe ? 'flex-end' : 'flex-start' },
+        ]}
+      >
+        <View style={[styles.bubble, { backgroundColor: bgColor }]}>
+          <MyMarkdown content={item.text} textColor={textColor} />
+        </View>
+        <Text
+          style={{
+            ...styles.timestamp,
+            color: theme.screen.text,
+            textAlign: isMe ? 'right' : 'left',
+          }}
+        >
+          {new Date(item.timestamp).toLocaleString()}
+        </Text>
+      </View>
+    );
+  };
 
   return (
     <View style={[styles.container, { backgroundColor: theme.screen.background }]}>
+      <CustomStackHeader label={chatTitle} />
       <FlatList
         data={chatMessages}
         keyExtractor={(item) => item.id}

--- a/apps/frontend/app/app/(app)/chats/details/styles.ts
+++ b/apps/frontend/app/app/(app)/chats/details/styles.ts
@@ -9,12 +9,16 @@ export default StyleSheet.create({
     gap: 10,
   },
   messageItem: {
+    maxWidth: '80%',
+    gap: 4,
+  },
+  bubble: {
     padding: 10,
-    borderRadius: 10,
+    borderRadius: 3,
   },
   timestamp: {
     fontSize: 12,
     fontFamily: 'Poppins_400Regular',
-    marginBottom: 4,
+    marginTop: 2,
   },
 });

--- a/apps/frontend/app/app/(app)/chats/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/index.tsx
@@ -13,7 +13,7 @@ interface Chat {
   title: string;
 }
 
-const CHATS: Chat[] = [
+export const CHATS: Chat[] = [
   { id: '1', owner: '1', title: 'General' },
   { id: '2', owner: '2', title: 'Project X' },
 ];

--- a/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -18,6 +18,7 @@ import { myContrastColor } from '@/helper/colorHelper';
 
 export interface MyMarkdownProps {
   content: string;
+  textColor?: string;
 }
 
 export const replaceLinebreaks = (sourceContent: string) => {
@@ -33,7 +34,7 @@ export const replaceLinebreaks = (sourceContent: string) => {
   return sourceContent;
 };
 
-const MyMarkdown: React.FC<MyMarkdownProps> = ({ content }) => {
+const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorProp }) => {
   const { primaryColor, selectedTheme } = useSelector(
     (state: RootState) => state.settings
   );
@@ -61,7 +62,7 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content }) => {
   const source = { html: result || '' };
 
   const fontSize = 16;
-  const textColor = theme.sheet.text;
+  const textColor = textColorProp ?? theme.sheet.text;
   const contrastColor = myContrastColor(primaryColor, theme, selectedTheme === 'dark');
 
   const tagsStyles = {


### PR DESCRIPTION
## Summary
- enhance MyMarkdown to accept custom textColor
- show chat list titles as exported constant
- restyle chat bubbles with smaller radius and alignment
- display chat title with back navigation

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn workspace rocket-meals-dev lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68777299764c8330a98d820a760fb358