### PR TITLE
Remove default padding from BaseBottomModal

### DIFF
--- a/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
+++ b/apps/frontend/app/components/BaseBottomModal/BaseBottomModal.tsx
@@ -133,6 +133,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     gap: 20,
     alignItems: 'center',
-    padding: 20,
+    padding: 0,
   },
 });

--- a/apps/frontend/app/components/DistanceModal/DistanceModal.tsx
+++ b/apps/frontend/app/components/DistanceModal/DistanceModal.tsx
@@ -35,7 +35,7 @@ const DistanceModal: React.FC<DistanceModalProps> = ({
       onClose={onClose}
       title={translate(TranslationKeys.distance)}
     >
-      <View style={{ gap: 20 }}>
+      <View style={{ gap: 20, padding: 20 }}>
         <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
           {translate(
             TranslationKeys.distance_based_canteen_selection_or_if_asked_on_real_location

--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -105,7 +105,7 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
       {children}
       {modalVisible && (
         <ModalSheet visible={modalVisible} onClose={() => setModalVisible(false)} title={translate(titleKey)}>
-          <View>
+          <View style={{ padding: 20 }}>
             <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
               {translate(messageKey)}
             </Text>


### PR DESCRIPTION
## Summary
- remove default padding from `BaseBottomModal`
- add padding directly in `DistanceModal`
- add padding directly in `ExpoUpdateChecker`

## Testing
- `yarn workspace rocket-meals-dev lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687a577e8b7c8330ab7dcc4c4619b60f