### PR TITLE
Adjust wiki link padding

### DIFF
--- a/apps/frontend/app/components/Drawer/styles.ts
+++ b/apps/frontend/app/components/Drawer/styles.ts
@@ -72,6 +72,7 @@ export const styles = StyleSheet.create({
   link: {
     fontSize: 14,
     fontFamily: 'Poppins_400Regular',
+    paddingHorizontal: 2,
   },
   bar: {
     color: '#696969',


### PR DESCRIPTION
## Summary
- add horizontal padding for wiki links at the bottom of the drawer

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*

------
https://chatgpt.com/codex/tasks/task_e_68782893b4348330b900eb26c97c3608