### PR TITLE
feat: notify chat participants on new messages

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/chat-message-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/chat-message-hook/index.ts
@@ -1,0 +1,80 @@
+import { defineHook } from '@directus/extensions-sdk';
+import { DatabaseInitializedCheck } from '../helpers/DatabaseInitializedCheck';
+import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
+import { ItemsServiceHelper } from '../helpers/ItemsServiceHelper';
+import { CollectionNames, DatabaseTypes } from 'repo-depkit-common';
+
+const HOOK_NAME = 'chat_message_notify';
+
+export default defineHook(async ({ action }, apiContext) => {
+  const allTablesExist = await DatabaseInitializedCheck.checkAllTablesExistWithApiContext(
+    HOOK_NAME,
+    apiContext,
+  );
+  if (!allTablesExist) {
+    return;
+  }
+
+  const myDatabaseHelper = new MyDatabaseHelper(apiContext);
+
+  action(CollectionNames.CHAT_MESSAGES + '.items.create', async meta => {
+    const chatMessageId = meta.key as string;
+
+    const chatMessageService = new ItemsServiceHelper<DatabaseTypes.ChatMessages>(
+      myDatabaseHelper,
+      CollectionNames.CHAT_MESSAGES,
+    );
+    const chatsParticipantsService = new ItemsServiceHelper<DatabaseTypes.ChatsParticipants>(
+      myDatabaseHelper,
+      CollectionNames.CHATS_PARTICIPANTS,
+    );
+    const profilesService = myDatabaseHelper.getProfilesHelper();
+    const pushNotificationService = myDatabaseHelper.getPushNotificationsHelper();
+
+    const chatMessage = await chatMessageService.readOne(chatMessageId, { fields: ['*'] });
+    const chatId = chatMessage.chat as string | undefined;
+    if (!chatId) {
+      return;
+    }
+
+    const participants = await chatsParticipantsService.findItems(
+      { chats_id: chatId },
+      { fields: ['profiles_id'] },
+    );
+
+    const expoTokensSet = new Set<string>();
+
+    for (const participant of participants) {
+      const profileId = participant.profiles_id as string | undefined;
+      if (!profileId) continue;
+      const profile = await profilesService.readOne(profileId, { fields: ['devices.*'] });
+      const devices = profile.devices as DatabaseTypes.Devices[] | undefined;
+      if (!devices) continue;
+      for (const device of devices) {
+        const token = getExpoPushTokenFromDevice(device);
+        if (token) {
+          expoTokensSet.add(token);
+        }
+      }
+    }
+
+    const expoTokens = Array.from(expoTokensSet);
+    if (expoTokens.length === 0) {
+      return;
+    }
+
+    const pushNotificationObj: Partial<DatabaseTypes.PushNotifications> = {
+      expo_push_tokens: expoTokens,
+      message_title: 'Neue Chat Nachricht',
+      message_body: chatMessage.message || '',
+      message_data: { chat_id: chatId, chat_message_id: chatMessageId },
+    };
+
+    await pushNotificationService.createOne(pushNotificationObj);
+  });
+
+  function getExpoPushTokenFromDevice(device: DatabaseTypes.Devices): string | undefined {
+    const pushTokenObj: any = device.pushTokenObj;
+    return pushTokenObj?.pushtokenObj?.data;
+  }
+});

--- a/packages/common/src/databaseTypes/CollectionNames.ts
+++ b/packages/common/src/databaseTypes/CollectionNames.ts
@@ -59,4 +59,7 @@ export enum CollectionNames {
   FOODOFFER_CATEGORIES = 'foodoffers_categories',
   WORKFLOWS = 'workflows',
   WORKFLOWS_RUNS = 'workflows_runs',
+  CHATS = 'chats',
+  CHAT_MESSAGES = 'chat_messages',
+  CHATS_PARTICIPANTS = 'chats_participants',
 }


### PR DESCRIPTION
## Summary
- notify chat participants via push notification when new messages arrive
- add chat related collections to CollectionNames enum

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b04e3a79f48330899e3d8549ac6d59