### PR TITLE
fix(frontend): make LeafletView map fill screen

### DIFF
--- a/apps/frontend/app/app/(app)/leaflet-view/index.tsx
+++ b/apps/frontend/app/app/(app)/leaflet-view/index.tsx
@@ -43,7 +43,7 @@ const LeafletViewScreen = () => {
   return (
     <View style={styles.container}>
       <LeafletView
-        style={styles.map}
+        webviewStyle={styles.map}
         mapCenterPosition={CENTER}
         zoom={13}
         source={{ html }}


### PR DESCRIPTION
## Summary
- ensure LeafletView uses `webviewStyle` so the embedded map fills the screen

## Testing
- `npm test` *(fails: directus-extension-rocket-meals-bundle@workspace: This package doesn't seem to be present in your lockfile)*
- `CI=true yarn workspace rocket-meals-dev test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6899281bca308330b8e31138524dc8a6