### PR TITLE
feat(common): move price sorting and enums to shared module

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -16,7 +16,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { CampusSortOption } from '@/constants/SortingEnums';
+import { CampusSortOption } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';

--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -13,7 +13,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { FoodSortOption } from '@/constants/SortingEnums';
+import { FoodSortOption } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import {
@@ -57,15 +57,7 @@ import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagem
 import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import * as Notifications from 'expo-notifications';
-import {
-  intelligentSort,
-  sortByEatingHabits,
-  sortByFoodName,
-  sortByOwnFavorite,
-  sortByPublicFavorite,
-  sortByFoodCategory,
-  sortByFoodOfferCategory,
-} from 'repo-depkit-common';
+import { sortFoodOffers } from '@/helper/foodOfferSortHelper';
 import { format, addDays } from 'date-fns';
 import { BusinessHoursHelper } from '@/redux/actions/BusinessHours/BusinessHours';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';
@@ -362,62 +354,21 @@ const index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
     return format(day, 'dd.MM.yyyy'); // Return the date if it's not Today, Yesterday, or Tomorrow
   };
 
-  const updateSort = (id: FoodSortOption, foodOffers: DatabaseTypes.Foodoffers[]) => {
-    // Copy food offers to avoid mutation
-    let copiedFoodOffers = [...foodOffers];
+  const updateSort = (
+    id: FoodSortOption,
+    foodOffers: DatabaseTypes.Foodoffers[]
+  ) => {
+    const sortedOffers = sortFoodOffers(id, foodOffers, {
+      languageCode,
+      ownFoodFeedbacks,
+      profile,
+      foodCategories,
+      foodOfferCategories,
+    });
 
-    // Sorting logic based on option id
-    switch (id) {
-      case FoodSortOption.ALPHABETICAL:
-        copiedFoodOffers = sortByFoodName(copiedFoodOffers, languageCode);
-        break;
-      case FoodSortOption.FAVORITE:
-        copiedFoodOffers = sortByOwnFavorite(
-          copiedFoodOffers,
-          ownFoodFeedbacks
-        );
-        break;
-      case FoodSortOption.EATING:
-        copiedFoodOffers = sortByEatingHabits(
-          copiedFoodOffers,
-          profile.markings
-        );
-        break;
-      case FoodSortOption.FOOD_CATEGORY:
-        copiedFoodOffers = sortByFoodCategory(
-          copiedFoodOffers,
-          foodCategories,
-            languageCode
-        );
-        break;
-      case FoodSortOption.FOODOFFER_CATEGORY:
-        copiedFoodOffers = sortByFoodOfferCategory(
-          copiedFoodOffers,
-          foodOfferCategories
-        );
-        break;
-      case FoodSortOption.RATING:
-        copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
-        break;
-      case FoodSortOption.INTELLIGENT:
-        copiedFoodOffers = intelligentSort(
-          copiedFoodOffers,
-          ownFoodFeedbacks,
-          profile.markings,
-          languageCode,
-          foodCategories,
-          foodOfferCategories
-        );
-        break;
-      default:
-        console.warn('Unknown sorting option:', id);
-        break;
-    }
-
-    // Dispatch updated food offers and close the sheet
     dispatch({
       type: SET_SELECTED_CANTEEN_FOOD_OFFERS,
-      payload: copiedFoodOffers,
+      payload: sortedOffers,
     });
   };
 

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -16,7 +16,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ApartmentSortOption } from '@/constants/SortingEnums';
+import { ApartmentSortOption } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';

--- a/apps/frontend/app/components/BuildingSortSheet/BuildingSortSheet.tsx
+++ b/apps/frontend/app/components/BuildingSortSheet/BuildingSortSheet.tsx
@@ -19,7 +19,7 @@ import {
   CampusSortOption,
   ApartmentSortOption,
   BuildingSortOption,
-} from '@/constants/SortingEnums';
+} from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/colorHelper';

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -17,16 +17,8 @@ import FoodItem from '@/components/FoodItem/FoodItem';
 import CanteenFeedbackLabels from '@/components/CanteenFeedbackLabels/CanteenFeedbackLabels';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
