### PR TITLE
feat: serve rss feed as xml

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-rss-endpoint/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-rss-endpoint/index.ts
@@ -1,10 +1,10 @@
 import {defineEndpoint} from '@directus/extensions-sdk';
 import {MyDatabaseHelper} from '../helpers/MyDatabaseHelper';
 import {ApiContext} from '../helpers/ApiContext';
-import {RssBuilder} from "./RssBuilder";
+import {RssBuilder} from './RssBuilder';
 
 
-const EndpointTopName = 'rss-news';
+const EndpointTopName = 'rss-news.xml';
 
 export default defineEndpoint({
     id: EndpointTopName,
@@ -18,7 +18,7 @@ export default defineEndpoint({
             });
 
             const rss = RssBuilder.buildRss(news, myDatabaseHelper.getServerUrl());
-            res.set('Content-Type', 'application/rss+xml');
+            res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
             res.send(rss);
         });
     }


### PR DESCRIPTION
## Summary
- expose rss news endpoint as `.xml`
- explicitly return rss XML content type

## Testing
- `CI=1 yarn workspace directus-extension-rocket-meals-bundle testOnly src/news-rss-endpoint/__tests__/news-rss-endpoint.test.ts`
- `CI=1 yarn test` *(fails: Error generating PDF: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b2304153b483308e28ecda8b09de31