### PR TITLE
Add expo-leaflet screen

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -767,6 +767,19 @@ export default function Layout() {
         />
 
         <Drawer.Screen
+          name='expo-leaflet/index'
+          options={{
+            header: () => (
+              <CustomStackHeader
+                label={translate(TranslationKeys.expo_leaflet)}
+                key={'ExpoLeaflet'}
+              />
+            ),
+            title: translate(TranslationKeys.expo_leaflet),
+          }}
+        />
+
+        <Drawer.Screen
           name='vertical-image-scroll/index'
           options={{
             header: () => (

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -92,6 +92,19 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/expo-leaflet')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='map' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.expo_leaflet)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
         <TouchableOpacity
           style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
           onPress={() => router.push('/vertical-image-scroll')}

--- a/apps/frontend/app/app/(app)/expo-leaflet/index.tsx
+++ b/apps/frontend/app/app/(app)/expo-leaflet/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View } from 'react-native';
+import { ExpoLeaflet, MapLayer, MapMarker } from 'expo-leaflet';
+import { useTheme } from '@/hooks/useTheme';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { TranslationKeys } from '@/locales/keys';
+
+const mapLayers: MapLayer[] = [
+  {
+    layerType: 'TileLayer',
+    baseLayer: true,
+    baseLayerName: 'OpenStreetMap',
+    baseLayerIsChecked: true,
+    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  },
+];
+
+const mapMarkers: MapMarker[] = [
+  {
+    id: '1',
+    position: { lat: 52.52, lng: 13.405 },
+    icon: '<span>📍</span>',
+    size: [32, 32],
+  },
+  {
+    id: '2',
+    position: { lat: 52.521, lng: 13.41 },
+    icon: '<span>🍔</span>',
+    size: [32, 32],
+  },
+];
+
+const ExpoLeafletScreen = () => {
+  useSetPageTitle(TranslationKeys.expo_leaflet);
+  const { theme } = useTheme();
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.screen.background }}>
+      <ExpoLeaflet
+        mapCenterPosition={{ lat: 52.52, lng: 13.405 }}
+        mapLayers={mapLayers}
+        mapMarkers={mapMarkers}
+        zoom={13}
+        onMessage={(e) => console.log('expo-leaflet', e.tag)}
+        backgroundColor={theme.screen.background}
+      />
+    </View>
+  );
+};
+
+export default ExpoLeafletScreen;

--- a/apps/frontend/app/app/(app)/expo-leaflet/styles.ts
+++ b/apps/frontend/app/app/(app)/expo-leaflet/styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -251,6 +251,7 @@ export enum TranslationKeys {
   app_download = 'app_download',
   react_native_qrcode_svg = 'react_native_qrcode_svg',
   settings_list_check = 'settings_list_check',
+  expo_leaflet = 'expo_leaflet',
   vertical_image_scroll = 'vertical_image_scroll',
   foodoffers_scroll = 'foodoffers_scroll',
   chats = 'chats',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2513,6 +2513,16 @@
     "tr": "Settings List Check",
     "zh": "Settings List Check"
   },
