### PR TITLE
Fix bottom modal scroll and swipe behavior

### DIFF
--- a/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
+++ b/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   Dimensions,
   StyleSheet,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import Modal from 'react-native-modal';
@@ -21,6 +23,17 @@ export interface BaseBottomModalProps {
 const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, title, children }) => {
   const { theme } = useTheme();
 
+  const scrollViewRef = useRef<ScrollView>(null);
+  const scrollOffset = useRef(0);
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffset.current = event.nativeEvent.contentOffset.y;
+  };
+
+  const handleScrollTo = (p: number) => {
+    scrollViewRef.current?.scrollTo({ y: p, animated: false });
+  };
+
   return (
     <Modal
       isVisible={visible}
@@ -30,6 +43,9 @@ const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, tit
       swipeDirection="down"
       onSwipeComplete={onClose}
       propagateSwipe
+      scrollTo={handleScrollTo}
+      scrollOffset={scrollOffset.current}
+      scrollOffsetMax={Dimensions.get('window').height}
     >
       <View style={[styles.sheet, { backgroundColor: theme.sheet.sheetBg }]}>
         <TouchableOpacity
@@ -43,10 +59,13 @@ const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, tit
         </View>
         {title && <Text style={[styles.title, { color: theme.sheet.text }]}>{title}</Text>}
         <ScrollView
+          ref={scrollViewRef}
           style={styles.scrollView}
           contentContainerStyle={styles.contentContainer}
           nestedScrollEnabled
           showsVerticalScrollIndicator={false}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
         >
           {children}
         </ScrollView>


### PR DESCRIPTION
## Summary
- allow bottom modal content to scroll and still support swipe-to-close

## Testing
- `npx jest` *(fails: Jest failed to parse TS files)*

------
https://chatgpt.com/codex/tasks/task_e_687a44b348e083308715150da771f4e7