### PR TITLE
Fix update checker bottom sheet

### DIFF
--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -34,13 +34,18 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
   const bottomSheetRef = useRef<BottomSheet>(null);
   const [updating, setUpdating] = useState(false);
 
+  useEffect(() => {
+    if (modalVisible) {
+      bottomSheetRef.current?.expand();
+    }
+  }, [modalVisible]);
+
   const checkForUpdates = async () => {
     if (!isSmartPhone()) return;
     try {
       const update = await Updates.checkForUpdateAsync();
       if (update.isAvailable) {
         setModalVisible(true);
-        setTimeout(() => bottomSheetRef.current?.expand(), 0);
       }
     } catch (e) {
       console.error('Error while checking updates', e);


### PR DESCRIPTION
## Summary
- remove `setTimeout` logic that failed to open the update bottom sheet in time
- expand the update bottom sheet when `modalVisible` is set

## Testing
- `yarn test` *(fails: project expects yarn workspace dependencies to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68783c97c2a48330819383b9006d009f