### PR TITLE
Improve AppDownload QR card layout

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -71,7 +71,14 @@ const AppDownload = () => {
 
   const contrastColor = myContrastColor(primaryColor, theme, selectedTheme === 'dark');
 
-  const qrSize = CardDimensionHelper.getCardDimension(screenWidth);
+  const gapBetweenCards = 10;
+  const paddingHorizontal = 20;
+  const availableWidth = screenWidth - paddingHorizontal * 2;
+  const maxQrSize = (availableWidth - gapBetweenCards) / 2;
+  const qrSize = Math.min(
+    CardDimensionHelper.getCardDimension(screenWidth),
+    maxQrSize,
+  );
 
   return (
     <ScrollView

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -27,6 +27,7 @@ export default StyleSheet.create({
     width: '100%',
     flexDirection: 'row',
     flexWrap: 'wrap',
+    alignItems: 'center',
     justifyContent: 'center',
     gap: 10,
     marginTop: 20,


### PR DESCRIPTION
## Summary
- center QR code cards and match foodoffers spacing
- limit card width using available screen size

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68812145db848330a62b87f81673385e