### PR TITLE
Add App Download QR codes

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -3,14 +3,16 @@ import {
   Image,
   ScrollView,
   Text,
-  View,
+    Dimensions,
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import styles from './styles';
+import CardWithText from '@/components/CardWithText/CardWithText';
+import CardDimensionHelper from '@/helper/CardDimensionHelper';
+import QrCode from '@/components/QrCode';
 import { getImageUrl } from '@/constants/HelperFunctions';
 
 const AppDownload = () => {
@@ -19,7 +21,10 @@ const AppDownload = () => {
   const { serverInfo, appSettings, primaryColor } = useSelector(
     (state: RootState) => state.settings
   );
+  
+  
   const [projectName, setProjectName] = useState('');
+  const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
   const projectColor = serverInfo?.info?.project?.project_color || primaryColor;
 
   useEffect(() => {
@@ -28,15 +33,23 @@ const AppDownload = () => {
     }
   }, [serverInfo]);
 
+    
+
+  useEffect(() => {
+    const sub = Dimensions.addEventListener('change', ({ window }) => {
+      setScreenWidth(window.width);
+    });
+    return () => sub?.remove();
+  }, []);
+
 
 
   const projectLogo =
     serverInfo?.info?.project?.project_logo &&
     getImageUrl(serverInfo.info.project.project_logo);
 
-  const iconSource = projectLogo
-    ? { uri: projectLogo }
-    : require('../../../../assets/images/icon.png');
+  
+  const cardSize = CardDimensionHelper.getCardWidth(screenWidth, 2);
 
 
   return (
@@ -50,6 +63,14 @@ const AppDownload = () => {
       <View style={styles.content}>
         <Image source={iconSource} style={styles.icon} />
         <Text style={{ ...styles.heading, color: theme.screen.text }}>{projectName}</Text>
+        <View style={styles.cardsContainer}>
+          <CardWithText topRadius={0} containerStyle={{ width: cardSize, backgroundColor: theme.card.background }} imageContainerStyle={{ height: cardSize }} contentStyle={styles.cardContent} imageChildren={<QrCode value={appSettings?.app_stores_url_to_google || ""} size={cardSize * 0.9} />}>
+            <Text style={{ ...styles.cardTitle, color: theme.screen.text }}>Google Play</Text>
+          </CardWithText>
+          <CardWithText topRadius={0} containerStyle={{ width: cardSize, backgroundColor: theme.card.background }} imageContainerStyle={{ height: cardSize }} contentStyle={styles.cardContent} imageChildren={<QrCode value={appSettings?.app_stores_url_to_apple || ""} size={cardSize * 0.9} />}>
+            <Text style={{ ...styles.cardTitle, color: theme.screen.text }}>Apple Store</Text>
+          </CardWithText>
+        </View>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -23,4 +23,22 @@ export default StyleSheet.create({
     resizeMode: 'contain',
     marginBottom: 10,
   },
+  cardsContainer: {
+    width: '100%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    gap: 10,
+    marginTop: 20,
+  },
+  cardContent: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+    textAlign: 'center',
+  },
 });


### PR DESCRIPTION
## Summary
- show QR codes for iOS and Android on the experimental App Download page
- style cards and layout for QR codes

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68822fa5890483309954f248c943e0e9