### PR TITLE
Add workflow to push master to stable and update fork sync

### DIFF
--- a/.github/workflows/push-stable.yml
+++ b/.github/workflows/push-stable.yml
@@ -1,0 +1,25 @@
+name: 🚀 Push Master to Stable
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push-master-to-stable:
+    name: 🚀 Update Stable Branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🔄 Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: 📤 Push master to stable
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git push origin HEAD:stable --force

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -45,10 +45,10 @@ jobs:
           REPO_FULL_NAME="${{ github.repository }}"
           echo "Syncing fork: $REPO_FULL_NAME"
           echo "Upstream repository: rocket-meals/rocket-meals"
-          echo "Target branch: master"
+          echo "Target branch: stable"
 
           # Sync the fork with the upstream repository using --force to handle conflicts
-          gh repo sync "$REPO_FULL_NAME" -b master --force
+          gh repo sync "$REPO_FULL_NAME" -b stable --force
 
           echo "✅ Fork synchronization completed successfully!"
 


### PR DESCRIPTION
## Summary
- add manual workflow to push `master` to `stable`
- update fork sync workflow to sync from `stable` instead of `master`

## Testing
- `yarn test` *(fails: 6 failed, 100 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8a6c7dc883309dcd3d17366c7252