### PR TITLE
Improve QRCode logo handling

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -88,6 +88,8 @@ const AppDownload = () => {
                 value={appSettings.app_stores_url_to_apple}
                 size={qrSize}
                 logoSource={appleLogo}
+                logoBackgroundColor='white'
+                logoMargin={2}
               />
               <RedirectButton
                 label='iOS'
@@ -107,6 +109,8 @@ const AppDownload = () => {
                 value={appSettings.app_stores_url_to_google}
                 size={qrSize}
                 logoSource={googleLogo}
+                logoBackgroundColor='white'
+                logoMargin={2}
                 />
               <RedirectButton
                 label='Android'

--- a/apps/frontend/app/components/QrCode/index.tsx
+++ b/apps/frontend/app/components/QrCode/index.tsx
@@ -1,33 +1,32 @@
 import React from 'react';
-import { Image, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { QrCodeProps } from './types';
 
-const QrCode: React.FC<QrCodeProps> = ({ value, size = 200, logoSource, logoUrl }) => {
+const QrCode: React.FC<QrCodeProps> = ({
+  value,
+  size = 200,
+  logoSource,
+  logoUrl,
+  logoSize,
+  logoBackgroundColor = 'white',
+  logoMargin,
+}) => {
   const logo = logoSource ? logoSource : logoUrl ? { uri: logoUrl } : undefined;
+  const calculatedLogoSize = logoSize ?? size / 5;
 
   return (
-    <View style={{ width: size, height: size }}>
-      <QRCode value={value} size={size} />
-      {logo && (
-        <View
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <Image
-            source={logo}
-            style={{ width: size / 5, height: size / 5, resizeMode: 'contain' }}
-          />
-        </View>
-      )}
-    </View>
+    <QRCode
+      value={value}
+      size={size}
+      {...(logo
+        ? {
+            logo,
+            logoSize: calculatedLogoSize,
+            logoBackgroundColor,
+            ...(logoMargin !== undefined ? { logoMargin } : {}),
+          }
+        : {})}
+    />
   );
 };
 

--- a/apps/frontend/app/components/QrCode/types.ts
+++ b/apps/frontend/app/components/QrCode/types.ts
@@ -5,4 +5,7 @@ export interface QrCodeProps {
   size?: number;
   logoSource?: ImageSourcePropType;
   logoUrl?: string;
+  logoSize?: number;
+  logoBackgroundColor?: string;
+  logoMargin?: number;
 }


### PR DESCRIPTION
## Summary
- add logoMargin prop to QrCode component
- default logo background to white and expose margin option
- use new margin and white background in experimental App Download screen

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6880f323bc088330b0d131e002fa6750