### PR TITLE
Improve data privacy layout and group headers

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -30,6 +30,7 @@ import {
 import { isWeb } from '@/constants/Constants';
 import SettingsList from '@/components/SettingsList';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
+import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import NicknameSheet from '@/components/NicknameSheet/NicknameSheet';
 import ColorSchemeSheet from '@/components/ColorSchemeSheet/ColorSchemeSheet';
 import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
@@ -321,9 +322,9 @@ const Settings = () => {
             width: windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
           }}
         >
-          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+          <SettingsGroupTitle>
             {translate(TranslationKeys.group_account_personalization)}
-          </Text>
+          </SettingsGroupTitle>
           {/* Account & Nickname */}
           <View style={{ gap: 0 }}>
             <SettingsList
@@ -431,9 +432,9 @@ const Settings = () => {
               groupPosition='bottom'
             />
           </View>
-          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+          <SettingsGroupTitle>
             {translate(TranslationKeys.group_canteen_usage)}
-          </Text>
+          </SettingsGroupTitle>
           {/* Canteen */}
           <View style={{ gap: 0 }}>
             <SettingsList iconBgColor={foods_area_color}
@@ -536,9 +537,9 @@ const Settings = () => {
             groupPosition='bottom'
           />
           </View>
-          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+          <SettingsGroupTitle>
             {translate(TranslationKeys.group_app_settings)}
-          </Text>
+          </SettingsGroupTitle>
           {/* color Scheme */}
           <View style={{ gap: 0 }}>
             <SettingsList
@@ -636,9 +637,9 @@ const Settings = () => {
               groupPosition='bottom'
             />
           </View>
-          <Text style={{ ...styles.groupHeading, color: theme.screen.text }}>
+          <SettingsGroupTitle>
             {translate(TranslationKeys.group_app_management)}
-          </Text>
+          </SettingsGroupTitle>
           <View style={{ gap: 0 }}>
             <SettingsList iconBgColor={primaryColor}
               leftIcon={<Ionicons name='cloud-download-outline' size={24} color={theme.screen.icon} />}

--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -15,6 +15,7 @@ import SettingsList from '@/components/SettingsList';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 
 const parseMarkdown = (text: string, theme: any) => {
   return text.split('\n').map((line, index) => {
@@ -139,7 +140,7 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
               styles.infoContainer,
               {
                 width:
-                  windowWidth < 500 ? '100%' : isWeb ? '80%' : '90%',
+                  windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
               },
             ]}
           >
@@ -155,15 +156,11 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
               },
             ]}
           >
-            <View>
-              <Text
-                style={{ ...styles.labelParagraph, color: theme.header.text }}
-              >
-                {translate(
-                  TranslationKeys.your_data_which_we_know_if_you_have_a_profile
-                )}
-              </Text>
-            </View>
+          <SettingsGroupTitle>
+            {translate(
+              TranslationKeys.your_data_which_we_know_if_you_have_a_profile
+            )}
+          </SettingsGroupTitle>
             {/* Info Items List */}
             <View
               style={{
@@ -217,19 +214,11 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
                   windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
               }}
             >
-              <View>
-                <Text
-                  style={{
-                    marginBottom: 10,
-                    fontSize: 16,
-                    color: theme.header.text,
-                  }}
-                >
-                  {translate(
-                    TranslationKeys.translation_all_on_device_saved_data
-                  )}
-                </Text>
-              </View>
+            <SettingsGroupTitle>
+              {translate(
+                TranslationKeys.translation_all_on_device_saved_data
+              )}
+            </SettingsGroupTitle>
               {dataDevice.map((data, index) => {
                 if (!data?.value) return null;
                 const last = index === dataDevice.length - 1;

--- a/apps/frontend/app/components/DataAcces/styles.ts
+++ b/apps/frontend/app/components/DataAcces/styles.ts
@@ -43,11 +43,11 @@ export default StyleSheet.create({
 
   infoContainer: {
     // width: width * 0.9,
-
-    padding: 15,
+    paddingHorizontal: 0,
+    paddingVertical: 0,
     elevation: 3,
     marginTop: 20,
-    marginBottom: 20
+    marginBottom: 20,
   },
   infoRow: {
     flexDirection: 'row',

--- a/apps/frontend/app/components/SettingsGroupTitle/SettingsGroupTitle.tsx
+++ b/apps/frontend/app/components/SettingsGroupTitle/SettingsGroupTitle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const SettingsGroupTitle: React.FC<Props> = ({ children }) => {
+  const { theme } = useTheme();
+  return (
+    <Text style={[styles.heading, { color: theme.screen.text }]}>{children}</Text>
+  );
+};
+
+export default SettingsGroupTitle;
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 16,
+    fontFamily: 'Poppins_400Regular',
+    marginTop: 20,
+    marginBottom: 10,
+  },
+});

--- a/apps/frontend/app/components/SettingsGroupTitle/index.ts
+++ b/apps/frontend/app/components/SettingsGroupTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SettingsGroupTitle';


### PR DESCRIPTION
## Summary
- add `SettingsGroupTitle` component for unified headings
- use `SettingsGroupTitle` in settings screen and data privacy (data access) screen
- adjust Data Access list styles to remove horizontal padding

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68860fe59f58833098b24bc10f8c8366