### PR TITLE
Add custom header for chat screens

### DIFF
--- a/apps/frontend/app/app/(app)/chats/_layout.tsx
+++ b/apps/frontend/app/app/(app)/chats/_layout.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useTheme } from '@/hooks/useTheme';
+import { Stack } from 'expo-router';
+import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+
+export default function ChatsLayout() {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.header.background },
+        headerTintColor: theme.header.text,
+      }}
+    >
+      <Stack.Screen
+        name='index'
+        options={{
+          header: () => (
+            <CustomStackHeader label={translate(TranslationKeys.chats)} />
+          ),
+        }}
+      />
+      <Stack.Screen
+        name='details/index'
+        options={{
+          headerShown: false,
+        }}
+      />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- add a stack layout for chats with a `CustomStackHeader`

## Testing
- `yarn workspace directus-extension-rocket-meals-bundle test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687795a5ccb4833096840729c4049131