### PR TITLE
Fix crash in experimental app-download screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -14,6 +14,7 @@ import CardWithText from '@/components/CardWithText/CardWithText';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 import QrCode from '@/components/QrCode';
 import { getImageUrl } from '@/constants/HelperFunctions';
+import styles from './styles';
 
 const AppDownload = () => {
   useSetPageTitle(TranslationKeys.app_download);
@@ -47,6 +48,10 @@ const AppDownload = () => {
   const projectLogo =
     serverInfo?.info?.project?.project_logo &&
     getImageUrl(serverInfo.info.project.project_logo);
+
+  const iconSource = projectLogo
+    ? { uri: projectLogo }
+    : require('../../../../assets/images/icon.png');
 
   
   const cardSize = CardDimensionHelper.getCardWidth(screenWidth, 2);


### PR DESCRIPTION
## Summary
- fix missing `iconSource` constant causing runtime crash
- import `styles` in experimental AppDownload screen

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6882461b2ca48330ad5731b35b17900b