### PR TITLE
Fix FoodOffer info item display with external link modal

### DIFF
--- a/apps/frontend/app/components/ExternalLinkModal/ExternalLinkModal.tsx
+++ b/apps/frontend/app/components/ExternalLinkModal/ExternalLinkModal.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import BaseModal from '@/components/BaseModal';
+import { useTheme } from '@/hooks/useTheme';
+import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
+import { useSelector } from 'react-redux';
+import { myContrastColor } from '@/helper/colorHelper';
+import { RootState } from '@/redux/reducer';
+
+export interface ExternalLinkModalProps {
+  visible: boolean;
+  url: string;
+  onClose: () => void;
+}
+
+const ExternalLinkModal: React.FC<ExternalLinkModalProps> = ({
+  visible,
+  url,
+  onClose,
+}) => {
+  const { theme } = useTheme();
+  const { primaryColor, selectedTheme: mode } = useSelector(
+    (state: RootState) => state.settings,
+  );
+  const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+
+  const handleOpen = () => {
+    CommonSystemActionHelper.openExternalURL(url, true);
+    onClose();
+  };
+
+  return (
+    <BaseModal isVisible={visible} onClose={onClose} title="Externen Link öffnen?">
+      <View style={{ gap: 20, width: '100%', alignItems: 'center' }}>
+        <TouchableOpacity
+          style={{
+            backgroundColor: primaryColor,
+            padding: 10,
+            borderRadius: 8,
+            alignItems: 'center',
+            width: '80%',
+          }}
+          onPress={handleOpen}
+        >
+          <Text style={{ color: contrastColor }}>Ja bitte</Text>
+        </TouchableOpacity>
+        <Text style={{ color: theme.modal.text, textAlign: 'center' }}>{url}</Text>
+      </View>
+    </BaseModal>
+  );
+};
+
+export default ExternalLinkModal;
+export type { ExternalLinkModalProps };

--- a/apps/frontend/app/components/ExternalLinkModal/index.ts
+++ b/apps/frontend/app/components/ExternalLinkModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ExternalLinkModal';
+export type { ExternalLinkModalProps } from './ExternalLinkModal';

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -34,6 +34,7 @@ import {
   SET_SELECTED_FOOD_MARKINGS,
 } from '@/redux/Types/types';
 import PermissionModal from '../PermissionModal/PermissionModal';
+import ExternalLinkModal from '../ExternalLinkModal';
 import { router } from 'expo-router';
 import { createSelector } from 'reselect';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -71,6 +72,8 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       Dimensions.get('window').width
     );
     const [warning, setWarning] = useState(false);
+    const [showLinkModal, setShowLinkModal] = useState(false);
+    const [externalUrl, setExternalUrl] = useState<string | null>(null);
     const dispatch = useDispatch();
     const { theme } = useTheme();
     const { translate } = useLanguage();
@@ -204,7 +207,8 @@ const FoodItem: React.FC<FoodItemProps> = memo(
               {...triggerProps}
               onPress={() => {
                 if (item.redirect_url) {
-                  openInBrowser(item.redirect_url);
+                  setExternalUrl(item.redirect_url);
+                  setShowLinkModal(true);
                 } else {
                   const foodId =
                     item?.food && typeof item.food !== 'string'
@@ -482,6 +486,16 @@ const FoodItem: React.FC<FoodItemProps> = memo(
         </Tooltip>
 
         <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+        {externalUrl && (
+          <ExternalLinkModal
+            visible={showLinkModal}
+            url={externalUrl}
+            onClose={() => {
+              setShowLinkModal(false);
+              setExternalUrl(null);
+            }}
+          />
+        )}
       </>
     );
   },

--- a/apps/frontend/app/helper/staticFoodOfferHelper.ts
+++ b/apps/frontend/app/helper/staticFoodOfferHelper.ts
@@ -70,18 +70,24 @@ export function sortOffers(
   return copiedFoodOffers;
 }
 
-function convertStaticToOffer(el: DatabaseTypes.FoodofferInfoItems): DatabaseTypes.Foodoffers {
-  const info = el.info_item as unknown as DatabaseTypes.FoodoffersInfoItems | undefined;
-  const name = info?.name as unknown as DatabaseTypes.AppElements | undefined;
-  const translations = (name as any)?.translations;
-  const image = info?.image as any;
+function convertStaticToOffer(
+  el: DatabaseTypes.FoodofferInfoItems,
+): DatabaseTypes.Foodoffers {
+  const info = el.info_item as unknown as
+    | DatabaseTypes.FoodoffersInfoItems
+    | undefined;
+  const nameElement = (el.name || info?.name) as
+    | DatabaseTypes.AppElements
+    | undefined;
+  const translations = (nameElement as any)?.translations;
+  const imageElement = (el.image || info?.image) as any;
   return {
     id: `static-${el.id}`,
     food: {
       id: `static-food-${el.id}`,
       translations: translations,
-      image: image?.id ?? image,
-      image_remote_url: image?.data?.full_url ?? null,
+      image: imageElement?.id ?? imageElement,
+      image_remote_url: imageElement?.data?.full_url ?? null,
     } as any,
     redirect_url: el.link ?? null,
     markings: [],


### PR DESCRIPTION
## Summary
- support info item images/names via `convertStaticToOffer`
- add `ExternalLinkModal` for external URL confirmation
- show modal when tapping FoodOffer info items

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac66d19c8330a13985da56e31b27