### PR TITLE
fix: correct helper name

### DIFF
--- a/apps/backend-sync/src/DirectusDatabaseSync.ts
+++ b/apps/backend-sync/src/DirectusDatabaseSync.ts
@@ -6,7 +6,7 @@ import {CookieJar} from 'cookiejar';
 import FormData from 'form-data';
 
 import {createRequire} from 'module';
-import {FetchIngoreSelfSignedCertHelper} from "./FetchIngoreSelfSignedCertHelper";
+import {FetchIgnoreSelfSignedCertHelper} from "./FetchIgnoreSelfSignedCertHelper";
 
 const require = createRequire(import.meta.url);
 
@@ -131,7 +131,7 @@ export class DirectusDatabaseSync {
         //console.log("admin_email: "+admin_email);
         //console.log("admin_password: "+admin_password)
 
-        const response = await FetchIngoreSelfSignedCertHelper.fetch(`${this.config.directusInstanceUrl}/auth/login`, {
+        const response = await FetchIgnoreSelfSignedCertHelper.fetch(`${this.config.directusInstanceUrl}/auth/login`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -181,7 +181,7 @@ export class DirectusDatabaseSync {
             headersObject = { Cookie: headers.get('cookie') };
         }
 
-        return await FetchIngoreSelfSignedCertHelper.fetch(url, this.fetchGetOptions(headersObject, 'GET'));
+        return await FetchIgnoreSelfSignedCertHelper.fetch(url, this.fetchGetOptions(headersObject, 'GET'));
     };
 
     private async fetchGetResponseJson(url: string, headers: any){
@@ -195,7 +195,7 @@ export class DirectusDatabaseSync {
 
         // Patch settings with an empty object
         console.log(' -  Patching with empty');
-        await FetchIngoreSelfSignedCertHelper.fetch(`${this.getUrlSettings()}`, {
+        await FetchIgnoreSelfSignedCertHelper.fetch(`${this.getUrlSettings()}`, {
             method: 'PATCH',
             headers: {
                 Cookie: headers.get('cookie'),
@@ -227,7 +227,7 @@ export class DirectusDatabaseSync {
         }
 
         // Patch updated settings
-        const response = await FetchIngoreSelfSignedCertHelper.fetch(`${this.getUrlSettings()}`, {
+        const response = await FetchIgnoreSelfSignedCertHelper.fetch(`${this.getUrlSettings()}`, {
             method: 'PATCH',
             headers: {
                 Cookie: headers.get('cookie'),
@@ -364,7 +364,7 @@ export class DirectusDatabaseSync {
 
         // Import collection into Directus
         console.log(` -  Importing ${displayName}`);
-        const response = await FetchIngoreSelfSignedCertHelper.fetch(`${this.config.directusInstanceUrl}/utils/import/${displayName}`, {
+        const response = await FetchIgnoreSelfSignedCertHelper.fetch(`${this.config.directusInstanceUrl}/utils/import/${displayName}`, {
             method: 'POST',
             headers: { Cookie: headers.get('cookie'), ...formData.getHeaders() },
             body: formData as any,

--- a/apps/backend-sync/src/DockerDirectusPingHelper.ts
+++ b/apps/backend-sync/src/DockerDirectusPingHelper.ts
@@ -1,5 +1,5 @@
 import {DockerDirectusHelper} from "./DockerDirectusHelper";
-import {FetchIngoreSelfSignedCertHelper} from "./FetchIngoreSelfSignedCertHelper";
+import {FetchIgnoreSelfSignedCertHelper} from "./FetchIgnoreSelfSignedCertHelper";
 
 export class DockerDirectusPingHelper {
 
@@ -17,7 +17,7 @@ export class DockerDirectusPingHelper {
         console.log(`⏳ Prüfe Directus Ping Status...`);
 
         // Versuche zuerst den standard Ping endpoint
-        let response = await FetchIngoreSelfSignedCertHelper.fetch(pingCheckUrl, {
+        let response = await FetchIgnoreSelfSignedCertHelper.fetch(pingCheckUrl, {
           method: 'GET',
           headers: {
             'Accept': 'application/json'

--- a/apps/backend-sync/src/FetchIgnoreSelfSignedCertHelper.ts
+++ b/apps/backend-sync/src/FetchIgnoreSelfSignedCertHelper.ts
@@ -1,7 +1,7 @@
 import * as https from 'https';
 import fetch from 'node-fetch';
 
-export class FetchIngoreSelfSignedCertHelper {
+export class FetchIgnoreSelfSignedCertHelper {
 
   public static async fetch(url: string, options: any = {}): Promise<any> {
     // Prüfe das Protokoll der URL


### PR DESCRIPTION
## Summary
- rename helper to FetchIgnoreSelfSignedCertHelper
- update imports and usages

## Testing
- `npx tsc --pretty false -p apps/backend-sync/tsconfig.json --noEmit`
- `yarn test` *(fails: build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ff1c3098833094467709344cc610