### PR TITLE
Fix DownloadItem sizing

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -20,11 +20,12 @@ export default StyleSheet.create({
   downloadRow: {
     width: '100%',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
     gap: 10,
     marginTop: 20,
   },
   downloadItem: {
-    flex: 1,
+    
   },
 });

--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -25,7 +25,7 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
       onPress={onPress}
       containerStyle={[
         styles.card,
-        { backgroundColor: theme.card.background },
+        { backgroundColor: theme.card.background, width: size },
         containerStyle,
       ]}
       imageContainerStyle={[styles.imageContainer, { height: size }]}

--- a/apps/frontend/app/components/DownloadItem/styles.ts
+++ b/apps/frontend/app/components/DownloadItem/styles.ts
@@ -1,9 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  card: {
-    flex: 1,
-  },
+  card: {},
   imageContainer: {
   },
   label: {


### PR DESCRIPTION
## Summary
- update DownloadItem container to use explicit card width
- remove flex usage in DownloadItem styles
- adjust download screen row layout for consistent spacing

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68829ac914008330815fa60a2a268a76