### PR TITLE
Fix app download QR debug

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import styles from './styles';
+import { getImageUrl } from '@/constants/HelperFunctions';
 import RedirectButton from '@/components/RedirectButton';
 import QRCode from 'qrcode';
 
@@ -51,6 +52,14 @@ const AppDownload = () => {
     }
   };
 
+  const projectLogo =
+    serverInfo?.info?.project?.project_logo &&
+    getImageUrl(serverInfo.info.project.project_logo);
+
+  const iconSource = projectLogo
+    ? { uri: projectLogo }
+    : require('../../../../assets/images/icon.png');
+
   return (
     <ScrollView
       style={{ ...styles.container, backgroundColor: theme.screen.background }}
@@ -60,12 +69,15 @@ const AppDownload = () => {
       }}
     >
       <View style={styles.content}>
-        <Image source={require('../../../../assets/images/icon.png')} style={styles.icon} />
+        <Image source={iconSource} style={styles.icon} />
         <Text style={{ ...styles.heading, color: theme.screen.text }}>{projectName}</Text>
         <View style={styles.qrRow}>
           {iosQr ? (
             <View style={styles.qrCol}>
-              <Image source={{ uri: iosQr }} style={styles.qr} />
+              <View style={styles.qrDebugWrapper}>
+                <Image source={{ uri: iosQr }} style={styles.qr} />
+              </View>
+              <Text selectable style={styles.uriText}>{iosQr}</Text>
               <RedirectButton
                 label='iOS'
                 onClick={() => appSettings?.app_stores_url_to_apple && openInBrowser(appSettings.app_stores_url_to_apple)}
@@ -74,7 +86,10 @@ const AppDownload = () => {
           ) : null}
           {androidQr ? (
             <View style={styles.qrCol}>
-              <Image source={{ uri: androidQr }} style={styles.qr} />
+              <View style={styles.qrDebugWrapper}>
+                <Image source={{ uri: androidQr }} style={styles.qr} />
+              </View>
+              <Text selectable style={styles.uriText}>{androidQr}</Text>
               <RedirectButton
                 label='Android'
                 onClick={() => appSettings?.app_stores_url_to_google && openInBrowser(appSettings.app_stores_url_to_google)}

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -37,4 +37,12 @@ export default StyleSheet.create({
     width: 150,
     height: 150,
   },
+  qrDebugWrapper: {
+    backgroundColor: 'rgba(255, 0, 0, 0.2)',
+    padding: 5,
+  },
+  uriText: {
+    fontSize: 10,
+    color: 'gray',
+  },
 });


### PR DESCRIPTION
## Summary
- load project logo as icon in experimental AppDownload screen
- add QR code debug styles and show generated URI text

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688001879008833085ac6a84dba98b8b