### PR TITLE
Add campus missing translation

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -442,7 +442,7 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                     color: theme.screen.text,
                   }}
                 >
-                  No Campus Found
+                  {translate(TranslationKeys.no_campus_found)}
                 </Text>
               </View>
             )}

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -53,6 +53,7 @@ export enum TranslationKeys {
   no_value = 'no_value',
   no_data_found = 'no_data_found',
   no_canteens_found = 'no_canteens_found',
+  no_campus_found = 'no_campus_found',
   accountbalanceLastTransaction = 'accountbalanceLastTransaction',
   accountbalanceDateUpdated = 'accountbalanceDateUpdated',
   sort = 'sort',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2863,6 +2863,16 @@
     "tr": "Yerleşke",
     "zh": "校园"
   },
+  "no_campus_found": {
+    "de": "Kein Campus gefunden.",
+    "en": "No campus found.",
+    "ar": "لم يتم العثور على حرم جامعي.",
+    "es": "No se encontró campus.",
+    "fr": "Aucun campus trouvé.",
+    "ru": "Кампус не найден.",
+    "tr": "Yerleşke bulunamadı.",
+    "zh": "未找到校园。"
+  },
   "housing": {
     "de": "Wohnen",
     "en": "Housing",


### PR DESCRIPTION
## Summary
- add translation key for missing campuses
- translate empty campus list message

## Testing
- `yarn test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882b16c44cc83309b5a664c0f34ffe0