### PR TITLE
chore: add workflow to sync dev to master

### DIFF
--- a/.github/workflows/sync-dev-to-master.yml
+++ b/.github/workflows/sync-dev-to-master.yml
@@ -1,0 +1,46 @@
+name: "🛠️ Sync dev to master"
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🔄 Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "🤖 Configure Git"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: "🚀 Merge dev into master"
+        id: merge
+        run: |
+          git fetch origin dev master
+          git checkout master
+          if git merge --ff-only origin/dev; then
+            git push origin master
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "📨 Create pull request"
+        if: steps.merge.outputs.merged == 'false'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: master
+          head: dev
+          title: "Merge dev into master"
+          body: "Automatischer Pull Request, weil der direkte Merge fehlgeschlagen ist."


### PR DESCRIPTION
## Summary
- add workflow to push dev into master or open PR if merge fails

## Testing
- `npm test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c6abfd148330bfbfbcce8f565ffd