### PR TITLE
ci: skip sonar report commit if empty

### DIFF
--- a/.github/workflows/combined-ci.yml
+++ b/.github/workflows/combined-ci.yml
@@ -78,16 +78,23 @@ jobs:
       - name: 📥 Download SonarCloud reports
         run: |
           SONAR_PROJECT=$(grep -E '^sonar.projectKey' sonar-project.properties | cut -d= -f2)
-          yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir apps/sonarCloudReportDownloader/reports
+          OUTPUT_DIR=apps/sonarCloudReportDownloader/reports
+          echo "Saving SonarCloud reports to $OUTPUT_DIR"
+          yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir "$OUTPUT_DIR"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: 💾 Commit reports
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add -f apps/sonarCloudReportDownloader/reports
-          git commit -m "chore: update sonarcloud reports" || echo "No changes to commit"
-          git push
+          if [ -d apps/sonarCloudReportDownloader/reports ]; then
+            echo "Committing reports from apps/sonarCloudReportDownloader/reports"
+            git add -f apps/sonarCloudReportDownloader/reports
+            git commit -m "chore: update sonarcloud reports" || echo "No changes to commit"
+            git push
+          else
+            echo "No reports generated at apps/sonarCloudReportDownloader/reports, skipping commit"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/apps/sonarCloudReportDownloader/src/index.ts
+++ b/apps/sonarCloudReportDownloader/src/index.ts
@@ -120,13 +120,14 @@ async function generateReport(
 
 async function main() {
   const { token, project, qualities, "output-dir": outputDir } = argv;
+  const resolvedOutputDir = path.resolve(outputDir);
 
   console.log(`Generating reports for project ${project}...`);
   console.log(`Impact Software Qualities: ${qualities.join(", ")}`);
-  console.log(`Output directory: ${outputDir}`);
+  console.log(`Output directory: ${resolvedOutputDir}`);
 
   for (const quality of qualities) {
-    await generateReport(token, project, quality, outputDir);
+    await generateReport(token, project, quality, resolvedOutputDir);
   }
 
   console.log("All reports generated successfully ✅");


### PR DESCRIPTION
## Summary
- avoid workflow failure when SonarCloud reports directory is missing
- log report output directory in workflow and downloader app

## Testing
- `yarn test` (fails: connect ENETUNREACH 185.232.0.200:443)
- `yarn app-backend-test` (fails: connect ENETUNREACH 185.232.0.200:443)


------
https://chatgpt.com/codex/tasks/task_e_68bbd886e09c8330bcb37656908255a3