### PR TITLE
Add leaflet-test screen

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -715,6 +715,19 @@ export default function Layout() {
         />
 
         <Drawer.Screen
+          name='leaflet-test/index'
+          options={{
+            header: () => (
+              <CustomStackHeader
+                label={translate(TranslationKeys.leaflet_test)}
+                key={'LeafletTest'}
+              />
+            ),
+            title: translate(TranslationKeys.leaflet_test),
+          }}
+        />
+
+        <Drawer.Screen
           name='vertical-image-scroll/index'
           options={{
             header: () => (

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -70,6 +70,28 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() =>
+            router.push({
+              pathname: '/leaflet-test',
+              params: {
+                lat: String(buildingPosition?.lat ?? '52.275'),
+                lng: String(buildingPosition?.lng ?? '7.4584'),
+                zoom: '16',
+              },
+            })
+          }
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='map' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.leaflet_test)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
         <TouchableOpacity
           style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
           onPress={() => router.push('/vertical-image-scroll')}

--- a/apps/frontend/app/app/(app)/leaflet-test/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-test/index.tsx
@@ -1,0 +1,119 @@
+import React, { useMemo, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import useSelectedCanteen from '@/hooks/useSelectedCanteen';
+import { Text, Platform } from 'react-native';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { RootState } from '@/redux/reducer';
+import MyMap from '@/components/MyMap/MyMap';
+import {
+  MARKER_DEFAULT_SIZE,
+  MyMapMarkerIcons,
+  getDefaultIconAnchor,
+} from '@/components/MyMap/markerUtils';
+import { Asset } from 'expo-asset';
+import * as FileSystem from 'expo-file-system';
+
+const POSITION_BUNDESTAG = {
+  lat: 52.518594247456804,
+  lng: 13.376281624711964,
+};
+
+const LeafletMap = () => {
+  useSetPageTitle(TranslationKeys.leaflet_test);
+
+  const { buildings } = useSelector(
+      (state: RootState) => state.canteenReducer
+  );
+  const selectedCanteen = useSelectedCanteen();
+
+  const [markerIconSrc, setMarkerIconSrc] = useState<string | null>(null);
+  const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(null);
+  const [modalVisible, setModalVisible] = useState(false);
+
+  // Load marker asset asynchronously
+  useEffect(() => {
+    const loadMarkerIcon = async () => {
+      try {
+        const mapMarkerIcon = require('@/assets/map/marker-icon-2x.png');
+        const asset = await Asset.fromModule(mapMarkerIcon);
+        await asset.downloadAsync();
+
+        if (Platform.OS === 'web') {
+          setMarkerIconSrc(asset.uri);
+        } else if (asset.localUri) {
+          const content = await FileSystem.readAsStringAsync(asset.localUri, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
+          setMarkerIconSrc(content);
+        }
+      } catch (error) {
+        console.error('Error loading marker icon:', error);
+      }
+    };
+
+    loadMarkerIcon();
+  }, []);
+
+  const centerPosition = useMemo(() => {
+    if (selectedCanteen?.building) {
+      const building = buildings.find((b) => b.id === selectedCanteen.building);
+      const coords = (building as any)?.coordinates?.coordinates;
+      if (coords && coords.length === 2) {
+        return { lat: Number(coords[1]), lng: Number(coords[0]) };
+      }
+    }
+    return undefined;
+  }, [selectedCanteen, buildings]);
+
+  if (!markerIconSrc) {
+    // Optional: Add a loading spinner or placeholder here
+    return null;
+  }
+
+  const markers = [
+    {
+      id: 'example',
+      position: POSITION_BUNDESTAG,
+      icon:
+        Platform.OS === 'web'
+          ? MyMapMarkerIcons.getIconForWebByUri(markerIconSrc)
+          : MyMapMarkerIcons.getIconForWebByBase64(markerIconSrc),
+      size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
+      iconAnchor: getDefaultIconAnchor(
+          MARKER_DEFAULT_SIZE,
+          MARKER_DEFAULT_SIZE,
+      ),
+    },
+  ];
+
+  const handleMarkerClick = (id: string) => {
+    console.log('marker clicked', id);
+    setSelectedMarkerId(id);
+  };
+
+  const handleSelectionChange = (id: string | null) => {
+    setModalVisible(id !== null);
+    setSelectedMarkerId(id);
+  };
+
+  const renderMarkerModal = (id: string, onClose: () => void) => (
+    <Text onPress={onClose}>{id}</Text>
+  );
+
+  return (
+    <>
+      <Text>Selected: {selectedMarkerId ?? 'none'} Visible: {String(modalVisible)}</Text>
+      <MyMap
+        mapCenterPosition={centerPosition || POSITION_BUNDESTAG}
+        mapMarkers={markers}
+        onMarkerClick={handleMarkerClick}
+        onMapEvent={(e) => console.log('map event', e.tag)}
+        renderMarkerModal={renderMarkerModal}
+        onMarkerSelectionChange={handleSelectionChange}
+      />
+    </>
+  );
+};
+
+export default LeafletMap;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -238,6 +238,7 @@ export enum TranslationKeys {
   please_select_your_canteen = 'please_select_your_canteen',
   map = 'map',
   leaflet_map = 'leaflet_map',
+  leaflet_test = 'leaflet_test',
   news = 'news',
   food_offers = 'food_offers',
   read_more = 'read_more',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2383,6 +2383,16 @@
     "tr": "Leaflet Haritası",
     "zh": "Leaflet 地图"
   },
+  "leaflet_test": {
+    "de": "Leaflet Test",
+    "en": "Leaflet Test",
+    "ar": "اختبار ليفليت",
+    "es": "Prueba Leaflet",
+    "fr": "Test Leaflet",
+    "ru": "Тест Leaflet",
+    "tr": "Leaflet Testi",
+    "zh": "Leaflet 测试"
+  },
   "news": {
     "de": "News",
     "en": "News",


### PR DESCRIPTION
## Summary
- duplicate LeafletMap screen as LeafletTest
- wire LeafletTest into drawer layout
- link to LeafletTest from the experimentell page
- add translations for `leaflet_test`

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68850adc75d88330a7fda9dfcbea3d65