### PR TITLE
Fix BaseBottomModal scrollTo handler

### DIFF
--- a/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
+++ b/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
@@ -30,8 +30,18 @@ const BaseBottomModal: React.FC<BaseBottomModalProps> = ({ visible, onClose, tit
     scrollOffset.current = event.nativeEvent.contentOffset.y;
   };
 
-  const handleScrollTo = (p: number) => {
-    scrollViewRef.current?.scrollTo({ y: p, animated: false });
+  const handleScrollTo = (
+    p: {
+      x?: number;
+      y?: number;
+      animated?: boolean;
+    } | number
+  ) => {
+    if (typeof p === 'number') {
+      scrollViewRef.current?.scrollTo({ y: p, animated: false });
+    } else {
+      scrollViewRef.current?.scrollTo(p);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- fix scroll-to handler in BaseBottomModal so that long modal content can be scrolled

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687a4a0a47108330884b928b96b7eab5