### PR TITLE
Keep full-screen image size and show pull-down hint

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -54,7 +54,7 @@ export default function ImageFullScreen() {
   const startX = useSharedValue(0);
   const startY = useSharedValue(0);
   const imageOpacity = useSharedValue(1);
-  const indicatorOpacity = useSharedValue(0);
+  const indicatorOpacity = useSharedValue(1);
 
   const windowHeight = Dimensions.get('window').height;
   const CLOSE_DISTANCE = windowHeight * 0.25;
@@ -98,11 +98,9 @@ export default function ImageFullScreen() {
         if (event.translationY > 0) {
           const progress = Math.min(event.translationY / FADE_DISTANCE, 1);
           imageOpacity.value = 1 - progress;
-          indicatorOpacity.value = progress;
-          dismissScale.value = 1 - progress * 0.5;
+          dismissScale.value = 1;
         } else {
           imageOpacity.value = 1;
-          indicatorOpacity.value = 0;
           dismissScale.value = 1;
         }
       }
@@ -119,7 +117,6 @@ export default function ImageFullScreen() {
           startX.value = 0;
           startY.value = 0;
           imageOpacity.value = withTiming(1);
-          indicatorOpacity.value = withTiming(0);
           dismissScale.value = withTiming(1);
         }
       }
@@ -149,7 +146,7 @@ export default function ImageFullScreen() {
       imageOpacity.value = 1;
       baseScale.value = 1;
       pinchScale.value = 1;
-      indicatorOpacity.value = 0;
+      indicatorOpacity.value = 1;
       dismissScale.value = 1;
     }, [])
   );
@@ -286,5 +283,5 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignItems: 'center',
   },
-  backText: { marginTop: 8, fontSize: 16 },
+  backText: { marginTop: 8, fontSize: 12 },
 });


### PR DESCRIPTION
## Summary
- Keep image scale constant during pull-down gestures
- Always display the pull-down hint and shrink its font size

## Testing
- `yarn test` *(fails: monorepo@workspace:.: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688e481e0c248330a00a1309fe9615ef