### PR TITLE
Fix leaflet test debug output

### DIFF
--- a/apps/frontend/app/app/(app)/leaflet-map/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-map/index.tsx
@@ -42,14 +42,13 @@ const LeafletMap = () => {
 
         if (Platform.OS === 'web') {
           setMarkerIconSrc(asset.uri);
-        } else if (asset.localUri || asset.uri) {
-          const fileUri = asset.localUri ?? asset.uri;
-          if (fileUri) {
-            const content = await FileSystem.readAsStringAsync(fileUri, {
-              encoding: FileSystem.EncodingType.Base64,
-            });
-            setMarkerIconSrc(content);
-          }
+        } else if (asset.localUri) {
+          const content = await FileSystem.readAsStringAsync(asset.localUri, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
+          setMarkerIconSrc(content);
+        } else {
+          setMarkerError('marker asset missing localUri');
         }
       } catch (error) {
         console.error('Error loading marker icon:', error);
@@ -111,7 +110,15 @@ const LeafletMap = () => {
   return (
     <View style={{ flex: 1 }}>
       {markerError && (
-        <View style={{ maxHeight: '50%' }}>
+        <View
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '40%',
+          }}
+        >
           <ScrollView>
             <Text selectable>{markerError}</Text>
           </ScrollView>

--- a/apps/frontend/app/app/(app)/leaflet-test/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-test/index.tsx
@@ -42,14 +42,13 @@ const LeafletMap = () => {
 
         if (Platform.OS === 'web') {
           setMarkerIconSrc(asset.uri);
-        } else if (asset.localUri || asset.uri) {
-          const fileUri = asset.localUri ?? asset.uri;
-          if (fileUri) {
-            const content = await FileSystem.readAsStringAsync(fileUri, {
-              encoding: FileSystem.EncodingType.Base64,
-            });
-            setMarkerIconSrc(content);
-          }
+        } else if (asset.localUri) {
+          const content = await FileSystem.readAsStringAsync(asset.localUri, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
+          setMarkerIconSrc(content);
+        } else {
+          setMarkerError('marker asset missing localUri');
         }
       } catch (error) {
         console.error('Error loading marker icon:', error);
@@ -111,7 +110,15 @@ const LeafletMap = () => {
   return (
     <View style={{ flex: 1 }}>
       {markerError && (
-        <View style={{ maxHeight: '50%' }}>
+        <View
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '40%',
+          }}
+        >
           <ScrollView>
             <Text selectable>{markerError}</Text>
           </ScrollView>


### PR DESCRIPTION
## Summary
- show leaflet debug errors at bottom of screen
- fix native marker load when asset path missing

## Testing
- `yarn test` *(fails: connect ENETUNREACH, missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68855b8518dc83308894d09f6a0a4030