### PR TITLE
feat: add manual food attribute sorting

### DIFF
--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -110,10 +110,30 @@ const Index = () => {
     }
   };
 
+  const sortAttributes = (attrs: FoodAttribute[]) => {
+    const manualSorted = attrs
+      .filter(
+        (attr) =>
+          attr.manualSort !== undefined &&
+          attr.manualSort !== null &&
+          attr.manualSort !== 0
+      )
+      .sort((a, b) => (a.manualSort ?? 0) - (b.manualSort ?? 0));
+    const autoSorted = attrs
+      .filter(
+        (attr) =>
+          attr.manualSort === undefined ||
+          attr.manualSort === null ||
+          attr.manualSort === 0
+      )
+      .sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
+    return [...manualSorted, ...autoSorted];
+  };
+
   useEffect(() => {
     if (initialFoodAttributes.length > 0) {
-      setFoodAttributes(
-        initialFoodAttributes.map((attr: any, index: number) => {
+      const mapped = initialFoodAttributes
+        .map((attr: any, index: number) => {
           const title = attr?.translations
             ? getFoodAttributesTranslation(attr?.translations, language)
             : '';
@@ -124,8 +144,8 @@ const Index = () => {
             manualSort: undefined,
             selected: attr.status === 'published' ? true : false,
           };
-        })
-      );
+        });
+      setFoodAttributes(sortAttributes(mapped));
     } else {
       getAllFoodAttributes();
     }
@@ -135,8 +155,10 @@ const Index = () => {
     const numericValue = Math.max(0, Math.min(99, parseInt(newValue) || 0));
 
     setFoodAttributes((prev: any) =>
-      prev.map((attr: any) =>
-        attr.id === id ? { ...attr, manualSort: numericValue } : attr
+      sortAttributes(
+        prev.map((attr: any) =>
+          attr.id === id ? { ...attr, manualSort: numericValue } : attr
+        )
       )
     );
   };

--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -47,6 +47,7 @@ import { FoodAttributesHelper } from '@/redux/actions/FoodAttributes/FoodAttribu
 type FoodAttribute = {
   id: string;
   sort: number;
+  manualSort?: number;
   selected: boolean;
   alias?: string;
 };
@@ -120,6 +121,7 @@ const Index = () => {
             id: attr?.id,
             alias: title ? title : attr?.alias,
             sort: attr.sort || index + 1,
+            manualSort: undefined,
             selected: attr.status === 'published' ? true : false,
           };
         })
@@ -129,12 +131,12 @@ const Index = () => {
     }
   }, [initialFoodAttributes]);
 
