### PR TITLE
Fix image zoom and header spacing

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -77,13 +77,13 @@ export default function ImageFullScreen() {
           </TouchableOpacity>
         </View>
       )}
-      <TouchableWithoutFeedback onPress={toggleControls} onLongPress={() => setModalVisible(true)}>
-        <PinchGestureHandler onGestureEvent={pinchHandler}>
-          <Animated.View style={styles.flex}>
+      <PinchGestureHandler onGestureEvent={pinchHandler}>
+        <Animated.View style={styles.flex}>
+          <TouchableWithoutFeedback onPress={toggleControls} onLongPress={() => setModalVisible(true)}>
             <Image source={{ uri: String(uri) }} style={[styles.image, animatedStyle]} contentFit='contain' />
-          </Animated.View>
-        </PinchGestureHandler>
-      </TouchableWithoutFeedback>
+          </TouchableWithoutFeedback>
+        </Animated.View>
+      </PinchGestureHandler>
       <BaseBottomModal visible={modalVisible} onClose={() => setModalVisible(false)}>
         <SettingsList
           leftIcon={<Ionicons name='cloud-download-outline' size={24} color={theme.screen.icon} />}

--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -35,6 +35,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '@/hooks/useTheme';
 import ServerStatusLoader from '@/components/ServerStatusLoader/ServerStatusLoader';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { usePathname } from 'expo-router';
 import { GluestackUIProvider } from '@gluestack-ui/themed';
 import { config } from '@gluestack-ui/config';
 import ExpoUpdateLoader from '@/components/ExpoUpdateLoader/ExpoUpdateLoader';
@@ -56,6 +57,7 @@ ServerAPI.createAuthentificationStorage(
 
 export default function Layout() {
   const { theme } = useTheme();
+  const pathname = usePathname();
   const [fontsLoaded] = useFonts({
     Poppins_100Thin,
     Poppins_100Thin_Italic,
@@ -118,12 +120,12 @@ export default function Layout() {
                       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
                       style={{ flex: 1, backgroundColor: theme.screen.iconBg }}
                     >
-                      <SafeAreaView
-                        style={{ flex: 1, backgroundColor: theme.screen.iconBg }}
-                        edges={['top', 'bottom']}
-                      >
-                        <Slot />
-                      </SafeAreaView>
+                        <SafeAreaView
+                          style={{ flex: 1, backgroundColor: theme.screen.iconBg }}
+                          edges={pathname?.includes('image-full-screen') ? ['bottom'] : ['top', 'bottom']}
+                        >
+                          <Slot />
+                        </SafeAreaView>
                     </KeyboardAvoidingView>
                   </ExpoUpdateChecker>
                 </ServerStatusLoader>


### PR DESCRIPTION
## Summary
- remove the header safe area for the fullscreen image route
- restructure ImageFullScreen so pinch zoom works

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688cf46200ec83309c9faf56b5892b44