### PR TITLE
Add base64 marker to map pages

### DIFF
--- a/apps/frontend/app/app/(app)/leaflet-map/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-map/index.tsx
@@ -24,6 +24,14 @@ const POSITION_IMG_MARKER = {
   lng: 13.376281624711964,
 };
 
+const POSITION_IMG_MARKER_BASE64 = {
+  lat: 52.5205942474568,
+  lng: 13.376281624711964,
+};
+
+const LOCAL_BASE64_MARKER =
+  'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=';
+
 const EXTERNAL_MARKER_URL =
   'https://cdn4.iconfinder.com/data/icons/small-n-flat/24/map-marker-512.png';
 
@@ -105,6 +113,16 @@ const LeafletMap = () => {
       id: 'img-marker',
       position: POSITION_IMG_MARKER,
       icon: MyMapMarkerIcons.getIconForWebByUri(EXTERNAL_MARKER_URL),
+      size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
+      iconAnchor: getDefaultIconAnchor(
+        MARKER_DEFAULT_SIZE,
+        MARKER_DEFAULT_SIZE,
+      ),
+    },
+    {
+      id: 'img-marker-base64',
+      position: POSITION_IMG_MARKER_BASE64,
+      icon: MyMapMarkerIcons.getIconForWebByBase64(LOCAL_BASE64_MARKER),
       size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
       iconAnchor: getDefaultIconAnchor(
         MARKER_DEFAULT_SIZE,

--- a/apps/frontend/app/app/(app)/leaflet-test/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-test/index.tsx
@@ -29,6 +29,14 @@ const POSITION_IMG_MARKER_BASE64 = {
   lng: 13.376281624711964,
 };
 
+const POSITION_IMG_MARKER_LOCAL = {
+  lat: 52.5215942474568,
+  lng: 13.376281624711964,
+};
+
+const LOCAL_BASE64_MARKER =
+  'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=';
+
 const EXTERNAL_MARKER_URL =
   'https://cdn4.iconfinder.com/data/icons/small-n-flat/24/map-marker-512.png';
 
@@ -150,6 +158,16 @@ const LeafletMap = () => {
           },
         ]
       : []),
+    {
+      id: 'img-marker-local-base64',
+      position: POSITION_IMG_MARKER_LOCAL,
+      icon: MyMapMarkerIcons.getIconForWebByBase64(LOCAL_BASE64_MARKER),
+      size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
+      iconAnchor: getDefaultIconAnchor(
+        MARKER_DEFAULT_SIZE,
+        MARKER_DEFAULT_SIZE,
+      ),
+    },
   ];
 
   const handleMarkerClick = (id: string) => {


### PR DESCRIPTION
## Summary
- add a third marker to `leaflet-map`
- add the same marker in `leaflet-test`

## Testing
- `yarn install`
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6885ea18f0488330bab8159a9e76a079