### PR TITLE
Fix spacing between QR code and button

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -34,7 +34,7 @@ export default StyleSheet.create({
   },
   qrCol: {
     alignItems: 'center',
-    gap: 10,
+    gap: 5,
     overflow: 'hidden',
     borderBottomLeftRadius: 18,
     borderBottomRightRadius: 18,


### PR DESCRIPTION
## Summary
- tweak App Download styles to reduce gap

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68812ea832008330865799d67a25406c