### PR TITLE
refactor: move sorting helper to shared package

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -70,7 +70,7 @@ import { SET_CANTEENS, SET_SELECTED_CANTEEN, UPDATE_PRIVACY_POLICY_DATE } from '
 import { HashHelper } from '@/helper/hashHelper';
 import { CollectionKeys } from '@/constants/collectionKeys';
 import { RootState } from '@/redux/reducer';
-import { sortMarkingsByGroup, sortBySortField } from '@/helper/sortingHelper';
+import { sortMarkingsByGroup, sortBySortField } from 'repo-depkit-common';
 import { SET_NEWS } from '@/redux/Types/types';
 import { SET_CHATS } from '@/redux/Types/types';
 

--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -65,7 +65,7 @@ import {
   sortByPublicFavorite,
   sortByFoodCategory,
   sortByFoodOfferCategory,
-} from '@/helper/sortingHelper';
+} from 'repo-depkit-common';
 import { format, addDays } from 'date-fns';
 import { BusinessHoursHelper } from '@/redux/actions/BusinessHours/BusinessHours';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -73,7 +73,7 @@ import {
   sortByFoodCategory,
   sortByFoodOfferCategory,
   sortBySortField,
-} from '@/helper/sortingHelper';
+} from 'repo-depkit-common';
 import { format, addDays } from 'date-fns';
 import { BusinessHoursHelper } from '@/redux/actions/BusinessHours/BusinessHours';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';

--- a/apps/frontend/app/app/(monitor)/_layout.tsx
+++ b/apps/frontend/app/app/(monitor)/_layout.tsx
@@ -12,7 +12,7 @@ import { SET_APP_SETTINGS, UPDATE_MARKINGS } from '@/redux/Types/types';
 import { RootState } from '@/redux/reducer';
 import { ActivityIndicator, View } from 'react-native';
 import { AppSettingsHelper } from '@/redux/actions/AppSettings/AppSettings';
-import { sortMarkingsByGroup } from '@/helper/sortingHelper';
+import { sortMarkingsByGroup } from 'repo-depkit-common';
 
 export default function MonitorLayout() {
   const { theme } = useTheme();

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -43,7 +43,7 @@ import {
   sortByFoodName,
   sortByFoodOfferCategoryOnly,
   sortByFoodCategoryOnly,
-} from '@/helper/sortingHelper';
+} from 'repo-depkit-common';
 import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups';
 const index = () => {
   useSetPageTitle('list-day-screen');

--- a/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -33,7 +33,7 @@ import { UPDATE_MARKINGS } from '@/redux/Types/types';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
-import { sortMarkingsByGroup } from '@/helper/sortingHelper';
+import { sortMarkingsByGroup } from 'repo-depkit-common';
 
 const fontSize = 10;
 

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -25,7 +25,7 @@ import {
   sortByFoodOfferCategory, sortByFoodOfferCategoryOnly,
   sortByOwnFavorite,
   sortByPublicFavorite,
-} from '@/helper/sortingHelper';
+} from 'repo-depkit-common';
 import { FoodSortOption } from '@/constants/SortingEnums';
 import styles from './styles';
 import BaseBottomSheet from '@/components/BaseBottomSheet';

--- a/apps/frontend/app/components/Labels/index.tsx
+++ b/apps/frontend/app/components/Labels/index.tsx
@@ -12,7 +12,7 @@ import { createSelector } from 'reselect';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
-import { sortMarkingsByGroup } from '@/helper/sortingHelper';
+import { sortMarkingsByGroup } from 'repo-depkit-common';
 import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups';
 
 interface LabelsProps {

--- a/apps/frontend/app/components/SortSheet/SortSheet.tsx
+++ b/apps/frontend/app/components/SortSheet/SortSheet.tsx
@@ -24,7 +24,7 @@ import {
   sortByPublicFavorite,
   sortByFoodCategory,
   sortByFoodOfferCategory,
-} from '@/helper/sortingHelper';
+} from 'repo-depkit-common';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/colorHelper';
 import { TranslationKeys } from '@/locales/keys';

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -6,3 +6,4 @@ export * from "./src/databaseTypes/CollectionNames";
 export * from "./src/AppLinks";
 export * from "./src/GlobalParams";
 export * from "./src/DistanceHelper";
