### PR TITLE
ci: download sonarcloud reports

### DIFF
--- a/.github/workflows/combined-ci.yml
+++ b/.github/workflows/combined-ci.yml
@@ -60,6 +60,37 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  sonarcloud-report:
+    name: 📥 Download SonarCloud Report
+    runs-on: ubuntu-latest
+    needs: [sonarqube, check-repository]
+    if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
+    steps:
+      - name: 🔄 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🧰 Setup Node.js, Yarn & Dependencies
+        uses: ./.github/actions/setup-and-install
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: 📥 Download SonarCloud reports
+        run: |
+          SONAR_PROJECT=$(grep -E '^sonar.projectKey' sonar-project.properties | cut -d= -f2)
+          yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir apps/sonarCloudReportDownloader/reports
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: 💾 Commit reports
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -f apps/sonarCloudReportDownloader/reports
+          git commit -m "chore: update sonarcloud reports" || echo "No changes to commit"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   backend-directus:
     name: 🔨 Directus Backend Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add workflow job to download and commit SonarCloud issue reports

## Testing
- `CI=1 yarn test` *(fails: libatk-1.0.so.0 missing; ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bb57884e1c83308b6abd642bffe32d