### PR TITLE
chore: sync workflow uses master branch

### DIFF
--- a/.github/workflows/syncWithUpstream.yml
+++ b/.github/workflows/syncWithUpstream.yml
@@ -25,5 +25,5 @@ jobs:
 
       - name: merge + push
         run: |
-          git merge --ff-only upstream/main
-          git push origin main
+          git merge --ff-only upstream/master
+          git push origin master


### PR DESCRIPTION
## Summary
- sync upstream workflow now targets master branch instead of main

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a90456bfa483309a910795d649828a