### PR TITLE
Fix DataAccess width

### DIFF
--- a/apps/frontend/app/components/DataAcces/styles.ts
+++ b/apps/frontend/app/components/DataAcces/styles.ts
@@ -18,6 +18,7 @@ export default StyleSheet.create({
     paddingBottom: 0,
   },
   contentContainer: {
+    width: '100%',
     alignItems: 'center',
     paddingHorizontal: 10,
     paddingVertical: 40,


### PR DESCRIPTION
## Summary
- ensure DataAccess contentContainer spans full width so SettingsList renders correctly

## Testing
- `yarn test` *(fails: Failed to fetch or parse news page; Error generating PDF)*

------
https://chatgpt.com/codex/tasks/task_e_6887a9138d508330b8e60bdaa1ffeb24