### PR TITLE
Fix spacing for right icons in SettingsList

### DIFF
--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -121,8 +121,12 @@ const styles = StyleSheet.create({
     fontSize: 13,
   },
   rightWrapper: {
-    justifyContent: 'center',
+    width: 34,
+    height: 34,
+    borderRadius: 8,
     alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 12,
   },
   separator: {
     width: '100%',


### PR DESCRIPTION
## Summary
- ensure right side icons have consistent spacing with transparent wrapper

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6884adc95e58833096811b98dfed28fa