### PR TITLE
Fix routing regression

### DIFF
--- a/apps/frontend/app/app/(app)/index.tsx
+++ b/apps/frontend/app/app/(app)/index.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react-native';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { CanteenHelper } from '@/redux/actions/Canteens/Canteens';
@@ -44,15 +43,18 @@ const Home = () => {
   const { canteens } = useSelector(
     (state: RootState) => state.canteenReducer
   );
-  const selectedCanteen = useSelectedCanteen();
   const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
   const [screenWidth, setScreenWidth] = useState(
     Dimensions.get('window').width
   );
 
+  const { loggedIn } = useSelector((state: RootState) => state.authReducer);
+
   const checkCanteenSelection = () => {
-    if (selectedCanteen) {
+    if (loggedIn) {
       router.push('/(app)/' + AppScreens.FOOD_OFFERS);
+    } else {
+      router.push('/(auth)/login');
     }
   };
 
@@ -136,7 +138,7 @@ const Home = () => {
 
   useEffect(() => {
     checkCanteenSelection();
-  }, [selectedCanteen]); // Dependency gesetzt
+  }, [loggedIn]);
 
   useEffect(() => {
     const handleResize = () => {

--- a/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -95,7 +95,7 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
         ownCanteenFeedBackLabelEntries,
         label?.id,
         likeStats,
-        selectedCanteen.id,
+        selectedCanteen?.id,
         date
       )) as DatabaseTypes.CanteensFeedbacksLabelsEntries;
     getLabelEntries(label?.id);


### PR DESCRIPTION
## Summary
- revert previous routing changes
- redirect to foodoffers when logged in
- restore canteen id check and selectedCanteen safety

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6887f04426b08330bc651f2a52d2b092