### PR TITLE
Fix DownloadItem appearance

### DIFF
--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -4,6 +4,8 @@ import CardWithText from '../CardWithText/CardWithText';
 import { DownloadItemProps } from './types';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
 
 const DownloadItem: React.FC<DownloadItemProps> = ({
   label,
@@ -12,13 +14,21 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
   containerStyle,
 }) => {
   const { theme } = useTheme();
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
   return (
     <CardWithText
       onPress={onPress}
       imageSource={imageSource}
-      containerStyle={[styles.card, { backgroundColor: theme.card.background }, containerStyle]}
+      containerStyle={[
+        styles.card,
+        { backgroundColor: theme.card.background },
+        containerStyle,
+      ]}
       imageContainerStyle={styles.imageContainer}
-      bottomContent={<Text style={[styles.label, { color: theme.screen.text }]}>{label}</Text>}
+      borderColor={primaryColor}
+      bottomContent={
+        <Text style={[styles.label, { color: theme.screen.text }]}>{label}</Text>
+      }
     />
   );
 };

--- a/apps/frontend/app/components/DownloadItem/styles.ts
+++ b/apps/frontend/app/components/DownloadItem/styles.ts
@@ -10,7 +10,7 @@ export default StyleSheet.create({
   label: {
     paddingVertical: 10,
     textAlign: 'center',
-    fontFamily: 'Poppins_700Bold',
+    fontFamily: 'Poppins_400Regular',
     fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary
- style DownloadItem label like FoodItem
- add project color separator to DownloadItem

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68827c589ecc83309e8c2be1ca53c340