### PR TITLE
Fix download items layout

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -20,6 +20,7 @@ export default StyleSheet.create({
   downloadRow: {
     width: '100%',
     flexDirection: 'row',
+    alignItems: 'stretch',
     flexWrap: 'wrap',
     marginTop: 20,
   },


### PR DESCRIPTION
## Summary
- align download row items like the foodoffers list

## Testing
- `yarn workspace rocket-meals-dev test`

------
https://chatgpt.com/codex/tasks/task_e_6882a44c654c8330a8218b621a439b92