### PR TITLE
feat: add script to make static properties readonly

### DIFF
--- a/apps/sonarCloudReportDownloader/package.json
+++ b/apps/sonarCloudReportDownloader/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "start": "tsx src/index.ts",
-    "debug": "yarn run start"
+    "debug": "yarn run start",
+    "fix:readonly": "tsx src/fixStaticReadonly.ts"
   },
   "author": "",
   "license": "ISC",

--- a/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
+++ b/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+import path from "path";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const argv = yargs(hideBin(process.argv))
+  .option("csv", {
+    alias: "c",
+    type: "string",
+    demandOption: true,
+    describe: "Path to maintainability CSV report",
+  })
+  .option("root", {
+    alias: "r",
+    type: "string",
+    default: process.cwd(),
+    describe: "Root directory of the project",
+  })
+  .help()
+  .alias("h", "help").argv as any;
+
+const csvPath = path.resolve(argv.csv);
+const rootDir = path.resolve(argv.root);
+
+const csvContent = fs.readFileSync(csvPath, "utf-8");
+const lines = csvContent.split(/\r?\n/).slice(1); // skip header
+
+for (const line of lines) {
+  if (!line.includes("Make this public static property readonly.")) {
+    continue;
+  }
+  const match = line.match(/^"[^\"]+","[^\"]+","([^\"]+)",(\d+)/);
+  if (!match) {
+    continue;
+  }
+  const componentPath = match[1];
+  const lineNumber = parseInt(match[2], 10);
+  const fileRelPath = componentPath.split(":")[1];
+  const filePath = path.join(rootDir, fileRelPath);
+
+  if (!fs.existsSync(filePath)) {
+    console.warn(`File not found: ${filePath}`);
+    continue;
+  }
+
+  const fileLines = fs.readFileSync(filePath, "utf-8").split(/\r?\n/);
+  const index = lineNumber - 1;
+  if (index < 0 || index >= fileLines.length) {
+    console.warn(`Line ${lineNumber} out of range in ${filePath}`);
+    continue;
+  }
+
+  const targetLine = fileLines[index];
+  if (/static\s+readonly/.test(targetLine)) {
+    continue; // already readonly
+  }
+  if (!/\bstatic\b/.test(targetLine)) {
+    continue; // no static keyword
+  }
+
+  fileLines[index] = targetLine.replace(/\bstatic\b/, "static readonly");
+  fs.writeFileSync(filePath, fileLines.join("\n"), "utf-8");
+  console.log(`Updated ${filePath}:${lineNumber}`);
+}


### PR DESCRIPTION
## Summary
- add fixer script to turn public static properties into static readonly based on maintainability CSV
- expose fixer via `fix:readonly` script in sonarCloudReportDownloader

## Testing
- `npx tsc --project apps/sonarCloudReportDownloader/tsconfig.json --noEmit`
- `CI=1 yarn test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc29034b2c83309a5440ecc5969ab0