### PR TITLE
Add debug logout screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/debug-logout/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/debug-logout/index.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { ScrollView, View, Text, TouchableOpacity } from 'react-native';
+import { useDispatch } from 'react-redux';
+import {
+  CLEAR_CANTEENS,
+  CLEAR_CAMPUSES,
+  CLEAR_APARTMENTS,
+  CLEAR_FOODS,
+  CLEAR_MANAGEMENT,
+  CLEAR_NEWS,
+  CLEAR_SETTINGS,
+  CLEAR_POPUP_EVENTS_HASH,
+  CLEAR_COLLECTION_DATES_LAST_UPDATED,
+  CLEAR_ANONYMOUSLY,
+  ON_LOGOUT,
+} from '@/redux/Types/types';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { persistor } from '@/redux/store';
+import { router } from 'expo-router';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import styles from './styles';
+
+const DebugLogout = () => {
+  const dispatch = useDispatch();
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+
+  const steps = [
+    {
+      label: 'CLEAR_CANTEENS',
+      action: () => dispatch({ type: CLEAR_CANTEENS }),
+    },
+    {
+      label: 'CLEAR_CAMPUSES',
+      action: () => dispatch({ type: CLEAR_CAMPUSES }),
+    },
+    {
+      label: 'CLEAR_APARTMENTS',
+      action: () => dispatch({ type: CLEAR_APARTMENTS }),
+    },
+    {
+      label: 'CLEAR_FOODS',
+      action: () => dispatch({ type: CLEAR_FOODS }),
+    },
+    {
+      label: 'CLEAR_MANAGEMENT',
+      action: () => dispatch({ type: CLEAR_MANAGEMENT }),
+    },
+    {
+      label: 'CLEAR_NEWS',
+      action: () => dispatch({ type: CLEAR_NEWS }),
+    },
+    {
+      label: 'CLEAR_SETTINGS',
+      action: () => dispatch({ type: CLEAR_SETTINGS }),
+    },
+    {
+      label: 'CLEAR_POPUP_EVENTS_HASH',
+      action: () => dispatch({ type: CLEAR_POPUP_EVENTS_HASH }),
+    },
+    {
+      label: 'CLEAR_COLLECTION_DATES_LAST_UPDATED',
+      action: () => dispatch({ type: CLEAR_COLLECTION_DATES_LAST_UPDATED }),
+    },
+    {
+      label: 'REMOVE_STORAGE',
+      action: async () => {
+        await AsyncStorage.multiRemove(['auth_data', 'persist:root']);
+      },
+    },
+    {
+      label: 'CLEAR_ANONYMOUSLY',
+      action: () => dispatch({ type: CLEAR_ANONYMOUSLY }),
+    },
+    {
+      label: 'ON_LOGOUT',
+      action: () => dispatch({ type: ON_LOGOUT }),
+    },
+    {
+      label: 'RESET_STORE',
+      action: () => dispatch({ type: 'RESET_STORE' }),
+    },
+    {
+      label: 'PURGE_PERSISTOR',
+      action: () => persistor.purge(),
+    },
+    {
+      label: 'ROUTER_REPLACE_LOGIN',
+      action: () =>
+        router.replace({ pathname: '/(auth)/login', params: { logout: 'true' } }),
+    },
+  ];
+
+  return (
+    <ScrollView
+      style={{ ...styles.container, backgroundColor: theme.screen.background }}
+      contentContainerStyle={{
+        ...styles.contentContainer,
+        backgroundColor: theme.screen.background,
+      }}
+    >
+      <View style={{ ...styles.content }}>
+        <Text style={{ ...styles.heading, color: theme.screen.text }}>
+          {translate(TranslationKeys.debug_logout)}
+        </Text>
+        {steps.map((step, index) => (
+          <TouchableOpacity
+            key={index}
+            style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+            onPress={step.action}
+          >
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {step.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default DebugLogout;

--- a/apps/frontend/app/app/(app)/experimentell/debug-logout/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/debug-logout/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {},
+  content: {
+    width: '100%',
+    height: '100%',
+    padding: 20,
+  },
+  heading: {
+    fontSize: 24,
+    fontFamily: 'Poppins_700Bold',
+    marginVertical: 10,
+  },
+  listItem: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+    padding: 10,
+    marginVertical: 10,
+  },
+  body: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+  },
+});

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -106,6 +106,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/experimentell/debug-logout')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='bug' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.debug_logout)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -243,6 +243,7 @@ export enum TranslationKeys {
   show_more_information = 'show_more_information',
   course_timetable = 'course_timetable',
   experimentell = "experimentell",
+  debug_logout = 'debug_logout',
   vertical_image_scroll = 'vertical_image_scroll',
   foodoffers_scroll = 'foodoffers_scroll',
   chats = 'chats',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2443,6 +2443,16 @@
     "tr": "Experimentell",
     "zh": "Experimentell"
   },
+  "debug_logout": {
+    "de": "Debug Logout",
+    "en": "Debug Logout",
+    "ar": "Debug Logout",
+    "es": "Debug Logout",
+    "fr": "Debug Logout",
+    "ru": "Debug Logout",
+    "tr": "Debug Logout",
+    "zh": "Debug Logout"
+  },
   "vertical_image_scroll": {
     "de": "Vertikaler Bildlauf",
     "en": "Vertical Image Scroll",


### PR DESCRIPTION
## Summary
- add new translation key `debug_logout`
- add translations for the key
- expose new entry on experimentell screen
- implement DebugLogout screen

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle workspace missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687dfb6d6d288330ae26d953690d5857