### PR TITLE
Update expo update modal and distance modal

### DIFF
--- a/apps/frontend/app/components/DistanceModal/DistanceModal.tsx
+++ b/apps/frontend/app/components/DistanceModal/DistanceModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useSelector } from 'react-redux';
@@ -35,7 +35,7 @@ const DistanceModal: React.FC<DistanceModalProps> = ({
       onClose={onClose}
       title={translate(TranslationKeys.distance)}
     >
-      <View style={{ gap: 20 }}>
+      <ScrollView contentContainerStyle={{ gap: 20 }}>
         <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
           {translate(
             TranslationKeys.distance_based_canteen_selection_or_if_asked_on_real_location
@@ -54,7 +54,12 @@ const DistanceModal: React.FC<DistanceModalProps> = ({
             {translate(TranslationKeys.use_current_position_for_distance)}
           </Text>
         </TouchableOpacity>
-      </View>
+        <Text style={{ color: theme.screen.text }}>
+          {
+            'Wir teilen deinen aktuellen Standort nicht mit uns. Er wird ausschließlich auf deinem Handy verwendet, um die Entfernung zu berechnen. Aus Datenschutzgründen verlassen diese Daten niemals dein Gerät und werden nicht gespeichert. So kannst du sicher sein, dass deine Privatsphäre geschützt ist, während du den vollen Funktionsumfang testen kannst.'
+          }
+        </Text>
+      </ScrollView>
     </BaseBottomModal>
   );
 };

--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -66,7 +66,7 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
         setModalVisible(true);
       } else if (showUpToDate) {
         setUpdateAvailable(false);
-        setTitleKey(TranslationKeys.no_updates_available);
+        setTitleKey(TranslationKeys.updates);
         setMessageKey(TranslationKeys.no_updates_available);
         setModalVisible(true);
       }

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -289,6 +289,7 @@ export enum TranslationKeys {
   update_available = 'update_available',
   update_available_message = 'update_available_message',
   no_updates_available = 'no_updates_available',
+  updates = 'updates',
   send = 'send',
   button_disabled = 'button_disabled',
   select = 'select',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3694,7 +3694,7 @@
     "zh": "选择一个表单提交"
   },
   "no_updates_available": {
-    "de": "Keine Updates verfügbar",
+    "de": "Es gibt keine weiteren Updates, du scheinst das aktuellste Update zu haben.",
     "en": "App is up to date",
     "ar": "التطبيق محدث",
     "es": "La aplicación está actualizada",
@@ -3702,5 +3702,15 @@
     "ru": "Приложение обновлено",
     "tr": "Uygulama güncel",
     "zh": "应用已是最新版本"
+  },
+  "updates": {
+    "de": "Updates",
+    "en": "Updates",
+    "ar": "التحديثات",
+    "es": "Actualizaciones",
+    "fr": "Mises à jour",
+    "ru": "Обновления",
+    "tr": "Güncellemeler",
+    "zh": "更新"
   }
 }


### PR DESCRIPTION
## Summary
- tweak no-update modal to show generic "Updates" title
- add long privacy notice in distance modal and enable scrolling
- update translation keys and texts

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68798b9ef368833081e0c25ef8aab5b7