### PR TITLE
fix: sync sonarcloud report step before pushing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,20 +98,25 @@ jobs:
           yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir "$OUTPUT_DIR"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - name: "💾 Commit reports"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          if [ -d apps/sonarCloudReportDownloader/reports ]; then
-            echo "Committing reports from apps/sonarCloudReportDownloader/reports"
-            git add -f apps/sonarCloudReportDownloader/reports
-            git commit -m "chore: update sonarcloud reports [skip ci]" || echo "No changes to commit"
-            git push
-          else
-            echo "No reports generated at apps/sonarCloudReportDownloader/reports, skipping commit"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: "💾 Commit reports"
+          run: |
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git pull --rebase origin "$GITHUB_REF_NAME"
+            if [ -d apps/sonarCloudReportDownloader/reports ]; then
+              echo "Committing reports from apps/sonarCloudReportDownloader/reports"
+              git add -f apps/sonarCloudReportDownloader/reports
+              if git diff --cached --quiet; then
+                echo "No changes to commit"
+              else
+                git commit -m "chore: update sonarcloud reports [skip ci]"
+                git push
+              fi
+            else
+              echo "No reports generated at apps/sonarCloudReportDownloader/reports, skipping commit"
+            fi
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   backend-directus:
     name: "🔨 Directus Backend Build"


### PR DESCRIPTION
## Summary
- ensure sonarcloud report step pulls latest branch and only pushes when commit exists

## Testing
- `yarn test` *(fails: Failed to fetch or parse news page: connect ENETUNREACH 185.232.0.200:443)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6178b31883309819b7cd591556da