### PR TITLE
feat(frontend): share downloaded image on native

### DIFF
--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   Dimensions,
   Text,
+  Share,
 } from 'react-native';
 import { useLocalSearchParams, router, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -175,7 +176,14 @@ export default function ImageFullScreen() {
       } else {
         const filename = extension ? `${name}.${extension}` : name;
         const fileUri = FileSystem.documentDirectory + filename;
-        await FileSystem.downloadAsync(String(highResUri), fileUri);
+        const { uri } = await FileSystem.downloadAsync(
+          String(highResUri),
+          fileUri
+        );
+        await Share.share({
+          url: uri,
+          message: uri,
+        });
         toast('Image downloaded', 'success');
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- use React Native Share API after file download to make image saving work on native

## Testing
- `yarn --cwd apps/frontend/app lint` *(fails: project in apps/frontend/app not installed)*
- `CI=1 yarn --cwd apps/frontend/app test` *(fails: project in apps/frontend/app not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688f5b9ec2308330a950fce7085acd8b