### PR TITLE
Fix SonarCloud report path in CI workflow

### DIFF
--- a/.github/workflows/combined-ci.yml
+++ b/.github/workflows/combined-ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: 📥 Download SonarCloud reports
         run: |
           SONAR_PROJECT=$(grep -E '^sonar.projectKey' sonar-project.properties | cut -d= -f2)
-          OUTPUT_DIR=apps/sonarCloudReportDownloader/reports
+          OUTPUT_DIR=reports
           echo "Saving SonarCloud reports to $OUTPUT_DIR"
           yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir "$OUTPUT_DIR"
         env:


### PR DESCRIPTION
## Summary
- ensure SonarCloud reports save inside app workspace instead of nested path

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1676d4d08330820863261c9153eb