### PR TITLE
Add persistent zoom and headerless layout to image screen

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/_layout.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/_layout.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+import { useTheme } from '@/hooks/useTheme';
+
+export default function Layout() {
+  const { theme } = useTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.header.background },
+        headerTintColor: theme.header.text,
+      }}
+    >
+      <Stack.Screen name='index' options={{ headerShown: false }} />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- allow persistent pinch zoom and reposition close/download icons
- hide header on image-full-screen screen

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688ce923a6f483309ead02d304152ce0