### PR TITLE
Fix header in image fullscreen screen

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -940,6 +940,12 @@ export default function Layout() {
             headerShown: false,
           }}
         />
+        <Drawer.Screen
+          name='image-full-screen'
+          options={{
+            headerShown: false,
+          }}
+        />
       </Drawer>
     </>
   );


### PR DESCRIPTION
## Summary
- register image-full-screen route in the drawer layout to hide its header

## Testing
- `npx expo --version`
- `npx expo lint` *(fails: couldn't find a script named "eslint")*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688d57bb6b3c8330ba660e8198783423