### PR TITLE
Improve SettingsList wrapping and add demo screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -176,6 +176,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/experimentell/settings-list-check')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='format-list-text' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.settings_list_check)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/app/(app)/experimentell/settings-list-check/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-check/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ScrollView, View, Text } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { TranslationKeys } from '@/locales/keys';
+import SettingsList from '@/components/SettingsList';
+import styles from './styles';
+
+const SettingsListCheck = () => {
+  useSetPageTitle(TranslationKeys.settings_list_check);
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+  return (
+    <ScrollView
+      style={{ ...styles.container, backgroundColor: theme.screen.background }}
+      contentContainerStyle={{
+        ...styles.contentContainer,
+        backgroundColor: theme.screen.background,
+      }}
+    >
+      <View style={{ ...styles.content }}>
+        <Text style={{ ...styles.heading, color: theme.screen.text }}>
+          {translate(TranslationKeys.settings_list_check)}
+        </Text>
+        <SettingsList
+          iconBgColor={primaryColor}
+          leftIcon={
+            <MaterialCommunityIcons
+              name='format-list-text'
+              size={24}
+              color={theme.screen.icon}
+            />
+          }
+          title='Dies ist ein extrem langer Titel, der in dieser Zeile nicht vollständig angezeigt werden kann.'
+          value='Auch dieser sehr lange Wert sollte ordentlich umgebrochen werden, damit alles lesbar bleibt.'
+          groupPosition='single'
+        />
+      </View>
+    </ScrollView>
+  );
+};
+
+export default SettingsListCheck;

--- a/apps/frontend/app/app/(app)/experimentell/settings-list-check/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-check/styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {},
+  content: {
+    width: '100%',
+    height: '100%',
+    padding: 20,
+  },
+  heading: {
+    fontSize: 24,
+    fontFamily: 'Poppins_700Bold',
+    marginVertical: 10,
+  },
+});

--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -128,14 +128,16 @@ const styles = StyleSheet.create({
   textWrapper: {
     flex: 1,
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
-    justifyContent: 'space-between',
   },
   titleContainer: {
     flexShrink: 1,
+    minWidth: 0,
   },
   valueContainer: {
     marginLeft: 8,
+    flexShrink: 0,
   },
   title: {
     fontSize: 16,

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -250,6 +250,7 @@ export enum TranslationKeys {
   rate_app = 'rate_app',
   app_download = 'app_download',
   react_native_qrcode_svg = 'react_native_qrcode_svg',
+  settings_list_check = 'settings_list_check',
   vertical_image_scroll = 'vertical_image_scroll',
   foodoffers_scroll = 'foodoffers_scroll',
   chats = 'chats',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2503,6 +2503,16 @@
     "tr": "React Native QRCode SVG",
     "zh": "React Native QRCode SVG"
   },
+  "settings_list_check": {
+    "de": "Settings List Check",
+    "en": "Settings List Check",
+    "ar": "Settings List Check",
+    "es": "Settings List Check",
+    "fr": "Settings List Check",
+    "ru": "Settings List Check",
+    "tr": "Settings List Check",
+    "zh": "Settings List Check"
+  },
   "vertical_image_scroll": {
     "de": "Vertikaler Bildlauf",
     "en": "Vertical Image Scroll",


### PR DESCRIPTION
## Summary
- wrap SettingsList rows so long titles/values break onto a new line
- add a translation key for `settings_list_check`
- add new experimentell screen demonstrating long title/value
- link the new screen from the experimentell menu

## Testing
- `yarn workspace rocket-meals-dev lint` *(fails: Couldn't find a script named "eslint")*
- `CI=true yarn workspace rocket-meals-dev test --runInBand` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68865c5c1ffc8330956dd07456a6a03d