+  "expo_leaflet": {
+    "de": "Expo Leaflet",
+    "en": "Expo Leaflet",
+    "ar": "Expo Leaflet",
+    "es": "Expo Leaflet",
+    "fr": "Expo Leaflet",
+    "ru": "Expo Leaflet",
+    "tr": "Expo Leaflet",
+    "zh": "Expo Leaflet"
+  },
   "vertical_image_scroll": {
     "de": "Vertikaler Bildlauf",
     "en": "Vertical Image Scroll",

--- a/apps/frontend/app/package.json
+++ b/apps/frontend/app/package.json
@@ -61,6 +61,7 @@
     "expo-image-manipulator": "~13.0.6",
     "expo-image-picker": "~16.0.3",
     "expo-intent-launcher": "~12.0.2",
+    "expo-leaflet": "^1.0.3",
     "expo-linking": "~7.0.3",
     "expo-localization": "~16.0.0",
     "expo-location": "~18.0.10",

--- a/apps/frontend/app/yarn.lock
+++ b/apps/frontend/app/yarn.lock
@@ -3144,6 +3144,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-leaflet/core@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@react-leaflet/core@npm:1.1.1"
+  peerDependencies:
+    leaflet: ^1.7.1
+    react: ^17.0.1
+    react-dom: ^17.0.1
+  checksum: 10c0/785491751ade1273b0d20b273ba81dbe700e3247c48a5087017dcb250e6b6932491444ff8ac7b88a7f136d7921aef833ed3b270b6940713b292e38cd85519881
+  languageName: node
+  linkType: hard
+
 "@react-native-aria/accordion@npm:^0.0.2":
   version: 0.0.2
   resolution: "@react-native-aria/accordion@npm:0.0.2"
@@ -7579,6 +7590,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-leaflet@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "expo-leaflet@npm:1.0.3"
+  dependencies:
+    leaflet: "npm:^1.7.1"
+    lodash.isequal: "npm:^4.5.0"
+    react-leaflet: "npm:^3.2.0"
+  peerDependencies:
+    expo-asset: 7.x || 8.x
+    expo-file-system: 8.x || 9.x || 11.x
+    react: 16.x || 17.x
+    react-measure: ^2.3.0
+    react-native: "*"
+    react-native-webview: 8.x || 9.x || 10.x || 11.x
+  checksum: 10c0/fbcc21f8eede4ac1231183d3e49843de9511f403d256f068252ee6c788cbe85c1ae8690c93acf581ef51b29bf8df36ae5f77288362be1e845e86daac58450703
+  languageName: node
+  linkType: hard
+
 "expo-linking@npm:~7.0.3":
   version: 7.0.5
   resolution: "expo-linking@npm:7.0.5"
@@ -10302,6 +10331,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"leaflet@npm:^1.7.1":
+  version: 1.9.4
+  resolution: "leaflet@npm:1.9.4"
+  checksum: 10c0/f639441dbb7eb9ae3fcd29ffd7d3508f6c6106892441634b0232fafb9ffb1588b05a8244ec7085de2c98b5ed703894df246898477836cfd0ce5b96d4717b5ca1
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -10484,6 +10520,13 @@ __metadata:
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: 10c0/762998a63e095412b6099b8290903e0a8ddcb353ac6e2e0f2d7e7d03abd4275fe3c689d88960eb90b0dde4f177554d51a690f22a343932ecbc50a5d111849987
+  languageName: node
+  linkType: hard
+
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: 10c0/dfdb2356db19631a4b445d5f37868a095e2402292d59539a987f134a8778c62a2810c2452d11ae9e6dcac71fc9de40a6fedcb20e2952a15b431ad8b29e50e28f
   languageName: node
   linkType: hard
 
@@ -12228,13 +12271,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qr.js@npm:0.0.0":
-  version: 0.0.0
-  resolution: "qr.js@npm:0.0.0"
-  checksum: 10c0/1c6a4c7a58d04e52ec2fee99e39b680fdc5b2a510a981df42c36b716a8eac6634d130fc4d65af8f030f2a07dbf5fa046b97cdfa7456c250ebb50a73916efdcb5
-  languageName: node
-  linkType: hard
-
 "qrcode-terminal@npm:0.11.0":
   version: 0.11.0
   resolution: "qrcode-terminal@npm:0.11.0"
@@ -12424,6 +12460,19 @@ __metadata:
   version: 19.1.0
   resolution: "react-is@npm:19.1.0"
   checksum: 10c0/b6c6cadd172d5d39f66d493700d137a5545c294a62ce0f8ec793d59794c97d2bed6bad227626f16bd0e90004ed7fdc8ed662a004e6edcf5d2b7ecb6e3040ea6b
+  languageName: node
+  linkType: hard
+
+"react-leaflet@npm:^3.2.0":
+  version: 3.2.5
+  resolution: "react-leaflet@npm:3.2.5"
+  dependencies:
+    "@react-leaflet/core": "npm:^1.1.1"
+  peerDependencies:
+    leaflet: ^1.7.1
+    react: ^17.0.1
+    react-dom: ^17.0.1
+  checksum: 10c0/02c72b59c597d602994da2958af05f0eb0dc7bfadddd56d8e501038f671f3072a274c4c316a58967387e022036fa77cc6a56a601702b1a68403ffb11aee8ec89
   languageName: node
   linkType: hard
 
@@ -12808,7 +12857,6 @@ __metadata:
   checksum: 10c0/dfcef981bc6b02497ed0f300faadd06c7b78dbb90de5d082c2760ab055962af68df0b6222fbecd903eea3b711a0af8c22c9612731acdc90d9980f5c586093a32
   languageName: node
   linkType: hard
-
 
 "react-redux@npm:^9.1.2":
   version: 9.2.0
@@ -13413,6 +13461,7 @@ __metadata:
     expo-image-manipulator: "npm:~13.0.6"
     expo-image-picker: "npm:~16.0.3"
     expo-intent-launcher: "npm:~12.0.2"
+    expo-leaflet: "npm:^1.0.3"
     expo-linking: "npm:~7.0.3"
     expo-localization: "npm:~16.0.0"
     expo-location: "npm:~18.0.10"


### PR DESCRIPTION
## Summary
- install expo-leaflet in the frontend app
- add `expo_leaflet` translation keys
- hook the new screen into the experimental screen and drawer
- implement a basic `ExpoLeaflet` map screen with sample markers

## Testing
- `yarn install` *(fails: some peer deps and build steps)*
- `yarn test` *(fails: monorepo workspace not found / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_688b3307516c83309cfdebc467bfe62d