### PR TITLE
Fix monitor list auto scroll timing

### DIFF
--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -93,6 +93,8 @@ const index = () => {
   const optionalFoodsScrollRef = useRef<ScrollView>(null);
   const [foodScrollIndex, setFoodScrollIndex] = useState(0);
   const [optionalFoodScrollIndex, setOptionalFoodScrollIndex] = useState(0);
+  const [isFoodAtEnd, setIsFoodAtEnd] = useState(false);
+  const [isOptionalFoodAtEnd, setIsOptionalFoodAtEnd] = useState(false);
   const windowHeight = Dimensions.get('window').height;
   const windowWidth = Dimensions.get('window').width;
   const headerRef = useRef<View>(null);
@@ -574,13 +576,21 @@ const index = () => {
             : tableMaxHeight;
         const visibleRows = Math.floor(currentHeight / rowHeight);
         const remainingRows = foods.length - (foodScrollIndex + visibleRows);
+        const bottomIndex = Math.max(foods.length - visibleRows, 0);
 
         let nextIndex;
 
         if (remainingRows > 0) {
           nextIndex = foodScrollIndex + 1;
+          if (isFoodAtEnd) setIsFoodAtEnd(false);
         } else {
-          nextIndex = 0;
+          if (!isFoodAtEnd) {
+            nextIndex = bottomIndex;
+            setIsFoodAtEnd(true);
+          } else {
+            nextIndex = 0;
+            setIsFoodAtEnd(false);
+          }
         }
 
         setFoodScrollIndex(nextIndex);
@@ -614,13 +624,21 @@ const index = () => {
         const visibleRows = Math.floor(currentHeight / rowHeight);
         const remainingRows =
           optionalFoods.length - (optionalFoodScrollIndex + visibleRows);
+        const bottomIndex = Math.max(optionalFoods.length - visibleRows, 0);
 
         let nextIndex;
 
         if (remainingRows > 0) {
           nextIndex = optionalFoodScrollIndex + 1;
+          if (isOptionalFoodAtEnd) setIsOptionalFoodAtEnd(false);
         } else {
-          nextIndex = 0;
+          if (!isOptionalFoodAtEnd) {
+            nextIndex = bottomIndex;
+            setIsOptionalFoodAtEnd(true);
+          } else {
+            nextIndex = 0;
+            setIsOptionalFoodAtEnd(false);
+          }
         }
 
         setOptionalFoodScrollIndex(nextIndex);


### PR DESCRIPTION
## Summary
- keep food list at bottom for one cycle before jumping to top
- mirror logic for optional foods

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688c002fdc38833091eec539ed63d80a