### PR TITLE
Fix in-memory Directus test setup

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/TestUserMemory.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/TestUserMemory.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
 
   db = getDatabase();
   await install(db);
-  await migrate(db);
+  await migrate(db, 'latest');
   const schema = await getSchema({ database: db });
   usersService = new ItemsService('directus_users', { schema, knex: db });
 });


### PR DESCRIPTION
## Summary
- run Directus migrations in tests to set up schema

## Testing
- `DB_CLIENT=sqlite3 DB_FILENAME=':memory:' node --experimental-vm-modules node_modules/jest/bin/jest.js apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/TestUserMemory.ts --config apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json`

------
https://chatgpt.com/codex/tasks/task_e_68983bb828a483309fa63660e049cdc2