### PR TITLE
Fix image overlay blocking touches

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -652,7 +652,7 @@ export default function FoodDetailsScreen() {
                 style={styles.mobileFeaturedImage}
               />
               </TouchableOpacity>
-              <View style={styles.overlay}>
+              <View style={styles.overlay} pointerEvents='box-none'>
                 <View style={styles.mobileDetailsHeader}>
                   <View style={styles.row}>
                     <View />


### PR DESCRIPTION
## Summary
- allow taps on the food detail image

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688cd70196788330a268156907de51bb