### PR TITLE
Add info items to food offers

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/styles.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/styles.ts
@@ -87,4 +87,8 @@ export default StyleSheet.create({
     fontSize: 16,
     fontFamily: 'Poppins_500Medium',
   },
+  infoItemContainer: {
+    width: '100%',
+    marginTop: 20,
+  },
 });


### PR DESCRIPTION
## Summary
- fetch `foodOffersInfoItems` from redux state
- combine info items with food offers into `DayItem` list
- render info items with markdown alongside food offers
- style container for info items

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6888b1ebb2d4833080316924cce872ef