### PR TITLE
Add bottom padding for CardWithText text spacing

### DIFF
--- a/apps/frontend/app/components/CardWithText/styles.ts
+++ b/apps/frontend/app/components/CardWithText/styles.ts
@@ -21,5 +21,6 @@ export default StyleSheet.create({
     alignItems: 'stretch',
     justifyContent: 'center',
     flex: 1,
+    paddingBottom: 18,
   },
 });


### PR DESCRIPTION
## Summary
- adjust CardWithText styles so the text inside has a margin bottom equal to the card's border radius

## Testing
- `yarn install` *(fails: some peer dependencies and builds required)*
- `yarn test` *(fails: internal error about missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68781461a8e88330a179c0907438b350