### PR TITLE
Fix padding on Data privacy screen

### DIFF
--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -126,7 +126,12 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
     <View
       style={{ ...styles.container, backgroundColor: theme.screen.background }}
     >
-      <ScrollView>
+      <ScrollView
+        contentContainerStyle={{
+          ...styles.contentContainer,
+          backgroundColor: theme.screen.background,
+        }}
+      >
         <View style={{ alignItems: 'center' }}>
           <View style={styles.imageContainer}>
             <Image

--- a/apps/frontend/app/components/DataAcces/styles.ts
+++ b/apps/frontend/app/components/DataAcces/styles.ts
@@ -20,6 +20,8 @@ export default StyleSheet.create({
   },
   contentContainer: {
     alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 40,
   },
 
   imageContainer: {


### PR DESCRIPTION
## Summary
- add padding to DataAccess screen's ScrollView
- match padding style with Settings screen

## Testing
- `yarn test` *(fails: monorepo workspace not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68861b46f4f883309099da4027505409