### PR TITLE
Update logout logic to match debug flow

### DIFF
--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -1,7 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Dispatch } from 'redux';
 import {
-  CLEAR_ANONYMOUSLY,
   CLEAR_APARTMENTS,
   CLEAR_CAMPUSES,
   CLEAR_CANTEENS,
@@ -11,7 +10,6 @@ import {
   CLEAR_NEWS,
   CLEAR_SETTINGS,
   CLEAR_POPUP_EVENTS_HASH,
-  ON_LOGOUT,
 } from '@/redux/Types/types';
 import { persistor } from '@/redux/store';
 
@@ -31,12 +29,7 @@ export const performLogout = async (
     dispatch({ type: CLEAR_POPUP_EVENTS_HASH });
     dispatch({ type: CLEAR_COLLECTION_DATES_LAST_UPDATED });
     await AsyncStorage.multiRemove(['auth_data', 'persist:root']);
-    if (asGuest) {
-      dispatch({ type: CLEAR_ANONYMOUSLY });
-    } else {
-      dispatch({ type: ON_LOGOUT });
-    }
-    dispatch({ type: 'RESET_STORE' });
+    // legacy parameter kept for compatibility, currently not used
     persistor.purge();
     router.replace({ pathname: '/(auth)/login', params: { logout: 'true' } });
   } catch (error) {


### PR DESCRIPTION
## Summary
- simplify logout helper logic by removing ON_LOGOUT calls

## Testing
- `yarn test` *(fails: Failed to fetch or parse news page: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687e13178a5c8330a46d818dac6966f2