### PR TITLE
Fix distance helper types

### DIFF
--- a/packages/common/src/DistanceHelper.ts
+++ b/packages/common/src/DistanceHelper.ts
@@ -10,8 +10,8 @@ export type LocationType = {
  * @returns distance in meters rounded to the nearest integer
  */
 export function calculateDistanceInMeter(
-  selectedLocation: Array<number>,
-  targetLocation: Array<number>
+  selectedLocation: [number, number],
+  targetLocation: [number, number]
 ): number {
   if (selectedLocation && targetLocation) {
     const toRadians = (degrees: number) => (degrees * Math.PI) / 180;

--- a/packages/common/src/__tests__/DistanceHelper.test.ts
+++ b/packages/common/src/__tests__/DistanceHelper.test.ts
@@ -2,8 +2,8 @@ import { calculateDistanceInMeter } from 'repo-depkit-common';
 
 describe('calculateDistanceInMeter', () => {
   it('returns a precise distance for long ranges', () => {
-    const berlin = [13.4050, 52.5200];
-    const losAngeles = [-118.2437, 34.0522];
+    const berlin: [number, number] = [13.4050, 52.5200];
+    const losAngeles: [number, number] = [-118.2437, 34.0522];
 
     const distance = calculateDistanceInMeter(berlin, losAngeles);
     const expected = 9309675; // approximate distance in meters


### PR DESCRIPTION
## Summary
- fix `calculateDistanceInMeter` parameter types
- update distance helper tests

## Testing
- `yarn workspace directus-extension-rocket-meals-bundle test` *(fails: ENETUNREACH while fetching external site)*

------
https://chatgpt.com/codex/tasks/task_e_687a9aee6aac8330a6e5d7472de96188