### PR TITLE
Fix distance calculation for geolocation

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -247,7 +247,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
       }
       const loc = await Location.getCurrentPositionAsync({});
       setSelectedBuilding({
-        coordinates: { coordinates: [loc.coords.latitude, loc.coords.longitude] },
+        coordinates: { coordinates: [loc.coords.longitude, loc.coords.latitude] },
       } as any);
       closeDistanceSheet();
     } catch (error) {

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -242,7 +242,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
       }
       const loc = await Location.getCurrentPositionAsync({});
       setSelectedBuilding({
-        coordinates: { coordinates: [loc.coords.latitude, loc.coords.longitude] },
+        coordinates: { coordinates: [loc.coords.longitude, loc.coords.latitude] },
       } as any);
       closeDistanceSheet();
     } catch (error) {

--- a/apps/frontend/app/helper/distanceHelper.ts
+++ b/apps/frontend/app/helper/distanceHelper.ts
@@ -7,14 +7,15 @@ export function calculateDistanceInMeter(
   selectedLocation: Array<number>,
   targetLocation: Array<number>
 ): Number {
+  // selectedLocation and targetLocation follow the [longitude, latitude] order
   if (selectedLocation && targetLocation) {
     const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
 
     const earthRadiusMeters = 6371000; // Earth's radius in meters
-    const lat1 = toRadians(selectedLocation[0]);
-    const lon1 = toRadians(selectedLocation[1]);
-    const lat2 = toRadians(targetLocation[0]);
-    const lon2 = toRadians(targetLocation[1]);
+    const lon1 = toRadians(selectedLocation[0]);
+    const lat1 = toRadians(selectedLocation[1]);
+    const lon2 = toRadians(targetLocation[0]);
+    const lat2 = toRadians(targetLocation[1]);
 
     const deltaLat = lat2 - lat1;
     const deltaLon = lon2 - lon1;


### PR DESCRIPTION
## Summary
- correct order for longitude/latitude in `calculateDistanceInMeter`
- adjust current location code to store `[longitude, latitude]`

## Testing
- `yarn test` *(fails: monorepo@workspace not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68799285f79483309b3cd617d5648f6c