### PR TITLE
fix: reset image position after canceling drag

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -102,6 +102,8 @@ export default function ImageFullScreen() {
         } else {
           translationX.value = withTiming(0);
           translationY.value = withTiming(0);
+          startX.value = 0;
+          startY.value = 0;
           imageOpacity.value = withTiming(1);
         }
       }


### PR DESCRIPTION
## Summary
- ensure fullscreen image resets to original position after drag down cancel

## Testing
- `npx jest --passWithNoTests`
- `yarn workspace rocket-meals-dev lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_688dff6b9cd08330bb96ce4843e460a4