### PR TITLE
Group settings list

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -316,6 +316,9 @@ const Settings = () => {
             width: windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
           }}
         >
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+            {translate(TranslationKeys.group_account_personalization)}
+          </Text>
           {/* Account & Nickname */}
           <View style={{ gap: 0 }}>
             <SettingList
@@ -357,6 +360,49 @@ const Settings = () => {
               groupPosition='bottom'
             />
           </View>
+          {user?.id ? (
+            <SettingList iconBgColor={primaryColor}
+              leftIcon={
+                <Entypo name='login' size={24} color={theme.screen.icon} />
+              }
+              label={translate(TranslationKeys.logout)}
+              rightIcon={
+                <Entypo name='login' size={24} color={theme.screen.icon} />
+              }
+              handleFunction={handleLogout}
+            />
+          ) : (
+            <SettingList iconBgColor={primaryColor}
+              leftIcon={
+                <Entypo name='login' size={24} color={theme.screen.icon} />
+              }
+              label={translate(TranslationKeys.sign_in)}
+              rightIcon={
+                <Entypo name='login' size={24} color={theme.screen.icon} />
+              }
+              handleFunction={handleLogin}
+            />
+          )}
+          {user?.id && (
+            <SettingList iconBgColor={primaryColor}
+              leftIcon={
+                <AntDesign
+                  name='deleteuser'
+                  size={24}
+                  color={theme.screen.icon}
+                />
+              }
+              label={`${translate(TranslationKeys.account_delete)}`}
+              rightIcon={
+                <Octicons
+                  name='chevron-right'
+                  size={24}
+                  color={theme.screen.icon}
+                />
+              }
+              handleFunction={handleDeleteAccount}
+            />
+          )}
           {/* Language */}
           <SettingList iconBgColor={primaryColor}
             leftIcon={
@@ -373,6 +419,9 @@ const Settings = () => {
             }
             handleFunction={() => openLanguageModal()}
           />
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+            {translate(TranslationKeys.group_canteen_usage)}
+          </Text>
           {/* Canteen */}
           <SettingList iconBgColor={primaryColor}
             leftIcon={
@@ -392,24 +441,6 @@ const Settings = () => {
               />
             }
             handleFunction={openCanteenSheet}
-          />
-          <SettingList iconBgColor={primaryColor}
-            leftIcon={
-              <Ionicons
-                name='bag-add-sharp'
-                size={24}
-                color={theme.screen.icon}
-              />
-            }
-            label={translate(TranslationKeys.eating_habits)}
-            rightIcon={
-              <Octicons
-                name='chevron-right'
-                size={24}
-                color={theme.screen.icon}
-              />
-            }
-            handleFunction={() => router.navigate('/eating-habits')}
           />
           <SettingList iconBgColor={primaryColor}
             leftIcon={
@@ -453,6 +484,24 @@ const Settings = () => {
           <SettingList iconBgColor={primaryColor}
             leftIcon={
               <Ionicons
+                name='bag-add-sharp'
+                size={24}
+                color={theme.screen.icon}
+              />
+            }
+            label={translate(TranslationKeys.eating_habits)}
+            rightIcon={
+              <Octicons
+                name='chevron-right'
+                size={24}
+                color={theme.screen.icon}
+              />
+            }
+            handleFunction={() => router.navigate('/eating-habits')}
+          />
+          <SettingList iconBgColor={primaryColor}
+            leftIcon={
+              <Ionicons
                 name='notifications'
                 size={24}
                 color={theme.screen.icon}
@@ -468,6 +517,9 @@ const Settings = () => {
             }
             handleFunction={() => router.navigate('/notification')}
           />
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+            {translate(TranslationKeys.group_app_settings)}
+          </Text>
           {/* color Scheme */}
           <View style={{ gap: 0 }}>
             <SettingList
@@ -565,55 +617,15 @@ const Settings = () => {
               groupPosition='bottom'
             />
           </View>
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+            {translate(TranslationKeys.group_app_management)}
+          </Text>
           <SettingList iconBgColor={primaryColor}
             leftIcon={<Ionicons name='cloud-download-outline' size={24} color={theme.screen.icon} />}
             label={translate(TranslationKeys.CHECK_FOR_APP_UPDATES)}
             rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
             handleFunction={handleCheckForUpdates}
           />
-          {user?.id ? (
-            <SettingList iconBgColor={primaryColor}
-              leftIcon={
-                <Entypo name='login' size={24} color={theme.screen.icon} />
-              }
-              label={translate(TranslationKeys.logout)}
-              rightIcon={
-                <Entypo name='login' size={24} color={theme.screen.icon} />
-              }
-              handleFunction={handleLogout}
-            />
-          ) : (
-            <SettingList iconBgColor={primaryColor}
-              leftIcon={
-                <Entypo name='login' size={24} color={theme.screen.icon} />
-              }
-              label={translate(TranslationKeys.sign_in)}
-              rightIcon={
-                <Entypo name='login' size={24} color={theme.screen.icon} />
-              }
-              handleFunction={handleLogin}
-            />
-          )}
-          {user?.id && (
-            <SettingList iconBgColor={primaryColor}
-              leftIcon={
-                <AntDesign
-                  name='deleteuser'
-                  size={24}
-                  color={theme.screen.icon}
-                />
-              }
-              label={`${translate(TranslationKeys.account_delete)}`}
-              rightIcon={
-                <Octicons
-                  name='chevron-right'
-                  size={24}
-                  color={theme.screen.icon}
-                />
-              }
-              handleFunction={handleDeleteAccount}
-            />
-          )}
           <SettingList iconBgColor={primaryColor}
             leftIcon={
               <MaterialCommunityIcons

--- a/apps/frontend/app/app/(app)/settings/styles.ts
+++ b/apps/frontend/app/app/(app)/settings/styles.ts
@@ -158,6 +158,12 @@ export default StyleSheet.create({
     fontSize: 28,
     fontFamily: 'Poppins_700Bold',
   },
+  groupHeading: {
+    fontSize: 22,
+    fontFamily: 'Poppins_700Bold',
+    marginTop: 20,
+    marginBottom: 10,
+  },
   logo: {
     width: 72,
     height: 72,

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -379,6 +379,10 @@ export enum TranslationKeys {
   Oct = 'Oct',
   Nov = 'Nov',
   Dec = 'Dec',
+  group_account_personalization = 'group_account_personalization',
+  group_canteen_usage = 'group_canteen_usage',
+  group_app_settings = 'group_app_settings',
+  group_app_management = 'group_app_management',
   // NOT IN TRANSLATION
   feedback_and_support = 'Feedback & Support',
   Food_Plan_Week = 'FoodPlan:Week',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3792,5 +3792,45 @@
     "ru": "Обновления",
     "tr": "Güncellemeler",
     "zh": "更新"
+  },
+  "group_account_personalization": {
+    "de": "Konto & Personalisierung",
+    "en": "Account & Personalization",
+    "ar": "الحساب والتخصيص",
+    "es": "Cuenta y personalización",
+    "fr": "Compte et personnalisation",
+    "ru": "Аккаунт и персонализация",
+    "tr": "Hesap ve kişiselleştirme",
+    "zh": "账户和个性化"
+  },
+  "group_canteen_usage": {
+    "de": "Mensa & Nutzung",
+    "en": "Canteen & Usage",
+    "ar": "المقصف والاستخدام",
+    "es": "Comedor y uso",
+    "fr": "Cantine et utilisation",
+    "ru": "Столовая и использование",
+    "tr": "Yemekhane ve kullanım",
+    "zh": "食堂和使用"
+  },
+  "group_app_settings": {
+    "de": "App-Einstellungen",
+    "en": "App Settings",
+    "ar": "إعدادات التطبيق",
+    "es": "Configuración de la aplicación",
+    "fr": "Paramètres de l'application",
+    "ru": "Настройки приложения",
+    "tr": "Uygulama ayarları",
+    "zh": "应用设置"
+  },
+  "group_app_management": {
+    "de": "App-Verwaltung",
+    "en": "App Management",
+    "ar": "إدارة التطبيق",
+    "es": "Gestión de la aplicación",
+    "fr": "Gestion de l'application",
+    "ru": "Управление приложением",
+    "tr": "Uygulama yönetimi",
+    "zh": "应用管理"
   }
 }


### PR DESCRIPTION
## Summary
- group account, usage, app settings, and app management headings on settings screen
- add group heading styles and translations
- wire new translation keys

## Testing
- `yarn install` *(fails: some peer deps)*
- `yarn test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a032a7808330a6f4ee456a4dc05c