### PR TITLE
Add debug log view to leaflet-test screen

### DIFF
--- a/apps/frontend/app/app/(app)/leaflet-test/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-test/index.tsx
@@ -29,8 +29,12 @@ const LeafletMap = () => {
 
   const [markerIconSrc, setMarkerIconSrc] = useState<string | null>(null);
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(null);
-  const [modalVisible, setModalVisible] = useState(false);
   const [markerError, setMarkerError] = useState<string | null>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const addLog = (msg: string) => {
+    setLogs((l) => [...l, msg]);
+  };
 
   // Load marker asset asynchronously
   useEffect(() => {
@@ -48,11 +52,15 @@ const LeafletMap = () => {
           });
           setMarkerIconSrc(content);
         } else {
-          setMarkerError('marker asset missing localUri');
+          const msg = 'marker asset missing localUri';
+          addLog(msg);
+          setMarkerError(msg);
         }
       } catch (error) {
         console.error('Error loading marker icon:', error);
-        setMarkerError(String(error));
+        const msg = String(error);
+        addLog(msg);
+        setMarkerError(msg);
       }
     };
 
@@ -95,12 +103,13 @@ const LeafletMap = () => {
 
   const handleMarkerClick = (id: string) => {
     console.log('marker clicked', id);
+    addLog(`marker clicked: ${id}`);
     setSelectedMarkerId(id);
   };
 
   const handleSelectionChange = (id: string | null) => {
-    setModalVisible(id !== null);
     setSelectedMarkerId(id);
+    addLog(`selection change: ${id ?? 'none'}`);
   };
 
   const renderMarkerModal = (id: string, onClose: () => void) => (
@@ -109,33 +118,27 @@ const LeafletMap = () => {
 
   return (
     <View style={{ flex: 1 }}>
-      {markerError && (
-        <View
-          style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: '40%',
-          }}
-        >
-          <ScrollView>
-            <Text selectable>{markerError}</Text>
-          </ScrollView>
-        </View>
-      )}
       <View style={{ flex: 1 }}>
-        <Text>
-          Selected: {selectedMarkerId ?? 'none'} Visible: {String(modalVisible)}
-        </Text>
         <MyMap
           mapCenterPosition={centerPosition || POSITION_BUNDESTAG}
           mapMarkers={markers}
           onMarkerClick={handleMarkerClick}
-          onMapEvent={(e) => console.log('map event', e.tag)}
+          onMapEvent={(e) => {
+            addLog(`map event: ${e.tag}`);
+          }}
           renderMarkerModal={renderMarkerModal}
           onMarkerSelectionChange={handleSelectionChange}
         />
+      </View>
+      <View style={{ flex: 1 }}>
+        <ScrollView>
+          {markerError && <Text selectable>{markerError}</Text>}
+          {logs.map((l, i) => (
+            <Text key={i} selectable>
+              {l}
+            </Text>
+          ))}
+        </ScrollView>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- split `leaflet-test` screen into two equal height views
- top view hosts the `MyMap` component
- bottom view displays a selectable debug log
- log map events and marker selections

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6885d2a04a108330af19984da16ae5ee