### PR TITLE
Hide pull down hint when controls are hidden

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -187,15 +187,17 @@ export default function ImageFullScreen() {
     <Animated.View
       style={[styles.container, { backgroundColor: theme.screen.background }]}
     >
-      <Animated.View
-        pointerEvents='none'
-        style={[styles.backIndicator, indicatorStyle]}
-      >
-        <Ionicons name='chevron-down' size={48} color={theme.screen.text} />
-        <Text style={[styles.backText, { color: theme.screen.text }]}>
-          {translate(TranslationKeys.pull_down_to_close)}
-        </Text>
-      </Animated.View>
+      {showControls && (
+        <Animated.View
+          pointerEvents='none'
+          style={[styles.backIndicator, indicatorStyle]}
+        >
+          <Ionicons name='chevron-down' size={48} color={theme.screen.text} />
+          <Text style={[styles.backText, { color: theme.screen.text }]}>
+            {translate(TranslationKeys.pull_down_to_close)}
+          </Text>
+        </Animated.View>
+      )}
       {showControls && (
         <View
           style={[


### PR DESCRIPTION
## Summary
- hide "pull down to close" text when image controls are hidden

## Testing
- `npx expo lint` (fails: Couldn't find a script named "eslint")
- `CI=true yarn workspace rocket-meals-dev test`

------
https://chatgpt.com/codex/tasks/task_e_688e61daef5883309d08e549fa222ae6