### PR TITLE
Fix logout route on native

### DIFF
--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -16,7 +16,7 @@ import {
 
 export const performLogout = async (
   dispatch: Dispatch,
-  router: { push: (args: { pathname: string; params?: Record<string, string> }) => void },
+  router: { replace: (args: { pathname: string; params?: Record<string, string> }) => void },
   asGuest: boolean = false,
 ) => {
   try {
@@ -36,7 +36,7 @@ export const performLogout = async (
     } else {
       dispatch({ type: ON_LOGOUT });
     }
-    router.push({ pathname: '/(auth)/login', params: { logout: 'true' } });
+    router.replace({ pathname: '/(auth)/login', params: { logout: 'true' } });
   } catch (error) {
     console.error('Error during logout:', error);
   }


### PR DESCRIPTION
## Summary
- ensure logout helper uses `router.replace` to avoid black screen after logging out

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not present in lockfile)*
- `yarn app-backend-test` *(fails: directus-extension-rocket-meals-bundle not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6878c127c0b88330b2031baa88d6f2d7