### PR TITLE
Update DownloadItem QR code integration

### DIFF
--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -20,18 +20,18 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
   return (
     <CardWithText
       onPress={onPress}
-      imageSource={imageSource}
       containerStyle={[
         styles.card,
         { backgroundColor: theme.card.background },
         containerStyle,
       ]}
       imageContainerStyle={styles.imageContainer}
+      topRadius={0}
       borderColor={primaryColor}
       imageChildren={
         qrValue ? (
-          <View style={styles.qrOverlay} pointerEvents='none'>
-            <QrCode value={qrValue} size={110} />
+          <View style={styles.qrContainer} pointerEvents='none'>
+            <QrCode value={qrValue} size={110} image={imageSource} />
           </View>
         ) : undefined
       }

--- a/apps/frontend/app/components/DownloadItem/styles.ts
+++ b/apps/frontend/app/components/DownloadItem/styles.ts
@@ -13,12 +13,10 @@ export default StyleSheet.create({
     fontFamily: 'Poppins_400Regular',
     fontSize: 16,
   },
-  qrOverlay: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    left: 0,
+  qrContainer: {
+    flex: 1,
     alignItems: 'center',
+    justifyContent: 'center',
     paddingTop: 10,
   },
 });

--- a/apps/frontend/app/components/DownloadItem/types.ts
+++ b/apps/frontend/app/components/DownloadItem/types.ts
@@ -4,6 +4,10 @@ import { StyleProp, ViewStyle } from 'react-native';
 
 export interface DownloadItemProps {
   label: string;
+  /**
+   * Image shown in the middle of the QR code. Previously this image was used
+   * as the card's header background but is now passed directly to the QR code.
+   */
   imageSource: ImageSourcePropType;
   onPress?: () => void;
   containerStyle?: StyleProp<ViewStyle>;


### PR DESCRIPTION
## Summary
- embed store logos inside the QR codes rather than as card images
- adjust styles so the QR code uses the card image area
- set the card's top border radius to 0

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68828c1cbf08833083c0fa0e8f3d46c7