### PR TITLE
fix: configure test server host and port

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/DirectusTestServerSetup.test.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/DirectusTestServerSetup.test.ts
@@ -15,7 +15,7 @@ describe('DirectusTestServerSetup', () => {
     serverSetup = new DirectusTestServerSetup();
     
     expect(serverSetup).toBeInstanceOf(DirectusTestServerSetup);
-    expect(serverSetup.getDirectusUrl()).toBe('http://0.0.0.0:8055');
+    expect(serverSetup.getDirectusUrl()).toBe('http://127.0.0.1:8055');
   });
 
   it('should create instance with custom options', () => {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/DirectusTestServerSetup.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/DirectusTestServerSetup.ts
@@ -65,7 +65,8 @@ export class DirectusTestServerSetup {
       debug: options.debug ?? false,
     };
 
-    this.directusUrl = `http://${this.options.host}:${this.options.port}`;
+    const clientHost = this.options.host === '0.0.0.0' ? '127.0.0.1' : this.options.host;
+    this.directusUrl = `http://${clientHost}:${this.options.port}`;
   }
 
   /**
@@ -182,6 +183,8 @@ export class DirectusTestServerSetup {
       DB_CLIENT: this.options.dbClient,
       DB_FILENAME: this.options.dbFilename,
       SECRET: this.options.secret,
+      PORT: String(this.options.port),
+      HOST: this.options.host,
       ADMIN_EMAIL: this.options.adminEmail,
       ADMIN_PASSWORD: this.options.adminPassword,
     };

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/ExampleUsage.test.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/__tests__/ExampleUsage.test.ts
@@ -29,7 +29,7 @@ describe('Example: Using DirectusTestServerSetup in different tests', () => {
     
     // Get server URL
     const serverUrl = testServer.getDirectusUrl();
-    expect(serverUrl).toBe('http://0.0.0.0:8056');
+    expect(serverUrl).toBe('http://127.0.0.1:8056');
   });
 
   it('should allow admin login and user operations', async () => {


### PR DESCRIPTION
## Summary
- ensure Directus test server uses configured host and port
- update tests to expect localhost URL

## Testing
- `npm test -- src/__tests__/DirectusTestServerSetup.test.ts --runInBand` *(fails: directus-extension-rocket-meals-bundle@workspace:.: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf4bf1cd08330bc1ec6e46748d0b5