### PR TITLE
refactor: remove unused mode variable

### DIFF
--- a/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -25,7 +25,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 	const [showTooltip, setShowTooltip] = useState(false);
 	const likeLoading = false;
 	const dislikeLoading = false;
-	const { primaryColor, language, appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+	const { primaryColor, language, appSettings } = useSelector((state: RootState) => state.settings);
 
 	const { profile } = useSelector((state: RootState) => state.authReducer);
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;


### PR DESCRIPTION
## Summary
- remove unused `mode` assignment from MarkingLabels component

## Testing
- `yarn lint`
- `CI=1 yarn test` *(fails: libatk-1.0.so.0 missing; network ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bdacf37b848330b53a5fc14d180a67