### PR TITLE
Localize search bar placeholders

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -401,7 +401,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
               placeholderTextColor={theme.screen.placeholder}
               onChangeText={setQuery}
               value={query}
-              placeholder='Search campus here...'
+              placeholder={translate(TranslationKeys.search_campus_here)}
             />
           </View>
           <View style={{ ...styles.campusContainer, gap: isWeb ? 10 : 10 }}>

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -505,7 +505,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
               placeholderTextColor={theme.screen.placeholder}
               onChangeText={setQuery}
               value={query}
-              placeholder='Search campus here...'
+              placeholder={translate(TranslationKeys.search_apartment_here)}
             />
           </View>
           <View style={{ ...styles.campusContainer, gap: isWeb ? 10 : 10 }}>

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -25,6 +25,8 @@ export enum TranslationKeys {
   nickname = 'nickname',
   search = 'search',
   search_here = 'search_here',
+  search_campus_here = 'search_campus_here',
+  search_apartment_here = 'search_apartment_here',
   type_here = 'type_here',
   enter_number = 'enter_number',
   iban_format = 'iban_format',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -259,6 +259,26 @@
     "tr": "Burada ara...",
     "zh": "在这里搜索..."
   },
+  "search_campus_here": {
+    "de": "Campus suchen...",
+    "en": "Search campus here...",
+    "ar": "ابحث عن الحرم الجامعي هنا...",
+    "es": "Buscar campus aquí...",
+    "fr": "Rechercher le campus ici...",
+    "ru": "Искать кампус здесь...",
+    "tr": "Yerleşkeyi burada ara...",
+    "zh": "在这里搜索校园..."
+  },
+  "search_apartment_here": {
+    "de": "Apartment suchen...",
+    "en": "Search apartment here...",
+    "ar": "ابحث عن شقة هنا...",
+    "es": "Buscar apartamento aquí...",
+    "fr": "Rechercher un appartement ici...",
+    "ru": "Искать квартиру здесь...",
+    "tr": "Daireyi burada ara...",
+    "zh": "在这里搜索公寓..."
+  },
   "type_here": {
     "de": "Hier eingeben...",
     "en": "Type here...",


### PR DESCRIPTION
## Summary
- add new search strings for campus and apartment pages
- expose keys for new strings
- localize campus and housing search bars

## Testing
- `yarn install` *(fails: Some peer deps and heavy builds but completes with warnings)*
- `yarn test` *(fails: missing lockfile packages)*

------
https://chatgpt.com/codex/tasks/task_e_68798c3617548330bded4f5b5ebdc181