### PR TITLE
Update bottom sheet modal styles

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useCallback, useMemo } from 'react';
-import { Dimensions, View, TouchableOpacity } from 'react-native';
+import { Dimensions, View, TouchableOpacity, Text } from 'react-native';
 import BottomSheet, {
   BottomSheetBackdrop,
   type BottomSheetProps,
@@ -15,12 +15,13 @@ import styles from './styles';
 export interface BaseBottomSheetProps
   extends Omit<BottomSheetProps, 'backdropComponent'> {
   onClose?: () => void;
+  title?: string;
 }
 
 const MAX_HEIGHT = Dimensions.get('window').height * 0.8;
 
 const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
-  ({ onClose, children, backgroundStyle, onChange, ...props }, ref) => {
+  ({ onClose, title, children, backgroundStyle, onChange, ...props }, ref) => {
     const renderBackdrop = useCallback(
       (backdropProps: BottomSheetBackdropProps) => (
         <BottomSheetBackdrop
@@ -55,7 +56,6 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
       <BottomSheet
         ref={ref}
         snapPoints={snapPoints}
-        enableDynamicSizing
         maxDynamicContentSize={MAX_HEIGHT}
         backdropComponent={renderBackdrop}
         backgroundStyle={backgroundStyle}
@@ -63,15 +63,18 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(
         onChange={handleChange}
         {...props}
       >
-        <View style={[styles.header, { backgroundColor: headerBg }]}>
-          <View style={styles.placeholder} />
-          <View style={[styles.handle, { backgroundColor: handleColor }]} />
-          <TouchableOpacity
-            style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
-            onPress={onClose}
-          >
-            <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
-          </TouchableOpacity>
+        <View style={[styles.headerContainer, { backgroundColor: headerBg }]}>
+          <View style={styles.handleRow}>
+            <View style={styles.placeholder} />
+            <View style={[styles.handle, { backgroundColor: handleColor }]} />
+            <TouchableOpacity
+              style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]}
+              onPress={onClose}
+            >
+              <AntDesign name='close' size={24} color={theme.sheet.closeIcon} />
+            </TouchableOpacity>
+          </View>
+          {title && <Text style={[styles.title, { color: theme.sheet.text }]}>{title}</Text>}
         </View>
         {children}
       </BottomSheet>

--- a/apps/frontend/app/components/BaseBottomSheet/styles.ts
+++ b/apps/frontend/app/components/BaseBottomSheet/styles.ts
@@ -1,14 +1,16 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  header: {
+  headerContainer: {
     width: '100%',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
     borderTopRightRadius: 28,
     borderTopLeftRadius: 28,
     padding: 10,
+  },
+  handleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   closeButton: {
     width: 45,
@@ -27,5 +29,11 @@ export default StyleSheet.create({
   placeholder: {
     width: 45,
     height: 45,
+  },
+  title: {
+    marginTop: 10,
+    textAlign: 'center',
+    fontSize: 18,
+    fontFamily: 'Poppins_700Bold',
   },
 });

--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -78,6 +78,7 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
         enablePanDownToClose
         onClose={() => setModalVisible(false)}
         backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
+        title={translate(TranslationKeys.update_available)}
       >
         <BottomSheetView style={sheetStyles.contentContainer}>
           <Text style={{ color: theme.screen.text, textAlign: 'center' }}>

--- a/apps/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
+++ b/apps/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
@@ -19,8 +19,6 @@ const MarkingBottomSheet = forwardRef<BottomSheet, MarkingBottomSheetProps>(
         backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }}
         enablePanDownToClose
         handleComponent={null}
-        enableHandlePanningGesture={false}
-        enableContentPanningGesture={false}
         onClose={onClose}
       >
         <MenuSheet closeSheet={onClose} />


### PR DESCRIPTION
## Summary
- tweak BaseBottomSheet to always use 80% height and add optional title
- update style definitions for new header layout
- show title in ExpoUpdateChecker modal
- allow dragging to close MarkingBottomSheet

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68781390c5348330bdf5025977f134e6