### PR TITLE
Fix AppDownload card layout

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -8,7 +8,8 @@ export default StyleSheet.create({
   content: {
     width: '100%',
     height: '100%',
-    padding: 20,
+    paddingVertical: 20,
+    paddingHorizontal: 10,
     alignItems: 'center',
   },
   icon: {


### PR DESCRIPTION
## Summary
- tweak AppDownload page layout so download items can render horizontally

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6882ad78cc0c8330b5664817560a3447