### PR TITLE
Fix chats header layout

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -727,6 +727,14 @@ export default function Layout() {
           }}
         />
 
+        <Drawer.Screen
+          name='chats'
+          options={{
+            title: translate(TranslationKeys.chats),
+            headerShown: false,
+          }}
+        />
+
 
         <Drawer.Screen
           name='notification/index'


### PR DESCRIPTION
## Summary
- register chats route in the drawer and hide drawer header

## Testing
- `yarn test` *(fails: package not present in lockfile)*
- `yarn test` in `apps/frontend/app` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6878316b2cd4833094bdabf83167917b