### PR TITLE
Fix DownloadItem size

### DIFF
--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Text, View, useWindowDimensions } from 'react-native';
 import CardWithText from '../CardWithText/CardWithText';
 import { DownloadItemProps } from './types';
 import styles from './styles';
@@ -7,6 +7,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import QrCode from '@/components/QrCode';
+import CardDimensionHelper from '@/helper/CardDimensionHelper';
 
 const DownloadItem: React.FC<DownloadItemProps> = ({
   label,
@@ -17,6 +18,8 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
 }) => {
   const { theme } = useTheme();
   const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { width: screenWidth } = useWindowDimensions();
+  const size = CardDimensionHelper.getCardWidth(screenWidth, 2);
   return (
     <CardWithText
       onPress={onPress}
@@ -25,13 +28,13 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
         { backgroundColor: theme.card.background },
         containerStyle,
       ]}
-      imageContainerStyle={styles.imageContainer}
+      imageContainerStyle={[styles.imageContainer, { height: size }]}
       topRadius={0}
       borderColor={primaryColor}
       imageChildren={
         qrValue ? (
           <View style={styles.qrContainer} pointerEvents='none'>
-            <QrCode value={qrValue} size={120} image={imageSource} />
+            <QrCode value={qrValue} size={size} image={imageSource} />
           </View>
         ) : undefined
       }

--- a/apps/frontend/app/components/DownloadItem/styles.ts
+++ b/apps/frontend/app/components/DownloadItem/styles.ts
@@ -5,7 +5,6 @@ export default StyleSheet.create({
     flex: 1,
   },
   imageContainer: {
-    height: 120,
   },
   label: {
     paddingVertical: 10,


### PR DESCRIPTION
## Summary
- dynamically size `DownloadItem` using `CardDimensionHelper.getCardWidth`
- allow height override for QR code container

## Testing
- `yarn test` *(fails: "directus-extension-rocket-meals-bundle" missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688296680ea88330aabed4f34d5c4ea4