-import {
-  intelligentSort,
-  sortByEatingHabits,
-  sortByFoodCategory,
-  sortByFoodName,
-  sortByFoodOfferCategory, sortByFoodOfferCategoryOnly,
-  sortByOwnFavorite,
-  sortByPublicFavorite,
-} from 'repo-depkit-common';
-import { FoodSortOption } from '@/constants/SortingEnums';
+import { sortFoodOffers } from '@/helper/foodOfferSortHelper';
+import { FoodSortOption } from 'repo-depkit-common';
 import styles from './styles';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
@@ -117,53 +109,23 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({
       : null;
 
   const sortOffers = useCallback(
-    (foodOffers: DatabaseTypes.Foodoffers[]) => {
-      let copiedFoodOffers = [...foodOffers];
-      console.log('sortOffers - initial', JSON.parse(JSON.stringify(copiedFoodOffers)));
-
-      switch (sortBy as FoodSortOption) {
-        case FoodSortOption.ALPHABETICAL:
-          copiedFoodOffers = sortByFoodName(copiedFoodOffers, language);
-          console.log('sortOffers - after sortByFoodName', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        case FoodSortOption.FAVORITE:
-          copiedFoodOffers = sortByOwnFavorite(copiedFoodOffers, ownFoodFeedbacks);
-          console.log('sortOffers - after sortByOwnFavorite', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        case FoodSortOption.EATING:
-          copiedFoodOffers = sortByEatingHabits(copiedFoodOffers, profile.markings);
-          console.log('sortOffers - after sortByEatingHabits', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        case FoodSortOption.FOOD_CATEGORY:
-          copiedFoodOffers = sortByFoodCategory(copiedFoodOffers, foodCategories, language);
-          console.log('sortOffers - after sortByFoodCategory', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        case FoodSortOption.FOODOFFER_CATEGORY:
-          copiedFoodOffers = sortByFoodOfferCategoryOnly(copiedFoodOffers, foodOfferCategories);
-          console.log('sortOffers - after sortByFoodOfferCategory', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        case FoodSortOption.RATING:
-          copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
-          console.log('sortOffers - after sortByPublicFavorite', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        case FoodSortOption.INTELLIGENT:
-          copiedFoodOffers = intelligentSort(
-            copiedFoodOffers,
-            ownFoodFeedbacks,
-            profile.markings,
-            language,
-            foodCategories,
-            foodOfferCategories,
-          );
-          console.log('sortOffers - after intelligentSort', JSON.parse(JSON.stringify(copiedFoodOffers)));
-          break;
-        default:
-          break;
-      }
-
-      return copiedFoodOffers;
-    },
-    [sortBy, language, ownFoodFeedbacks, profile.markings, foodCategories, foodOfferCategories],
+    (foodOffers: DatabaseTypes.Foodoffers[]) =>
+      sortFoodOffers(sortBy as FoodSortOption, foodOffers, {
+        languageCode: language,
+        ownFoodFeedbacks,
+        profile,
+        foodCategories,
+        foodOfferCategories,
+        useFoodOfferCategoryOnly: true,
+      }),
+    [
+      sortBy,
+      language,
+      ownFoodFeedbacks,
+      profile,
+      foodCategories,
+      foodOfferCategories,
+    ],
   );
 
   useEffect(() => {

--- a/apps/frontend/app/components/SortSheet/SortSheet.tsx
+++ b/apps/frontend/app/components/SortSheet/SortSheet.tsx
@@ -13,11 +13,12 @@ import {
 
 import { SortSheetProps } from './types';
 import Checkbox from 'expo-checkbox';
-import { FoodSortOption } from '@/constants/SortingEnums';
+import { FoodSortOption } from 'repo-depkit-common';
 import { SET_SELECTED_CANTEEN_FOOD_OFFERS, SET_SORTING } from '@/redux/Types/types';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   intelligentSort,
+  sortByPrice,
   sortByEatingHabits,
   sortByFoodName,
   sortByOwnFavorite,
@@ -91,6 +92,16 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
       icon: <AntDesign name='star' size={24} />,
     },
     {
+      id: FoodSortOption.PRICE_ASCENDING,
+      label: 'sort_option_price_ascending',
+      icon: <FontAwesome5 name='sort-numeric-up' size={24} />,
+    },
+    {
+      id: FoodSortOption.PRICE_DESCENDING,
+      label: 'sort_option_price_descending',
+      icon: <FontAwesome5 name='sort-numeric-down' size={24} />,
+    },
+    {
       id: FoodSortOption.ALPHABETICAL,
       label: 'sort_option_alphabetical',
       icon: <FontAwesome5 name='sort-alpha-down' size={24} />,
@@ -141,6 +152,20 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
         break;
       case FoodSortOption.RATING:
         copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
+        break;
+      case FoodSortOption.PRICE_ASCENDING:
+        copiedFoodOffers = sortByPrice(
+          copiedFoodOffers,
+          profile?.price_group,
+          false
+        );
+        break;
+      case FoodSortOption.PRICE_DESCENDING:
+        copiedFoodOffers = sortByPrice(
+          copiedFoodOffers,
+          profile?.price_group,
+          true
+        );
         break;
       case FoodSortOption.INTELLIGENT:
         copiedFoodOffers = intelligentSort(

--- a/apps/frontend/app/helper/foodOfferSortHelper.ts
+++ b/apps/frontend/app/helper/foodOfferSortHelper.ts
@@ -1,0 +1,94 @@
+import {
+  DatabaseTypes,
+  FoodSortOption,
+  intelligentSort,
+  sortByPrice,
+  sortByEatingHabits,
+  sortByFoodName,
+  sortByOwnFavorite,
+  sortByPublicFavorite,
+  sortByFoodCategory,
+  sortByFoodOfferCategory,
+  sortByFoodOfferCategoryOnly,
+} from 'repo-depkit-common';
+
+interface SortContext {
+  languageCode: string;
+  ownFoodFeedbacks: any[];
+  profile: { price_group?: string; markings: any };
+  foodCategories: any[];
+  foodOfferCategories: any[];
+  useFoodOfferCategoryOnly?: boolean;
+}
+
+export function sortFoodOffers(
+  id: FoodSortOption,
+  foodOffers: DatabaseTypes.Foodoffers[],
+  {
+    languageCode,
+    ownFoodFeedbacks,
+    profile,
+    foodCategories,
+    foodOfferCategories,
+    useFoodOfferCategoryOnly,
+  }: SortContext
+): DatabaseTypes.Foodoffers[] {
+  let copiedFoodOffers = [...foodOffers];
+
+  switch (id) {
+    case FoodSortOption.ALPHABETICAL:
+      copiedFoodOffers = sortByFoodName(copiedFoodOffers, languageCode);
+      break;
+    case FoodSortOption.FAVORITE:
+      copiedFoodOffers = sortByOwnFavorite(copiedFoodOffers, ownFoodFeedbacks);
+      break;
+    case FoodSortOption.EATING:
+      copiedFoodOffers = sortByEatingHabits(copiedFoodOffers, profile.markings);
+      break;
+    case FoodSortOption.FOOD_CATEGORY:
+      copiedFoodOffers = sortByFoodCategory(
+        copiedFoodOffers,
+        foodCategories,
+        languageCode
+      );
+      break;
+    case FoodSortOption.FOODOFFER_CATEGORY:
+      copiedFoodOffers = useFoodOfferCategoryOnly
+        ? sortByFoodOfferCategoryOnly(copiedFoodOffers, foodOfferCategories)
+        : sortByFoodOfferCategory(copiedFoodOffers, foodOfferCategories);
+      break;
+    case FoodSortOption.RATING:
+      copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
+      break;
+    case FoodSortOption.PRICE_ASCENDING:
+      copiedFoodOffers = sortByPrice(
+        copiedFoodOffers,
+        profile?.price_group,
+        false
+      );
+      break;
+    case FoodSortOption.PRICE_DESCENDING:
+      copiedFoodOffers = sortByPrice(
+        copiedFoodOffers,
+        profile?.price_group,
+        true
+      );
+      break;
+    case FoodSortOption.INTELLIGENT:
+      copiedFoodOffers = intelligentSort(
+        copiedFoodOffers,
+        ownFoodFeedbacks,
+        profile.markings,
+        languageCode,
+        foodCategories,
+        foodOfferCategories
+      );
+      break;
+    default:
+      console.warn('Unknown sorting option:', id);
+      break;
+  }
+
+  return copiedFoodOffers;
+}
+

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -71,6 +71,8 @@ export enum TranslationKeys {
   sort_option_distance = 'sort_option_distance',
   sort_option_food_category = 'sort_option_food_category',
   sort_option_foodoffer_category = 'sort_option_foodoffer_category',
+  sort_option_price_ascending = 'sort_option_price_ascending',
+  sort_option_price_descending = 'sort_option_price_descending',
   general = 'general',
   food_category_label = 'food_category_label',
   foodoffer_category_label = 'foodoffer_category_label',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -709,6 +709,26 @@
     "tr": "Yemek Teklifi Kategorisi",
     "zh": "餐品类别"
   },
+  "sort_option_price_ascending": {
+    "de": "Preis aufsteigend",
+    "en": "Price ascending",
+    "ar": "السعر تصاعدي",
+    "es": "Precio ascendente",
+    "fr": "Prix croissant",
+    "ru": "Цена по возрастанию",
+    "tr": "Artan fiyata göre",
+    "zh": "价格升序"
+  },
+  "sort_option_price_descending": {
+    "de": "Preis absteigend",
+    "en": "Price descending",
+    "ar": "السعر تنازلي",
+    "es": "Precio descendente",
+    "fr": "Prix décroissant",
+    "ru": "Цена по убыванию",
+    "tr": "Azalan fiyata göre",
+    "zh": "价格降序"
+  },
   "general": {
     "de": "Allgemeines",
     "en": "General",

--- a/apps/frontend/app/redux/Types/stateTypes.ts
+++ b/apps/frontend/app/redux/Types/stateTypes.ts
@@ -3,7 +3,7 @@ import {
   FoodSortOption,
   CampusSortOption,
   ApartmentSortOption,
-} from '@/constants/SortingEnums';
+} from 'repo-depkit-common';
 
 export interface AuthState {
   user: DatabaseTypes.DirectusUsers | Record<string, any> | null;

--- a/apps/frontend/app/redux/reducer/settingsReducer.ts
+++ b/apps/frontend/app/redux/reducer/settingsReducer.ts
@@ -20,7 +20,7 @@ import {
   FoodSortOption,
   CampusSortOption,
   ApartmentSortOption,
-} from '@/constants/SortingEnums';
+} from 'repo-depkit-common';
 
 const initialState = {
   selectedTheme: 'systematic',

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -7,3 +7,4 @@ export * from "./src/AppLinks";
 export * from "./src/GlobalParams";
 export * from "./src/DistanceHelper";
 export * from "./src/SortingHelper";
+export * from "./src/SortingEnums";

--- a/packages/common/src/SortingEnums.ts
+++ b/packages/common/src/SortingEnums.ts
@@ -6,6 +6,8 @@ export enum FoodSortOption {
   FOODOFFER_CATEGORY = 'foodoffer_category',
   RATING = 'rating',
   ALPHABETICAL = 'alphabetical',
+  PRICE_ASCENDING = 'price_ascending',
+  PRICE_DESCENDING = 'price_descending',
   NONE = 'none',
 }
 

--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -320,6 +320,33 @@ export function sortByPublicFavorite(foodOffers: DatabaseTypes.Foodoffers[]) {
     return foodOffers;
   }
 
+export function sortByPrice(
+  foodOffers: DatabaseTypes.Foodoffers[],
+  priceGroup?: string,
+  descending = false
+) {
+  console.log('sortByPrice - before', JSON.parse(JSON.stringify(foodOffers)));
+
+  foodOffers.sort((a, b) => {
+    const getPrice = (offer: DatabaseTypes.Foodoffers) => {
+      return priceGroup === 'guest'
+        ? offer?.price_guest ?? 0
+        : priceGroup === 'employee'
+        ? offer?.price_employee ?? 0
+        : offer?.price_student ?? 0;
+    };
+
+    const priceA = getPrice(a);
+    const priceB = getPrice(b);
+
+    return descending ? priceB - priceA : priceA - priceB;
+  });
+
+  console.log('sortByPrice - after', JSON.parse(JSON.stringify(foodOffers)));
+  return foodOffers;
+}
+
+
 
 export function sortByEatingHabits(
     foodOffers: DatabaseTypes.Foodoffers[],


### PR DESCRIPTION
## Summary
- move FoodSortOption and related enums into repo-depkit-common
- add shared sortByPrice helper alongside existing sorting utilities
- update frontend to import enums and use common price sorting

## Testing
- `npx jest --passWithNoTests` *(fails: Cannot use import statement outside a module)*
- `npm --prefix apps/frontend/app run lint` *(fails: project in apps/frontend/app/package.json doesn't seem to have been installed)*

------
https://chatgpt.com/codex/tasks/task_e_689a04de71c883309c86ab63d2347c1a