### PR TITLE
Fix container width on Data Access page

### DIFF
--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -137,7 +137,10 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
           <View
             style={[
               styles.infoContainer,
-              { width: windowWidth > 600 ? '85%' : '90%' },
+              {
+                width:
+                  windowWidth < 500 ? '100%' : isWeb ? '80%' : '90%',
+              },
             ]}
           >
             <View>{parseMarkdown(dataAccessText, theme)}</View>
@@ -146,7 +149,10 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
           <View
             style={[
               styles.infoContainer,
-              { width: windowWidth > 600 ? '90%' : '100%' },
+              {
+                width:
+                  windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
+              },
             ]}
           >
             <View>


### PR DESCRIPTION
## Summary
- tweak container widths in DataAccess to match Settings page style

## Testing
- `yarn install --immutable` *(fails: lockfile would have been modified)*

------
https://chatgpt.com/codex/tasks/task_e_6886018ae008833095cfb3d1273ff36f