### PR TITLE
refactor(frontend): use MyImage component

### DIFF
--- a/apps/frontend/app/app/(app)/campus/details/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/index.tsx
@@ -1,15 +1,5 @@
-import {
-  ActivityIndicator,
-  Dimensions,
-  Image,
-  Linking,
-  Platform,
-  SafeAreaView,
-  ScrollView,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Dimensions, Linking, Platform, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useEffect, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -168,7 +158,7 @@ const details = () => {
                     : Dimensions.get('window').width - 20,
               }}
             >
-              <Image
+              <MyImage
                 source={
                   campusDetails?.image || campusDetails?.image_remote_url
                     ? {

--- a/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/app-download/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Image, ScrollView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { useTheme } from '@/hooks/useTheme';
@@ -61,7 +62,7 @@ const AppDownload = () => {
       }}
     >
       <View style={styles.content}>
-        <Image source={iconSource} style={styles.icon} />
+        <MyImage source={iconSource} style={styles.icon} />
         <View style={styles.itemsContainer}>
           <DownloadItem
             label='iOS'

--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState,} from 'react';
 import {useFocusEffect, useLocalSearchParams} from 'expo-router';
-import {Dimensions, Image, SafeAreaView, ScrollView, Text, TouchableOpacity, View,} from 'react-native';
+import { Dimensions, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { router } from 'expo-router';
 import styles from './styles';
 import {useTheme} from '@/hooks/useTheme';
@@ -510,7 +511,7 @@ export default function FoodDetailsScreen() {
                     }}
                   >
                   <TouchableOpacity onPress={openFullScreenImage} activeOpacity={0.9}>
