### PR TITLE
Fix language settings item group style

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -424,6 +424,7 @@ const Settings = () => {
               />
             }
             handleFunction={() => openLanguageModal()}
+            groupPosition='bottom'
           />
           <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
             {translate(TranslationKeys.group_canteen_usage)}


### PR DESCRIPTION
## Summary
- style: group the language SettingList item with `groupPosition="bottom"` so it aligns with adjacent items

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6883e3a8092083308760b99794523552