### PR TITLE
Fix web setImmediate issue

### DIFF
--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -1,3 +1,5 @@
+// Polyfill for environments where `setImmediate` is not available (e.g. web)
+import 'setimmediate';
 import React, { useEffect } from 'react';
 import { Slot } from 'expo-router';
 import { RootSiblingParent } from 'react-native-root-siblings';


### PR DESCRIPTION
## Summary
- polyfill `setImmediate` in app layout to avoid web runtime error

## Testing
- `yarn test` *(fails: react peer dependencies and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68893e0f87008330abff9fe51478269b