### PR TITLE
Add verticalScrollTopFood component

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -728,6 +728,19 @@ export default function Layout() {
         />
 
         <Drawer.Screen
+          name='vertical-scroll-top-food/index'
+          options={{
+            header: () => (
+              <CustomStackHeader
+                label={translate(TranslationKeys.vertical_scroll_top_food)}
+                key={'vertical_scroll_top_food'}
+              />
+            ),
+            title: translate(TranslationKeys.vertical_scroll_top_food),
+          }}
+        />
+
+        <Drawer.Screen
           name='foodoffers-scroll/index'
           options={{
             title: translate(TranslationKeys.foodoffers_scroll),

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -84,6 +84,18 @@ const index = () => {
         </TouchableOpacity>
         <TouchableOpacity
           style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/vertical-scroll-top-food')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='image-multiple' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.vertical_scroll_top_food)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
           onPress={() => router.push('/foodoffers-scroll')}
         >
           <View style={styles.col}>

--- a/apps/frontend/app/app/(app)/vertical-scroll-top-food/index.tsx
+++ b/apps/frontend/app/app/(app)/vertical-scroll-top-food/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { TranslationKeys } from '@/locales/keys';
+import VerticalScrollTopFood from '@/components/VerticalScrollTopFood';
+
+const VerticalScrollTopFoodScreen = () => {
+  useSetPageTitle(TranslationKeys.vertical_scroll_top_food);
+  return <VerticalScrollTopFood />;
+};
+
+export default VerticalScrollTopFoodScreen;

--- a/apps/frontend/app/components/VerticalScrollTopFood/index.tsx
+++ b/apps/frontend/app/components/VerticalScrollTopFood/index.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, Dimensions, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/useTheme';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import CardDimensionHelper from '@/helper/CardDimensionHelper';
+import AutoImageScroller from '@/components/AutoImageScroller';
+import styles from './styles';
+import { getImageUrl } from '@/constants/HelperFunctions';
+import { loadMostLikedOrDislikedFoods } from '@/helper/FoodHelper';
+
+const PAGE_SIZE = 20;
+const MAX_ITEMS = 100;
+
+const VerticalScrollTopFood: React.FC = () => {
+  const { theme } = useTheme();
+  const { amountColumnsForcard } = useSelector((state: RootState) => state.settings);
+  const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
+
+  const numColumns = CardDimensionHelper.getNumColumns(screenWidth, amountColumnsForcard);
+
+  useEffect(() => {
+    const sub = Dimensions.addEventListener('change', ({ window }) => {
+      setScreenWidth(window.width);
+    });
+    return () => sub?.remove();
+  }, []);
+
+  const size =
+    amountColumnsForcard === 0
+      ? CardDimensionHelper.getCardDimension(screenWidth)
+      : CardDimensionHelper.getCardWidth(screenWidth, numColumns);
+
+  const [images, setImages] = useState<string[]>([]);
+  const offset = useRef(0);
+
+  const fetchImages = async () => {
+    if (offset.current >= MAX_ITEMS) return;
+    const result = await loadMostLikedOrDislikedFoods(
+      Math.min(PAGE_SIZE, MAX_ITEMS - offset.current),
+      offset.current,
+      undefined,
+      true
+    );
+    const urls =
+      (result ?? [])
+        .map((food: any) => getImageUrl(String((food as any).image)))
+        .filter(Boolean);
+    setImages(prev => [...prev, ...urls]);
+    offset.current += urls.length;
+  };
+
+  useEffect(() => {
+    fetchImages();
+  }, []);
+
+  const loadMoreImages = () => {
+    fetchImages();
+  };
+
+  const [speedPercent, setSpeedPercent] = useState(5);
+
+  return (
+    <View key={amountColumnsForcard} style={[styles.container, { backgroundColor: theme.screen.background }]}>
+      <View style={styles.controls}>
+        <TouchableOpacity onPress={() => setSpeedPercent(s => Math.max(1, s - 1))}>
+          <Ionicons name='remove' size={24} color={theme.primary} />
+        </TouchableOpacity>
+        <Text style={{ color: theme.primary }}>{Math.round(speedPercent)}%/s</Text>
+        <TouchableOpacity onPress={() => setSpeedPercent(s => s + 1)}>
+          <Ionicons name='add' size={24} color={theme.primary} />
+        </TouchableOpacity>
+      </View>
+      <AutoImageScroller
+        images={images}
+        numColumns={numColumns}
+        size={size}
+        speedPercent={speedPercent}
+        loadMore={loadMoreImages}
+      />
+    </View>
+  );
+};
+
+export default VerticalScrollTopFood;

--- a/apps/frontend/app/components/VerticalScrollTopFood/styles.ts
+++ b/apps/frontend/app/components/VerticalScrollTopFood/styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 8,
+    gap: 10,
+  },
+  image: {
+    margin: 5,
+    borderRadius: 8,
+  },
+});

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -247,6 +247,7 @@ export enum TranslationKeys {
   rate_app = 'rate_app',
   app_download = 'app_download',
   vertical_image_scroll = 'vertical_image_scroll',
+  vertical_scroll_top_food = 'vertical_scroll_top_food',
   foodoffers_scroll = 'foodoffers_scroll',
   chats = 'chats',
   chat = 'chat',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2483,6 +2483,16 @@
     "tr": "Dikey Resim Kaydırma",
     "zh": "垂直图片滚动"
   },
+  "vertical_scroll_top_food": {
+    "de": "Top-Essen-Scroll",
+    "en": "Top Food Scroll",
+    "ar": "Top Food Scroll",
+    "es": "Top Food Scroll",
+    "fr": "Top Food Scroll",
+    "ru": "Top Food Scroll",
+    "tr": "Top Food Scroll",
+    "zh": "Top Food Scroll"
+  },
   "foodoffers_scroll": {
     "de": "Speiseplan-Scroll",
     "en": "Food Offers Scroll",

--- a/packages/common/src/AppLinks.ts
+++ b/packages/common/src/AppLinks.ts
@@ -29,6 +29,7 @@ export enum AppScreens {
     NOTIFICATION = 'notification',
     SUPPORT_TICKET = 'support-ticket',
     VERTICAL_IMAGE_SCROLL = 'vertical-image-scroll',
+    VERTICAL_SCROLL_TOP_FOOD = 'vertical-scroll-top-food',
     WIKIS = 'wikis',
     BIG_SCREEN = 'bigScreen',
     FOOD_PLAN_DAY = 'foodPlanDay',


### PR DESCRIPTION
## Summary
- add `VerticalScrollTopFood` component
- create screen to display this component
- wire screen into drawer navigation and experimental menu
- update translations and app links

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68800bf6e38883308ce03729b283c3eb