### PR TITLE
feat(frontend): set rating text color to white

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -551,7 +551,7 @@ export default function FoodDetailsScreen() {
                         <Text
                           style={{
                             ...styles.totalRating,
-                            color: theme.screen.text,
+                            color: '#fff',
                           }}
                         >
                           {(foodDetails?.rating_average ||
@@ -674,7 +674,7 @@ export default function FoodDetailsScreen() {
                         <Text
                           style={{
                             ...styles.mobileTotalRating,
-                            color: theme.screen.text,
+                            color: '#fff',
                           }}
                         >
                           {(foodDetails?.rating_average ||


### PR DESCRIPTION
## Summary
- ensure food rating text overlays are white for readability

## Testing
- `yarn lint` (fails: Couldn't find a script named "eslint")
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688ea77d89e88330a39eb0876675421e