### PR TITLE
Reduce bottom padding in CardWithText

### DIFF
--- a/apps/frontend/app/components/CardWithText/styles.ts
+++ b/apps/frontend/app/components/CardWithText/styles.ts
@@ -21,6 +21,6 @@ export default StyleSheet.create({
     alignItems: 'stretch',
     justifyContent: 'center',
     flex: 1,
-    paddingBottom: 18,
+    paddingBottom: 9,
   },
 });


### PR DESCRIPTION
## Summary
- update `CardWithText` styles to reduce bottom padding

## Testing
- `yarn test` *(fails: monorepo isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878283b033c8330aecc18ab8495a650