### PR TITLE
Add developer server switch

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -33,6 +33,7 @@ import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateC
 import NicknameSheet from '@/components/NicknameSheet/NicknameSheet';
 import ColorSchemeSheet from '@/components/ColorSchemeSheet/ColorSchemeSheet';
 import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
+import ServerSelectionSheet from '@/components/ServerSelectionSheet/ServerSelectionSheet';
 import { router, useFocusEffect } from 'expo-router';
 import {
   themes,
@@ -41,6 +42,7 @@ import {
   AmountColumn,
   days,
 } from '../../../constants/SettingData';
+import { devConfig, swosyConfig, studiFutterConfig, type CustomerConfig } from '@/config';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import AmountColumns from '@/components/AmountColumn/AmountColumns';
@@ -80,6 +82,7 @@ import {
   showFormatedPrice,
 } from '@/constants/HelperFunctions';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
+import { ServerAPI } from '@/redux/actions';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { DatabaseTypes } from 'repo-depkit-common';
@@ -102,6 +105,7 @@ const Settings = () => {
   const amountColumnSheetRef = useRef<BottomSheet>(null);
   const firstDaySheetRef = useRef<BottomSheet>(null);
   const colorSchemeSheetRef = useRef<BottomSheet>(null);
+  const serverSheetRef = useRef<BottomSheet>(null);
   const [disabled, setDisabled] = useState(false);
   const { manualCheck } = useExpoUpdateChecker();
   const {
@@ -222,6 +226,21 @@ const Settings = () => {
 
   const closeFirstDayModal = () => {
     firstDaySheetRef?.current?.close();
+  };
+
+  // server selection
+  const openServerSheet = () => {
+    serverSheetRef?.current?.expand();
+  };
+
+  const closeServerSheet = () => {
+    serverSheetRef?.current?.close();
+  };
+
+  const handleSelectServer = async (config: CustomerConfig) => {
+    ServerAPI.serverUrlCustom = config.server_url;
+    await AsyncStorage.setItem('server_url_custom', config.server_url);
+    await performLogout(dispatch, router);
   };
 
   const handleCheckForUpdates = () => {
@@ -738,6 +757,23 @@ const Settings = () => {
               {translate(TranslationKeys.developerModeActive)}
             </Text>
           )}
+          {isManagement && isDevMode && (
+            <SettingList
+              leftIcon={
+                <MaterialCommunityIcons
+                  name='server'
+                  size={24}
+                  color={theme.screen.icon}
+                />
+              }
+              label={translate(TranslationKeys.backend_server)}
+              value={serverInfo?.info?.project?.project_name}
+              rightIcon={
+                <Octicons name='chevron-right' size={24} color={theme.screen.icon} />
+              }
+              handleFunction={openServerSheet}
+            />
+          )}
         </View>
       </ScrollView>
       {isActive && (
@@ -874,12 +910,29 @@ const Settings = () => {
             handleComponent={null}
             onClose={closeDrawerSheet}
           >
-            <DrawerPositionSheet
-              closeSheet={closeDrawerSheet}
-              selectedPosition={drawerPosition}
-              onSelect={(position) => {
-                handleDrawerPosition(position);
-              }}
+          <DrawerPositionSheet
+            closeSheet={closeDrawerSheet}
+            selectedPosition={drawerPosition}
+            onSelect={(position) => {
+              handleDrawerPosition(position);
+            }}
+          />
+          </BaseBottomSheet>
+          <BaseBottomSheet
+            ref={serverSheetRef}
+            index={-1}
+            backgroundStyle={{
+              ...styles.sheetBackground,
+              backgroundColor: theme.sheet.sheetBg,
+            }}
+            enablePanDownToClose
+            handleComponent={null}
+            onClose={closeServerSheet}
+          >
+            <ServerSelectionSheet
+              closeSheet={closeServerSheet}
+              selectedServer={ServerAPI.getServerUrl()}
+              onSelect={handleSelectServer}
             />
           </BaseBottomSheet>
         </>

--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Slot } from 'expo-router';
 import { RootSiblingParent } from 'react-native-root-siblings';
 import {
@@ -74,6 +74,14 @@ export default function Layout() {
     Poppins_900Black,
     Poppins_900Black_Italic,
   });
+
+  useEffect(() => {
+    AsyncStorage.getItem('server_url_custom').then((url) => {
+      if (url) {
+        ServerAPI.serverUrlCustom = url;
+      }
+    });
+  }, []);
 
   if (!fontsLoaded) {
     return (

--- a/apps/frontend/app/components/ServerOption/ServerOption.tsx
+++ b/apps/frontend/app/components/ServerOption/ServerOption.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/useTheme';
+import { useSelector } from 'react-redux';
+import { myContrastColor } from '@/helper/colorHelper';
+import type { RootState } from '@/redux/reducer';
+import type { CustomerConfig } from '@/config';
+
+interface ServerOptionProps {
+  server: CustomerConfig;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+const ServerOption: React.FC<ServerOptionProps> = ({ server, isSelected, onPress }) => {
+  const { theme } = useTheme();
+  const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+  return (
+    <TouchableOpacity
+      style={{
+        ...styles.row,
+        paddingHorizontal: 10,
+        backgroundColor: isSelected ? primaryColor : theme.screen.iconBg,
+      }}
+      onPress={onPress}
+    >
+      <MaterialCommunityIcons
+        name="server"
+        size={24}
+        color={isSelected ? contrastColor : theme.screen.icon}
+        style={styles.icon}
+      />
+      <Text
+        style={{
+          ...styles.text,
+          color: isSelected ? contrastColor : theme.header.text,
+        }}
+      >
+        {server.projectName}
+      </Text>
+      <MaterialCommunityIcons
+        name={isSelected ? 'checkbox-marked' : 'checkbox-blank'}
+        size={24}
+        color={isSelected ? contrastColor : theme.screen.icon}
+        style={styles.radioButton}
+      />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    marginTop: 10,
+    width: '100%',
+    height: 50,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 12,
+  },
+  icon: {
+    marginRight: 10,
+  },
+  text: {
+    flex: 1,
+    fontSize: 16,
+    color: 'black',
+  },
+  radioButton: {
+    marginLeft: 'auto',
+  },
+});
+
+export default ServerOption;

--- a/apps/frontend/app/components/ServerSelectionSheet/ServerSelectionSheet.tsx
+++ b/apps/frontend/app/components/ServerSelectionSheet/ServerSelectionSheet.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { isWeb } from '@/constants/Constants';
+import styles from './styles';
+import ServerOption from '@/components/ServerOption/ServerOption';
+import { devConfig, swosyConfig, studiFutterConfig, CustomerConfig } from '@/config';
+import { TranslationKeys } from '@/locales/keys';
+
+export interface ServerSelectionSheetProps {
+  closeSheet: () => void;
+  selectedServer: string;
+  onSelect: (config: CustomerConfig) => void;
+}
+
+const ServerSelectionSheet: React.FC<ServerSelectionSheetProps> = ({
+  closeSheet,
+  selectedServer,
+  onSelect,
+}) => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const servers: CustomerConfig[] = [devConfig, swosyConfig, studiFutterConfig];
+
+  return (
+    <BottomSheetScrollView
+      style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View
+        style={{
+          ...styles.sheetHeader,
+          paddingRight: isWeb ? 10 : 0,
+          paddingTop: isWeb ? 10 : 0,
+        }}
+      >
+        <View />
+        <Text
+          style={{
+            ...styles.sheetHeading,
+            fontSize: isWeb ? 40 : 28,
+            color: theme.sheet.text,
+          }}
+        >
+          {translate(TranslationKeys.backend_server)}
+        </Text>
+      </View>
+      <View style={styles.optionsContainer}>
+        {servers.map((srv) => (
+          <ServerOption
+            key={srv.projectSlug}
+            server={srv}
+            isSelected={selectedServer === srv.server_url}
+            onPress={() => {
+              onSelect(srv);
+              closeSheet();
+            }}
+          />
+        ))}
+      </View>
+    </BottomSheetScrollView>
+  );
+};
+
+export default ServerSelectionSheet;

--- a/apps/frontend/app/components/ServerSelectionSheet/styles.ts
+++ b/apps/frontend/app/components/ServerSelectionSheet/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  sheetView: {
+    width: '100%',
+    height: '100%',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+    padding: 10,
+    paddingBottom: 0,
+  },
+  contentContainer: {
+    alignItems: 'center',
+  },
+  sheetHeader: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderTopRightRadius: 28,
+    borderTopLeftRadius: 28,
+  },
+  sheetHeading: {
+    fontFamily: 'Poppins_700Bold',
+  },
+  optionsContainer: {
+    width: '100%',
+    paddingHorizontal: 10,
+    marginTop: 20,
+  },
+});

--- a/apps/frontend/app/components/ServerSelectionSheet/types.ts
+++ b/apps/frontend/app/components/ServerSelectionSheet/types.ts
@@ -1,0 +1,7 @@
+import type { CustomerConfig } from '@/config';
+
+export interface ServerSelectionSheetProps {
+  closeSheet: () => void;
+  selectedServer: string;
+  onSelect: (config: CustomerConfig) => void;
+}

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -14,6 +14,7 @@ export enum TranslationKeys {
   loggingInPleaseWait = 'loggingInPleaseWait',
   developer = 'developer',
   developerModeActive = 'developerModeActive',
+  backend_server = 'backend_server',
   developer_homepage = 'developer_homepage',
   download_or_open_the_app = 'download_or_open_the_app',
   software_homepage = 'software_homepage',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -149,6 +149,16 @@
     "tr": "Geliştirici Modu Aktif",
     "zh": "开发者模式已启用"
   },
+  "backend_server": {
+    "de": "Backend-Server",
+    "en": "Backend Server",
+    "ar": "خادم الخلفية",
+    "es": "Servidor Backend",
+    "fr": "Serveur Backend",
+    "ru": "Сервер Бэкэнда",
+    "tr": "Arka Uç Sunucusu",
+    "zh": "后端服务器"
+  },
   "developer_homepage": {
     "de": "Entwickler-Homepage",
     "en": "Developer Homepage",


### PR DESCRIPTION
## Summary
- add backend server translation key
- implement ServerOption item and ServerSelectionSheet
- add setting in developer mode for selecting backend server
- persist server selection and load it on startup

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6878ab1007a48330870560dd3278c43f