### PR TITLE
Fix monitor list-day-screen layout

### DIFF
--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -935,6 +935,7 @@ const index = () => {
                       </View>
                     );
                   })}
+                <View style={{ height: rowHeight }} />
               </View>
             </ScrollView>
             {optionalFoods?.length > 0 && (
@@ -1117,6 +1118,7 @@ const index = () => {
                       </Text>
                     </View>
                   ))}
+                <View style={{ height: rowHeight }} />
               </View>
             </ScrollView>
           </View>
@@ -1167,7 +1169,7 @@ const index = () => {
                             background_color: marking?.background_color,
                             hide_border: marking?.hide_border,
                           } as any}
-                          size={30}
+                          size={24}
                           color={MarkingColor}
                         />
                         <Text

--- a/apps/frontend/app/app/(monitor)/list-day-screen/styles.ts
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/styles.ts
@@ -24,6 +24,7 @@ export default StyleSheet.create({
   headerCell: {
     color: '#fff',
     fontSize: 10,
+    fontWeight: 'bold',
     fontFamily: 'Poppins_400Regular',
     textAlign: 'left',
     paddingHorizontal: 7,
@@ -63,7 +64,7 @@ export default StyleSheet.create({
   },
   title: {
     marginLeft: 5,
-    fontSize: 10,
+    fontSize: 8,
     maxWidth: '90%',
   },
   logoContainer: {


### PR DESCRIPTION
## Summary
- adjust legend styles with smaller icons and text
- make header text bold
- ensure auto-scroll doesn't cut off final row by adding footer spacer

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687a99742754833084c4c97763ba3023