### PR TITLE
ci: run mobile workflows after lint

### DIFF
--- a/.github/workflows/frontend_expo_update.yml
+++ b/.github/workflows/frontend_expo_update.yml
@@ -1,13 +1,6 @@
 name: 🤖 Expo Update
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'apps/frontend/app/**'
-      - 'packages/common/**'
-      - '.github/workflows/**'
-      - 'package.json'
   workflow_run:
     workflows: ["🔧 Auto-Linter"]
     branches: [master]
@@ -18,10 +11,12 @@ jobs:
   update:
     name: 🏗 EAS Update Production
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 🔄 Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: 🧰 Setup Node.js, Yarn & Dependencies
         uses: ./.github/actions/setup-and-install

--- a/.github/workflows/frontend_native_android.yml
+++ b/.github/workflows/frontend_native_android.yml
@@ -1,13 +1,6 @@
 name: 🤖 Build & Submit Android
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'apps/frontend/app/**'
-      - 'packages/common/**'
-      - '.github/workflows/**'
-      - 'package.json'
   workflow_run:
     workflows: ["🔧 Auto-Linter"]
     branches: [master]
@@ -18,12 +11,14 @@ jobs:
   check-build:
     name: 🔍 Check Build Number
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: 🔄 Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: 🔍 Compare Build Number
         id: check
@@ -38,6 +33,8 @@ jobs:
     steps:
       - name: 🔄 Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: 🧰 Setup Node.js, Yarn & Dependencies
         uses: ./.github/actions/setup-and-install

--- a/.github/workflows/frontend_native_ios.yml
+++ b/.github/workflows/frontend_native_ios.yml
@@ -1,13 +1,6 @@
 name: 🍏 Build & Submit iOS
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'apps/frontend/app/**'
-      - 'packages/common/**'
-      - '.github/workflows/**'
-      - 'package.json'
   workflow_run:
     workflows: ["🔧 Auto-Linter"]
     branches: [master]
@@ -18,12 +11,14 @@ jobs:
   check-build:
     name: 🔍 Check Build Number
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: 🔄 Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: 🔍 Compare Build Number
         id: check
@@ -38,6 +33,8 @@ jobs:
     steps:
       - name: 🔄 Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: 🧰 Setup Node.js, Yarn & Dependencies
         uses: ./.github/actions/setup-and-install


### PR DESCRIPTION
## Summary
- run iOS and Android builds only after Auto-Linter succeeds
- check out master in dependent workflows so linter fixes are included
- simplify expo update to use Auto-Linter workflow_run trigger

## Testing
- `yarn install`
- `yarn test` *(fails: directus-extension-rocket-meals-bundle workspace missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a85dbf5b8083309686af45f8e14ba8