### PR TITLE
fix: enable dynamic imports

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/tsconfig.json
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"target": "ES2019",
 		"lib": ["ES2019", "DOM"],
-		"moduleResolution": "node",
+                "module": "ESNext",
+                "moduleResolution": "node",
 		"strict": true,
 		"noFallthroughCasesInSwitch": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
## Summary
- enable ESNext modules in Directus extension tsconfig to allow dynamic imports

## Testing
- `npx -y yarn@1 workspace directus-extension-rocket-meals-bundle test` *(fails: ENETUNREACH; Cannot use import statement outside a module; Failed to generate PDF)*

------
https://chatgpt.com/codex/tasks/task_e_6897c85a3c608330afbc091f000af25d