### PR TITLE
Remove download cards from experimental page

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -1,48 +1,19 @@
-import React, { useEffect, useState } from 'react';
-import {
-  Image,
-  ScrollView,
-  Text,
-    Dimensions,
-} from 'react-native';
+import React from 'react';
+import { Image, ScrollView, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import CardWithText from '@/components/CardWithText/CardWithText';
-import CardDimensionHelper from '@/helper/CardDimensionHelper';
-import GooglePlayLogo from '@/assets/icons/google-play.png';
-import AppleStoreLogo from '@/assets/icons/apple-store.png';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import styles from './styles';
 
 const AppDownload = () => {
   useSetPageTitle(TranslationKeys.app_download);
   const { theme } = useTheme();
-  const { serverInfo, appSettings, primaryColor } = useSelector(
+  const { serverInfo } = useSelector(
     (state: RootState) => state.settings
   );
-  
-  
-  const [projectName, setProjectName] = useState('');
-  const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
-  const projectColor = serverInfo?.info?.project?.project_color || primaryColor;
-
-  useEffect(() => {
-    if (serverInfo && serverInfo.info) {
-      setProjectName(serverInfo.info.project.project_name);
-    }
-  }, [serverInfo]);
-
-    
-
-  useEffect(() => {
-    const sub = Dimensions.addEventListener('change', ({ window }) => {
-      setScreenWidth(window.width);
-    });
-    return () => sub?.remove();
-  }, []);
 
 
 
@@ -53,9 +24,6 @@ const AppDownload = () => {
   const iconSource = projectLogo
     ? { uri: projectLogo }
     : require('../../../../assets/images/icon.png');
-
-  
-  const cardSize = CardDimensionHelper.getCardWidth(screenWidth, 2);
 
 
   return (
@@ -68,27 +36,6 @@ const AppDownload = () => {
     >
       <View style={styles.content}>
         <Image source={iconSource} style={styles.icon} />
-        <Text style={{ ...styles.heading, color: theme.screen.text }}>{projectName}</Text>
-        <View style={styles.cardsContainer}>
-          <CardWithText
-            topRadius={0}
-            containerStyle={{ width: cardSize, backgroundColor: theme.card.background }}
-            imageContainerStyle={{ height: cardSize }}
-            contentStyle={styles.cardContent}
-            imageSource={GooglePlayLogo}
-          >
-            <Text style={{ ...styles.cardTitle, color: theme.screen.text }}>Google Play</Text>
-          </CardWithText>
-          <CardWithText
-            topRadius={0}
-            containerStyle={{ width: cardSize, backgroundColor: theme.card.background }}
-            imageContainerStyle={{ height: cardSize }}
-            contentStyle={styles.cardContent}
-            imageSource={AppleStoreLogo}
-          >
-            <Text style={{ ...styles.cardTitle, color: theme.screen.text }}>Apple Store</Text>
-          </CardWithText>
-        </View>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -11,34 +11,10 @@ export default StyleSheet.create({
     padding: 20,
     alignItems: 'center',
   },
-  heading: {
-    fontSize: 24,
-    fontFamily: 'Poppins_700Bold',
-    marginVertical: 10,
-    textAlign: 'center',
-  },
   icon: {
     width: 120,
     height: 120,
     resizeMode: 'contain',
     marginBottom: 10,
-  },
-  cardsContainer: {
-    width: '100%',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    alignItems: 'stretch',
-    gap: 10,
-    marginTop: 20,
-  },
-  cardContent: {
-    alignItems: 'center',
-    paddingVertical: 10,
-  },
-  cardTitle: {
-    fontSize: 16,
-    fontFamily: 'Poppins_400Regular',
-    textAlign: 'center',
   },
 });


### PR DESCRIPTION
## Summary
- simplify the experimental app-download screen so only the logo is displayed
- cleanup unused styles
- fix missing `View` import

## Testing
- `yarn --cwd apps/frontend/app install`
- `yarn --cwd apps/frontend/app test`

------
https://chatgpt.com/codex/tasks/task_e_68826d6a7d088330b32bd351046fceba