### PR TITLE
Improve smooth scrolling for foodoffers

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -126,7 +126,7 @@ const FoodOffersScroll = () => {
   };
 
   const loadPrev = async () => {
-    if (loadingPrev) return;
+    if (loadingPrev || days.length === 0) return;
     setLoadingPrev(true);
     const firstDate = days[0].date;
     const prevDate = subDays(new Date(firstDate), 1).toISOString().split('T')[0];
@@ -145,8 +145,10 @@ const FoodOffersScroll = () => {
     setRefreshing(false);
   };
 
+  const SCROLL_THRESHOLD = 300;
+
   const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-    if (e.nativeEvent.contentOffset.y <= 100) {
+    if (e.nativeEvent.contentOffset.y <= SCROLL_THRESHOLD) {
       loadPrev();
     }
   };


### PR DESCRIPTION
## Summary
- prevent crashes by ensuring days are loaded before accessing index 0
- pre-load previous days earlier and guard loadPrev

## Testing
- `yarn test` *(fails: monorepo@workspace not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687c2ec9a6c48330b245bcfca29adea7