### PR TITLE
feat(frontend): respect settings week start in calendar

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -23,6 +23,7 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
     primaryColor,
     appSettings,
     selectedTheme: mode,
+    firstDayOfTheWeek,
   } = useSelector((state: RootState) => state.settings);
   const { selectedDate } = useSelector((state: RootState) => state.food);
   const foods_area_color = appSettings?.foods_area_color
@@ -33,6 +34,17 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
     theme,
     mode === 'dark'
   );
+
+  const weekStartMap: Record<string, number> = {
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6,
+    sunday: 0,
+  };
+  const firstDay = weekStartMap[firstDayOfTheWeek?.id] ?? 1;
 
   const navigateMonth = (direction: 'next' | 'prev') => {
     const newMonth = new Date(currentMonth);
@@ -128,6 +140,7 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet }) => {
         <Calendar
           key={currentMonth.toISOString()}
           style={styles.calendar}
+          firstDay={firstDay}
           current={currentMonth.toISOString().split('T')[0]}
           onDayPress={(day: any) => {
             dispatch({


### PR DESCRIPTION
## Summary
- use firstDayOfTheWeek from settings to control calendar week start

## Testing
- `yarn workspace rocket-meals-dev lint` *(fails: Couldn't find the node_modules state file - running an install might help (findPackageLocation))*
- `yarn workspace rocket-meals-dev test --watchAll=false` *(fails: Couldn't find the node_modules state file - running an install might help (findPackageLocation))*

------
https://chatgpt.com/codex/tasks/task_e_688e8e407cf0833080a3d899cf5173ce