### PR TITLE
Fix scroll in BaseBottomModal

### DIFF
--- a/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
+++ b/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
@@ -1,14 +1,12 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   Dimensions,
   StyleSheet,
-  ScrollView,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
 } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import Modal from 'react-native-modal';
 import { AntDesign } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
@@ -23,17 +21,6 @@ export interface BaseBottomModalProps {
 const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, title, children }) => {
   const { theme } = useTheme();
 
-  const scrollViewRef = useRef<ScrollView>(null);
-  const scrollOffset = useRef(0);
-
-  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    scrollOffset.current = event.nativeEvent.contentOffset.y;
-  };
-
-  const handleScrollTo = (p: number) => {
-    scrollViewRef.current?.scrollTo({ y: p, animated: false });
-  };
-
   return (
     <Modal
       isVisible={visible}
@@ -43,9 +30,6 @@ const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, tit
       swipeDirection="down"
       onSwipeComplete={onClose}
       propagateSwipe
-      scrollTo={handleScrollTo}
-      scrollOffset={scrollOffset.current}
-      scrollOffsetMax={Dimensions.get('window').height}
     >
       <View style={[styles.sheet, { backgroundColor: theme.sheet.sheetBg }]}>
         <TouchableOpacity
@@ -59,12 +43,10 @@ const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, tit
         </View>
         {title && <Text style={[styles.title, { color: theme.sheet.text }]}>{title}</Text>}
         <ScrollView
-          ref={scrollViewRef}
           style={styles.scrollView}
           contentContainerStyle={styles.contentContainer}
           nestedScrollEnabled
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
+          showsVerticalScrollIndicator={false}
         >
           {children}
         </ScrollView>


### PR DESCRIPTION
## Summary
- allow content scrolling in BaseBottomModal by using `ScrollView` from `react-native-gesture-handler`
- remove unused scroll management logic

## Testing
- `yarn test` *(fails: monorepo not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687a2d7607a88330b18140cbebd6f854