### PR TITLE
Fix spacing and button layout in AppDownload screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -102,6 +102,7 @@ const AppDownload = () => {
                   appSettings?.app_stores_url_to_apple &&
                   openInBrowser(appSettings.app_stores_url_to_apple)
                 }
+                style={{ width: '100%', marginVertical: 10 }}
                 iconRight={
                   <FontAwesome6
                     name='arrow-up-right-from-square'
@@ -129,6 +130,7 @@ const AppDownload = () => {
                   appSettings?.app_stores_url_to_google &&
                   openInBrowser(appSettings.app_stores_url_to_google)
                 }
+                style={{ width: '100%', marginVertical: 10 }}
                 iconRight={
                   <FontAwesome6
                     name='arrow-up-right-from-square'

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -26,7 +26,9 @@ export default StyleSheet.create({
   qrRow: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-around',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 10,
     marginTop: 20,
   },
   qrCol: {

--- a/apps/frontend/app/components/ProjectButton/index.tsx
+++ b/apps/frontend/app/components/ProjectButton/index.tsx
@@ -12,6 +12,7 @@ const ProjectButton: React.FC<ProjectButtonProps> = ({
   onPress,
   iconLeft,
   iconRight,
+  style,
 }) => {
   const { primaryColor, selectedTheme } = useSelector(
     (state: RootState) => state.settings
@@ -31,7 +32,7 @@ const ProjectButton: React.FC<ProjectButtonProps> = ({
 
   return (
     <TouchableOpacity
-      style={[styles.container, { backgroundColor: primaryColor }]}
+      style={[styles.container, { backgroundColor: primaryColor }, style]}
       onPress={onPress}
     >
       {iconLeft}

--- a/apps/frontend/app/components/ProjectButton/types.ts
+++ b/apps/frontend/app/components/ProjectButton/types.ts
@@ -1,7 +1,9 @@
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
 export interface ProjectButtonProps {
   text: string;
   onPress?: () => void;
   iconLeft?: ReactNode;
   iconRight?: ReactNode;
+  style?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
## Summary
- allow custom styles for `ProjectButton`
- center QR cards with gap
- stretch download buttons across each QR card

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68810e6424fc833091f6ae318c73708b