### PR TITLE
ci: ensure repository checkout before build-number comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
       - name: "🔍 Compare Build Number"
         id: check
         uses: ./.github/actions/check-build-number


### PR DESCRIPTION
## Summary
- ensure the build-number check job checks out repository before using local action

## Testing
- `yarn lint`
- `yarn test` *(fails: Failed to fetch or parse news page: ENETUNREACH 185.232.0.200:443)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4cf264ec8330967d2bfa32718c6c