### PR TITLE
Adjust available-from modal and badge

### DIFF
--- a/apps/frontend/app/components/ApartmentItem/styles.ts
+++ b/apps/frontend/app/components/ApartmentItem/styles.ts
@@ -64,7 +64,6 @@ export default StyleSheet.create({
     gap: 10,
     paddingVertical: 5,
     paddingHorizontal: 10,
-    height: '80%',
   },
   freeBadgeText: {
     fontSize: 16,

--- a/apps/frontend/app/components/AvailableFromModal/AvailableFromModal.tsx
+++ b/apps/frontend/app/components/AvailableFromModal/AvailableFromModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from 'react-native';
-import BaseModal from '@/components/BaseModal';
+import BaseBottomModal from '@/components/BaseBottomModal';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -21,11 +21,11 @@ const AvailableFromModal: React.FC<AvailableFromModalProps> = ({
   const formatted = new Date(availableFrom).toLocaleDateString();
 
   return (
-    <BaseModal isVisible={visible} onClose={onClose} title={translate(TranslationKeys.free_rooms)}>
-      <Text style={{ color: theme.modal.text, textAlign: 'center' }}>
+    <BaseBottomModal visible={visible} onClose={onClose} title={translate(TranslationKeys.free_rooms)}>
+      <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
         {translate(TranslationKeys.free_from)}: {formatted}
       </Text>
-    </BaseModal>
+    </BaseBottomModal>
   );
 };
 


### PR DESCRIPTION
## Summary
- make AvailableFromModal use the same bottom sheet style as DistanceModal
- remove fixed 80% height from AvailableFromBadge

## Testing
- `yarn workspace directus-extension-rocket-meals-bundle test` *(fails: ENETUNREACH / libatk missing)*

------
https://chatgpt.com/codex/tasks/task_e_688488c9a9808330b676c19f7624e42a