### PR TITLE
Improve settings row design

### DIFF
--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -17,6 +17,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import useKioskMode from '@/hooks/useKioskMode';
 
+
 const EventsScreen = () => {
   useSetPageTitle(TranslationKeys.events);
   const { theme } = useTheme();
@@ -24,6 +25,7 @@ const EventsScreen = () => {
   const dispatch = useDispatch();
   const kioskMode = useKioskMode();
   const { popupEvents } = useSelector((state: RootState) => state.food);
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
   const [selectedEvent, setSelectedEvent] = useState<any | null>(null);
   const bottomSheetRef = useRef<BottomSheet>(null);
   const [isActive, setIsActive] = useState(false);
@@ -58,6 +60,7 @@ const EventsScreen = () => {
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.background }}>
       <ScrollView contentContainerStyle={styles.container}>
         <SettingList
+          iconBgColor={primaryColor}
           leftIcon={<MaterialIcons name='refresh' size={24} color={theme.screen.icon} />}
           label={translate(TranslationKeys.reset_seen_popup_events)}
           rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
@@ -66,6 +69,7 @@ const EventsScreen = () => {
         {!kioskMode &&
           popupEvents.map((event: any) => (
             <SettingList
+              iconBgColor={primaryColor}
               key={event.id}
               leftIcon={<MaterialIcons name='event' size={24} color={theme.screen.icon} />}
               label={

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -351,7 +351,7 @@ const Settings = () => {
             </View>
           </View>
           {/* NickName */}
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialCommunityIcons
                 name='account'
@@ -379,7 +379,7 @@ const Settings = () => {
             }}
           />
           {/* Language */}
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Ionicons name='language' size={24} color={theme.screen.icon} />
             }
@@ -395,7 +395,7 @@ const Settings = () => {
             handleFunction={() => openLanguageModal()}
           />
           {/* Canteen */}
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialIcons
                 name='restaurant-menu'
@@ -414,7 +414,7 @@ const Settings = () => {
             }
             handleFunction={openCanteenSheet}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Ionicons
                 name='bag-add-sharp'
@@ -432,7 +432,7 @@ const Settings = () => {
             }
             handleFunction={() => router.navigate('/eating-habits')}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialIcons name='euro' size={24} color={theme.screen.icon} />
             }
@@ -452,7 +452,7 @@ const Settings = () => {
             }
             handleFunction={() => router.navigate('/price-group')}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Ionicons name='card' size={24} color={theme.screen.icon} />
             }
@@ -471,7 +471,7 @@ const Settings = () => {
             }
             handleFunction={() => router.navigate('/account-balance')}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Ionicons
                 name='notifications'
@@ -490,7 +490,7 @@ const Settings = () => {
             handleFunction={() => router.navigate('/notification')}
           />
           {/* color Scheme */}
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialCommunityIcons
                 name='theme-light-dark'
@@ -517,7 +517,7 @@ const Settings = () => {
           />
 
 
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Entypo name='menu' size={24} color={theme.screen.icon} />
             }
@@ -539,7 +539,7 @@ const Settings = () => {
             handleFunction={() => openDrawerSheet()}
           />
 
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <FontAwesome5
                 name='columns'
@@ -562,7 +562,7 @@ const Settings = () => {
             }
             handleFunction={() => openAmountColumnModal()}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Feather name='calendar' size={24} color={theme.screen.icon} />
             }
@@ -577,14 +577,14 @@ const Settings = () => {
             }
           handleFunction={() => openFirstDayModal()}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={<Ionicons name='cloud-download-outline' size={24} color={theme.screen.icon} />}
             label={translate(TranslationKeys.CHECK_FOR_APP_UPDATES)}
             rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
             handleFunction={handleCheckForUpdates}
           />
           {user?.id ? (
-            <SettingList
+            <SettingList iconBgColor={primaryColor}
               leftIcon={
                 <Entypo name='login' size={24} color={theme.screen.icon} />
               }
@@ -595,7 +595,7 @@ const Settings = () => {
               handleFunction={handleLogout}
             />
           ) : (
-            <SettingList
+            <SettingList iconBgColor={primaryColor}
               leftIcon={
                 <Entypo name='login' size={24} color={theme.screen.icon} />
               }
@@ -607,7 +607,7 @@ const Settings = () => {
             />
           )}
           {user?.id && (
-            <SettingList
+            <SettingList iconBgColor={primaryColor}
               leftIcon={
                 <AntDesign
                   name='deleteuser'
@@ -626,7 +626,7 @@ const Settings = () => {
               handleFunction={handleDeleteAccount}
             />
           )}
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialCommunityIcons
                 name='database-eye'
@@ -644,7 +644,7 @@ const Settings = () => {
             }
           handleFunction={() => router.navigate('/data-access')}
         />
-        <SettingList
+        <SettingList iconBgColor={primaryColor}
           leftIcon={
             <MaterialIcons name='event' size={24} color={theme.screen.icon} />
           }
@@ -654,7 +654,7 @@ const Settings = () => {
           }
           handleFunction={() => router.navigate('/events')}
         />
-        <SettingList
+        <SettingList iconBgColor={primaryColor}
           leftIcon={
             <MaterialIcons
               name='support-agent'
@@ -672,7 +672,7 @@ const Settings = () => {
             }
             handleFunction={() => router.navigate('/support-FAQ')}
           />
-          <SettingList
+          <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialCommunityIcons
                 name='license'
@@ -758,7 +758,7 @@ const Settings = () => {
             </Text>
           )}
           {isManagement && isDevMode && (
-            <SettingList
+            <SettingList iconBgColor={primaryColor}
               leftIcon={
                 <MaterialCommunityIcons
                   name='server'

--- a/apps/frontend/app/components/SettingList/SettingList.tsx
+++ b/apps/frontend/app/components/SettingList/SettingList.tsx
@@ -3,8 +3,10 @@ import React, { useEffect, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
-import { Ionicons, Octicons } from '@expo/vector-icons';
 import { SettingListProps } from './types';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import { myContrastColor } from '@/helper/colorHelper';
 
 const SettingList: React.FC<SettingListProps> = ({
   leftIcon,
@@ -12,8 +14,12 @@ const SettingList: React.FC<SettingListProps> = ({
   rightIcon,
   value,
   handleFunction,
+  iconBgColor,
 }) => {
   const { theme } = useTheme();
+  const { primaryColor, selectedTheme } = useSelector(
+    (state: RootState) => state.settings
+  );
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
@@ -39,7 +45,22 @@ const SettingList: React.FC<SettingListProps> = ({
       onPress={handleFunction}
     >
       <View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-        {leftIcon}
+        <View
+          style={{
+            ...styles.iconBox,
+            backgroundColor: iconBgColor || primaryColor,
+          }}
+        >
+          {React.isValidElement(leftIcon)
+            ? React.cloneElement(leftIcon, {
+                color: myContrastColor(
+                  iconBgColor || primaryColor,
+                  theme,
+                  selectedTheme === 'dark'
+                ),
+              })
+            : leftIcon}
+        </View>
         <Text
           style={{
             ...styles.label,

--- a/apps/frontend/app/components/SettingList/styles.ts
+++ b/apps/frontend/app/components/SettingList/styles.ts
@@ -13,11 +13,19 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     width: '48%',
+    gap: 10,
   },
   label: {
     fontFamily: 'Poppins_700Bold',
   },
   value: {
     fontFamily: 'Poppins_400Regular',
+  },
+  iconBox: {
+    width: 34,
+    height: 34,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/apps/frontend/app/components/SettingList/types.ts
+++ b/apps/frontend/app/components/SettingList/types.ts
@@ -5,5 +5,6 @@ export interface SettingListProps {
   label: string;
   rightIcon?: React.ReactNode;
   value?: string;
+  iconBgColor?: string;
   handleFunction: (event: GestureResponderEvent) => void;
 }


### PR DESCRIPTION
## Summary
- adjust `SettingList` to render icons inside colorized boxes
- pass `iconBgColor` to `SettingList` usage in Settings and Events screens
- update styles accordingly

## Testing
- `yarn lint` *(fails: couldn't find script "eslint")*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68835b8c90d08330b4759ac3948a980d