### PR TITLE
feat(frontend): add admin food feedback screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/food-feedbacks-admin/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/food-feedbacks-admin/index.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import styles from './styles';
+import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
+import { DatabaseTypes } from 'repo-depkit-common';
+import SettingsList from '@/components/SettingsList';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { ChatsHelper } from '@/redux/actions/Chats/Chats';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import { SET_CHATS } from '@/redux/Types/types';
+import { router } from 'expo-router';
+
+const FoodFeedbacksAdmin = () => {
+        useSetPageTitle(TranslationKeys.food_feedbacks);
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const dispatch = useDispatch();
+        const chats = useSelector((state: RootState) => state.chats.chats);
+        const { profile } = useSelector((state: RootState) => state.authReducer);
+        const [loading, setLoading] = useState(false);
+        const [feedbacks, setFeedbacks] = useState<DatabaseTypes.FoodsFeedbacks[]>([]);
+
+        const feedbackHelper = useMemo(() => new FoodFeedbackHelper(), []);
+        const chatsHelper = useMemo(() => new ChatsHelper(), []);
+
+        const fetchFeedbacks = async () => {
+                try {
+                        setLoading(true);
+                        const result = (await feedbackHelper.fetchAllFoodFeedbacks({
+                                sort: ['-date_created'],
+                                filter: { status: { _eq: 'published' } },
+                        })) as DatabaseTypes.FoodsFeedbacks[];
+                        setFeedbacks(result);
+                } catch (e) {
+                        console.error('Error fetching feedbacks:', e);
+                } finally {
+                        setLoading(false);
+                }
+        };
+
+        useEffect(() => {
+                fetchFeedbacks();
+        }, []);
+
+        const openChat = async (feedback: DatabaseTypes.FoodsFeedbacks) => {
+                try {
+                        let existing = chats.find(c => c.foods_feedback === feedback.id);
+                        if (!existing) {
+                                const newChat = (await chatsHelper.createItem({
+                                        foods_feedback: feedback.id,
+                                        status: 'published',
+                                        participants: [
+                                                { profiles_id: profile?.id },
+                                                { profiles_id: feedback.profile as string },
+                                        ],
+                                })) as DatabaseTypes.Chats;
+                                if (newChat) {
+                                        dispatch({ type: SET_CHATS, payload: [...chats, newChat] });
+                                        existing = newChat;
+                                }
+                        }
+                        if (existing) {
+                                router.push({ pathname: '/chats/details', params: { chat_id: existing.id } });
+                        }
+                } catch (e) {
+                        console.error('Error creating chat:', e);
+                }
+        };
+
+        return (
+                <ScrollView
+                        style={{ ...styles.container, backgroundColor: theme.screen.background }}
+                        contentContainerStyle={{ ...styles.contentContainer, backgroundColor: theme.screen.background }}
+                >
+                        <View style={styles.content}>
+                                <Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.food_feedbacks)}</Text>
+                                {loading ? (
+                                        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
+                                                <ActivityIndicator size="large" color={theme.screen.text} />
+                                        </View>
+                                ) : (
+                                        feedbacks.map((item, index) => (
+                                                <SettingsList
+                                                        key={item.id}
+                                                        leftIcon={<MaterialCommunityIcons name="comment-text" size={24} color={theme.screen.icon} />}
+                                                        title={item.comment || '-'}
+                                                        value={item.rating ? String(item.rating) : undefined}
+                                                        rightIcon={<MaterialCommunityIcons name="chat-plus" size={24} color={theme.screen.icon} />}
+                                                        onPress={() => openChat(item)}
+                                                        groupPosition={
+                                                                feedbacks.length === 1
+                                                                        ? 'single'
+                                                                        : index === 0
+                                                                                ? 'top'
+                                                                                : index === feedbacks.length - 1
+                                                                                        ? 'bottom'
+                                                                                        : 'middle'
+                                                        }
+                                                />
+                                        ))
+                                )}
+                        </View>
+                </ScrollView>
+        );
+};
+
+export default FoodFeedbacksAdmin;
+

--- a/apps/frontend/app/app/(app)/experimentell/food-feedbacks-admin/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/food-feedbacks-admin/styles.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+        container: {
+                flex: 1,
+        },
+        contentContainer: {},
+        content: {
+                width: '100%',
+                height: '100%',
+                padding: 20,
+        },
+        heading: {
+                fontSize: 24,
+                fontFamily: 'Poppins_700Bold',
+                marginVertical: 10,
+        },
+});
+

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -76,19 +76,29 @@ const index = () => {
 						<Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.foodoffers_scroll)}</Text>
 					</View>
 					<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-				</TouchableOpacity>
-				<TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/chats')}>
-					<View style={styles.col}>
-						<MaterialCommunityIcons name="chat" color={theme.screen.icon} size={24} />
-						<Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.chats)}</Text>
-					</View>
-					<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-				</TouchableOpacity>
-				<TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/debug-logout')}>
-					<View style={styles.col}>
-						<MaterialCommunityIcons name="bug" color={theme.screen.icon} size={24} />
-						<Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.debug_logout)}</Text>
-					</View>
+                                </TouchableOpacity>
+                                <TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/chats')}>
+                                        <View style={styles.col}>
+                                                <MaterialCommunityIcons name="chat" color={theme.screen.icon} size={24} />
+                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.chats)}</Text>
+                                        </View>
+                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
+                                        onPress={() => router.push('/experimentell/food-feedbacks-admin')}
+                                >
+                                        <View style={styles.col}>
+                                                <MaterialCommunityIcons name="clipboard-text" color={theme.screen.icon} size={24} />
+                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.food_feedbacks)}</Text>
+                                        </View>
+                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
+                                </TouchableOpacity>
+                                <TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/debug-logout')}>
+                                        <View style={styles.col}>
+                                                <MaterialCommunityIcons name="bug" color={theme.screen.icon} size={24} />
+                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.debug_logout)}</Text>
+                                        </View>
 					<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
 				</TouchableOpacity>
 				<TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/rate-app')}>


### PR DESCRIPTION
## Summary
- list recent food feedbacks in experimentell section
- allow admins to start chats for feedback items, linking the feedback

## Testing
- `yarn lint app/(app)/experimentell/food-feedbacks-admin/index.tsx app/(app)/experimentell/food-feedbacks-admin/styles.ts app/(app)/experimentell/index.tsx` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68b60128f19c83308459777ac90229ea