### PR TITLE
fix: allow workflow edits for fork sync

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,10 +1,14 @@
 name: 🔄 Fork Synchronization
 
+permissions:
+  contents: write
+  workflows: write
+
 on:
   # Run hourly
   schedule:
     - cron: '0 * * * *'  # Every hour at minute 0
-  
+
   # Allow manual triggering
   workflow_dispatch:
 
@@ -33,12 +37,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: 🔄 Sync Fork with Upstream
         if: steps.check-fork.outputs.is_fork == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           REPO_FULL_NAME="${{ github.repository }}"
           echo "Syncing fork: $REPO_FULL_NAME"


### PR DESCRIPTION
## Summary
- grant workflow and contents write permissions to sync workflow

## Testing
- `yarn test` *(fails: monorepo@workspace not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2cd44888330b3badf1e781f6a78