### PR TITLE
Allow navigation when no canteens exist

### DIFF
--- a/apps/frontend/app/app/(app)/index.tsx
+++ b/apps/frontend/app/app/(app)/index.tsx
@@ -20,15 +20,22 @@ import {
   SET_SELECTED_CANTEEN,
 } from '@/redux/Types/types';
 import { useFocusEffect, useRouter } from 'expo-router';
+import { useNavigation } from 'expo-router';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
-import { DatabaseTypes, AppLinks, AppScreens } from 'repo-depkit-common';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { DatabaseTypes, AppScreens } from 'repo-depkit-common';
+import { MaterialCommunityIcons, Ionicons } from '@expo/vector-icons';
+import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { RootState } from '@/redux/reducer';
+import { TranslationKeys } from '@/locales/keys';
+import { useLanguage } from '@/hooks/useLanguage';
 
 const Home = () => {
   const dispatch = useDispatch();
   const router = useRouter();
+  const drawerNavigation =
+    useNavigation<DrawerNavigationProp<Record<string, object | undefined>>>();
   const { theme } = useTheme();
+  const { translate } = useLanguage();
   const canteenHelper = new CanteenHelper();
   const buildingsHelper = new BuildingsHelper();
   const { serverInfo } = useSelector((state: RootState) => state.settings);
@@ -140,6 +147,33 @@ const Home = () => {
 
   const iscenter =
     screenWidth > 768 ? 'flex-start' : screenWidth > 480 ? 'center' : 'center';
+
+  if (!loading && (!canteens || canteens.length === 0)) {
+    return (
+      <View
+        style={{
+          ...styles.emptyContainer,
+          backgroundColor: theme.screen.background,
+        }}
+      >
+        <Text style={{ color: theme.screen.text }}>
+          {translate(TranslationKeys.no_canteens_found)}
+        </Text>
+        <TouchableOpacity
+          style={{
+            ...styles.continueButton,
+            backgroundColor: theme.screen.iconBg,
+          }}
+          onPress={() => drawerNavigation.toggleDrawer()}
+        >
+          <Ionicons name='menu' size={24} color={theme.screen.icon} />
+          <Text style={{ ...styles.continueLabel, color: theme.screen.text }}>
+            {translate(TranslationKeys.open_drawer)}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
     <View

--- a/apps/frontend/app/app/(app)/styles.ts
+++ b/apps/frontend/app/app/(app)/styles.ts
@@ -51,4 +51,23 @@ export default StyleSheet.create({
     top: 5,
     right: 5,
   },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+    gap: 10,
+  },
+  continueButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 10,
+  },
+  continueLabel: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+    marginLeft: 5,
+  },
 });

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -50,6 +50,7 @@ export enum TranslationKeys {
   amount_ratings = 'amount_ratings',
   no_value = 'no_value',
   no_data_found = 'no_data_found',
+  no_canteens_found = 'no_canteens_found',
   accountbalanceLastTransaction = 'accountbalanceLastTransaction',
   accountbalanceDateUpdated = 'accountbalanceDateUpdated',
   sort = 'sort',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2733,6 +2733,16 @@
     "tr": "Yemekhaneler",
     "zh": "食堂"
   },
+  "no_canteens_found": {
+    "de": "Keine Mensen gefunden.",
+    "en": "No canteens found.",
+    "ar": "لم يتم العثور على مقاصف.",
+    "es": "No se encontraron cantinas.",
+    "fr": "Aucune cantine trouvée.",
+    "ru": "Столовые не найдены.",
+    "tr": "Yemekhane bulunamadı.",
+    "zh": "未找到食堂。"
+  },
   "buildings": {
     "de": "Gebäude",
     "en": "Buildings",


### PR DESCRIPTION
## Summary
- add translation key for missing canteens
- support empty canteen state in home screen with continue button
- expose new styles for empty state

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6879857d72c883308bc561aac1f4af15