### PR TITLE
Add high resolution images in fullscreen

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -137,10 +137,13 @@ export default function FoodDetailsScreen() {
   };
 
   const openFullScreenImage = () => {
-    const uri =
-      foodDetails?.image_remote_url ||
-      (foodDetails?.image ? getImageUrl(foodDetails.image) : defaultImage);
-    router.push({ pathname: '/(app)/image-full-screen', params: { uri } });
+    if (foodDetails?.image_remote_url) {
+      router.push({ pathname: '/(app)/image-full-screen', params: { uri: foodDetails.image_remote_url } });
+    } else if (foodDetails?.image) {
+      router.push({ pathname: '/(app)/image-full-screen', params: { assetId: String(foodDetails.image) } });
+    } else {
+      router.push({ pathname: '/(app)/image-full-screen', params: { uri: defaultImage } });
+    }
   };
 
   const filterAttributes = () => {

--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -17,13 +17,16 @@ import BaseBottomModal from '@/components/BaseBottomModal';
 import SettingsList from '@/components/SettingsList';
 import * as FileSystem from 'expo-file-system';
 import useToast from '@/hooks/useToast';
+import { getHighResImageUrl } from '@/constants/HelperFunctions';
 
 export default function ImageFullScreen() {
-  const { uri } = useLocalSearchParams<{ uri: string }>();
+  const { uri, assetId } = useLocalSearchParams<{ uri?: string; assetId?: string }>();
   const { theme } = useTheme();
   const toast = useToast();
   const [showControls, setShowControls] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
+
+  const imageUri = assetId ? getHighResImageUrl(String(assetId)) : String(uri);
 
   const baseScale = useSharedValue(1);
   const pinchScale = useSharedValue(1);
@@ -88,15 +91,15 @@ export default function ImageFullScreen() {
     try {
       if (Platform.OS === 'web') {
         const link = document.createElement('a');
-        link.href = String(uri);
+        link.href = String(imageUri);
         link.download = '';
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
       } else {
-        const filename = String(uri).split('/').pop() || `image_${Date.now()}`;
+        const filename = String(imageUri).split('/').pop() || `image_${Date.now()}`;
         const fileUri = FileSystem.documentDirectory + filename;
-        await FileSystem.downloadAsync(String(uri), fileUri);
+        await FileSystem.downloadAsync(String(imageUri), fileUri);
         toast('Image downloaded', 'success');
       }
     } catch (e) {
@@ -119,7 +122,7 @@ export default function ImageFullScreen() {
       <GestureDetector gesture={composedGesture}>
         <Animated.View style={styles.flex}>
           <TouchableWithoutFeedback onPress={toggleControls} onLongPress={() => setModalVisible(true)}>
-            <AnimatedImage source={{ uri: String(uri) }} style={[styles.image, animatedStyle]} contentFit='contain' />
+            <AnimatedImage source={{ uri: String(imageUri) }} style={[styles.image, animatedStyle]} contentFit='contain' />
           </TouchableWithoutFeedback>
         </Animated.View>
       </GestureDetector>

--- a/apps/frontend/app/constants/HelperFunctions.ts
+++ b/apps/frontend/app/constants/HelperFunctions.ts
@@ -66,11 +66,15 @@ export const numToOneDecimal = (num: number) => {
   return Math.round(num * 10) / 10;
 };
 
-export const getImageUrl = (imageId: string) => {
+export const getImageUrl = (imageId: string, size: number = 512) => {
   if (!imageId) {
     return null;
   }
-  return `${Server.ServerUrl}/assets/${imageId}?fit=cover&width=512&height=512&quality=100`;
+  return `${Server.ServerUrl}/assets/${imageId}?fit=cover&width=${size}&height=${size}&quality=100`;
+};
+
+export const getHighResImageUrl = (imageId: string, size: number = 2048) => {
+  return getImageUrl(imageId, size);
 };
 
 export const getFormValueImageUrl = (imageId: string) => {


### PR DESCRIPTION
## Summary
- allow custom size in `getImageUrl` and add `getHighResImageUrl`
- support `assetId` in fullscreen image screen
- switch food details to pass `assetId` when available

## Testing
- `yarn workspace rocket-meals-dev lint` *(fails: Couldn't find a script named "eslint")*

------
https://chatgpt.com/codex/tasks/task_e_688d62d38b808330a934ef030b4c13db