### PR TITLE
Add apartment free badge and modal

### DIFF
--- a/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
+++ b/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
@@ -16,6 +16,7 @@ import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import CardWithText from '../CardWithText/CardWithText';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
+import AvailableFromModal from '../AvailableFromModal';
 
 const ApartmentItem: React.FC<BuildingItemProps> = ({
   apartment,
@@ -37,6 +38,7 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
   );
+  const [showFreeModal, setShowFreeModal] = useState(false);
   const housing_area_color = appSettings?.housing_area_color
     ? appSettings?.housing_area_color
     : projectColor;
@@ -77,6 +79,7 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({
   }, [amountColumnsForcard, screenWidth]);
 
   return (
+    <>
     <Tooltip
       placement='top'
       trigger={(triggerProps) => (
@@ -119,12 +122,31 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({
           }}
           borderColor={housing_area_color}
           imageChildren={
-            <View style={styles.imageActionContainer}>
-              {isManagement ? (
-                <Tooltip
-                  placement='top'
-                  trigger={(triggerProps) => (
-                    <TouchableOpacity
+            <>
+              {apartment?.available_from && (
+                <TouchableOpacity
+                  style={{
+                    ...styles.freeBadge,
+                    backgroundColor: housing_area_color,
+                  }}
+                  onPress={() => setShowFreeModal(true)}
+                >
+                  <MaterialCommunityIcons
+                    name='door-open'
+                    size={20}
+                    color={contrastColor}
+                  />
+                  <Text style={{ ...styles.freeBadgeText, color: contrastColor }}>
+                    {translate(TranslationKeys.free_rooms)}
+                  </Text>
+                </TouchableOpacity>
+              )}
+              <View style={styles.imageActionContainer}>
+                {isManagement ? (
+                  <Tooltip
+                    placement='top'
+                    trigger={(triggerProps) => (
+                      <TouchableOpacity
                       {...triggerProps}
                       style={styles.editImageButton}
                       onPress={() => {
@@ -167,7 +189,8 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({
                   {getDistanceUnit(apartment?.distance)}
                 </Text>
               </TouchableOpacity>
-            </View>
+              </View>
+            </>
           }
         >
           <Text style={{ ...styles.campusName, color: theme.screen.text }}>
@@ -184,6 +207,12 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({
         </TooltipText>
       </TooltipContent>
     </Tooltip>
+    <AvailableFromModal
+      visible={showFreeModal}
+      onClose={() => setShowFreeModal(false)}
+      availableFrom={String(apartment?.available_from)}
+    />
+    </>
   );
 };
 

--- a/apps/frontend/app/components/ApartmentItem/styles.ts
+++ b/apps/frontend/app/components/ApartmentItem/styles.ts
@@ -53,6 +53,21 @@ export default StyleSheet.create({
     paddingVertical: 5,
     paddingHorizontal: 10,
   },
+  freeBadge: {
+    position: 'absolute',
+    top: 5,
+    right: 5,
+    borderRadius: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+  },
+  freeBadgeText: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+  },
   distance: {
     fontSize: 16,
     fontFamily: 'Poppins_400Regular',

--- a/apps/frontend/app/components/AvailableFromModal/AvailableFromModal.tsx
+++ b/apps/frontend/app/components/AvailableFromModal/AvailableFromModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Text } from 'react-native';
+import BaseModal from '@/components/BaseModal';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+
+export interface AvailableFromModalProps {
+  visible: boolean;
+  onClose: () => void;
+  availableFrom: string;
+}
+
+const AvailableFromModal: React.FC<AvailableFromModalProps> = ({
+  visible,
+  onClose,
+  availableFrom,
+}) => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const formatted = new Date(availableFrom).toLocaleDateString();
+
+  return (
+    <BaseModal isVisible={visible} onClose={onClose} title={translate(TranslationKeys.free_rooms)}>
+      <Text style={{ color: theme.modal.text, textAlign: 'center' }}>
+        {translate(TranslationKeys.free_from)}: {formatted}
+      </Text>
+    </BaseModal>
+  );
+};
+
+export default AvailableFromModal;
+export type { AvailableFromModalProps };

--- a/apps/frontend/app/components/AvailableFromModal/index.ts
+++ b/apps/frontend/app/components/AvailableFromModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './AvailableFromModal';
+export type { AvailableFromModalProps } from './AvailableFromModal';

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -75,6 +75,7 @@ export enum TranslationKeys {
   food_category_label = 'food_category_label',
   foodoffer_category_label = 'foodoffer_category_label',
   free_rooms = 'free_rooms',
+  free_from = 'free_from',
   foodweekplan = 'foodweekplan',
   monitorDayPlan = 'monitorDayPlan',
   foodBigScreen = 'foodBigScreen',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -749,6 +749,16 @@
     "tr": "Boş Odalar",
     "zh": "空房间"
   },
+  "free_from": {
+    "de": "Frei ab",
+    "en": "Free from",
+    "ar": "متاح من",
+    "es": "Libre desde",
+    "fr": "Libre à partir de",
+    "ru": "Свободно с",
+    "tr": "Şu tarihten itibaren boş",
+    "zh": "从...开始空闲"
+  },
   "foodweekplan": {
     "de": "Speiseplan: Woche",
     "en": "Food Plan: Week",


### PR DESCRIPTION
## Summary
- show free rooms badge on apartment cards
- add modal to display when a room becomes available
- translate new `free_from` key

## Testing
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68847f80923c8330bf415fc709c48f1d