### PR TITLE
Update monitor list-day sorting

### DIFF
--- a/apps/frontend/app/helper/sortingHelper.ts
+++ b/apps/frontend/app/helper/sortingHelper.ts
@@ -54,7 +54,7 @@ export function sortByFoodCategory(
     return foodOffers;
 }
 
-function sortByFoodCategoryOnly(
+export function sortByFoodCategoryOnly(
     foodOffers: DatabaseTypes.Foodoffers[],
     categories: DatabaseTypes.FoodsCategories[]
 ) {
@@ -99,7 +99,7 @@ export function sortByFoodOfferCategory(
     return foodOffers;
 }
 
-function sortByFoodOfferCategoryOnly(
+export function sortByFoodOfferCategoryOnly(
     foodOffers: DatabaseTypes.Foodoffers[],
     categories: DatabaseTypes.FoodoffersCategories[]
 ) {


### PR DESCRIPTION
## Summary
- export category sorting helpers
- fetch food offer categories on Monitor List Day
- sort food offers by alphabetical name, food offer category, and food category for monitor day list

## Testing
- `yarn install` *(fails: puppeteer build)*
- `yarn test` *(fails: missing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68798a80383083309b247b363c47a450