### PR TITLE
Fix app download button styling

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -33,6 +33,8 @@ const AppDownload = () => {
   const [projectName, setProjectName] = useState('');
   const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 
+  const projectColor = serverInfo?.info?.project?.project_color || primaryColor;
+
   useEffect(() => {
     const sub = Dimensions.addEventListener('change', ({ window }) => {
       setScreenWidth(window.width);
@@ -70,7 +72,7 @@ const AppDownload = () => {
     ? { uri: projectLogo }
     : require('../../../../assets/images/icon.png');
 
-  const contrastColor = myContrastColor(primaryColor, theme, selectedTheme === 'dark');
+  const contrastColor = myContrastColor(projectColor, theme, selectedTheme === 'dark');
 
   const gapBetweenCards = 10;
   const paddingHorizontal = 20;
@@ -94,7 +96,7 @@ const AppDownload = () => {
         imageContainerStyle={[styles.qrImageContainer, { height: qrSize }]}
         contentStyle={{ paddingBottom: 0 }}
         topRadius={0}
-        borderColor={primaryColor}
+        borderColor={projectColor}
         imageChildren={
           <QrCode
             value={url}
@@ -106,13 +108,14 @@ const AppDownload = () => {
         }
         bottomContent={
           <TouchableOpacity
-            style={[styles.qrButton, { backgroundColor: primaryColor }]}
+            style={[styles.qrButton, { backgroundColor: projectColor }]}
           >
             <Text style={[styles.qrButtonText, { color: contrastColor }]}>{label}</Text>
             <FontAwesome6
               name='arrow-up-right-from-square'
               size={20}
               color={contrastColor}
+              style={{ marginLeft: 5 }}
             />
           </TouchableOpacity>
         }

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -58,8 +58,11 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 5,
     paddingHorizontal: 18,
     height: 43,
+    borderBottomLeftRadius: 18,
+    borderBottomRightRadius: 18,
   },
   qrButtonText: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- adjust App Download card to use project color
- make QR button fill the bottom area and center the label

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688150de88408330936a5599d4c466a0