### PR TITLE
fix: correct yaml indentation in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,25 +98,25 @@ jobs:
           yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir "$OUTPUT_DIR"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        - name: "💾 Commit reports"
-          run: |
-            git config user.name "github-actions"
-            git config user.email "github-actions@github.com"
-            git pull --rebase origin "$GITHUB_REF_NAME"
-            if [ -d apps/sonarCloudReportDownloader/reports ]; then
-              echo "Committing reports from apps/sonarCloudReportDownloader/reports"
-              git add -f apps/sonarCloudReportDownloader/reports
-              if git diff --cached --quiet; then
-                echo "No changes to commit"
-              else
-                git commit -m "chore: update sonarcloud reports [skip ci]"
-                git push
-              fi
+      - name: "💾 Commit reports"
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git pull --rebase origin "$GITHUB_REF_NAME"
+          if [ -d apps/sonarCloudReportDownloader/reports ]; then
+            echo "Committing reports from apps/sonarCloudReportDownloader/reports"
+            git add -f apps/sonarCloudReportDownloader/reports
+            if git diff --cached --quiet; then
+              echo "No changes to commit"
             else
-              echo "No reports generated at apps/sonarCloudReportDownloader/reports, skipping commit"
+              git commit -m "chore: update sonarcloud reports [skip ci]"
+              git push
             fi
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          else
+            echo "No reports generated at apps/sonarCloudReportDownloader/reports, skipping commit"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   backend-directus:
     name: "🔨 Directus Backend Build"


### PR DESCRIPTION
## Summary
- fix indentation in SonarCloud report download step to resolve CI workflow YAML error

## Testing
- `CI=1 yarn test` *(fails: Failed to fetch or parse news page: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6557e75c83309e5b1091b3dc112d