-  const handleSortChange = (id: string, newValue: string) => {
+  const handleManualSortChange = (id: string, newValue: string) => {
     const numericValue = Math.max(0, Math.min(99, parseInt(newValue) || 0));
 
     setFoodAttributes((prev: any) =>
       prev.map((attr: any) =>
-        attr.id === id ? { ...attr, sort: numericValue } : attr
+        attr.id === id ? { ...attr, manualSort: numericValue } : attr
       )
     );
   };
@@ -355,9 +357,14 @@ const Index = () => {
                   return (
                     <View style={styles.attributeContainer} key={attribute?.id}>
                       <TextInput
-                        value={attribute?.sort}
+                        value={
+                          attribute?.manualSort !== undefined &&
+                          attribute?.manualSort !== null
+                            ? String(attribute.manualSort)
+                            : ''
+                        }
                         onChangeText={(text) =>
-                          handleSortChange(attribute.id, text)
+                          handleManualSortChange(attribute.id, text)
                         }
                         keyboardType='numeric'
                         maxLength={2}
@@ -425,10 +432,36 @@ const Index = () => {
               //       .map(({ id, sort, alias }) => ({ id, sort, alias }))
               //   : [];
               // console.log('selectedAttributes', selectedAttributes);
-              const sortedIds = foodAttributes
-                ?.filter((attr) => attr.selected)
-                .sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0))
-                .map(({ id }) => id);
+              const selectedAttributes =
+                foodAttributes?.filter((attr) => attr.selected) || [];
+              const manualSorted = selectedAttributes
+                .filter(
+                  (attr) =>
+                    attr.manualSort !== undefined &&
+                    attr.manualSort !== null &&
+                    attr.manualSort !== 0
+                )
+                .sort(
+                  (a, b) => (a.manualSort ?? 0) - (b.manualSort ?? 0)
+                );
+              const autoSorted = selectedAttributes
+                .filter(
+                  (attr) =>
+                    attr.manualSort === undefined ||
+                    attr.manualSort === null ||
+                    attr.manualSort === 0
+                )
+                .sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
+              const sortedAttributes = [...manualSorted, ...autoSorted];
+              const formatted = sortedAttributes.map((attr) => ({
+                foodAttribute: {
+                  id: attr.id,
+                  ...(attr.manualSort
+                    ? { manualSort: attr.manualSort }
+                    : {}),
+                },
+              }));
+
               router.push({
                 pathname: '/list-day-screen',
                 params: {
@@ -439,8 +472,8 @@ const Index = () => {
                     ?.additionalSelectedCanteen?.id
                     ? foodPlan?.additionalSelectedCanteen?.id
                     : '',
-                  foodAttributesData: sortedIds
-                    ? JSON.stringify(sortedIds)
+                  foodAttributesData: formatted
+                    ? JSON.stringify(formatted)
                     : '',
                 },
               });

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -200,44 +200,56 @@ const index = () => {
             ? JSON.parse(foodAttributesData)
             : foodAttributesData;
 
-        const attributeIds: string[] = Array.isArray(parsedData)
+        const attributeItems: any[] = Array.isArray(parsedData)
           ? parsedData
           : [];
 
-        let attributeDataCopy: any[] = [];
-        if (
-          foodAttributesDict &&
-          Object?.keys(foodAttributesDict)?.length > 0
-        ) {
-          attributeDataCopy = attributeIds.map((id: string) => {
-            const attr = foodAttributesDict[id];
+        const attributeDataCopy = await Promise.all(
+          attributeItems.map(async (item: any) => {
+            const id = item?.foodAttribute?.id;
+            const manualSort = item?.foodAttribute?.manualSort;
+            if (!id) return null;
+
+            let attr = foodAttributesDict[id];
+            if (!attr) {
+              attr = (await foodAttributesHelper.fetchFoodAttributeById(
+                id
+              )) as DatabaseTypes.FoodsAttributes;
+            }
             const title = attr?.translations
               ? getFoodAttributesTranslation(attr.translations, language)
               : '';
             return {
               id: id,
               alias: title || attr?.alias || '-',
+              sort: attr?.sort || 0,
+              manualSort: manualSort !== undefined ? Number(manualSort) : undefined,
             };
-          });
-        } else {
-          attributeDataCopy = await Promise.all(
-            attributeIds.map(async (id: string) => {
-              const attr = (await foodAttributesHelper.fetchFoodAttributeById(
-                id
-              )) as DatabaseTypes.FoodsAttributes;
-              const title = attr?.translations
-                ? getFoodAttributesTranslation(attr.translations, language)
-                : '';
-              return {
-                id: id,
-                alias: title || attr?.alias || '-',
-              };
-            })
-          );
-        }
+          })
+        );
 
-        setFoodAttributesDataFull(attributeDataCopy);
-        const aliases = attributeDataCopy.map((attr) => attr.alias);
+        const filteredData = attributeDataCopy.filter(Boolean) as any[];
+
+        const manualSorted = filteredData
+          .filter(
+            (attr) =>
+              attr.manualSort !== undefined &&
+              attr.manualSort !== null &&
+              attr.manualSort !== 0
+          )
+          .sort((a, b) => (a.manualSort ?? 0) - (b.manualSort ?? 0));
+        const autoSorted = filteredData
+          .filter(
+            (attr) =>
+              attr.manualSort === undefined ||
+              attr.manualSort === null ||
+              attr.manualSort === 0
+          )
+          .sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
+        const ordered = [...manualSorted, ...autoSorted];
+
+        setFoodAttributesDataFull(ordered);
+        const aliases = ordered.map((attr) => attr.alias);
         setFoodAttributesColumn(aliases);
       } catch (error) {
         console.error('Error processing food attributes:', error);

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -362,18 +362,23 @@ const index = () => {
         // Initialize array with placeholders for all possible attributes
         const sortedValues = foodAttributesDataFull.map(() => null);
 
-        // Fill in the actual values where they exist
-        if (offer.attribute_values) {
-          offer.attribute_values.forEach((attrValue: any) => {
-            const rawAttr = attrValue.food_attribute;
-            const attrId =
-              typeof rawAttr === 'object' ? rawAttr?.id : rawAttr;
-            if (attrId && attributeSortMap[attrId]) {
-              const position = attributeSortMap[attrId].index;
-              sortedValues[position] = attrValue;
-            }
-          });
-        }
+        const combinedValues = [
+          ...(offer?.food?.attribute_values || []),
+          ...(offer?.attribute_values || []),
+        ];
+
+        combinedValues.forEach((attrValue: any) => {
+          const rawAttr = attrValue.food_attribute;
+          const attrId =
+            typeof rawAttr === 'object' ? rawAttr?.id : rawAttr;
+          if (attrId && attributeSortMap[attrId]) {
+            const position = attributeSortMap[attrId].index;
+            const merged = attrValue.attribute_value
+              ? { ...attrValue, ...attrValue.attribute_value }
+              : attrValue;
+            sortedValues[position] = merged;
+          }
+        });
 
         result[offer.id] = sortedValues;
       });

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -348,24 +348,19 @@ const index = () => {
     if (!foodOffers || !foodAttributesDataFull) return {};
     try {
       // Create a map for quick lookup of sort order by attribute id
-      const attributeSortMap: Record<string, { index: number; alias: string }> =
-        {};
+      const attributeSortMap: Record<string, { index: number }> = {};
       foodAttributesDataFull?.forEach((attr, index: number) => {
-        attributeSortMap[attr.id] = { index, alias: attr.alias };
+        attributeSortMap[attr.id] = { index };
       });
 
       // Process each food offer
-      const result: Record<string, Array<{ value: any; alias: string }>> = {};
+      const result: Record<string, Array<any>> = {};
 
       foodOffers.forEach((offer: any) => {
         if (!offer.id) return;
 
-        // Initialize array with empty values for all possible attributes
-        const sortedValues = foodAttributesDataFull.map((attr) => ({
-          value: null, // or '-' if you prefer
-          alias: attr.alias,
-          exists: false,
-        }));
+        // Initialize array with placeholders for all possible attributes
+        const sortedValues = foodAttributesDataFull.map(() => null);
 
         // Fill in the actual values where they exist
         if (offer.attribute_values) {
@@ -373,11 +368,7 @@ const index = () => {
             const attrId = attrValue.food_attribute?.id;
             if (attributeSortMap[attrId]) {
               const position = attributeSortMap[attrId].index;
-              sortedValues[position] = {
-                value: attrValue, // or extract specific value if needed
-                alias: attributeSortMap[attrId].alias,
-                exists: true,
-              };
+              sortedValues[position] = attrValue;
             }
           });
         }
@@ -393,7 +384,7 @@ const index = () => {
   };
 
   const formatAttributeValue = (attr: any) => {
-    if (!attr?.value) return '-';
+    if (!attr) return '-';
     const {
       number_value,
       string_value,
@@ -403,7 +394,7 @@ const index = () => {
       color_value,
       icon_value,
       food_attribute,
-    } = attr.value;
+    } = attr;
 
     const rawValue =
       string_value ??

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -365,8 +365,10 @@ const index = () => {
         // Fill in the actual values where they exist
         if (offer.attribute_values) {
           offer.attribute_values.forEach((attrValue: any) => {
-            const attrId = attrValue.food_attribute?.id;
-            if (attributeSortMap[attrId]) {
+            const rawAttr = attrValue.food_attribute;
+            const attrId =
+              typeof rawAttr === 'object' ? rawAttr?.id : rawAttr;
+            if (attrId && attributeSortMap[attrId]) {
               const position = attributeSortMap[attrId].index;
               sortedValues[position] = attrValue;
             }

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -392,6 +392,42 @@ const index = () => {
     }
   };
 
+  const formatAttributeValue = (attr: any) => {
+    if (!attr?.value) return '-';
+    const {
+      number_value,
+      string_value,
+      date_value,
+      time_value,
+      boolean_value,
+      color_value,
+      icon_value,
+      food_attribute,
+    } = attr.value;
+
+    const rawValue =
+      string_value ??
+      number_value ??
+      date_value ??
+      time_value ??
+      color_value ??
+      icon_value ??
+      (boolean_value !== undefined && boolean_value !== null
+        ? boolean_value
+        : null);
+
+    if (rawValue === null || rawValue === undefined || rawValue === '') {
+      return '-';
+    }
+
+    const { prefix, suffix } = food_attribute || {};
+    let formatted = '';
+    if (prefix) formatted += `${prefix} `;
+    formatted += rawValue;
+    if (suffix) formatted += ` ${suffix}`;
+    return formatted.trim();
+  };
+
   useFocusEffect(
     useCallback(() => {
       if (foods) {
@@ -876,15 +912,16 @@ const index = () => {
                             })}
                         </View>
                         {foodAttributes[item?.id] &&
-                          foodAttributes[item?.id]?.map((attr: any) => {
-                            const attributeColumnWidth = (
-                              Number(columnPercentages.attributes) /
-                              foodAttributes[item?.id].length
-                            ).toFixed(2);
-                            if (!attr?.value) {
+                          foodAttributes[item?.id]?.map(
+                            (attr: any, idx: number) => {
+                              const attributeColumnWidth = (
+                                Number(columnPercentages.attributes) /
+                                foodAttributes[item?.id].length
+                              ).toFixed(2);
+                              const value = formatAttributeValue(attr);
                               return (
                                 <Text
-                                  key={`${item.id}`}
+                                  key={`${item.id}-${idx}`}
                                   style={[
                                     styles.cell,
                                     {
@@ -893,55 +930,11 @@ const index = () => {
                                     },
                                   ]}
                                 >
-                                  -
+                                  {value}
                                 </Text>
                               );
                             }
-
-                            const { number_value } = attr.value;
-                            const { prefix, suffix } =
-                              attr?.value?.food_attribute || {};
-
-                            if (
-                              number_value === undefined ||
-                              number_value === null
-                            ) {
-                              return (
-                                <Text
-                                  key={`${item.id}`}
-                                  style={[
-                                    styles.cell,
-                                    {
-                                      width: (attributeColumnWidth +
-                                        '%') as DimensionValue,
-                                    },
-                                  ]}
-                                >
-                                  -
-                                </Text>
-                              );
-                            }
-
-                            let value = '';
-                            if (prefix) value += `${prefix} `;
-                            value += number_value;
-                            if (suffix) value += ` ${suffix}`;
-
-                            return (
-                              <Text
-                                key={`${item.id}`}
-                                style={[
-                                  styles.cell,
-                                  {
-                                    width: (attributeColumnWidth +
-                                      '%') as DimensionValue,
-                                  },
-                                ]}
-                              >
-                                {value.trim()}
-                              </Text>
-                            );
-                          })}
+                          )}
                         <Text
                           style={[
                             styles.cell,
@@ -1058,15 +1051,16 @@ const index = () => {
                           })}
                       </View>
                       {optionalFoodAttributes[item?.id] &&
-                        optionalFoodAttributes[item?.id]?.map((attr: any) => {
-                          const attributeColumnWidth = (
-                            Number(columnPercentages.attributes) /
-                            optionalFoodAttributes[item?.id].length
-                          ).toFixed(2);
-                          if (!attr?.value) {
+                        optionalFoodAttributes[item?.id]?.map(
+                          (attr: any, idx: number) => {
+                            const attributeColumnWidth = (
+                              Number(columnPercentages.attributes) /
+                              optionalFoodAttributes[item?.id].length
+                            ).toFixed(2);
+                            const value = formatAttributeValue(attr);
                             return (
                               <Text
-                                key={`${item.id}`}
+                                key={`${item.id}-${idx}`}
                                 style={[
                                   styles.cell,
                                   {
@@ -1075,55 +1069,11 @@ const index = () => {
                                   },
                                 ]}
                               >
-                                -
+                                {value}
                               </Text>
                             );
                           }
-
-                          const { number_value } = attr?.value;
-                          const { prefix, suffix } =
-                            attr?.value?.food_attribute || {};
-
-                          if (
-                            number_value === undefined ||
-                            number_value === null
-                          ) {
-                            return (
-                              <Text
-                                key={`${item.id}`}
-                                style={[
-                                  styles.cell,
-                                  {
-                                    width: (attributeColumnWidth +
-                                      '%') as DimensionValue,
-                                  },
-                                ]}
-                              >
-                                -
-                              </Text>
-                            );
-                          }
-
-                          let value = '';
-                          if (prefix) value += `${prefix} `;
-                          value += number_value;
-                          if (suffix) value += ` ${suffix}`;
-
-                          return (
-                            <Text
-                              key={`${item.id}`}
-                              style={[
-                                styles.cell,
-                                {
-                                  width: (attributeColumnWidth +
-                                    '%') as DimensionValue,
-                                },
-                              ]}
-                            >
-                              {value.trim()}
-                            </Text>
-                          );
-                        })}
+                        )}
 
                       <Text
                         style={[

--- a/apps/frontend/app/redux/actions/FoodOffers/FoodOffers.ts
+++ b/apps/frontend/app/redux/actions/FoodOffers/FoodOffers.ts
@@ -120,7 +120,7 @@ export const fetchFoodsByCanteen = async (
     const response = await axios.get('/items/foodoffers', {
       params: {
         fields:
-          '*,food.*,!food.feedbacks,food.translations.*,markings.*, attribute_values.*, attribute_values.food_attribute.*,attribute_values.food_attribute.group.*, attribute_values.food_attribute.translations.*, foods_attributes_values.*', // Exclude food.feedbacks field as per the API call
+          '*,food.*,!food.feedbacks,food.translations.*,markings.*, attribute_values.*, attribute_values.food_attribute.*,attribute_values.food_attribute.group.*, attribute_values.food_attribute.translations.*, food.attribute_values.*, food.attribute_values.food_attribute.*, food.attribute_values.food_attribute.group.*, food.attribute_values.food_attribute.translations.*, foods_attributes_values.*', // Exclude food.feedbacks field as per the API call
         limit: -1, // Fetch all results
         filter: { _and: baseFilter },
       },


### PR DESCRIPTION
## Summary
- allow optional manual sorting of food attributes in food plan setup
- sort day list attributes by manual sort then server order

## Testing
- `npx jest apps/frontend/app --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6891ca8f3d7c8330b9b7e33c83fe2b10