### PR TITLE
Fix DownloadItem card width

### DIFF
--- a/apps/frontend/app/components/DownloadItem/index.tsx
+++ b/apps/frontend/app/components/DownloadItem/index.tsx
@@ -17,9 +17,15 @@ const DownloadItem: React.FC<DownloadItemProps> = ({
   qrValue,
 }) => {
   const { theme } = useTheme();
-  const { primaryColor } = useSelector((state: RootState) => state.settings);
+  const { primaryColor, amountColumnsForcard } = useSelector(
+    (state: RootState) => state.settings
+  );
   const { width: screenWidth } = useWindowDimensions();
-  const size = CardDimensionHelper.getCardWidth(screenWidth, 2);
+  const size =
+    (amountColumnsForcard === 0
+      ? CardDimensionHelper.getCardDimension(screenWidth)
+      : CardDimensionHelper.getCardWidth(screenWidth, amountColumnsForcard)) -
+    5;
   return (
     <CardWithText
       onPress={onPress}


### PR DESCRIPTION
## Summary
- subtract layout gap from DownloadItem width

## Testing
- `yarn test` *(fails: "monorepo@workspace:.: This package doesn't seem to be present in your lockfile")*

------
https://chatgpt.com/codex/tasks/task_e_6882c38ada7c8330b3f085362ac8a1df