### PR TITLE
Fix logout helper and add my test logout option

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/debug-logout/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/debug-logout/index.tsx
@@ -93,6 +93,17 @@ const DebugLogout = () => {
     },
   ];
 
+  const myTestLogout = async () => {
+    const exclude = ['CLEAR_ANONYMOUSLY', 'ON_LOGOUT', 'RESET_STORE'];
+    for (const step of steps) {
+      if (exclude.includes(step.label)) continue;
+      const result = step.action();
+      if (result instanceof Promise) {
+        await result;
+      }
+    }
+  };
+
   return (
     <ScrollView
       style={{ ...styles.container, backgroundColor: theme.screen.background }}
@@ -116,6 +127,14 @@ const DebugLogout = () => {
             </Text>
           </TouchableOpacity>
         ))}
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={myTestLogout}
+        >
+          <Text style={{ ...styles.body, color: theme.screen.text }}>
+            MY_TEST_LOGOUT
+          </Text>
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -33,7 +33,6 @@ export const performLogout = async (
     await AsyncStorage.multiRemove(['auth_data', 'persist:root']);
     if (asGuest) {
       dispatch({ type: CLEAR_ANONYMOUSLY });
-      dispatch({ type: CLEAR_ANONYMOUSLY });
     } else {
       dispatch({ type: ON_LOGOUT });
     }

--- a/apps/frontend/app/redux/reducer/authReducer.ts
+++ b/apps/frontend/app/redux/reducer/authReducer.ts
@@ -60,8 +60,8 @@ const authReducer = (state = initialState, actions: any) => {
     }
     case CLEAR_ANONYMOUSLY: {
       return {
-        ...state,
-        loggedIn: false,
+        ...initialState,
+        isDevMode: state.isDevMode,
       };
     }
     case ON_LOGOUT: {


### PR DESCRIPTION
## Summary
- restore defaults for CLEAR_ANONYMOUSLY
- remove duplicate CLEAR_ANONYMOUSLY dispatch in `performLogout`
- add `myTestLogout` button to debug logout screen

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687e0eb1e0608330b6e4c94f8c129d2d