### PR TITLE
Restore foodoffers-scroll header and hide nav bar

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -728,6 +728,14 @@ export default function Layout() {
         />
 
         <Drawer.Screen
+          name='foodoffers-scroll/index'
+          options={{
+            title: translate(TranslationKeys.foodoffers_scroll),
+            headerShown: false,
+          }}
+        />
+
+        <Drawer.Screen
           name='chats'
           options={{
             title: translate(TranslationKeys.chats),


### PR DESCRIPTION
## Summary
- re-add internal header section in `foodoffers-scroll` screen
- register `foodoffers-scroll` screen in root drawer with `headerShown: false`

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn workspace rocket-meals-dev lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687d3432b9e883309cbb7abf1a8b2d63