-                    <Image
+                    <MyImage
                       style={styles.featuredImage}
                       source={
                         foodDetails?.image_remote_url || foodDetails?.image
@@ -642,7 +643,7 @@ export default function FoodDetailsScreen() {
           ) : (
             <View style={styles.mobileImageContainer}>
               <TouchableOpacity onPress={openFullScreenImage} activeOpacity={0.9}>
-              <Image
+              <MyImage
                 source={
                   foodDetails?.image_remote_url || foodDetails?.image
                     ? {

--- a/apps/frontend/app/app/(app)/housing/details/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/details/index.tsx
@@ -1,15 +1,5 @@
-import {
-  ActivityIndicator,
-  Dimensions,
-  Image,
-  Linking,
-  Platform,
-  SafeAreaView,
-  ScrollView,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Dimensions, Linking, Platform, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -182,7 +172,7 @@ const details = () => {
                     : Dimensions.get('window').width - 20,
               }}
             >
-              <Image
+              <MyImage
                 source={
                   apartmentDetails?.image || apartmentDetails?.image_remote_url
                     ? {

--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -22,7 +22,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { Image } from 'expo-image';
+import MyImage from '@/components/MyImage';
 import BaseBottomModal from '@/components/BaseBottomModal';
 import SettingsList from '@/components/SettingsList';
 import * as FileSystem from 'expo-file-system';
@@ -259,8 +259,8 @@ export default function ImageFullScreen() {
         <Animated.View style={styles.flex}>
           <TouchableWithoutFeedback onPress={toggleControls} onLongPress={() => setModalVisible(true)}>
             <Animated.View style={[styles.imageWrapper, animatedStyle]}>
-              <Image source={{ uri: lowResUri }} style={styles.image} contentFit='contain' />
-              <Image
+              <MyImage source={{ uri: lowResUri }} style={styles.image} contentFit='contain' />
+              <MyImage
                 source={{ uri: highResUri }}
                 style={[styles.image, StyleSheet.absoluteFill]}
                 contentFit='contain'

--- a/apps/frontend/app/app/(app)/support-FAQ/index.tsx
+++ b/apps/frontend/app/app/(app)/support-FAQ/index.tsx
@@ -1,13 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import {
-  ScrollView,
-  Dimensions,
-  View,
-  Image,
-  Platform,
-  Linking,
-  Text,
-} from 'react-native';
+import { ScrollView, Dimensions, View, Platform, Linking, Text } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { useTheme } from '@/hooks/useTheme';
 import { router } from 'expo-router';
 import SettingsList from '@/components/SettingsList';
@@ -83,7 +76,7 @@ const supportfaq = () => {
       <ScrollView>
         <View style={{ alignItems: 'center', marginBottom: 20 }}>
           <View style={styles.imageContainer}>
-            <Image
+            <MyImage
               source={require('../../../assets/images/dataAccess.png')}
               style={styles.image}
             />

--- a/apps/frontend/app/app/(auth)/login.tsx
+++ b/apps/frontend/app/app/(auth)/login.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { View, Text, Dimensions, Image, ScrollView } from 'react-native';
+import { View, Text, Dimensions, ScrollView } from 'react-native';
+import MyImage from '@/components/MyImage';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import Form from '@/components/Login/Form';
@@ -239,7 +240,7 @@ export default function Login() {
     return (
       <View style={styles.detailedContentContainer}>
         {imageUrl && (
-          <Image
+          <MyImage
             source={{ uri: imageUrl }}
             style={{
               width: '95%',

--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -1,12 +1,5 @@
-import {
-  Animated,
-  Dimensions,
-  Easing,
-  Image,
-  ScrollView,
-  Text,
-  View,
-} from 'react-native';
+import { Animated, Dimensions, Easing, ScrollView, Text, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -455,7 +448,7 @@ const Index = () => {
           <>
             {height > width && (
               <View style={{ ...styles.col2 }}>
-                <Image
+                <MyImage
                   source={
                     currentFood?.food?.image_remote_url ||
                     getImageUrl(currentFood?.food?.image)
@@ -607,7 +600,7 @@ const Index = () => {
         <>
           {height < width && (
             <View style={{ ...styles.col2 }}>
-              <Image
+              <MyImage
                 source={
                   currentFood?.food?.image_remote_url ||
                   getImageUrl(currentFood?.food?.image)
@@ -632,7 +625,7 @@ const Index = () => {
       {foods && foods?.length < 1 && (
         <View style={styles.emptyContainer}>
           <View style={{ flex: 1 }}>
-            <Image
+            <MyImage
               source={require('@/assets/images/icon.png')}
               resizeMode='cover'
             />

--- a/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -1,12 +1,5 @@
-import {
-  View,
-  Text,
-  ScrollView,
-  Dimensions,
-  Image,
-  ActivityIndicator,
-  Platform,
-} from 'react-native';
+import { View, Text, ScrollView, Dimensions, ActivityIndicator, Platform } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
@@ -641,7 +634,7 @@ const index = () => {
                                               </Text>
                                             </View>
                                           ) : marking?.image?.uri ? (
-                                            <Image
+                                            <MyImage
                                               key={idx}
                                               source={marking.image.uri}
                                               style={{

--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -24,7 +24,8 @@ import {
   Poppins_900Black,
   Poppins_900Black_Italic,
 } from '@expo-google-fonts/poppins';
-import { Image, KeyboardAvoidingView, Platform, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { ThemeProvider } from '@/context/ThemeContext';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Provider } from 'react-redux';
@@ -97,7 +98,7 @@ export default function Layout() {
           backgroundColor: '#ffffff',
         }}
       >
-        <Image
+        <MyImage
           source={require('@/assets/images/company.png')}
           style={{ width: 250, height: 250 }}
           resizeMode='contain'

--- a/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
+++ b/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
@@ -1,4 +1,4 @@
-import { Dimensions, Image, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import React, { memo, useEffect, useState } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { isWeb } from '@/constants/Constants';

--- a/apps/frontend/app/components/AutoImageScroller/index.tsx
+++ b/apps/frontend/app/components/AutoImageScroller/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { FlatList, View, Dimensions } from 'react-native';
-import { Image } from 'expo-image';
+import MyImage from '@/components/MyImage';
 import styles from './styles';
 
 interface AutoImageScrollerProps {
@@ -76,7 +76,7 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({
     const offset = (columnIndex % 3) * (size / 3);
     return (
       <View style={{ transform: [{ translateY: offset }] }}>
-        <Image
+        <MyImage
           source={{ uri: item }}
           style={[styles.image, { width: size, height: size }]}
           contentFit='cover'

--- a/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Image, Pressable, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -143,7 +144,7 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({
             onHoverOut={() => setShowTooltip(false)}
           >
             {label?.image_remote_url || label?.image ? (
-              <Image
+              <MyImage
                 source={{
                   uri: label?.image_remote_url || getImageUrl(label?.image),
                 }}

--- a/apps/frontend/app/components/CardWithText/CardWithText.tsx
+++ b/apps/frontend/app/components/CardWithText/CardWithText.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Image, TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import styles from './styles';
 import { CardWithTextProps } from './types';
 
@@ -29,7 +30,7 @@ const CardWithText: React.FC<CardWithTextProps> = ({
     <TouchableOpacity style={[styles.card, topRadiusStyle, containerStyle]} {...rest}>
       <View style={[styles.imageContainer, topRadiusStyle, imageContainerStyle]}>
         {imageSource ? (
-          <Image style={[styles.image, topRadiusStyle, imageStyle]} source={imageSource} />
+          <MyImage style={[styles.image, topRadiusStyle, imageStyle]} source={imageSource} />
         ) : null}
         {imageChildren}
       </View>

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -1,8 +1,8 @@
 import { DimensionValue, Linking, Text, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useState } from 'react';
 import CustomCollapsible from '../CustomCollapsible/CustomCollapsible';
 import RedirectButton from '../RedirectButton';
-import { Image } from 'react-native';
 import styles from './styles';
 import { CustomMarkdownProps } from './types';
 import { myContrastColor } from '@/helper/colorHelper';
@@ -194,7 +194,7 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({
                   padding: 10,
                 }}
               >
-                <Image
+                <MyImage
                   source={{ uri: url }}
                   style={{
                     width: (imageWidth ? imageWidth : '100%') as DimensionValue,

--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import {
-  View,
-  Text,
-  Image,
-  Dimensions,
-  ScrollView,
-} from 'react-native';
+import { View, Text, Dimensions, ScrollView } from 'react-native';
+import MyImage from '@/components/MyImage';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -134,7 +129,7 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
       >
         <View style={{ alignItems: 'center' }}>
           <View style={styles.imageContainer}>
-            <Image
+            <MyImage
               source={require('../../assets/images/dataAccess.png')}
               style={styles.image}
             />

--- a/apps/frontend/app/components/Details/index.tsx
+++ b/apps/frontend/app/components/Details/index.tsx
@@ -1,4 +1,5 @@
-import {ActivityIndicator, Dimensions, Image, Linking, Pressable, Text, View} from 'react-native';
+import { ActivityIndicator, Dimensions, Linking, Pressable, Text, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -173,7 +174,7 @@ const handleRedirect = () => {
                                 </TooltipContent>
                               </Tooltip>
                             ) : image ? (
-                              <Image
+                              <MyImage
                                 source={image}
                                 style={[
                                   {

--- a/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -1,12 +1,5 @@
-import {
-  Text,
-  View,
-  Image,
-  TouchableOpacity,
-  ScrollView,
-  SafeAreaView,
-  Platform,
-} from 'react-native';
+import { Text, View, TouchableOpacity, ScrollView, SafeAreaView, Platform } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useEffect } from 'react';
 import { FontAwesome5, Ionicons } from '@expo/vector-icons';
 import { FontAwesome6 } from '@expo/vector-icons';
@@ -393,7 +386,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({
             onPress={() => navigation.navigate('foodoffers')}
           >
             <View style={styles.logoContainer}>
-              <Image
+              <MyImage
                 source={{
                   uri: getImageUrl(serverInfo?.info?.project?.project_logo),
                 }}

--- a/apps/frontend/app/components/ExpoUpdateLoader/ExpoUpdateLoader.tsx
+++ b/apps/frontend/app/components/ExpoUpdateLoader/ExpoUpdateLoader.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ActivityIndicator,
-  Image,
-} from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import MyImage from '@/components/MyImage';
 import * as Updates from 'expo-updates';
 import usePlatformHelper from '@/helper/platformHelper';
 import { TranslationKeys } from '@/locales/keys';
@@ -94,7 +88,7 @@ const ExpoUpdateLoader: React.FC<ExpoUpdateLoaderProps> = ({ children }) => {
 
   return (
     <View style={styles.container}>
-      <Image
+      <MyImage
         source={require('@/assets/images/company.png')}
         style={styles.logo}
         resizeMode='contain'

--- a/apps/frontend/app/components/FeedbackLabel/index.tsx
+++ b/apps/frontend/app/components/FeedbackLabel/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { Image, Pressable, Text, TouchableOpacity, View } from 'react-native';
+import { Pressable, Text, TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -116,7 +117,7 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({
           >
             {/* <View > */}
             {imageUrl && (
-              <Image source={{ uri: imageUrl }} style={styles.icon} />
+              <MyImage source={{ uri: imageUrl }} style={styles.icon} />
             )}
             {icon && getIconComponent(icon, theme.screen.icon)}
             <Text

--- a/apps/frontend/app/components/FileUpload/FileUpload.tsx
+++ b/apps/frontend/app/components/FileUpload/FileUpload.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Image, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import MyImage from '@/components/MyImage';
 import * as DocumentPicker from 'expo-document-picker';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -268,7 +269,7 @@ const FileUpload = ({
                   >
                     <Ionicons name='close' size={18} color={'red'} />
                   </TouchableOpacity>
-                  <Image
+                  <MyImage
                     source={{ uri: item?.image }}
                     style={styles.filePreview}
                   />

--- a/apps/frontend/app/components/ImageUpload/ImageUpload.tsx
+++ b/apps/frontend/app/components/ImageUpload/ImageUpload.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Image } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import MyImage from '@/components/MyImage';
 import * as ImagePicker from 'expo-image-picker';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -165,7 +166,7 @@ const ImageUpload = ({
           >
             <Ionicons name='close' size={18} color={'red'} />
           </TouchableOpacity>
-          <Image
+          <MyImage
             source={{ uri: value?.image ? value?.image : value }}
             style={styles.filePreview}
           />

--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Image } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
@@ -67,7 +68,7 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({
               closeSheet();
             }}
           >
-            <Image
+            <MyImage
               source={language.flag}
               style={styles.flagIcon}
               cachePolicy={'memory-disk'}

--- a/apps/frontend/app/components/Login/Header.tsx
+++ b/apps/frontend/app/components/Login/Header.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { SET_DRAWER_POSITION } from '@/redux/Types/types';
 import ModalComponent from '../ModalSetting/ModalComponent';
 import { languages } from '../../constants/SettingData';
-import { Image } from 'expo-image';
+import MyImage from '@/components/MyImage';
 import { Entypo, MaterialCommunityIcons } from '@expo/vector-icons';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { TranslationKeys } from '@/locales/keys';
@@ -100,7 +100,7 @@ const LoginHeader = () => {
   };
   return (
     <View style={styles.header}>
-      <Image
+      <MyImage
         source={{
           uri: getImageUrl(serverInfo?.info?.project?.project_logo),
         }}
@@ -156,7 +156,7 @@ const LoginHeader = () => {
                 changeLanguage(language);
               }}
             >
-              <Image
+              <MyImage
                 source={language.flag}
                 style={styles.flagIcon}
                 cachePolicy={'memory-disk'}

--- a/apps/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
+++ b/apps/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
@@ -1,4 +1,5 @@
-import { Dimensions, Image, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, Text, TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
@@ -159,7 +160,7 @@ const ManagementCanteensSheet: React.FC<ManagementCanteensSheetProps> = ({
                   height: screenWidth > 800 ? 210 : 160,
                 }}
               >
-                <Image
+                <MyImage
                   style={styles.image}
                   source={
                     canteen?.image_url || canteensData[index]?.image

--- a/apps/frontend/app/components/MarkingIcon/index.tsx
+++ b/apps/frontend/app/components/MarkingIcon/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, Image } from 'react-native';
+import { View, Text } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
 import { useMyContrastColor } from '@/helper/colorHelper';
@@ -69,7 +70,7 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({
   if (markingImage?.uri) {
     return (
       <View style={containerStyle}>
-        <Image
+        <MyImage
           source={markingImage}
           style={{
             width: size * imageScale,

--- a/apps/frontend/app/components/MenuSheet/MenuSheet.tsx
+++ b/apps/frontend/app/components/MenuSheet/MenuSheet.tsx
@@ -1,4 +1,5 @@
-import { Image, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React from 'react';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
@@ -49,7 +50,7 @@ const MenuSheet: React.FC<MenuSheetProps> = ({ closeSheet }) => {
       </View>
       <View style={{ ...styles.menuContainer, width: isWeb ? '90%' : '100%' }}>
         <View style={styles.imageContainer}>
-          <Image
+          <MyImage
             source={{
               uri:
                 markingDetails?.image_remote_url ||

--- a/apps/frontend/app/components/NewsItem/NewsItem.tsx
+++ b/apps/frontend/app/components/NewsItem/NewsItem.tsx
@@ -1,12 +1,5 @@
-import {
-  Dimensions,
-  Image,
-  Linking,
-  Platform,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Dimensions, Linking, Platform, Text, TouchableOpacity, View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import React, { useEffect, useState } from 'react';
 import styles from './styles';
 import { FontAwesome6 } from '@expo/vector-icons';
@@ -90,7 +83,7 @@ const NewsItem: React.FC<any> = ({ news }) => {
           height: screenWidth > 768 ? 220 : 180,
         }}
       >
-        <Image
+        <MyImage
           source={{
             uri: news?.image_remote_url,
           }}

--- a/apps/frontend/app/components/QrCode/index.tsx
+++ b/apps/frontend/app/components/QrCode/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
+import MyImage from '@/components/MyImage';
 import QRCode from 'react-native-qrcode-svg';
 import { QrCodeProps, QrCodeEcl } from './types';
 
@@ -53,7 +54,7 @@ const QrCode: React.FC<QrCodeProps> = ({
             borderRadius: 2,
           }}
         >
-          <Image
+          <MyImage
             source={imageSource}
             style={{ width: innerSizePx, height: innerSizePx, resizeMode: 'contain' }}
           />

--- a/apps/frontend/app/components/RssFeed/index.tsx
+++ b/apps/frontend/app/components/RssFeed/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, ScrollView, ActivityIndicator, TouchableOpacity, Linking, Image } from 'react-native';
+import { View, Text, ScrollView, ActivityIndicator, TouchableOpacity, Linking } from 'react-native';
+import MyImage from '@/components/MyImage';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 
@@ -105,7 +106,7 @@ const RssFeed: React.FC<RssFeedProps> = ({ urls, switchIntervalInSeconds }) => {
       <TouchableOpacity onPress={() => currentItem.link && Linking.openURL(currentItem.link)}>
         <Text style={[styles.title, { color: theme.screen.text }]}>{currentItem.title}</Text>
         {currentItem.image && (
-          <Image source={{ uri: currentItem.image }} style={styles.image} resizeMode='cover' />
+          <MyImage source={{ uri: currentItem.image }} style={styles.image} resizeMode='cover' />
         )}
         {currentItem.content && (
           <Text style={[styles.body, { color: theme.screen.text }]}>{currentItem.content}</Text>

--- a/apps/frontend/app/components/SignatureInterface/SignatureInterface.tsx
+++ b/apps/frontend/app/components/SignatureInterface/SignatureInterface.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import {
-  View,
-  TouchableOpacity,
-  Text,
-  Platform,
-  Dimensions,
-  Image,
-} from 'react-native';
+import { View, TouchableOpacity, Text, Platform, Dimensions } from 'react-native';
+import MyImage from '@/components/MyImage';
 import { useTheme } from '@/hooks/useTheme';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
@@ -132,7 +126,7 @@ const SignatureInterface = ({
     <View style={{ ...styles.container, backgroundColor: theme.screen.iconBg }}>
       {value && typeof value === 'string' && value?.startsWith('https') ? (
         <View style={styles.fileContainer}>
-          <Image
+          <MyImage
             source={{ uri: value }}
             style={{
               ...styles.filePreview,


### PR DESCRIPTION
## Summary
- replace direct Image usages with MyImage wrapper across frontend
- remove unused Image imports

## Testing
- `CI=1 npm --workspace apps/frontend/app test`
- `npm --workspace apps/frontend/app run lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_689d0467b6dc8330bdfb864cfb001885