### PR TITLE
Use bottom sheet for distance info

### DIFF
--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -20,6 +20,7 @@ const BuildingItem: React.FC<BuildingItemProps> = ({
   campus,
   openImageManagementSheet,
   setSelectedApartementId,
+  openDistanceSheet,
 }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
@@ -160,6 +161,7 @@ const BuildingItem: React.FC<BuildingItemProps> = ({
                   ...styles.directionButton,
                   backgroundColor: campus_area_color,
                 }}
+                onPress={openDistanceSheet}
               >
                 <MaterialCommunityIcons
                   name='map-marker-distance'

--- a/apps/frontend/app/components/BuildingItem/types.ts
+++ b/apps/frontend/app/components/BuildingItem/types.ts
@@ -2,4 +2,5 @@ export interface BuildingItemProps {
   campus: any;
   setSelectedApartementId: React.Dispatch<React.SetStateAction<string>>;
   openImageManagementSheet: () => void;
+  openDistanceSheet: () => void;
 }


### PR DESCRIPTION
## Summary
- add `openDistanceSheet` prop to BuildingItem
- open distance sheet from BuildingItem
- add DistanceInfoSheet bottom sheet to campus page

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6878264e7f788330b9689f2a0302a9e5