### PR TITLE
chore: authenticate fork sync with PAT

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -35,23 +35,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-      - name: 🔧 Setup GitHub CLI
-        if: steps.check-fork.outputs.is_fork == 'true'
-        run: |
-          gh --version
-          echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | gh auth login --with-token
-
       - name: 🔄 Sync Fork with Upstream
         if: steps.check-fork.outputs.is_fork == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           REPO_FULL_NAME="${{ github.repository }}"
           echo "Syncing fork: $REPO_FULL_NAME"
           echo "Upstream repository: rocket-meals/rocket-meals"
           echo "Target branch: master"
-          
+
           # Sync the fork with the upstream repository using --force to handle conflicts
           gh repo sync "$REPO_FULL_NAME" -b master --force
-          
+
           echo "✅ Fork synchronization completed successfully!"
 
       - name: ⏭️ Skip Fork Sync


### PR DESCRIPTION
## Summary
- ensure fork sync workflow uses personal access token via GH_TOKEN

## Testing
- `yarn test` *(fails: directus-extension-rocket-meals-bundle not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a99e9350d48330a777b87a981e9378