+export * from "./src/SortingHelper";

--- a/packages/common/src/__tests__/SortingHelper.test.ts
+++ b/packages/common/src/__tests__/SortingHelper.test.ts
@@ -1,0 +1,94 @@
+import {
+  sortByFoodName,
+  sortByFoodCategoryOnly,
+  sortByFoodOfferCategoryOnly,
+  sortByPublicFavorite,
+  sortByOwnFavorite,
+  sortByEatingHabits,
+  sortBySortField,
+} from 'repo-depkit-common';
+
+describe('SortingHelper', () => {
+  test('sortByFoodName sorts alphabetically', () => {
+    const offers: any = [
+      { food: { translations: [{ languages_code: 'en', name: 'Banana' }] } },
+      { food: { translations: [{ languages_code: 'en', name: 'Apple' }] } },
+    ];
+    const sorted = sortByFoodName(offers, 'en');
+    expect(sorted[0].food.translations[0].name).toBe('Apple');
+  });
+
+  test('sortByFoodCategoryOnly sorts by category sort value', () => {
+    const categories: any = [
+      { id: 'c1', sort: 2 },
+      { id: 'c2', sort: 1 },
+    ];
+    const offers: any = [
+      { food: { food_category: 'c1' } },
+      { food: { food_category: 'c2' } },
+    ];
+    const sorted = sortByFoodCategoryOnly(offers, categories);
+    expect((sorted[0].food as any).food_category).toBe('c2');
+  });
+
+  test('sortByFoodOfferCategoryOnly sorts by offer category', () => {
+    const categories: any = [
+      { id: 'o1', sort: 3 },
+      { id: 'o2', sort: 1 },
+    ];
+    const offers: any = [
+      { foodoffer_category: 'o1' },
+      { foodoffer_category: 'o2' },
+    ];
+    const sorted = sortByFoodOfferCategoryOnly(offers, categories);
+    expect(sorted[0].foodoffer_category).toBe('o2');
+  });
+
+  test('sortByPublicFavorite orders by rating average', () => {
+    const offers: any = [
+      { food: { rating_average: 4 } },
+      { food: { rating_average: null } },
+      { food: { rating_average: 2 } },
+    ];
+    const sorted = sortByPublicFavorite(offers);
+    expect(sorted.map((o: any) => o.food.rating_average)).toEqual([4, null, 2]);
+  });
+
+  test('sortByOwnFavorite orders by personal rating', () => {
+    const offers: any = [
+      { food: { id: 'f1' } },
+      { food: { id: 'f2' } },
+      { food: { id: 'f3' } },
+    ];
+    const feedbacks = [
+      { food: 'f1', rating: 5 },
+      { food: 'f2', rating: 1 },
+    ];
+    const sorted = sortByOwnFavorite(offers, feedbacks);
+    expect(sorted.map((o: any) => o.food.id)).toEqual(['f1', 'f3', 'f2']);
+  });
+
+  test('sortByEatingHabits orders liked, neutral, disliked', () => {
+    const offers: any = [
+      { id: '1', markings: [{ markings_id: 'm1' }] },
+      { id: '2', markings: [{ markings_id: 'm2' }] },
+      { id: '3', markings: [] },
+    ];
+    const profile = [
+      { markings_id: 'm1', like: true },
+      { markings_id: 'm2', like: false },
+    ];
+    const sorted = sortByEatingHabits(offers, profile);
+    expect(sorted.map((o: any) => o.id)).toEqual(['1', '3', '2']);
+  });
+
+  test('sortBySortField sorts numerically and keeps missing at end', () => {
+    const items = [
+      { id: 'a', sort: 3 },
+      { id: 'b', sort: 1 },
+      { id: 'c' },
+    ];
+    const sorted = sortBySortField(items);
+    expect(sorted.map((i) => i.id)).toEqual(['b', 'a', 'c']);
+  });
+});


### PR DESCRIPTION
## Summary
- move SortingHelper from frontend helper to shared repo-depkit-common package
- export new SortingHelper utilities from repo-depkit-common
- add comprehensive tests for sorting helper functions
- update frontend to import sorting helpers from repo-depkit-common

## Testing
- `npm test` (in packages/common)
- `npm test` *(fails: directus-extension-rocket-meals-bundle missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6890b3af805c83308fc8b9a1262d676c