### PR TITLE
Improve foodoffers scroll screen

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/styles.ts
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/styles.ts
@@ -13,4 +13,41 @@ export default StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  header: {
+    width: '100%',
+    paddingBottom: 10,
+    paddingVertical: 10,
+    gap: 10,
+  },
+  row: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  col1: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  col2: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  heading: {
+    fontSize: 18,
+    fontFamily: 'Poppins_400Regular',
+  },
+  foodContainer: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    flexWrap: 'wrap',
+    marginTop: 20,
+  },
+  feebackContainer: {
+    width: '100%',
+    marginTop: 20,
+  },
 });


### PR DESCRIPTION
## Summary
- add header with canteen and controls to scroll screen
- support loading previous days when scrolling up
- show feedback labels per day
- display selected date in header for debugging
- use multi-column layout like main food offers screen

## Testing
- `yarn workspace rocket-meals-dev lint` *(fails: package not present in lockfile)*
- `yarn workspace rocket-meals-dev test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687c11ae68f08330a4bb2ff9c9742216