### PR TITLE
Reduce chat bubble spacing on chat details screen

### DIFF
--- a/apps/frontend/app/app/(app)/chats/details/styles.ts
+++ b/apps/frontend/app/app/(app)/chats/details/styles.ts
@@ -4,10 +4,10 @@ export default StyleSheet.create({
 	container: {
 		flex: 1,
 	},
-	list: {
-		padding: 20,
-		gap: 10,
-	},
+        list: {
+                padding: 20,
+                gap: 2,
+        },
 	messageItem: {
 		maxWidth: '80%',
 		gap: 4,


### PR DESCRIPTION
## Summary
- tighten vertical gap between chat messages for a denser chat view

## Testing
- `yarn workspace rocket-meals-dev lint` *(fails: project in apps/frontend/app/package.json doesn't seem to have been installed)*
- `yarn workspace rocket-meals-dev test --watchAll=false` *(fails: project in apps/frontend/app/package.json doesn't seem to have been installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c0f9ed288330b8725f6d53772697