### PR TITLE
Update foodoffers-scroll header

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/_layout.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/_layout.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTheme } from '@/hooks/useTheme';
+import { Stack } from 'expo-router';
+
+export default function FoodOffersScrollLayout() {
+  const { theme } = useTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.header.background },
+        headerTintColor: theme.header.text,
+      }}
+    >
+      <Stack.Screen
+        name='index'
+        options={{
+          title: 'Food Offers Scroll',
+          headerShown: false,
+        }}
+      />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- hide header for foodoffers-scroll screen
- load 2 days earlier for smoother scrolling
- add drawer, price group and date info to header

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687c1a9f24908330977edb5fdebad893