### PR TITLE
Add App-Download cards

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { getImageUrl } from '@/constants/HelperFunctions';
+import DownloadItem from '@/components/DownloadItem';
 import styles from './styles';
 
 const AppDownload = () => {
@@ -36,6 +37,18 @@ const AppDownload = () => {
     >
       <View style={styles.content}>
         <Image source={iconSource} style={styles.icon} />
+        <View style={styles.downloadRow}>
+          <DownloadItem
+            label='iOS'
+            imageSource={require('../../../../assets/icons/apple-store.png')}
+            containerStyle={styles.downloadItem}
+          />
+          <DownloadItem
+            label='Android'
+            imageSource={require('../../../../assets/icons/google-play.png')}
+            containerStyle={styles.downloadItem}
+          />
+        </View>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -17,4 +17,14 @@ export default StyleSheet.create({
     resizeMode: 'contain',
     marginBottom: 10,
   },
+  downloadRow: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 10,
+    marginTop: 20,
+  },
+  downloadItem: {
+    flex: 1,
+  },
 });

--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Text } from 'react-native';
+import CardWithText from '../CardWithText/CardWithText';
+import { DownloadItemProps } from './types';
+import styles from './styles';
+import { useTheme } from '@/hooks/useTheme';
+
+const DownloadItem: React.FC<DownloadItemProps> = ({
+  label,
+  imageSource,
+  onPress,
+  containerStyle,
+}) => {
+  const { theme } = useTheme();
+  return (
+    <CardWithText
+      onPress={onPress}
+      imageSource={imageSource}
+      containerStyle={[styles.card, { backgroundColor: theme.card.background }, containerStyle]}
+      imageContainerStyle={styles.imageContainer}
+      bottomContent={<Text style={[styles.label, { color: theme.screen.text }]}>{label}</Text>}
+    />
+  );
+};
+
+export default DownloadItem;

--- a/apps/frontend/app/components/DownloadItem/styles.ts
+++ b/apps/frontend/app/components/DownloadItem/styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  card: {
+    flex: 1,
+  },
+  imageContainer: {
+    height: 120,
+  },
+  label: {
+    paddingVertical: 10,
+    textAlign: 'center',
+    fontFamily: 'Poppins_700Bold',
+    fontSize: 16,
+  },
+});

--- a/apps/frontend/app/components/DownloadItem/types.ts
+++ b/apps/frontend/app/components/DownloadItem/types.ts
@@ -1,0 +1,10 @@
+import { ImageSourcePropType } from 'react-native';
+
+import { StyleProp, ViewStyle } from 'react-native';
+
+export interface DownloadItemProps {
+  label: string;
+  imageSource: ImageSourcePropType;
+  onPress?: () => void;
+  containerStyle?: StyleProp<ViewStyle>;
+}


### PR DESCRIPTION
## Summary
- add new `DownloadItem` component
- show iOS and Android cards on App Download page

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688274ff6920833093e8d63dd2ad9508