### PR TITLE
Fix crash when initializing FoodOffersScroll

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -56,6 +56,16 @@ const FoodOffersScroll = () => {
   const [loadingPrev, setLoadingPrev] = useState(false);
   const navigation = useNavigation<DrawerNavigationProp<any>>();
 
+  if (!selectedCanteen) {
+    return (
+      <View style={[styles.loader, { backgroundColor: theme.screen.background }]}>
+        <Text style={{ color: theme.screen.text }}>
+          {translate(TranslationKeys.no_canteens_found)}
+        </Text>
+      </View>
+    );
+  }
+
   useEffect(() => {
     const sub = Dimensions.addEventListener('change', ({ window }) => {
       setScreenWidth(window.width);
@@ -64,7 +74,10 @@ const FoodOffersScroll = () => {
   }, []);
 
   const loadDay = useCallback(async (date: string) => {
-    const canteenId = selectedCanteen?.id as string;
+    if (!selectedCanteen) {
+      return { date, offers: [] } as DayData;
+    }
+    const canteenId = selectedCanteen.id as string;
     try {
       const res = await fetchFoodOffersByCanteen(canteenId, date);
       const offers = res?.data || [];
@@ -94,12 +107,12 @@ const FoodOffersScroll = () => {
   }, [init]);
 
   useEffect(() => {
-    if (initialized) {
+    if (initialized && days.length >= 3) {
       setTimeout(() => {
         flatListRef.current?.scrollToIndex({ index: 2, animated: false });
       }, 0);
     }
-  }, [initialized]);
+  }, [initialized, days.length]);
 
   const fetchCanteenLabels = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- guard `loadDay` for missing canteen
- avoid `scrollToIndex` when list items aren't loaded yet

## Testing
- `yarn install` *(fails: "package doesn't seem to be present in your lockfile")*
- `yarn workspace rocket-meals-dev test` *(fails: "package doesn't seem to be present in your lockfile")*

------
https://chatgpt.com/codex/tasks/task_e_687c33daaaf8833090d2b657ff99a513