### PR TITLE
Implement groupPosition styles in SettingsList

### DIFF
--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -25,6 +25,7 @@ const SettingsList: React.FC<SettingsListProps> = ({
   iconBackgroundColor,
   iconBgColor,
   showSeparator = true,
+  groupPosition,
 }) => {
   const { theme } = useTheme();
   const { primaryColor, selectedTheme } = useSelector(
@@ -36,15 +37,34 @@ const SettingsList: React.FC<SettingsListProps> = ({
   const iconBg = iconBackgroundColor || iconBgColor || primaryColor;
   const iconColor = myContrastColor(iconBg, theme, selectedTheme === 'dark');
 
+  const containerStyles: ViewStyle[] = [
+    styles.container,
+    { backgroundColor: theme.screen.iconBg } as ViewStyle,
+  ];
+
+  if (groupPosition === 'top') {
+    containerStyles.push({
+      borderTopLeftRadius: 5,
+      borderTopRightRadius: 5,
+      paddingTop: 5,
+    });
+  } else if (groupPosition === 'bottom') {
+    containerStyles.push({
+      borderBottomLeftRadius: 5,
+      borderBottomRightRadius: 5,
+      paddingBottom: 5,
+    });
+  } else if (groupPosition === 'single') {
+    containerStyles.push({
+      borderRadius: 5,
+      paddingTop: 5,
+      paddingBottom: 5,
+    });
+  }
+
   return (
     <>
-      <Container
-        onPress={pressHandler}
-        style={[
-          styles.container,
-          { backgroundColor: theme.screen.iconBg } as ViewStyle,
-        ]}
-      >
+      <Container onPress={pressHandler} style={containerStyles}>
         <View style={[styles.iconWrapper, { backgroundColor: iconBg }]}> 
           {React.isValidElement(leftIcon)
             ? React.cloneElement(leftIcon, { color: iconColor })

--- a/apps/frontend/app/components/SettingsList/types.ts
+++ b/apps/frontend/app/components/SettingsList/types.ts
@@ -31,8 +31,10 @@ export interface SettingsListProps {
    */
   showSeparator?: boolean;
   /**
-   * Group positioning from the old component. It has no effect but
-   * allows drop-in replacement without TypeScript errors.
+   * Visual grouping support. When set to "top" the item receives a
+   * rounded top border and extra padding at the top. "bottom" applies
+   * the same to the bottom side. "single" rounds all corners and
+   * adds padding on both sides. "middle" leaves the default styling.
    */
   groupPosition?: 'top' | 'middle' | 'bottom' | 'single';
 }


### PR DESCRIPTION
## Summary
- update SettingsList to apply rounded borders and padding based on `groupPosition`
- document new behaviour in SettingsList prop types

## Testing
- `yarn --cwd apps/frontend/app lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: internal error about lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6884c3f7c4008330af45537796aabbdc