### PR TITLE
Fix overlapping update checker title

### DIFF
--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -205,7 +205,8 @@ const modalStyles = StyleSheet.create({
     alignSelf: 'center',
   },
   title: {
-    marginTop: 10,
+    // position title below the close button so long titles don't overlap
+    marginTop: 60,
     marginBottom: 10,
     textAlign: 'center',
     fontSize: 18,


### PR DESCRIPTION
## Summary
- push the update modal title down so it doesn't overlap the close button

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6878bd57fcd08330a6886bd134b561bc