### PR TITLE
Fix header on foodoffers-scroll

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/_layout.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/_layout.tsx
@@ -8,6 +8,7 @@ export default function FoodOfferLayout() {
   return (
     <Stack
       screenOptions={{
+        headerShown: false,
         headerStyle: { backgroundColor: theme.header.background },
         headerTintColor: theme.header.text,
       }}
@@ -16,7 +17,6 @@ export default function FoodOfferLayout() {
         name='index'
         options={{
           title: 'Food Offers',
-          headerShown: false,
         }}
       />
     </Stack>


### PR DESCRIPTION
## Summary
- remove default navigation header from foodoffers-scroll screen

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687d4ae1128c83309ab92e27431d9e00