### PR TITLE
Fix web QR code display

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -133,7 +133,16 @@ const AppDownload = () => {
                 {appSettings.app_stores_url_to_apple}
               </Text>
               <View style={styles.qrDebugWrapper}>
-                {iosQr ? <SvgXml xml={iosQr} width={qrSize} height={qrSize} /> : null}
+                {iosQr ? (
+                  Platform.OS === 'web' ? (
+                    <div
+                      style={{ width: qrSize, height: qrSize }}
+                      dangerouslySetInnerHTML={{ __html: iosQr }}
+                    />
+                  ) : (
+                    <SvgXml xml={iosQr} width={qrSize} height={qrSize} />
+                  )
+                ) : null}
               </View>
               {iosQr ? (
                 <Text selectable style={styles.uriText}>{iosQr}</Text>
@@ -153,7 +162,16 @@ const AppDownload = () => {
                 {appSettings.app_stores_url_to_google}
               </Text>
               <View style={styles.qrDebugWrapper}>
-                {androidQr ? <SvgXml xml={androidQr} width={qrSize} height={qrSize} /> : null}
+                {androidQr ? (
+                  Platform.OS === 'web' ? (
+                    <div
+                      style={{ width: qrSize, height: qrSize }}
+                      dangerouslySetInnerHTML={{ __html: androidQr }}
+                    />
+                  ) : (
+                    <SvgXml xml={androidQr} width={qrSize} height={qrSize} />
+                  )
+                ) : null}
               </View>
               {androidQr ? (
                 <Text selectable style={styles.uriText}>{androidQr}</Text>


### PR DESCRIPTION
## Summary
- render QR code using `dangerouslySetInnerHTML` on web

## Testing
- `yarn test` *(fails: Error fetching/parsing pages and failing to launch browser)*

------
https://chatgpt.com/codex/tasks/task_e_688024d80db083308f36116e3759b2fb