### PR TITLE
chore: clean up early Sonar maintainability warnings

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -253,19 +253,19 @@ const AccountBalanceScreen = () => {
 				</View>
 				<View style={styles.additionalInfoContainer}>{appSettings && appSettings?.balance_translations && <CustomMarkdown content={getTextFromTranslation(appSettings?.balance_translations, language) || ''} backgroundColor={balance_area_color} imageWidth={'100%'} imageHeight={400} />}</View>
 			</View>
-			<View style={styles.additionalInfoContainer}>
-				{/* Debug Logs if isDevMode active*/}
-				{debugErrors.length > 0 && (
-					<View style={{ marginTop: 20 }}>
-						<Text style={{ ...styles.label, color: theme.header.text }}>{translate(TranslationKeys.debugErrors)}:</Text>
-						{debugErrors.map((errorItem, index) => (
-							<View key={index} style={{ marginVertical: 4 }}>
-								<Text style={{ ...styles.errorText, color: theme.header.text }}>{`${format(errorItem.timestamp, 'dd.MM.yyyy HH:mm:ss')} - ${errorItem.source}: ${errorItem.error}`}</Text>
-							</View>
-						))}
-					</View>
-				)}
-			</View>
+                        <View style={styles.additionalInfoContainer}>
+                                {/* Debug Logs if isDevMode active*/}
+                                {isDevMode && debugErrors.length > 0 && (
+                                        <View style={{ marginTop: 20 }}>
+                                                <Text style={{ ...styles.label, color: theme.header.text }}>{translate(TranslationKeys.debugErrors)}:</Text>
+                                                {debugErrors.map((errorItem, index) => (
+                                                        <View key={index} style={{ marginVertical: 4 }}>
+                                                                <Text style={{ ...styles.errorText, color: theme.header.text }}>{`${format(errorItem.timestamp, 'dd.MM.yyyy HH:mm:ss')} - ${errorItem.source}: ${errorItem.error}`}</Text>
+                                                        </View>
+                                                ))}
+                                        </View>
+                                )}
+                        </View>
 			{isActive && (
 				<BaseBottomSheet
 					ref={nfcSheetRef}

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -14,7 +14,7 @@ import ColorSchemeSheet from '@/components/ColorSchemeSheet/ColorSchemeSheet';
 import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
 import ServerSelectionSheet from '@/components/ServerSelectionSheet/ServerSelectionSheet';
 import { router, useFocusEffect } from 'expo-router';
-import { type CustomerConfig, getBuildNumber, getVersion, getVersionPatch } from '@/config';
+import { type CustomerConfig, getVersion } from '@/config';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { useLanguage } from '@/hooks/useLanguage';

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { FlatList, View, Text, RefreshControl, ActivityIndicator, Dimensions } from 'react-native';
+import { FlatList, View, Text, RefreshControl, ActivityIndicator } from 'react-native';
 import { addDays, format } from 'date-fns';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
@@ -36,8 +36,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 	const { ownFoodFeedbacks, foodCategories, foodOfferCategories } = useSelector((state: RootState) => state.food);
 	const { profile } = useSelector((state: RootState) => state.authReducer);
 	const selectedCanteen = canteens?.find(c => c.id === canteenId) as DatabaseTypes.Canteens | undefined;
-	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
-	const [days, setDays] = useState<DayData[]>([]);
+        const [days, setDays] = useState<DayData[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [refreshing, setRefreshing] = useState(false);
 	const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
@@ -93,12 +92,6 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		[sortBy, language, ownFoodFeedbacks, profile, foodCategories, foodOfferCategories]
 	);
 
-	useEffect(() => {
-		const sub = Dimensions.addEventListener('change', ({ window }) => {
-			setScreenWidth(window.width);
-		});
-		return () => sub?.remove();
-	}, []);
 
 	useEffect(() => {
 		setDays(prev => prev.map(d => ({ ...d, offers: sortOffers(d.offers) })));

--- a/apps/frontend/app/components/Login/AttentionSheet.tsx
+++ b/apps/frontend/app/components/Login/AttentionSheet.tsx
@@ -1,6 +1,6 @@
 import { Text, TouchableOpacity, View } from 'react-native';
 import React, { useCallback, useRef, useState } from 'react';
-import { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
 import { AttentionSheetProps } from './types';
 import { styles } from './styles';

--- a/apps/frontend/app/components/Login/ManagementSheet.tsx
+++ b/apps/frontend/app/components/Login/ManagementSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { styles } from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { SheetProps } from './types';


### PR DESCRIPTION
## Summary
- remove unused screen width logic in FoodOffersScrollList
- drop unused BottomSheetView imports in login sheets
- prune unused config helpers and gate debug logs by dev mode

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb538370c8330bdf9955dbee49a62