### PR TITLE
Improve experimental app screens

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -45,4 +45,21 @@ export default StyleSheet.create({
     fontSize: 10,
     color: 'gray',
   },
+  urlText: {
+    fontSize: 12,
+    color: 'gray',
+    textAlign: 'center',
+  },
+  debugLogContainer: {
+    maxHeight: 100,
+    marginTop: 20,
+    width: '100%',
+    borderWidth: 1,
+    borderColor: 'lightgray',
+    padding: 5,
+  },
+  debugLogText: {
+    fontSize: 10,
+    color: 'gray',
+  },
 });

--- a/apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ScrollView, View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -11,14 +11,22 @@ const RateApp = () => {
   useSetPageTitle(TranslationKeys.rate_app);
   const { theme } = useTheme();
   const { translate } = useLanguage();
+  const [debugLogs, setDebugLogs] = useState<string[]>([]);
+
+  const addLog = (msg: string) =>
+    setDebugLogs((logs) => [...logs, msg]);
 
   const handleRate = async () => {
     try {
+      addLog('Checking availability');
       const available = await StoreReview.isAvailableAsync();
+      addLog(`Available: ${available}`);
       if (available) {
         await StoreReview.requestReview();
+        addLog('Review requested');
       }
-    } catch (e) {
+    } catch (e: any) {
+      addLog(`Error: ${e?.message || e}`);
       console.log('Error requesting review', e);
     }
   };
@@ -43,6 +51,17 @@ const RateApp = () => {
             {translate(TranslationKeys.rate_app)}
           </Text>
         </TouchableOpacity>
+        {debugLogs.length > 0 && (
+          <View style={styles.debugLogContainer}>
+            <ScrollView>
+              {debugLogs.map((l, i) => (
+                <Text key={i} style={styles.debugLogText}>
+                  {l}
+                </Text>
+              ))}
+            </ScrollView>
+          </View>
+        )}
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/rate-app/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/rate-app/styles.ts
@@ -28,4 +28,15 @@ export default StyleSheet.create({
     fontSize: 16,
     fontFamily: 'Poppins_400Regular',
   },
+  debugLogContainer: {
+    maxHeight: 120,
+    marginTop: 10,
+    borderWidth: 1,
+    borderColor: 'lightgray',
+    padding: 5,
+  },
+  debugLogText: {
+    fontSize: 12,
+    color: 'gray',
+  },
 });


### PR DESCRIPTION
## Summary
- add debug log view for `rate-app` screen
- improve `app-download` with QR code sizing, store URLs and debug logs

## Testing
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688009bd34a48330b6c42df4307223df