### PR TITLE
feat: position pull down hint below controls

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -271,11 +271,10 @@ const styles = StyleSheet.create({
   image: { width: '100%', height: '100%' },
   backIndicator: {
     position: 'absolute',
-    top: 0,
-    bottom: 0,
+    top: 110,
     left: 0,
     right: 0,
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'center',
   },
   backText: { marginTop: 8, fontSize: 16 },


### PR DESCRIPTION
## Summary
- position pull-down-to-close text at top of full-screen image viewer beneath close/download controls

## Testing
- `npx jest apps/frontend/app` (no tests found)
- `yarn workspace rocket-meals-dev lint` (fails: Couldn't find the node_modules state file)


------
https://chatgpt.com/codex/tasks/task_e_688e3a4765bc8330aa34080b0df0840b