### PR TITLE
Adjust QR card for app download

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -92,6 +92,9 @@ const AppDownload = () => {
         onPress={() => openInBrowser(url)}
         containerStyle={[styles.qrCol, { width: qrSize, backgroundColor: theme.card.background }]}
         imageContainerStyle={[styles.qrImageContainer, { height: qrSize }]}
+        contentStyle={{ paddingBottom: 0 }}
+        topRadius={0}
+        borderColor={primaryColor}
         imageChildren={
           <QrCode
             value={url}


### PR DESCRIPTION
## Summary
- allow customizing QR card radius and border
- remove padding from QR button area so it fills the card

## Testing
- `yarn test` *(fails: Failed to fetch or parse news page; Failed to generate PDF)*

------
https://chatgpt.com/codex/tasks/task_e_68814754caac8330bad651a39e4852cc