### PR TITLE
Fix AppDownload layout

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/styles.ts
@@ -17,8 +17,8 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'stretch',
     justifyContent: 'center',
-    flexWrap: 'wrap',
-    gap: 10,
+    flexWrap: 'nowrap',
+    gap: 5,
     marginTop: 20,
   },
   icon: {


### PR DESCRIPTION
## Summary
- keep download items on one line
- tighten gap spacing

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6882bfb0a724833083b246b412f1813c