### PR TITLE
ci: autostash SonarCloud reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git pull --rebase origin "$GITHUB_REF_NAME"
+          git pull --rebase --autostash origin "$GITHUB_REF_NAME"
           if [ -d apps/sonarCloudReportDownloader/reports ]; then
             echo "Committing reports from apps/sonarCloudReportDownloader/reports"
             git add -f apps/sonarCloudReportDownloader/reports


### PR DESCRIPTION
## Summary
- prevent sonar report workflow from failing on local changes by autostashing before pulling

## Testing
- `npx prettier -c .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bda4e705b08330b82fd4467c436e8f