### PR TITLE
Extract distance calc to common

### DIFF
--- a/apps/frontend/app/helper/distanceHelper.ts
+++ b/apps/frontend/app/helper/distanceHelper.ts
@@ -3,39 +3,7 @@ export type LocationType = {
   longitude: number;
 };
 
-export function calculateDistanceInMeter(
-  selectedLocation: Array<number>,
-  targetLocation: Array<number>
-): Number {
-  // selectedLocation and targetLocation follow the [longitude, latitude] order
-  if (selectedLocation && targetLocation) {
-    const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
-
-    const earthRadiusMeters = 6371000; // Earth's radius in meters
-    const lon1 = toRadians(selectedLocation[0]);
-    const lat1 = toRadians(selectedLocation[1]);
-    const lon2 = toRadians(targetLocation[0]);
-    const lat2 = toRadians(targetLocation[1]);
-
-    const deltaLat = lat2 - lat1;
-    const deltaLon = lon2 - lon1;
-
-    const a =
-      Math.sin(deltaLat / 2) ** 2 +
-      Math.cos(lat1) * Math.cos(lat2) * Math.sin(deltaLon / 2) ** 2;
-
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-    const distance = earthRadiusMeters * c; // Distance in meters
-
-    // if (distance > 1000) {
-    //   return `${(distance / 1000).toFixed(2)} km`; // Return distance in kilometers with 2 decimal places
-    // } else {
-    return Math.round(distance); // Return distance in meters rounded to the nearest integer
-    // }
-  }
-  return 0;
-}
+export { calculateDistanceInMeter } from 'repo-depkit-common';
 
 export function getDistanceUnit(distance: number): string {
   if (distance > 1000) {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -5,3 +5,4 @@ export * as DatabaseTypes from "./src/databaseTypes/types";
 export * from "./src/databaseTypes/CollectionNames";
 export * from "./src/AppLinks";
 export * from "./src/GlobalParams";
+export * from "./src/DistanceHelper";

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,9 +5,23 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.3",
     "typescript": "*"
   },
   "dependencies": {
     "moment-timezone": "^0.5.48"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "jest-environment-node",
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest"
+      ]
+    }
   }
 }

--- a/packages/common/src/DistanceHelper.ts
+++ b/packages/common/src/DistanceHelper.ts
@@ -1,0 +1,39 @@
+export type LocationType = {
+  latitude: number;
+  longitude: number;
+};
+
+/**
+ * Calculate the great-circle distance between two points on Earth using the Haversine formula.
+ * @param selectedLocation Array in the order [longitude, latitude]
+ * @param targetLocation Array in the order [longitude, latitude]
+ * @returns distance in meters rounded to the nearest integer
+ */
+export function calculateDistanceInMeter(
+  selectedLocation: Array<number>,
+  targetLocation: Array<number>
+): number {
+  if (selectedLocation && targetLocation) {
+    const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+
+    const earthRadiusMeters = 6371000; // Earth's radius in meters
+    const lon1 = toRadians(selectedLocation[0]);
+    const lat1 = toRadians(selectedLocation[1]);
+    const lon2 = toRadians(targetLocation[0]);
+    const lat2 = toRadians(targetLocation[1]);
+
+    const deltaLat = lat2 - lat1;
+    const deltaLon = lon2 - lon1;
+
+    const a =
+      Math.sin(deltaLat / 2) ** 2 +
+      Math.cos(lat1) * Math.cos(lat2) * Math.sin(deltaLon / 2) ** 2;
+
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    const distance = earthRadiusMeters * c; // Distance in meters
+
+    return Math.round(distance);
+  }
+  return 0;
+}

--- a/packages/common/src/__tests__/DistanceHelper.test.ts
+++ b/packages/common/src/__tests__/DistanceHelper.test.ts
@@ -1,0 +1,14 @@
+import { calculateDistanceInMeter } from 'repo-depkit-common';
+
+describe('calculateDistanceInMeter', () => {
+  it('returns a precise distance for long ranges', () => {
+    const berlin = [13.4050, 52.5200];
+    const losAngeles = [-118.2437, 34.0522];
+
+    const distance = calculateDistanceInMeter(berlin, losAngeles);
+    const expected = 9309675; // approximate distance in meters
+    const tolerance = 1000; // allow 1 km difference
+
+    expect(Math.abs(distance - expected)).toBeLessThanOrEqual(tolerance);
+  });
+});


### PR DESCRIPTION
## Summary
- move distance calculation to repo-depkit-common
- add jest config and test for distance calculation
- use common helper in frontend

## Testing
- `npx jest` in packages/common

------
https://chatgpt.com/codex/tasks/task_e_6879978ccd90833095b0cc67437aa933