### PR TITLE
Revert latest Leaflet frontend change

### DIFF
--- a/apps/frontend/app/app/(app)/leaflet-map/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-map/index.tsx
@@ -97,7 +97,7 @@ const LeafletMap = () => {
           {
             id: 'example',
             position: POSITION_BUNDESTAG,
-            iconUrl:
+            icon:
               Platform.OS === 'web'
                 ? MyMapMarkerIcons.getIconForWebByUri(markerIconSrc)
                 : MyMapMarkerIcons.getIconForWebByBase64(markerIconSrc),
@@ -112,7 +112,7 @@ const LeafletMap = () => {
     {
       id: 'img-marker',
       position: POSITION_IMG_MARKER,
-      iconUrl: MyMapMarkerIcons.getIconForWebByUri(EXTERNAL_MARKER_URL),
+      icon: MyMapMarkerIcons.getIconForWebByUri(EXTERNAL_MARKER_URL),
       size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
       iconAnchor: getDefaultIconAnchor(
         MARKER_DEFAULT_SIZE,
@@ -122,7 +122,7 @@ const LeafletMap = () => {
     {
       id: 'img-marker-base64',
       position: POSITION_IMG_MARKER_BASE64,
-      iconUrl: MyMapMarkerIcons.getIconForWebByBase64(LOCAL_BASE64_MARKER),
+      icon: MyMapMarkerIcons.getIconForWebByBase64(LOCAL_BASE64_MARKER),
       size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
       iconAnchor: getDefaultIconAnchor(
         MARKER_DEFAULT_SIZE,

--- a/apps/frontend/app/app/(app)/leaflet-test/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-test/index.tsx
@@ -122,7 +122,7 @@ const LeafletMap = () => {
           {
             id: 'example',
             position: POSITION_BUNDESTAG,
-            iconUrl:
+            icon:
               Platform.OS === 'web'
                 ? MyMapMarkerIcons.getIconForWebByUri(markerIconSrc)
                 : MyMapMarkerIcons.getIconForWebByBase64(markerIconSrc),
@@ -137,7 +137,7 @@ const LeafletMap = () => {
     {
       id: 'img-marker',
       position: POSITION_IMG_MARKER,
-      iconUrl: MyMapMarkerIcons.getIconForWebByUri(EXTERNAL_MARKER_URL),
+      icon: MyMapMarkerIcons.getIconForWebByUri(EXTERNAL_MARKER_URL),
       size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
       iconAnchor: getDefaultIconAnchor(
         MARKER_DEFAULT_SIZE,
@@ -149,7 +149,7 @@ const LeafletMap = () => {
           {
             id: 'img-marker-base64',
             position: POSITION_IMG_MARKER_BASE64,
-            iconUrl: MyMapMarkerIcons.getIconForWebByBase64(externalMarkerBase64),
+            icon: MyMapMarkerIcons.getIconForWebByBase64(externalMarkerBase64),
             size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
             iconAnchor: getDefaultIconAnchor(
               MARKER_DEFAULT_SIZE,
@@ -161,7 +161,7 @@ const LeafletMap = () => {
     {
       id: 'img-marker-local-base64',
       position: POSITION_IMG_MARKER_LOCAL,
-      iconUrl: MyMapMarkerIcons.getIconForWebByBase64(LOCAL_BASE64_MARKER),
+      icon: MyMapMarkerIcons.getIconForWebByBase64(LOCAL_BASE64_MARKER),
       size: [MARKER_DEFAULT_SIZE, MARKER_DEFAULT_SIZE],
       iconAnchor: getDefaultIconAnchor(
         MARKER_DEFAULT_SIZE,

--- a/apps/frontend/app/components/MyMap/markerUtils.ts
+++ b/apps/frontend/app/components/MyMap/markerUtils.ts
@@ -11,13 +11,10 @@ export class MyMapMarkerIcons {
   static DEBUG_ICON = `<div style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; background-color: #FF000066; position: relative;'><div style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; background-color: #00FF0066; border-radius: 50%; position: absolute; top: 0%; left: 0%;'></div></div>`;
 
   static getIconForWebByUri(iconUri: string): string {
-    // Only return the URI so the webview can create the <img> tag itself
-    return iconUri;
+    return `<img src='${iconUri}' style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; object-fit: contain;'>`;
   }
 
   static getIconForWebByBase64(base64: string): string {
-    // Only return the base64 data URI. The leaflet web page will convert this
-    // string into an <img> tag.
-    return `data:image/png;base64,${base64}`;
+    return `<img src='data:image/png;base64,${base64}' style='width: ${MARKER_DEFAULT_SIZE}px; height: ${MARKER_DEFAULT_SIZE}px; object-fit: contain;'>`;
   }
 }


### PR DESCRIPTION
## Summary
- revert commit that changed the icon logic for the Leaflet map

## Testing
- `yarn test` *(fails: monorepo workspace not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6885faed7a688330901a0f01c31b676a