### PR TITLE
Update foodoffers-scroll screen

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/_layout.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/_layout.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { Stack } from 'expo-router';
+import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
 
 export default function FoodOffersScrollLayout() {
   const { theme } = useTheme();
+  const { translate } = useLanguage();
   return (
     <Stack
       screenOptions={{
@@ -14,8 +18,14 @@ export default function FoodOffersScrollLayout() {
       <Stack.Screen
         name='index'
         options={{
-          title: 'Food Offers Scroll',
+          title: 'Food Offers',
           headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name='details/index'
+        options={{
+          header: () => <CustomStackHeader label={translate(TranslationKeys.food_details)} />,
         }}
       />
     </Stack>


### PR DESCRIPTION
## Summary
- load only upcoming days for foodoffers-scroll
- reuse the foodoffers header layout
- add stack configuration with details screen

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687cba49ae888330847ebdea32173f2b