### PR TITLE
Fix width for data access lists

### DIFF
--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -167,19 +167,12 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
             )}
           </SettingsGroupTitle>
             {/* Info Items List */}
-            <View
-              style={{
-                ...styles.infoContainer,
-                width:
-                  windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
-              }}
-            >
-              {infoItems.map((item, index) => {
-                const last = index === infoItems.length - 1;
-                const first = index === 0;
-                const groupPosition =
-                  infoItems.length === 1
-                    ? 'single'
+          {infoItems.map((item, index) => {
+              const last = index === infoItems.length - 1;
+              const first = index === 0;
+              const groupPosition =
+                infoItems.length === 1
+                  ? 'single'
                     : first
                     ? 'top'
                     : last
@@ -209,16 +202,8 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
                   />
                 );
               })}
-            </View>
 
             {/* Device Data List */}
-            <View
-              style={{
-                ...styles.infoContainer,
-                width:
-                  windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
-              }}
-            >
             <SettingsGroupTitle>
               {translate(
                 TranslationKeys.translation_all_on_device_saved_data
@@ -260,7 +245,6 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
                   />
                 );
               })}
-            </View>
           </View>
         </View>
       </ScrollView>

--- a/apps/frontend/app/components/DataAcces/styles.ts
+++ b/apps/frontend/app/components/DataAcces/styles.ts
@@ -7,7 +7,6 @@ export default StyleSheet.create({
     flex: 1,
     backgroundColor: '#F9F9F9',
     // alignItems: 'center',
-    paddingTop: 50,
     // justifyContent:'center'
   },
   sheetView: {


### PR DESCRIPTION
## Summary
- remove unneeded View wrappers from DataAccess lists
- drop unused container padding

## Testing
- `yarn test` *(fails: monorepo@workspace not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688630b37c6083309489a06ca859b9d4