### PR TITLE
feat: reset image scale when released

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -65,8 +65,16 @@ export default function ImageFullScreen() {
       pinchScale.value = event.scale;
     })
     .onEnd(() => {
-      baseScale.value = baseScale.value * pinchScale.value;
-      pinchScale.value = 1;
+      const nextScale = baseScale.value * pinchScale.value;
+      if (nextScale < 1) {
+        baseScale.value = withTiming(1, { duration: 150 });
+        pinchScale.value = 1;
+        translationX.value = withTiming(0, { duration: 150 });
+        translationY.value = withTiming(0, { duration: 150 });
+      } else {
+        baseScale.value = nextScale;
+        pinchScale.value = 1;
+      }
     });
 
   const doubleTapGesture = Gesture.Tap()


### PR DESCRIPTION
## Summary
- ensure fullscreen images snap back to original size when released after being reduced

## Testing
- `npx jest --runInBand` (no tests found)
- `npx expo lint` (fails: Couldn't find the node_modules state file)


------
https://chatgpt.com/codex/tasks/task_e_688e52bf92e48330ba58693c69141718