### PR TITLE
Add icons and grouped settings rows

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -316,68 +316,47 @@ const Settings = () => {
             width: windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
           }}
         >
-          {/* Account */}
-
-          <View
-            style={{
-              ...styles.list,
-              backgroundColor: theme.screen.iconBg,
-              paddingHorizontal: isWeb ? 20 : 10,
-            }}
-          >
-            <View style={{ ...styles.col }}>
-              <MaterialCommunityIcons
-                name='clipboard-account'
-                size={24}
-                color={theme.screen.icon}
-              />
-              <Text style={{ ...styles.label, color: theme.screen.text }}>
-                {translate(TranslationKeys.account)}
-              </Text>
-            </View>
-            <View style={{ ...styles.col, maxWidth: '60%' }}>
-              <Text
-                style={{
-                  ...styles.value,
-                  color: theme.screen.text,
-                  fontSize: isWeb ? 16 : 14,
-                  textAlign: 'right',
-                }}
-              >
-                {user?.id
-                  ? user?.id
-                  : translate(TranslationKeys.without_account)}
-              </Text>
-            </View>
-          </View>
-          {/* NickName */}
-          <SettingList iconBgColor={primaryColor}
-            leftIcon={
-              <MaterialCommunityIcons
-                name='account'
-                size={24}
-                color={theme.screen.icon}
-              />
-            }
-            label={translate(TranslationKeys.nickname)}
-            value={profile?.id ? profile?.nickname : nickNameLocal}
-            rightIcon={
-              <MaterialCommunityIcons
-                name='pencil'
-                size={24}
-                color={theme.screen.icon}
-              />
-            }
-            handleFunction={() => {
-              openNicknameSheet();
-              setNickname(profile?.id ? profile?.nickname : nickNameLocal);
-              if (profile?.nickname === nickname) {
-                setDisabled(true);
-              } else {
-                setDisabled(false);
+          {/* Account & Nickname */}
+          <View style={{ gap: 0 }}>
+            <SettingList
+              iconBgColor={primaryColor}
+              leftIcon={<MaterialCommunityIcons name='clipboard-account' size={24} color={theme.screen.icon} />}
+              label={translate(TranslationKeys.account)}
+              value={user?.id ? user?.id : translate(TranslationKeys.without_account)}
+              handleFunction={() => {}}
+              groupPosition='top'
+            />
+            {/* NickName */}
+            <SettingList
+              iconBgColor={primaryColor}
+              leftIcon={
+                <MaterialCommunityIcons
+                  name='account'
+                  size={24}
+                  color={theme.screen.icon}
+                />
               }
-            }}
-          />
+              label={translate(TranslationKeys.nickname)}
+              value={profile?.id ? profile?.nickname : nickNameLocal}
+              rightIcon={
+                <MaterialCommunityIcons
+                  name='pencil'
+                  size={24}
+                  color={theme.screen.icon}
+                />
+              }
+              handleFunction={() => {
+                openNicknameSheet();
+                setNickname(profile?.id ? profile?.nickname : nickNameLocal);
+                if (profile?.nickname === nickname) {
+                  setDisabled(true);
+                } else {
+                  setDisabled(false);
+                }
+              }}
+              groupPosition='bottom'
+            />
+          </View>
           {/* Language */}
           <SettingList iconBgColor={primaryColor}
             leftIcon={
@@ -691,43 +670,21 @@ const Settings = () => {
             handleFunction={() => router.navigate('/licenseInformation')}
           />
           {/* Terms & Conditions */}
-          <View
-            style={{
-              ...styles.termList,
-              backgroundColor: theme.screen.iconBg,
-              paddingHorizontal: isWeb ? 20 : 10,
-            }}
-          >
-            <View style={styles.termRow}>
+          <SettingList
+            iconBgColor={primaryColor}
+            leftIcon={
               <MaterialCommunityIcons
-                name='clipboard-account'
+                name='file-document-check'
                 size={24}
                 color={theme.screen.icon}
               />
-              <Text
-                style={{
-                  ...styles.label,
-                  color: theme.screen.text,
-                  fontSize: isWeb ? 16 : 14,
-                }}
-              >
-                {translate(
-                  TranslationKeys.terms_and_conditions_accepted_and_privacy_policy_read_at_date
-                )}
-              </Text>
-            </View>
-            <View style={styles.termRow2}>
-              <Text
-                style={{
-                  ...styles.value,
-                  color: theme.screen.text,
-                  fontSize: isWeb ? 16 : 14,
-                }}
-              >
-                {termsAndPrivacyConsentAcceptedDate}
-              </Text>
-            </View>
-          </View>
+            }
+            label={translate(
+              TranslationKeys.terms_and_conditions_accepted_and_privacy_policy_read_at_date
+            )}
+            value={termsAndPrivacyConsentAcceptedDate}
+            handleFunction={() => {}}
+          />
           <TouchableOpacity
             style={styles.footer}
             onPress={() => {

--- a/apps/frontend/app/app/(app)/settings/styles.ts
+++ b/apps/frontend/app/app/(app)/settings/styles.ts
@@ -22,25 +22,9 @@ export default StyleSheet.create({
     justifyContent: 'space-between',
     borderRadius: 12,
   },
-  termList: {
-    width: '100%',
-    borderRadius: 12,
-    paddingVertical: 10,
-  },
   col: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 10,
-  },
-  termRow: {
-    width: '90%',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-  },
-  termRow2: {
-    width: '100%',
-    alignItems: 'flex-end',
     gap: 10,
   },
   label: {

--- a/apps/frontend/app/components/SettingList/SettingList.tsx
+++ b/apps/frontend/app/components/SettingList/SettingList.tsx
@@ -15,6 +15,7 @@ const SettingList: React.FC<SettingListProps> = ({
   value,
   handleFunction,
   iconBgColor,
+  groupPosition = 'single',
 }) => {
   const { theme } = useTheme();
   const { primaryColor, selectedTheme } = useSelector(
@@ -41,6 +42,25 @@ const SettingList: React.FC<SettingListProps> = ({
         ...styles.list,
         backgroundColor: theme.screen.iconBg,
         paddingHorizontal: isWeb ? 20 : 10,
+        ...(groupPosition === 'top' && {
+          borderBottomLeftRadius: 0,
+          borderBottomRightRadius: 0,
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          borderBottomWidth: 1,
+          borderColor: theme.screen.iconBg,
+        }),
+        ...(groupPosition === 'middle' && {
+          borderRadius: 0,
+          borderBottomWidth: 1,
+          borderColor: theme.screen.iconBg,
+        }),
+        ...(groupPosition === 'bottom' && {
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          borderBottomLeftRadius: 12,
+          borderBottomRightRadius: 12,
+        }),
       }}
       onPress={handleFunction}
     >

--- a/apps/frontend/app/components/SettingList/types.ts
+++ b/apps/frontend/app/components/SettingList/types.ts
@@ -7,4 +7,5 @@ export interface SettingListProps {
   value?: string;
   iconBgColor?: string;
   handleFunction: (event: GestureResponderEvent) => void;
+  groupPosition?: 'top' | 'middle' | 'bottom' | 'single';
 }


### PR DESCRIPTION
## Summary
- add grouping support in `SettingList`
- implement icon/row updates for Account and terms rows
- remove old term list styles

## Testing
- `yarn lint` *(fails: Couldn't find script "eslint")*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68837eb57e088330bb4910581a4190cd