### PR TITLE
feat(frontend): add game ideas screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/game-ideas/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/game-ideas/index.tsx
@@ -1,0 +1,208 @@
+import React, { useMemo, useState } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { TranslationKeys } from '@/locales/keys';
+import styles from './styles';
+
+interface Dish {
+  name: string;
+  rating: number;
+  price: number;
+}
+
+interface Marking {
+  name: string;
+  dislikes: number;
+}
+
+interface Card {
+  value: string;
+  revealed: boolean;
+  matched: boolean;
+}
+
+const dishes: Dish[] = [
+  { name: 'Pasta', rating: 4.5, price: 3.5 },
+  { name: 'Burger', rating: 4.1, price: 4.9 },
+  { name: 'Salad', rating: 3.8, price: 2.8 },
+  { name: 'Sushi', rating: 4.7, price: 5.5 },
+  { name: 'Pizza', rating: 4.3, price: 4.2 },
+  { name: 'Soup', rating: 3.9, price: 2.5 },
+];
+
+const markings: Marking[] = [
+  { name: 'Too Spicy', dislikes: 80 },
+  { name: 'Too Salty', dislikes: 60 },
+  { name: 'Too Sweet', dislikes: 40 },
+];
+
+const foodIcons = ['🍔', '🍕', '🍣', '🥗', '🍰', '🍟', '🌮', '🍜', '🍩', '🍇', '🍤', '🥐'];
+
+const getRandomPair = (): [Dish, Dish] => {
+  const shuffled = [...dishes].sort(() => Math.random() - 0.5);
+  return [shuffled[0], shuffled[1]];
+};
+
+const generateMemoryBoard = (): (Card | null)[] => {
+  const doubled = [...foodIcons, ...foodIcons];
+  const board: (Card | null)[] = doubled.map((v) => ({ value: v, revealed: false, matched: false }));
+  board.splice(Math.floor(Math.random() * (board.length + 1)), 0, null);
+  return board.sort(() => Math.random() - 0.5);
+};
+
+const GameIdeas = () => {
+  const { theme } = useTheme();
+  const { translate } = useLanguage();
+  useSetPageTitle(TranslationKeys.game_ideas);
+
+  const [ratingPair, setRatingPair] = useState<[Dish, Dish]>(getRandomPair());
+  const [ratingResult, setRatingResult] = useState<string>('');
+
+  const [pricePair, setPricePair] = useState<[Dish, Dish]>(getRandomPair());
+  const [priceResult, setPriceResult] = useState<string>('');
+
+  const [markingResult, setMarkingResult] = useState<string>('');
+
+  const [board, setBoard] = useState<(Card | null)[]>(generateMemoryBoard());
+  const [selected, setSelected] = useState<number[]>([]);
+
+  const mostDisliked = useMemo(
+    () => markings.reduce((a, b) => (a.dislikes > b.dislikes ? a : b)),
+    []
+  );
+
+  const handleRatingGuess = (dish: Dish) => {
+    const other = ratingPair.find((d) => d.name !== dish.name)!;
+    setRatingResult(dish.rating >= other.rating ? '✔' : '✖');
+    setRatingPair(getRandomPair());
+  };
+
+  const handlePriceGuess = (dish: Dish) => {
+    const other = pricePair.find((d) => d.name !== dish.name)!;
+    setPriceResult(dish.price >= other.price ? '✔' : '✖');
+    setPricePair(getRandomPair());
+  };
+
+  const handleMarkingGuess = (marking: Marking) => {
+    setMarkingResult(marking.name === mostDisliked.name ? '✔' : '✖');
+  };
+
+  const handleCardPress = (index: number) => {
+    const card = board[index];
+    if (!card || card.revealed || card.matched) return;
+    const newBoard = [...board];
+    newBoard[index] = { ...card, revealed: true };
+    const newSelected = [...selected, index];
+    setBoard(newBoard);
+    if (newSelected.length === 2) {
+      const [first, second] = newSelected;
+      if (newBoard[first]?.value === newBoard[second]?.value) {
+        newBoard[first]!.matched = true;
+        newBoard[second]!.matched = true;
+        setBoard(newBoard);
+      } else {
+        setTimeout(() => {
+          const hidden = [...newBoard];
+          hidden[first] = { ...hidden[first]!, revealed: false };
+          hidden[second] = { ...hidden[second]!, revealed: false };
+          setBoard(hidden);
+        }, 800);
+      }
+      setSelected([]);
+    } else {
+      setSelected(newSelected);
+    }
+  };
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: theme.screen.background }}
+      contentContainerStyle={styles.container}
+    >
+      <Text style={{ ...styles.heading, color: theme.screen.text }}>
+        {translate(TranslationKeys.game_ideas)}
+      </Text>
+
+      <Text style={{ ...styles.subheading, color: theme.screen.text }}>
+        {translate(TranslationKeys.guess_better_rated_dish)}
+      </Text>
+      <View style={styles.row}>
+        {ratingPair.map((dish) => (
+          <TouchableOpacity
+            key={dish.name}
+            style={{ ...styles.button, backgroundColor: theme.screen.iconBg }}
+            onPress={() => handleRatingGuess(dish)}
+          >
+            <Text style={{ color: theme.screen.text }}>{dish.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {ratingResult !== '' && (
+        <Text style={{ ...styles.result, color: theme.screen.text }}>{ratingResult}</Text>
+      )}
+
+      <Text style={{ ...styles.subheading, color: theme.screen.text }}>
+        {translate(TranslationKeys.guess_most_disliked_marking)}
+      </Text>
+      <View style={styles.row}>
+        {markings.map((m) => (
+          <TouchableOpacity
+            key={m.name}
+            style={{ ...styles.button, backgroundColor: theme.screen.iconBg }}
+            onPress={() => handleMarkingGuess(m)}
+          >
+            <Text style={{ color: theme.screen.text }}>{m.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {markingResult !== '' && (
+        <Text style={{ ...styles.result, color: theme.screen.text }}>{markingResult}</Text>
+      )}
+
+      <Text style={{ ...styles.subheading, color: theme.screen.text }}>
+        {translate(TranslationKeys.food_memory_game)}
+      </Text>
+      <View style={styles.memoryContainer}>
+        {board.map((card, idx) =>
+          card ? (
+            <TouchableOpacity
+              key={idx}
+              style={{ ...styles.memoryCard, backgroundColor: theme.screen.iconBg }}
+              onPress={() => handleCardPress(idx)}
+            >
+              <Text style={{ color: theme.screen.text, fontSize: 24 }}>
+                {card.revealed || card.matched ? card.value : '?'}
+              </Text>
+            </TouchableOpacity>
+          ) : (
+            <View key={idx} style={styles.memoryCard} />
+          )
+        )}
+      </View>
+
+      <Text style={{ ...styles.subheading, color: theme.screen.text }}>
+        {translate(TranslationKeys.guess_more_expensive_dish)}
+      </Text>
+      <View style={styles.row}>
+        {pricePair.map((dish) => (
+          <TouchableOpacity
+            key={dish.name}
+            style={{ ...styles.button, backgroundColor: theme.screen.iconBg }}
+            onPress={() => handlePriceGuess(dish)}
+          >
+            <Text style={{ color: theme.screen.text }}>{dish.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {priceResult !== '' && (
+        <Text style={{ ...styles.result, color: theme.screen.text }}>{priceResult}</Text>
+      )}
+    </ScrollView>
+  );
+};
+
+export default GameIdeas;
+
+

--- a/apps/frontend/app/app/(app)/experimentell/game-ideas/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/game-ideas/styles.ts
@@ -1,0 +1,48 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    padding: 20,
+    gap: 10,
+  },
+  heading: {
+    fontSize: 24,
+    fontFamily: 'Poppins_700Bold',
+    marginVertical: 10,
+  },
+  subheading: {
+    fontSize: 18,
+    fontFamily: 'Poppins_600SemiBold',
+    marginVertical: 10,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginBottom: 10,
+  },
+  button: {
+    padding: 10,
+    borderRadius: 10,
+    minWidth: 120,
+    alignItems: 'center',
+  },
+  result: {
+    fontSize: 20,
+    textAlign: 'center',
+  },
+  memoryContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginBottom: 10,
+  },
+  memoryCard: {
+    width: '19%',
+    aspectRatio: 1,
+    margin: '0.5%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 8,
+  },
+});
+

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -188,6 +188,18 @@ const index = () => {
           </View>
           <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
         </TouchableOpacity>
+        <TouchableOpacity
+          style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+          onPress={() => router.push('/experimentell/game-ideas')}
+        >
+          <View style={styles.col}>
+            <MaterialCommunityIcons name='gamepad-variant' color={theme.screen.icon} size={24} />
+            <Text style={{ ...styles.body, color: theme.screen.text }}>
+              {translate(TranslationKeys.game_ideas)}
+            </Text>
+          </View>
+          <Entypo name='chevron-small-right' color={theme.screen.icon} size={24} />
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -388,6 +388,11 @@ export enum TranslationKeys {
   group_app_settings = 'group_app_settings',
   pull_down_to_close = 'pull_down_to_close',
   group_app_management = 'group_app_management',
+  game_ideas = 'game_ideas',
+  guess_better_rated_dish = 'guess_better_rated_dish',
+  guess_most_disliked_marking = 'guess_most_disliked_marking',
+  food_memory_game = 'food_memory_game',
+  guess_more_expensive_dish = 'guess_more_expensive_dish',
   // NOT IN TRANSLATION
   feedback_and_support = 'Feedback & Support',
   Food_Plan_Week = 'FoodPlan:Week',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3883,4 +3883,55 @@
     "tr": "Uygulama yönetimi",
     "zh": "应用管理"
   }
+  ,
+  "game_ideas": {
+    "de": "Spielideen",
+    "en": "Game Ideas",
+    "ar": "Game Ideas",
+    "es": "Game Ideas",
+    "fr": "Game Ideas",
+    "ru": "Game Ideas",
+    "tr": "Game Ideas",
+    "zh": "Game Ideas"
+  },
+  "guess_better_rated_dish": {
+    "de": "Rate, welches Gericht besser bewertet ist",
+    "en": "Guess which dish is better rated",
+    "ar": "Guess which dish is better rated",
+    "es": "Adivina qué plato está mejor valorado",
+    "fr": "Devine quel plat est mieux noté",
+    "ru": "Угадай, какое блюдо оценено выше",
+    "tr": "Hangi yemeğin daha iyi değerlendirildiğini tahmin et",
+    "zh": "猜哪个菜评价更好"
+  },
+  "guess_most_disliked_marking": {
+    "de": "Rate, welches Kennzeichen am häufigsten abgelehnt wird",
+    "en": "Guess which marking is most disliked",
+    "ar": "Guess which marking is most disliked",
+    "es": "Adivina qué marcado es más rechazado",
+    "fr": "Devine quel marquage est le plus détesté",
+    "ru": "Угадай, какая маркировка не нравится чаще всего",
+    "tr": "Hangi işaretlemenin en çok beğenilmediğini tahmin et",
+    "zh": "猜哪种标记最不受喜欢"
+  },
+  "food_memory_game": {
+    "de": "Memory-Spiel mit Speisen (5x5)",
+    "en": "Food memory game (5x5)",
+    "ar": "Food memory game (5x5)",
+    "es": "Juego de memoria de comida (5x5)",
+    "fr": "Jeu de mémoire alimentaire (5x5)",
+    "ru": "Игра на память о еде (5x5)",
+    "tr": "Yemek hafıza oyunu (5x5)",
+    "zh": "食物记忆游戏 (5x5)"
+  },
+  "guess_more_expensive_dish": {
+    "de": "Rate, welches Gericht teurer ist",
+    "en": "Guess which dish is more expensive",
+    "ar": "Guess which dish is more expensive",
+    "es": "Adivina qué plato es más caro",
+    "fr": "Devine quel plat est plus cher",
+    "ru": "Угадай, какое блюдо дороже",
+    "tr": "Hangi yemeğin daha pahalı olduğunu tahmin et",
+    "zh": "猜哪个菜更贵"
+  }
 }


### PR DESCRIPTION
## Summary
- add experimental Game Ideas screen with rating, marking, memory and price mini-games
- hook experimental menu to new screen
- localize labels for new games

## Testing
- `yarn lint` *(fails: Couldn't find a script named "eslint")*


------
https://chatgpt.com/codex/tasks/task_e_6893faaea4788330bc9efeece678a9e9