### PR TITLE
Fix AppDownload card border

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -35,7 +35,6 @@ export default StyleSheet.create({
   qrCol: {
     alignItems: 'center',
     gap: 5,
-    overflow: 'hidden',
     borderBottomLeftRadius: 18,
     borderBottomRightRadius: 18,
   },


### PR DESCRIPTION
## Summary
- fix card style so borderColor shows

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6882045c975c83309c465ef526a2c7cd