### PR TITLE
Add Expo update check on resume

### DIFF
--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -36,6 +36,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { GluestackUIProvider } from '@gluestack-ui/themed';
 import { config } from '@gluestack-ui/config';
 import ExpoUpdateLoader from '@/components/ExpoUpdateLoader/ExpoUpdateLoader';
+import ExpoUpdateChecker from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 
 ServerAPI.createAuthentificationStorage(
   async () => {
@@ -102,17 +103,19 @@ export default function Layout() {
             <RootSiblingParent>
               <ThemeProvider>
                 <ServerStatusLoader>
-                  <KeyboardAvoidingView
-                    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-                    style={{ flex: 1, backgroundColor: theme.screen.iconBg }}
-                  >
-                    <SafeAreaView
+                  <ExpoUpdateChecker>
+                    <KeyboardAvoidingView
+                      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
                       style={{ flex: 1, backgroundColor: theme.screen.iconBg }}
-                      edges={['top', 'bottom']}
                     >
-                      <Slot />
-                    </SafeAreaView>
-                  </KeyboardAvoidingView>
+                      <SafeAreaView
+                        style={{ flex: 1, backgroundColor: theme.screen.iconBg }}
+                        edges={['top', 'bottom']}
+                      >
+                        <Slot />
+                      </SafeAreaView>
+                    </KeyboardAvoidingView>
+                  </ExpoUpdateChecker>
                 </ServerStatusLoader>
               </ThemeProvider>
             </RootSiblingParent>

--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { AppState, AppStateStatus, View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+import * as Updates from 'expo-updates';
+import ModalComponent from '../ModalSetting/ModalComponent';
+import { styles as modalStyles } from '../ModalSetting/styles';
+import usePlatformHelper from '@/helper/platformHelper';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import { useTheme } from '@/hooks/useTheme';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+
+interface ExpoUpdateCheckerProps {
+  children?: React.ReactNode;
+}
+
+const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
+  const appState = useRef<AppStateStatus>(AppState.currentState);
+  const { isSmartPhone } = usePlatformHelper();
+  const { translate } = useLanguage();
+  const { theme } = useTheme();
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+  const [modalVisible, setModalVisible] = useState(false);
+  const [updating, setUpdating] = useState(false);
+
+  const checkForUpdates = async () => {
+    if (!isSmartPhone()) return;
+    try {
+      const update = await Updates.checkForUpdateAsync();
+      if (update.isAvailable) {
+        setModalVisible(true);
+      }
+    } catch (e) {
+      console.error('Error while checking updates', e);
+    }
+  };
+
+  useEffect(() => {
+    if (!isSmartPhone()) return;
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (
+        appState.current.match(/inactive|background/) &&
+        nextState === 'active'
+      ) {
+        checkForUpdates();
+      }
+      appState.current = nextState;
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  const applyUpdate = async () => {
+    try {
+      setUpdating(true);
+      await Updates.fetchUpdateAsync();
+      await Updates.reloadAsync();
+    } catch (e) {
+      console.error('Error while applying updates', e);
+    }
+  };
+
+  return (
+    <>
+      {children}
+      <ModalComponent
+        isVisible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        title={translate(TranslationKeys.update_available)}
+        onSave={applyUpdate}
+        showButtons={false}
+      >
+        <View style={{ gap: 20 }}>
+          <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
+            {translate(TranslationKeys.update_available_message)}
+          </Text>
+          <View style={[modalStyles.buttonContainer, { width: '80%' }]}>
+            <TouchableOpacity
+              onPress={() => setModalVisible(false)}
+              style={[modalStyles.cancelButton, { borderColor: primaryColor }]}
+            >
+              <Text style={[modalStyles.buttonText, { color: theme.screen.text }]}>
+                {translate(TranslationKeys.cancel)}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={applyUpdate}
+              style={[modalStyles.saveButton, { backgroundColor: primaryColor }]}
+            >
+              {updating ? (
+                <ActivityIndicator color={theme.activeText} />
+              ) : (
+                <Text style={[modalStyles.buttonText, { color: theme.activeText }]}>
+                  {translate(TranslationKeys.to_update)}
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ModalComponent>
+    </>
+  );
+};
+
+export default ExpoUpdateChecker;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -282,6 +282,8 @@ export enum TranslationKeys {
   save = 'save',
   clear = 'clear',
   to_update = 'to_update',
+  update_available = 'update_available',
+  update_available_message = 'update_available_message',
   send = 'send',
   button_disabled = 'button_disabled',
   select = 'select',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2823,6 +2823,26 @@
     "tr": "Güncelle",
     "zh": "更新"
   },
+  "update_available": {
+    "de": "Update verf\u00fcgbar",
+    "en": "Update available",
+    "ar": "\u062a\u062d\u062f\u064a\u062b \u0645\u062a\u0627\u062d",
+    "es": "Actualizaci\u00f3n disponible",
+    "fr": "Mise \u00e0 jour disponible",
+    "ru": "\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435",
+    "tr": "G\u00fcncelleme mevcut",
+    "zh": "\u53ef\u7528\u7684\u66f4\u65b0"
+  },
+  "update_available_message": {
+    "de": "Eine neue Version ist verf\u00fcgbar. Jetzt aktualisieren?",
+    "en": "A new version is available. Update now?",
+    "ar": "\u0625\u0635\u062f\u0627\u0631 \u062c\u062f\u064a\u062f \u0645\u062a\u0627\u062d. \u0647\u0644 \u062a\u0631\u063a\u0628 \u0641\u064a \u0627\u0644\u062a\u062d\u062f\u064a\u062b \u0627\u0644\u0622\u0646?",
+    "es": "Hay una nueva versi\u00f3n disponible. \u00bfActualizar ahora?",
+    "fr": "Une nouvelle version est disponible. Mettre \u00e0 jour maintenant\u00a0?",
+    "ru": "\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u0430 \u043d\u043e\u0432\u0430\u044f \u0432\u0435\u0440\u0441\u0438\u044f. \u041e\u0431\u043d\u043e\u0432\u0438\u0442\u044c\u0441\u044f?",
+    "tr": "Yeni bir s\u00fcr\u00fcm mevcut. \u015eimdi g\u00fcncelle?",
+    "zh": "\u6709\u65b0\u7248\u672c\u3002\u73b0\u5728\u66f4\u65b0\u5417?"
+  },
   "send": {
     "de": "Senden",
     "en": "Send",


### PR DESCRIPTION
## Summary
- add new translations for update available message
- add `ExpoUpdateChecker` component to check for updates when the app resumes
- integrate update checker in root layout

## Testing
- `yarn install` *(fails: attempted but environment uses Yarn 4)*
- `yarn --cwd apps/frontend/app lint` *(failed: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6877c9c360908330955698d3e094c47a