### PR TITLE
Add rate app screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -118,6 +118,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/experimentell/rate-app')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='star' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.rate_app)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ScrollView, View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import * as StoreReview from 'expo-store-review';
+import styles from './styles';
+
+const RateApp = () => {
+  useSetPageTitle(TranslationKeys.rate_app);
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+
+  const handleRate = async () => {
+    try {
+      const available = await StoreReview.isAvailableAsync();
+      if (available) {
+        await StoreReview.requestReview();
+      }
+    } catch (e) {
+      console.log('Error requesting review', e);
+    }
+  };
+
+  return (
+    <ScrollView
+      style={{ ...styles.container, backgroundColor: theme.screen.background }}
+      contentContainerStyle={{
+        ...styles.contentContainer,
+        backgroundColor: theme.screen.background,
+      }}
+    >
+      <View style={{ ...styles.content }}>
+        <Text style={{ ...styles.heading, color: theme.screen.text }}>
+          {translate(TranslationKeys.rate_app)}
+        </Text>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={handleRate}
+        >
+          <Text style={{ ...styles.body, color: theme.screen.text }}>
+            {translate(TranslationKeys.rate_app)}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+};
+
+export default RateApp;

--- a/apps/frontend/app/app/(app)/experimentell/rate-app/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/rate-app/styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {},
+  content: {
+    width: '100%',
+    height: '100%',
+    padding: 20,
+  },
+  heading: {
+    fontSize: 24,
+    fontFamily: 'Poppins_700Bold',
+    marginVertical: 10,
+  },
+  listItem: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+    padding: 10,
+    marginVertical: 10,
+  },
+  body: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+  },
+});

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -244,6 +244,7 @@ export enum TranslationKeys {
   course_timetable = 'course_timetable',
   experimentell = "experimentell",
   debug_logout = 'debug_logout',
+  rate_app = 'rate_app',
   vertical_image_scroll = 'vertical_image_scroll',
   foodoffers_scroll = 'foodoffers_scroll',
   chats = 'chats',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2453,6 +2453,16 @@
     "tr": "Debug Logout",
     "zh": "Debug Logout"
   },
+  "rate_app": {
+    "de": "App bewerten",
+    "en": "Rate App",
+    "ar": "Rate App",
+    "es": "Rate App",
+    "fr": "Rate App",
+    "ru": "Rate App",
+    "tr": "Rate App",
+    "zh": "Rate App"
+  },
   "vertical_image_scroll": {
     "de": "Vertikaler Bildlauf",
     "en": "Vertical Image Scroll",


### PR DESCRIPTION
## Summary
- add `rate_app` translation key
- add translations for `rate_app`
- add an item in experimental index to open a new rating screen
- implement new `rate-app` screen using expo-store-review

## Testing
- `yarn install` *(fails: peer dependency warnings)*
- `CI=true yarn --cwd apps/frontend/app test` *(fails: workspace not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687e8e4395b4833087e1569729377fd9