### PR TITLE
feat: localize image pull-down indicator

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useLocalSearchParams, router, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
 import { useSelector } from 'react-redux';
 import Animated, {
   runOnJS,
@@ -26,6 +27,7 @@ import SettingsList from '@/components/SettingsList';
 import * as FileSystem from 'expo-file-system';
 import useToast from '@/hooks/useToast';
 import { getHighResImageUrl } from '@/constants/HelperFunctions';
+import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 
 export default function ImageFullScreen() {
@@ -33,6 +35,7 @@ export default function ImageFullScreen() {
   const { theme } = useTheme();
   const { drawerPosition } = useSelector((state: RootState) => state.settings);
   const toast = useToast();
+  const { translate } = useLanguage();
   const [showControls, setShowControls] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
 
@@ -175,7 +178,9 @@ export default function ImageFullScreen() {
         style={[styles.backIndicator, indicatorStyle]}
       >
         <Ionicons name='chevron-down' size={48} color={theme.screen.text} />
-        <Text style={[styles.backText, { color: theme.screen.text }]}>Release to close</Text>
+        <Text style={[styles.backText, { color: theme.screen.text }]}>
+          {translate(TranslationKeys.pull_down_to_close)}
+        </Text>
       </Animated.View>
       {showControls && (
         <View

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -386,6 +386,7 @@ export enum TranslationKeys {
   group_account_personalization = 'group_account_personalization',
   group_canteen_usage = 'group_canteen_usage',
   group_app_settings = 'group_app_settings',
+  pull_down_to_close = 'pull_down_to_close',
   group_app_management = 'group_app_management',
   // NOT IN TRANSLATION
   feedback_and_support = 'Feedback & Support',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3863,6 +3863,16 @@
     "tr": "Uygulama ayarları",
     "zh": "应用设置"
   },
+  "pull_down_to_close": {
+    "de": "Zum schließen runter ziehen",
+    "en": "Pull down to close",
+    "ar": "اسحب للأسفل للإغلاق",
+    "es": "Desliza hacia abajo para cerrar",
+    "fr": "Glissez vers le bas pour fermer",
+    "ru": "Потяните вниз, чтобы закрыть",
+    "tr": "Kapatmak için aşağı çekin",
+    "zh": "下拉以关闭"
+  },
   "group_app_management": {
     "de": "App-Verwaltung",
     "en": "App Management",


### PR DESCRIPTION
## Summary
- localize fullscreen image close hint
- add translation key for pull-down hint

## Testing
- `npm test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688e30d22bd08330a979a4bc1f92a837