### PR TITLE
Add chat inactivity notice

### DIFF
--- a/apps/frontend/app/app/(app)/chats/details/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/details/index.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TextInput, TouchableOpacity } from 'react-native';
+import { router } from 'expo-router';
+import SupportFAQ from '../../../../components/SupportFAQ/SupportFAQ';
 import { useTheme } from '@/hooks/useTheme';
 import { useLocalSearchParams } from 'expo-router';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -54,6 +56,11 @@ const ChatDetailsScreen = () => {
     const db = b.date_created || b.date_updated || '';
     return da < db ? 1 : -1;
   });
+
+  const lastMessageDate = sortedMessages[0]?.date_created || sortedMessages[0]?.date_updated;
+  const showOldMessageNotice = lastMessageDate
+    ? new Date(lastMessageDate).getTime() < Date.now() - 7 * 24 * 60 * 60 * 1000
+    : false;
 
   const handleSendMessage = async () => {
     if (!newMessage.trim() || !chat_id || !profile?.id) {
@@ -120,6 +127,17 @@ const ChatDetailsScreen = () => {
         contentContainerStyle={styles.list}
         inverted
       />
+      {showOldMessageNotice && (
+        <View style={styles.oldMessageContainer}>
+          <Text style={[styles.oldMessageText, { color: theme.screen.text }]}> 
+            {translate(TranslationKeys.chat_last_message_unanswered)}
+          </Text>
+          <SupportFAQ
+            label={translate(TranslationKeys.feedback_support_faq)}
+            onPress={() => router.navigate('/support-FAQ')}
+          />
+        </View>
+      )}
       <View style={styles.inputContainer}>
         <TextInput
           style={[

--- a/apps/frontend/app/app/(app)/chats/details/styles.ts
+++ b/apps/frontend/app/app/(app)/chats/details/styles.ts
@@ -40,4 +40,12 @@ export default StyleSheet.create({
     padding: 10,
     borderRadius: 5,
   },
+  oldMessageContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 10,
+    gap: 10,
+  },
+  oldMessageText: {
+    fontFamily: 'Poppins_400Regular',
+  },
 });

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -329,6 +329,7 @@ export enum TranslationKeys {
   cookies = 'cookies',
   feedback = 'feedback',
   feedback_support_faq = 'feedback_support_faq',
+  chat_last_message_unanswered = 'chat_last_message_unanswered',
   events = 'events',
   reset_seen_popup_events = 'reset_seen_popup_events',
   optional = 'optional',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3273,6 +3273,16 @@
     "tr": "Destek ve SSS",
     "zh": "支持和常见问题解答"
   },
+  "chat_last_message_unanswered": {
+    "de": "Es scheint, als wenn wir nicht auf deine letzte Nachricht geantwortet haben. Das tut uns leid. Schreibe uns doch am besten einfach eine E-Mail.",
+    "en": "It seems we did not respond to your last message. We're sorry. Please send us an email.",
+    "ar": "It seems we did not respond to your last message. Please send us an email.",
+    "es": "Parece que no respondimos a tu último mensaje. Por favor, envíanos un correo electrónico.",
+    "fr": "Il semble que nous n'ayons pas répondu à ton dernier message. Veuillez nous envoyer un e-mail.",
+    "ru": "Похоже, мы не ответили на ваше последнее сообщение. Пожалуйста, напишите нам электронное письмо.",
+    "tr": "Görünüyor ki son mesajınıza cevap vermedik. Lütfen bize bir e-posta gönderin.",
+    "zh": "看起来我们没有回复你的最后一条消息。请给我们发送电子邮件。"
+  },
   "events": {
     "de": "Events",
     "en": "Events",


### PR DESCRIPTION
## Summary
- add translation key for old chat notice
- show old-message info in chat details after 7 days

## Testing
- `yarn install` *(fails: "This package doesn't seem to be present in your lockfile")*
- `yarn test` *(fails: Error fetching or parsing news page, puppeteer errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887a4c4be1c83309d399f0796ced825