### PR TITLE
fix: fade fullscreen image using theme background

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -43,7 +43,7 @@ export default function ImageFullScreen() {
   const translationY = useSharedValue(0);
   const startX = useSharedValue(0);
   const startY = useSharedValue(0);
-  const containerOpacity = useSharedValue(1);
+  const imageOpacity = useSharedValue(1);
 
   const windowHeight = Dimensions.get('window').height;
   const CLOSE_DISTANCE = windowHeight * 0.3;
@@ -80,25 +80,26 @@ export default function ImageFullScreen() {
       if (scale.value > 1) {
         translationX.value = startX.value + event.translationX;
         translationY.value = startY.value + event.translationY;
-        containerOpacity.value = 1;
+        imageOpacity.value = 1;
       } else {
         translationY.value = event.translationY;
         if (event.translationY > 0) {
-          containerOpacity.value =
+          imageOpacity.value =
             1 - Math.min(event.translationY / FADE_DISTANCE, 1);
         } else {
-          containerOpacity.value = 1;
+          imageOpacity.value = 1;
         }
       }
     })
     .onEnd(() => {
       if (scale.value <= 1) {
         if (translationY.value > CLOSE_DISTANCE) {
+          imageOpacity.value = 1;
           runOnJS(router.back)();
         } else {
           translationX.value = withTiming(0);
           translationY.value = withTiming(0);
-          containerOpacity.value = withTiming(1);
+          imageOpacity.value = withTiming(1);
         }
       }
     });
@@ -111,6 +112,7 @@ export default function ImageFullScreen() {
       { translateX: translationX.value },
       { translateY: translationY.value },
     ],
+    opacity: imageOpacity.value,
   }));
 
   const toggleControls = () => setShowControls((p) => !p);
@@ -137,13 +139,9 @@ export default function ImageFullScreen() {
     }
   };
 
-  const containerStyle = useAnimatedStyle(() => ({
-    opacity: containerOpacity.value,
-  }));
-
   return (
     <Animated.View
-      style={[styles.container, { backgroundColor: theme.screen.background }, containerStyle]}
+      style={[styles.container, { backgroundColor: theme.screen.background }]}
     >
       {showControls && (
         <View style={styles.topRow} pointerEvents='box-none'>


### PR DESCRIPTION
## Summary
- fade fullscreen image to the screen's background color instead of white
- reset fade before leaving image screen

## Testing
- `npm test` *(fails: directus-extension-rocket-meals-bundle missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688dfbd02528833097d0327977aebb2e