### PR TITLE
test: initialize memory db with static imports

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json
@@ -12,15 +12,22 @@
 	"files": [
 		"dist"
 	],
-	"jest": {
-		"testEnvironment": "jest-environment-node",
-		"transform": {
-			"^.+\\.ts$": [
-				"ts-jest"
-			]
-		},
-		"testTimeout": 20000
-	},
+       "jest": {
+               "testEnvironment": "jest-environment-node",
+               "extensionsToTreatAsEsm": [".ts"],
+               "moduleNameMapper": {
+                       "^(\\.{1,2}/.*)\\.js$": "$1"
+               },
+               "transform": {
+                       "^.+\\.ts$": [
+                               "ts-jest",
+                               {
+                                       "useESM": true
+                               }
+                       ]
+               },
+               "testTimeout": 20000
+       },
 	"directus:extension": {
 		"type": "bundle",
 		"path": {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/TestUserMemory.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/TestUserMemory.ts
@@ -1,22 +1,26 @@
-import { beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import getDatabase from '@directus/api/database/index';
+import install from '@directus/api/database/seeds/run';
+import migrate from '@directus/api/database/migrations/run';
+import { getSchema } from '@directus/api/utils/get-schema';
+import { ItemsService } from '@directus/api/services/items';
 
 let usersService: any;
+let db: any;
 
 beforeAll(async () => {
   process.env.DB_CLIENT = 'sqlite3';
   process.env.DB_FILENAME = ':memory:';
 
-  const { default: getDatabase } = await import('@directus/api/database/index');
-  const { default: install } = await import('@directus/api/database/seeds/run');
-  const { default: migrate } = await import('@directus/api/database/migrations/run');
-  const { getSchema } = await import('@directus/api/utils/get-schema');
-  const { ItemsService } = await import('@directus/api/services/items');
-
-  const db = getDatabase();
+  db = getDatabase();
   await install(db);
   await migrate(db);
   const schema = await getSchema({ database: db });
   usersService = new ItemsService('directus_users', { schema, knex: db });
+});
+
+afterAll(async () => {
+  await db.destroy();
 });
 
 describe('in-memory database with ItemService', () => {


### PR DESCRIPTION
## Summary
- use static imports to set up an in-memory Directus database for user service tests
- close the database after tests to release resources
- configure Jest to treat TypeScript as ESM and map `.js` extensions for Directus modules

## Testing
- `DB_CLIENT=sqlite3 DB_FILENAME=':memory:' node --experimental-vm-modules node_modules/jest/bin/jest.js apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/TestUserMemory.ts --config apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json` *(fails: SQLITE_ERROR: no such column: accountability)*

------
https://chatgpt.com/codex/tasks/task_e_689832f095e4833099db83b7c8942cbc