### PR TITLE
Enable scroll in BaseModal

### DIFF
--- a/apps/frontend/app/components/BaseModal/BaseModal.tsx
+++ b/apps/frontend/app/components/BaseModal/BaseModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TouchableOpacity, Dimensions } from 'react-native';
+import { View, Text, TouchableOpacity, Dimensions, ScrollView } from 'react-native';
 import Modal from 'react-native-modal';
 import { AntDesign } from '@expo/vector-icons';
 import { styles } from './styles';
@@ -71,7 +71,13 @@ const BaseModal: React.FC<BaseModalProps> = ({
             {title}
           </Text>
         )}
-        {children}
+        <ScrollView
+          style={styles.scrollView}
+          nestedScrollEnabled
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          {children}
+        </ScrollView>
       </View>
     </Modal>
   );

--- a/apps/frontend/app/components/BaseModal/styles.ts
+++ b/apps/frontend/app/components/BaseModal/styles.ts
@@ -1,4 +1,6 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Dimensions } from 'react-native';
+
+const MAX_HEIGHT = Dimensions.get('window').height * 0.8;
 
 export const styles = StyleSheet.create({
   modalContainer: {
@@ -27,5 +29,9 @@ export const styles = StyleSheet.create({
     fontFamily: 'Poppins_700Bold',
     textAlign: 'center',
     width: '100%',
+  },
+  scrollView: {
+    width: '100%',
+    maxHeight: MAX_HEIGHT,
   },
 });


### PR DESCRIPTION
## Summary
- make BaseModal content scrollable via `ScrollView`
- limit modal scroll area height

## Testing
- `yarn test` *(fails: No tests found)*
- `yarn lint` *(fails: couldn't find a script `eslint` / expo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879f9069e3483309c76dc90b2bbf736