### PR TITLE
Align value to right in SettingsList

### DIFF
--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -130,6 +130,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     alignItems: 'center',
+    justifyContent: 'space-between',
   },
   titleContainer: {
     flexShrink: 1,
@@ -145,6 +146,7 @@ const styles = StyleSheet.create({
   },
   value: {
     fontSize: 13,
+    textAlign: 'right',
   },
   rightWrapper: {
     width: 34,


### PR DESCRIPTION
## Summary
- right-align value text within SettingsList
- space items out in SettingsList text area

## Testing
- `yarn install` *(fails: some peer deps and missing workspace)*
- `yarn test` *(fails: workspace missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6886820748dc8330b2444a5f56809f23