### PR TITLE
Add support screens using SettingsList

### DIFF
--- a/apps/frontend/app/app/(app)/support-FAQ/index.tsx
+++ b/apps/frontend/app/app/(app)/support-FAQ/index.tsx
@@ -10,7 +10,13 @@ import {
 } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { router } from 'expo-router';
-import SupportFAQ from '../../../components/SupportFAQ/SupportFAQ';
+import SettingsList from '@/components/SettingsList';
+import {
+  MaterialIcons,
+  Ionicons,
+  MaterialCommunityIcons,
+  Octicons,
+} from '@expo/vector-icons';
 import styles from './styles';
 import { useLanguage } from '@/hooks/useLanguage';
 import useToast from '@/hooks/useToast';
@@ -29,7 +35,7 @@ const supportfaq = () => {
   const [windowWidth, setWindowWidth] = useState(
     Dimensions.get('window').width
   );
-  const { serverInfo, appSettings } = useSelector(
+  const { serverInfo, appSettings, primaryColor } = useSelector(
     (state: RootState) => state.settings
   );
 
@@ -83,133 +89,116 @@ const supportfaq = () => {
             />
           </View>
 
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+            {translate(TranslationKeys.feedback_support_faq)}
+          </Text>
           <View
             style={[
               styles.section,
               { width: windowWidth > 600 ? '85%' : '95%' },
             ]}
           >
-            <SupportFAQ
-              icon='feedback'
-              label={`${translate(TranslationKeys.feedback)} & ${translate(
-                TranslationKeys.support
-              )}`}
-              text=''
-              onPress={() => router.navigate('/feedback-support')}
-              isArrowRight={true}
-              redirectIcon={false}
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<MaterialIcons name='feedback' size={24} color={theme.screen.icon} />}
+              label={`${translate(TranslationKeys.feedback)} & ${translate(TranslationKeys.support)}`}
+              rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+              handleFunction={() => router.navigate('/feedback-support')}
+              groupPosition={profile?.id ? 'top' : 'single'}
             />
             {profile?.id && (
-              <SupportFAQ
-                icon='email'
+              <SettingsList
+                iconBgColor={primaryColor}
+                leftIcon={<MaterialCommunityIcons name='email' size={24} color={theme.screen.icon} />}
                 label={translate(TranslationKeys.my_support_tickets)}
-                redirectIcon={false}
-                text=''
-                onPress={() => {
-                  if (profile?.id) {
-                    router.navigate('/support-ticket');
-                  } else {
-                    toast(
-                      'No permission to view My Support Tickets. Please log in.',
-                      'error'
-                    );
-                  }
-                }}
+                rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+                handleFunction={() => router.navigate('/support-ticket')}
+                groupPosition='bottom'
               />
             )}
           </View>
 
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>App</Text>
           <View
             style={[
               styles.section,
               { width: windowWidth > 600 ? '85%' : '95%' },
             ]}
           >
-            <SupportFAQ
-              icon='logo-apple'
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<Ionicons name='logo-apple' size={24} color={theme.screen.icon} />}
               label='Apple Store'
-              text=''
-              isArrowRight={false}
-              onPress={() => {
+              rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+              handleFunction={() => {
                 if (appSettings?.app_stores_url_to_apple) {
                   openInBrowser(appSettings?.app_stores_url_to_apple);
                 }
               }}
+              groupPosition='top'
             />
-            <SupportFAQ
-              icon='logo-google-playstore'
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<Ionicons name='logo-google-playstore' size={24} color={theme.screen.icon} />}
               label='Google Play Store'
-              text=''
-              isArrowRight={false}
-              onPress={() => {
+              rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+              handleFunction={() => {
                 if (appSettings?.app_stores_url_to_google) {
                   openInBrowser(appSettings?.app_stores_url_to_google);
                 }
               }}
+              groupPosition='middle'
             />
-            <SupportFAQ
-              icon='email'
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<MaterialCommunityIcons name='email' size={24} color={theme.screen.icon} />}
               label={translate(TranslationKeys.email)}
-              isArrowRight={false}
-              text='info@rocket-meals.de'
-              onPress={() => {
-                Linking.openURL(`mailto:info@rocket-meals.de`);
+              value='info@rocket-meals.de'
+              rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+              handleFunction={() => {
+                Linking.openURL('mailto:info@rocket-meals.de');
               }}
+              groupPosition='bottom'
             />
           </View>
 
+          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+            {translate(TranslationKeys.project_name)}
+          </Text>
           <View
             style={[
               styles.section,
               { width: windowWidth > 600 ? '85%' : '95%' },
             ]}
           >
-            <View
-              style={{ ...styles.row, backgroundColor: theme.screen.iconBg }}
-            >
-              <View style={styles.leftView}>
-                <Text
-                  style={[
-                    styles.linkText,
-                    {
-                      color: theme.screen.text,
-                      fontSize: windowWidth < 500 ? 14 : 18,
-                    },
-                  ]}
-                >
-                  {translate(TranslationKeys.project_name)}
-                </Text>
-              </View>
-              <View style={styles.textIcon}>
-                <Text
-                  style={[
-                    styles.iconText,
-                    {
-                      color: theme.screen.text,
-                      fontSize: windowWidth < 500 ? 14 : 18,
-                    },
-                  ]}
-                >
-                  {projectName?.length > 0 ? projectName : 'SWOSY Test'}
-                </Text>
-              </View>
-            </View>
-
-            <SupportFAQ
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<MaterialIcons name='info' size={24} color={theme.screen.icon} />}
+              label={translate(TranslationKeys.project_name)}
+              value={projectName?.length > 0 ? projectName : 'SWOSY Test'}
+              groupPosition='top'
+            />
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<MaterialIcons name='developer-mode' size={24} color={theme.screen.icon} />}
               label={translate(TranslationKeys.developer)}
-              isArrowRight={false}
-              text='Baumgartner Software UG'
-              onPress={() => {
+              value='Baumgartner Software UG'
+              rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+              handleFunction={() => {
                 openInBrowser('https://baumgartner-software.de/homepage/');
               }}
+              groupPosition='middle'
             />
-            <SupportFAQ
+            <SettingsList
+              iconBgColor={primaryColor}
+              leftIcon={<MaterialIcons name='apps' size={24} color={theme.screen.icon} />}
               label={translate(TranslationKeys.software_name)}
-              text='Rocket Meals'
-              isArrowRight={false}
-              onPress={() => {
+              value='Rocket Meals'
+              rightIcon={<Octicons name='chevron-right' size={24} color={theme.screen.icon} />}
+              handleFunction={() => {
                 openInBrowser('https://rocket-meals.de/homepage/');
               }}
+              groupPosition='bottom'
             />
           </View>
         </View>

--- a/apps/frontend/app/app/(app)/support-FAQ/styles.ts
+++ b/apps/frontend/app/app/(app)/support-FAQ/styles.ts
@@ -51,4 +51,10 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  groupHeading: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+    marginTop: 20,
+    marginBottom: 10,
+  },
 });

--- a/apps/frontend/app/app/(app)/support-ticket/index.tsx
+++ b/apps/frontend/app/app/(app)/support-ticket/index.tsx
@@ -3,23 +3,28 @@ import {
   Dimensions,
   ScrollView,
   Text,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import React, { useCallback, useEffect, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { AppFeedback } from '@/redux/actions/AppFeedback/AppFeedback';
-import { Entypo, MaterialCommunityIcons } from '@expo/vector-icons';
+import SettingsList from '@/components/SettingsList';
+import { Octicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { format } from 'date-fns';
 import { router, useFocusEffect } from 'expo-router';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { DatabaseTypes } from 'repo-depkit-common';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import { useLanguage } from '@/hooks/useLanguage';
 
 const index = () => {
   useSetPageTitle(TranslationKeys.my_support_tickets);
   const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
   const appFeedback = new AppFeedback();
   const [loading, setLoading] = useState(false);
   const [allTickets, setAllTickets] = useState<DatabaseTypes.AppFeedbacks[] | null>(null);
@@ -70,57 +75,50 @@ const index = () => {
           <ActivityIndicator size='large' color={theme.screen.text} />
         </View>
       ) : (
+        <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+          {translate(TranslationKeys.my_support_tickets)}
+        </Text>
         <View
           style={[styles.section, { width: windowWidth > 600 ? '85%' : '95%' }]}
         >
           {allTickets &&
             allTickets?.map((item, index: number) => (
-              <TouchableOpacity
-                style={{ ...styles.row, backgroundColor: theme.screen.iconBg }}
-                onPress={() => {
-                  router.push(`/feedback-support?app_feedbacks_id=${item.id}`);
-                }}
+              <SettingsList
                 key={index}
-              >
-                <View style={styles.leftView}>
+                iconBgColor={primaryColor}
+                leftIcon={
                   <MaterialCommunityIcons
-                    name={'bell'}
-                    size={25}
+                    name='bell'
+                    size={24}
                     color={theme.screen.icon}
                   />
-                  <Text
-                    style={[
-                      styles.linkText,
-                      {
-                        color: theme.screen.text,
-                        fontSize: windowWidth < 500 ? 14 : 18,
-                      },
-                    ]}
-                  >
-                    {item?.title}
-                  </Text>
-                </View>
-                <View style={styles.textIcon}>
-                  <Text
-                    style={[
-                      styles.iconText,
-                      {
-                        color: theme.screen.text,
-                        fontSize: windowWidth < 500 ? 14 : 18,
-                      },
-                    ]}
-                  >
-                    {item?.date_created
-                      ? format(new Date(item.date_created), 'dd.MM.yyyy HH:mm')
-                      : 'N/A'}
-                  </Text>
-                  <Entypo
-                    name={'chevron-small-right'}
-                    size={25}
+                }
+                label={item?.title}
+                value={
+                  item?.date_created
+                    ? format(new Date(item.date_created), 'dd.MM.yyyy HH:mm')
+                    : 'N/A'
+                }
+                rightIcon={
+                  <Octicons
+                    name='chevron-right'
+                    size={24}
                     color={theme.screen.icon}
                   />
-                </View>
-              </TouchableOpacity>
+                }
+                handleFunction={() =>
+                  router.push(`/feedback-support?app_feedbacks_id=${item.id}`)
+                }
+                groupPosition={
+                  allTickets.length === 1
+                    ? 'single'
+                    : index === 0
+                    ? 'top'
+                    : index === allTickets.length - 1
+                    ? 'bottom'
+                    : 'middle'
+                }
+              />
             ))}
         </View>
       )}

--- a/apps/frontend/app/app/(app)/support-ticket/styles.ts
+++ b/apps/frontend/app/app/(app)/support-ticket/styles.ts
@@ -37,4 +37,10 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  groupHeading: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+    marginTop: 20,
+    marginBottom: 10,
+  },
 });


### PR DESCRIPTION
## Summary
- use `SettingsList` component on Support & FAQ screen
- update Support Tickets screen with grouped `SettingsList`
- add `groupHeading` style to support screens

## Testing
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_688566a371448330bd043abb0b507fbf