### PR TITLE
feat: make update modal draggable

### DIFF
--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -109,6 +109,8 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
           isVisible={modalVisible}
           style={modalStyles.modalContainer}
           backdropOpacity={0}
+          swipeDirection="down"
+          onSwipeComplete={() => setModalVisible(false)}
         >
           <TouchableOpacity
             style={modalStyles.backdrop}
@@ -191,8 +193,9 @@ const modalStyles = StyleSheet.create({
   },
   handleRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
+    position: 'relative',
   },
   closeButton: {
     width: 45,
@@ -200,6 +203,8 @@ const modalStyles = StyleSheet.create({
     borderRadius: 50,
     justifyContent: 'center',
     alignItems: 'center',
+    position: 'absolute',
+    right: 0,
   },
   handle: {
     width: '30%',


### PR DESCRIPTION
## Summary
- enable closing the update modal by swiping down
- center the handle on the update modal

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn install` *(fails: puppeteer couldn't be built)*

------
https://chatgpt.com/codex/tasks/task_e_6878b0f7e5ec83308ff5c1f7329bff21