### PR TITLE
Add QR code component and update experimental screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -16,7 +16,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import styles from './styles';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import RedirectButton from '@/components/RedirectButton';
-import QRCode from 'qrcode';
+import QrCode from '@/components/QrCode';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 
 const AppDownload = () => {
@@ -24,22 +24,7 @@ const AppDownload = () => {
   const { theme } = useTheme();
   const { serverInfo, appSettings } = useSelector((state: RootState) => state.settings);
   const [projectName, setProjectName] = useState('');
-  const [iosQrUri, setIosQrUri] = useState<string>('');
-  const [androidQrUri, setAndroidQrUri] = useState<string>('');
   const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
-  const [debugLogs, setDebugLogs] = useState<string[]>([]);
-
-
-  const log = (msg: string) => setDebugLogs((logs) => [...logs, msg]);
-
-  const qrOptions = {
-    errorCorrectionLevel: 'H',
-    margin: 1,
-    color: {
-      dark: '#010599FF',
-      light: '#FFBF60FF',
-    },
-  };
 
   useEffect(() => {
     const sub = Dimensions.addEventListener('change', ({ window }) => {
@@ -54,40 +39,6 @@ const AppDownload = () => {
     }
   }, [serverInfo]);
 
-  useEffect(() => {
-    if (appSettings?.app_stores_url_to_apple) {
-      log(`Generate iOS QR for ${appSettings.app_stores_url_to_apple}`);
-      QRCode.toDataURL(
-        appSettings.app_stores_url_to_apple,
-        { errorCorrectionLevel: 'H', margin: 1, color: qrOptions.color },
-        (err, url) => {
-          if (err) {
-            console.error(err);
-            log(`iOS QR error: ${err}`);
-            return;
-          }
-          setIosQrUri(url);
-          log('iOS QR created');
-        }
-      );
-    }
-    if (appSettings?.app_stores_url_to_google) {
-      log(`Generate Android QR for ${appSettings.app_stores_url_to_google}`);
-      QRCode.toDataURL(
-        appSettings.app_stores_url_to_google,
-        { errorCorrectionLevel: 'H', margin: 1, color: qrOptions.color },
-        (err, url) => {
-          if (err) {
-            console.error(err);
-            log(`Android QR error: ${err}`);
-            return;
-          }
-          setAndroidQrUri(url);
-          log('Android QR created');
-        }
-      );
-    }
-  }, [appSettings]);
 
   const openInBrowser = async (url: string) => {
     try {
@@ -131,17 +82,11 @@ const AppDownload = () => {
               <Text selectable style={styles.urlText}>
                 {appSettings.app_stores_url_to_apple}
               </Text>
-              <View style={styles.qrDebugWrapper}>
-                {iosQrUri ? (
-                  <Image
-                    source={{ uri: iosQrUri }}
-                    style={{ width: qrSize, height: qrSize }}
-                  />
-                ) : null}
-              </View>
-              {iosQrUri ? (
-                <Text selectable style={styles.uriText}>{iosQrUri}</Text>
-              ) : null}
+              <QrCode
+                value={appSettings.app_stores_url_to_apple}
+                size={qrSize}
+                logoUrl="https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg"
+              />
               <RedirectButton
                 label='iOS'
                 onClick={() =>
@@ -156,17 +101,11 @@ const AppDownload = () => {
               <Text selectable style={styles.urlText}>
                 {appSettings.app_stores_url_to_google}
               </Text>
-              <View style={styles.qrDebugWrapper}>
-                {androidQrUri ? (
-                  <Image
-                    source={{ uri: androidQrUri }}
-                    style={{ width: qrSize, height: qrSize }}
-                  />
-                ) : null}
-              </View>
-              {androidQrUri ? (
-                <Text selectable style={styles.uriText}>{androidQrUri}</Text>
-              ) : null}
+              <QrCode
+                value={appSettings.app_stores_url_to_google}
+                size={qrSize}
+                logoUrl="https://upload.wikimedia.org/wikipedia/commons/d/d0/Google_Play_Arrow_logo.svg"
+              />
               <RedirectButton
                 label='Android'
                 onClick={() =>
@@ -177,17 +116,6 @@ const AppDownload = () => {
             </View>
           ) : null}
         </View>
-        {debugLogs.length > 0 && (
-          <View style={styles.debugLogContainer}>
-            <ScrollView>
-              {debugLogs.map((l, i) => (
-                <Text key={i} style={styles.debugLogText}>
-                  {l}
-                </Text>
-              ))}
-            </ScrollView>
-          </View>
-        )}
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -37,29 +37,9 @@ export default StyleSheet.create({
     width: 150,
     height: 150,
   },
-  qrDebugWrapper: {
-    backgroundColor: 'rgba(255, 0, 0, 0.2)',
-    padding: 5,
-  },
-  uriText: {
-    fontSize: 10,
-    color: 'gray',
-  },
   urlText: {
     fontSize: 12,
     color: 'gray',
     textAlign: 'center',
-  },
-  debugLogContainer: {
-    maxHeight: 100,
-    marginTop: 20,
-    width: '100%',
-    borderWidth: 1,
-    borderColor: 'lightgray',
-    padding: 5,
-  },
-  debugLogText: {
-    fontSize: 10,
-    color: 'gray',
   },
 });

--- a/apps/frontend/app/components/QrCode/index.tsx
+++ b/apps/frontend/app/components/QrCode/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import QRCode from 'react-native-qrcode-svg';
+import { QrCodeProps } from './types';
+
+const QrCode: React.FC<QrCodeProps> = ({ value, size = 200, logoSource, logoUrl }) => {
+  const logo = logoSource ? logoSource : logoUrl ? { uri: logoUrl } : undefined;
+
+  return (
+    <QRCode
+      value={value}
+      size={size}
+      {...(logo ? { logo, logoSize: size / 5, logoBackgroundColor: 'transparent' } : {})}
+    />
+  );
+};
+
+export default QrCode;

--- a/apps/frontend/app/components/QrCode/types.ts
+++ b/apps/frontend/app/components/QrCode/types.ts
@@ -1,0 +1,8 @@
+import { ImageSourcePropType } from 'react-native';
+
+export interface QrCodeProps {
+  value: string;
+  size?: number;
+  logoSource?: ImageSourcePropType;
+  logoUrl?: string;
+}


### PR DESCRIPTION
## Summary
- create `QrCode` component supporting optional logos
- download Apple and Google Play icons for QR code display
- simplify experimental `app-download` screen to use the new component and remove debug logs
- use remote URLs for Apple and Google icons instead of local assets

## Testing
- `npm test -- -b` *(fails: some tests cannot reach external URLs)*
- `npx tsc --noEmit` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68809a178a148330bfdf88f5efbc326f