### PR TITLE
chore: gate linting and analysis to upstream repo

### DIFF
--- a/.github/workflows/combined-ci.yml
+++ b/.github/workflows/combined-ci.yml
@@ -19,10 +19,26 @@ jobs:
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
+  check-repository:
+    name: 🔍 Check Repository
+    runs-on: ubuntu-latest
+    needs: setup
+    outputs:
+      is-upstream: ${{ steps.check.outputs.is-upstream }}
+    steps:
+      - name: 🔄 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: 🔍 Check Repository Type
+        id: check
+        uses: ./.github/actions/check-repository
+
   lint:
     name: 🎨 Prettier & ESLint
     runs-on: ubuntu-latest
-    needs: setup
+    needs: check-repository
+    if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
     steps:
       - name: 🔄 Checkout Repository
         uses: actions/checkout@v4
@@ -47,7 +63,8 @@ jobs:
   check-build:
     name: 🔍 Check Build Number
     runs-on: ubuntu-latest
-    needs: sonarqube
+    needs: [sonarqube, sonarcloud-report]
+    if: ${{ always() }}
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
@@ -59,25 +76,10 @@ jobs:
         id: check
         uses: ./.github/actions/check-build-number
 
-  check-repository:
-    name: 🔍 Check Repository
-    runs-on: ubuntu-latest
-    needs: lint
-    outputs:
-      is-upstream: ${{ steps.check.outputs.is-upstream }}
-    steps:
-      - name: 🔄 Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-      - name: 🔍 Check Repository Type
-        id: check
-        uses: ./.github/actions/check-repository
-
   sonarqube:
     name: 🔍 SonarQube Analysis
     runs-on: ubuntu-latest
-    needs: check-repository
+    needs: [lint, check-repository]
     if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
     steps:
       - name: 🔄 Checkout Repository
@@ -249,3 +251,21 @@ jobs:
         working-directory: ./apps/frontend/app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  push-changes:
+    name: 📤 Push Changes
+    runs-on: ubuntu-latest
+    needs: [backend-directus, sonarcloud-report, lint, check-repository]
+    if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
+    steps:
+      - name: 🔄 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 📤 Push accumulated changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git push


### PR DESCRIPTION
## Summary
- check repository before linting
- run prettier/eslint and sonar jobs only on main repo
- wait for sonar report before backend build
- push accumulated changes after analysis

## Testing
- `yarn lint .github/workflows/combined-ci.yml` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68bcad3235388330882c19025a1fa1a2