### PR TITLE
Fix chat layout

### DIFF
--- a/apps/frontend/app/app/(app)/chats/_layout.tsx
+++ b/apps/frontend/app/app/(app)/chats/_layout.tsx
@@ -26,7 +26,9 @@ export default function ChatsLayout() {
       <Stack.Screen
         name='details/index'
         options={{
-          headerShown: false,
+          header: () => (
+            <CustomStackHeader label={translate(TranslationKeys.chat)} />
+          ),
         }}
       />
     </Stack>

--- a/apps/frontend/app/app/(app)/chats/details/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/details/index.tsx
@@ -5,7 +5,6 @@ import { useLocalSearchParams } from 'expo-router';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { TranslationKeys } from '@/locales/keys';
 import MyMarkdown from '@/components/MyMarkdown/MyMarkdown';
-import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/colorHelper';
@@ -109,7 +108,6 @@ const ChatDetailsScreen = () => {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.screen.background }]}>
-      <CustomStackHeader label={chatTitle} />
       <FlatList
         data={chatMessages}
         keyExtractor={(item) => item.id}


### PR DESCRIPTION
## Summary
- remove chat page header from the details screen
- add header to the chat detail route so the back button still works

## Testing
- `yarn test` *(fails: ENETUNREACH 185.232.0.200)*

------
https://chatgpt.com/codex/tasks/task_e_687828d626ec83308a5114ac31769211