### PR TITLE
Add QR codes to app download cards

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, ScrollView, View } from 'react-native';
+import { Image, ScrollView, View, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { useTheme } from '@/hooks/useTheme';
@@ -12,7 +12,7 @@ import styles from './styles';
 const AppDownload = () => {
   useSetPageTitle(TranslationKeys.app_download);
   const { theme } = useTheme();
-  const { serverInfo } = useSelector(
+  const { serverInfo, appSettings } = useSelector(
     (state: RootState) => state.settings
   );
 
@@ -25,6 +25,9 @@ const AppDownload = () => {
   const iconSource = projectLogo
     ? { uri: projectLogo }
     : require('../../../../assets/images/icon.png');
+
+  const iosLink = appSettings?.app_stores_url_to_apple;
+  const androidLink = appSettings?.app_stores_url_to_google;
 
 
   return (
@@ -42,11 +45,15 @@ const AppDownload = () => {
             label='iOS'
             imageSource={require('../../../../assets/icons/apple-store.png')}
             containerStyle={styles.downloadItem}
+            qrValue={iosLink}
+            onPress={() => iosLink && Linking.openURL(iosLink)}
           />
           <DownloadItem
             label='Android'
             imageSource={require('../../../../assets/icons/google-play.png')}
             containerStyle={styles.downloadItem}
+            qrValue={androidLink}
+            onPress={() => androidLink && Linking.openURL(androidLink)}
           />
         </View>
       </View>

--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import CardWithText from '../CardWithText/CardWithText';
 import { DownloadItemProps } from './types';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
+import QrCode from '@/components/QrCode';
 
 const DownloadItem: React.FC<DownloadItemProps> = ({
   label,
   imageSource,
   onPress,
   containerStyle,
+  qrValue,
 }) => {
   const { theme } = useTheme();
   const { primaryColor } = useSelector((state: RootState) => state.settings);
@@ -26,6 +28,13 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
       ]}
       imageContainerStyle={styles.imageContainer}
       borderColor={primaryColor}
+      imageChildren={
+        qrValue ? (
+          <View style={styles.qrOverlay} pointerEvents='none'>
+            <QrCode value={qrValue} size={110} />
+          </View>
+        ) : undefined
+      }
       bottomContent={
         <Text style={[styles.label, { color: theme.screen.text }]}>{label}</Text>
       }

--- a/apps/frontend/app/components/DownloadItem/styles.ts
+++ b/apps/frontend/app/components/DownloadItem/styles.ts
@@ -13,4 +13,12 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_400Regular',
     fontSize: 16,
   },
+  qrOverlay: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    left: 0,
+    alignItems: 'center',
+    paddingTop: 10,
+  },
 });

--- a/apps/frontend/app/components/DownloadItem/types.ts
+++ b/apps/frontend/app/components/DownloadItem/types.ts
@@ -7,4 +7,9 @@ export interface DownloadItemProps {
   imageSource: ImageSourcePropType;
   onPress?: () => void;
   containerStyle?: StyleProp<ViewStyle>;
+  /**
+   * Optional value for rendering a QR code in the image section above
+   * the label.
+   */
+  qrValue?: string;
 }


### PR DESCRIPTION
## Summary
- allow `DownloadItem` to show QR code above the label
- adjust QR overlay styles

## Testing
- `yarn workspace rocket-meals-dev test` *(shows no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688281af4f18833081fcd91fbd7d951a