### PR TITLE
Refactor QR download cards

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -22,6 +22,7 @@ import QrCode from '@/components/QrCode';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 import appleLogo from "@/assets/icons/apple-store.png"
 import googleLogo from "@/assets/icons/google-play.png"
+import CardWithText from '@/components/CardWithText/CardWithText';
 
 const AppDownload = () => {
   useSetPageTitle(TranslationKeys.app_download);
@@ -80,6 +81,42 @@ const AppDownload = () => {
     maxQrSize,
   );
 
+  const renderQrCard = (
+    url: string | undefined,
+    label: string,
+    logo: any,
+  ) => {
+    if (!url) return null;
+    return (
+      <CardWithText
+        onPress={() => openInBrowser(url)}
+        containerStyle={[styles.qrCol, { width: qrSize, backgroundColor: theme.card.background }]}
+        imageContainerStyle={[styles.qrImageContainer, { height: qrSize }]}
+        imageChildren={
+          <QrCode
+            value={url}
+            size={qrSize}
+            image={logo}
+            backgroundColor='white'
+            margin={2}
+          />
+        }
+        bottomContent={
+          <TouchableOpacity
+            style={[styles.qrButton, { backgroundColor: primaryColor }]}
+          >
+            <Text style={[styles.qrButtonText, { color: contrastColor }]}>{label}</Text>
+            <FontAwesome6
+              name='arrow-up-right-from-square'
+              size={20}
+              color={contrastColor}
+            />
+          </TouchableOpacity>
+        }
+      />
+    );
+  };
+
   return (
     <ScrollView
       style={{ ...styles.container, backgroundColor: theme.screen.background }}
@@ -92,66 +129,8 @@ const AppDownload = () => {
         <Image source={iconSource} style={styles.icon} />
         <Text style={{ ...styles.heading, color: theme.screen.text }}>{projectName}</Text>
         <View style={styles.qrRow}>
-          {appSettings?.app_stores_url_to_apple ? (
-            <View style={[styles.qrCol, { width: qrSize, backgroundColor: theme.card.background }]}> 
-              <View style={[styles.qrImageContainer, { height: qrSize }]}> 
-                <QrCode
-                  value={appSettings.app_stores_url_to_apple}
-                  size={qrSize}
-                  image={appleLogo}
-                  backgroundColor='white'
-                  margin={2}
-                />
-              </View>
-              <TouchableOpacity
-                style={[
-                  styles.qrButton,
-                  { backgroundColor: primaryColor },
-                ]}
-                onPress={() =>
-                  appSettings?.app_stores_url_to_apple &&
-                  openInBrowser(appSettings.app_stores_url_to_apple)
-                }
-              >
-                <Text style={[styles.qrButtonText, { color: contrastColor }]}>iOS</Text>
-                <FontAwesome6
-                  name='arrow-up-right-from-square'
-                  size={20}
-                  color={contrastColor}
-                />
-              </TouchableOpacity>
-            </View>
-          ) : null}
-          {appSettings?.app_stores_url_to_google ? (
-            <View style={[styles.qrCol, { width: qrSize, backgroundColor: theme.card.background }]}> 
-              <View style={[styles.qrImageContainer, { height: qrSize }]}>
-                <QrCode
-                  value={appSettings.app_stores_url_to_google}
-                  size={qrSize}
-                  image={googleLogo}
-                  backgroundColor='white'
-                  margin={2}
-                />
-              </View>
-              <TouchableOpacity
-                style={[
-                  styles.qrButton,
-                  { backgroundColor: primaryColor },
-                ]}
-                onPress={() =>
-                  appSettings?.app_stores_url_to_google &&
-                  openInBrowser(appSettings.app_stores_url_to_google)
-                }
-              >
-                <Text style={[styles.qrButtonText, { color: contrastColor }]}>Android</Text>
-                <FontAwesome6
-                  name='arrow-up-right-from-square'
-                  size={20}
-                  color={contrastColor}
-                />
-              </TouchableOpacity>
-            </View>
-          ) : null}
+          {renderQrCard(appSettings?.app_stores_url_to_apple, 'iOS', appleLogo)}
+          {renderQrCard(appSettings?.app_stores_url_to_google, 'Android', googleLogo)}
         </View>
       </View>
     </ScrollView>

--- a/apps/frontend/app/components/CardWithText/CardWithText.tsx
+++ b/apps/frontend/app/components/CardWithText/CardWithText.tsx
@@ -9,23 +9,32 @@ const CardWithText: React.FC<CardWithTextProps> = ({
   imageContainerStyle,
   imageStyle,
   contentStyle,
+  topRadius = 18,
   borderColor,
   imageChildren,
   children,
+  bottomContent,
   ...rest
 }) => {
   const contentBorder = borderColor
     ? { borderTopColor: borderColor, borderTopWidth: 3 }
     : null;
 
+  const topRadiusStyle = {
+    borderTopLeftRadius: topRadius,
+    borderTopRightRadius: topRadius,
+  };
+
   return (
-    <TouchableOpacity style={[styles.card, containerStyle]} {...rest}>
-      <View style={[styles.imageContainer, imageContainerStyle]}>
-        <Image style={[styles.image, imageStyle]} source={imageSource} />
+    <TouchableOpacity style={[styles.card, topRadiusStyle, containerStyle]} {...rest}>
+      <View style={[styles.imageContainer, topRadiusStyle, imageContainerStyle]}>
+        {imageSource ? (
+          <Image style={[styles.image, topRadiusStyle, imageStyle]} source={imageSource} />
+        ) : null}
         {imageChildren}
       </View>
       <View style={[styles.cardContent, contentBorder, contentStyle]}>
-        {children}
+        {bottomContent ?? children}
       </View>
     </TouchableOpacity>
   );

--- a/apps/frontend/app/components/CardWithText/types.ts
+++ b/apps/frontend/app/components/CardWithText/types.ts
@@ -2,16 +2,30 @@ import { ImageSourcePropType, StyleProp, ViewStyle, ImageStyle, TouchableOpacity
 import React from 'react';
 
 export interface CardWithTextProps extends TouchableOpacityProps {
-  imageSource: ImageSourcePropType;
+  /**
+   * Optional image source for the upper section. When omitted the
+   * imageChildren prop can be used to render custom content (e.g. a QR code).
+   */
+  imageSource?: ImageSourcePropType;
   containerStyle?: StyleProp<ViewStyle>;
   imageContainerStyle?: StyleProp<ViewStyle>;
   imageStyle?: StyleProp<ImageStyle>;
   contentStyle?: StyleProp<ViewStyle>;
+  /**
+   * Optional top border radius for the card. Defaults to 18 to keep
+   * backwards compatibility with existing cards.
+   */
+  topRadius?: number;
   /**
    * Optional border color for the content section. If provided the component
    * will automatically apply a border with a default width.
    */
   borderColor?: string;
   imageChildren?: React.ReactNode;
+  /**
+   * Alternative content for the bottom section of the card. When provided it
+   * takes precedence over the regular children prop.
+   */
+  bottomContent?: React.ReactNode;
   children?: React.ReactNode;
 }


### PR DESCRIPTION
## Summary
- support optional top radius and bottom content in `CardWithText`
- apply new API to experimental AppDownload page

## Testing
- `yarn test` *(fails: Failed to fetch external resources and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688141c99494833086bae8e5ef8af5b8