### PR TITLE
fix: address top reliability issues

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/DirectusTestServerSetup.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/DirectusTestServerSetup.ts
@@ -226,8 +226,9 @@ export class DirectusTestServerSetup {
         }
 
         if (error) {
-          this.log(`Database bootstrap failed: ${error}`);
-          return reject(error);
+          const err = error instanceof Error ? error : new Error(String(error));
+          this.log(`Database bootstrap failed: ${err}`);
+          return reject(err);
         }
 
         this.log('Database bootstrap completed.');

--- a/apps/frontend/app/app/(auth)/login.tsx
+++ b/apps/frontend/app/app/(auth)/login.tsx
@@ -216,7 +216,7 @@ export default function Login() {
 						}}
 					/>
 				)}
-				{description && <Text style={{ ...styles.subTitle, color: theme.login.text }}>{description}</Text>}
+                                {!!description && <Text style={{ ...styles.subTitle, color: theme.login.text }}>{description}</Text>}
 			</View>
 		);
 	};

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useDispatch, useSelector } from 'react-redux';
 import { getImageUrl, showDayPlanPrice, showFormatedPrice } from '@/constants/HelperFunctions';
 import { getFoodAttributesTranslation, getTextFromTranslation } from '@/helper/resourceHelper';
-import { myContrastColor, useMyContrastColor } from '@/helper/colorHelper';
+import { myContrastColor } from '@/helper/colorHelper';
 import styles from './styles';
 import { fetchFoodsByCanteen } from '@/redux/actions/FoodOffers/FoodOffers';
 import { useFocusEffect, useLocalSearchParams } from 'expo-router';
@@ -934,7 +934,7 @@ const Index = () => {
 										const markingImage = marking?.image_remote_url ? { uri: marking?.image_remote_url } : { uri: getImageUrl(marking?.image) };
 										const markingText = getTextFromTranslation(marking?.translations, language);
 										const MarkingBackgroundColor = marking?.background_color;
-										const MarkingColor = useMyContrastColor(marking?.background_color, theme, mode === 'dark');
+                                                                                const MarkingColor = myContrastColor(marking?.background_color, theme, mode === 'dark');
 										return (
 											<View key={index} style={styles.iconText}>
 												<MarkingIcon

--- a/apps/frontend/app/components/Details/index.tsx
+++ b/apps/frontend/app/components/Details/index.tsx
@@ -53,7 +53,7 @@ const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 							<View
 								style={{
 									...styles.nutritionsContainer,
-									justifyContent: Dimensions.get('window').width > 800 ? 'flex-start' : 'flex-start',
+                                                                        justifyContent: 'flex-start',
 								}}
 							>
 								{item?.attributes &&

--- a/apps/frontend/app/components/MarkingIcon/index.tsx
+++ b/apps/frontend/app/components/MarkingIcon/index.tsx
@@ -20,10 +20,10 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color, co
 	const { theme } = useTheme();
 	const { selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 
-	const bgColor = marking?.background_color;
-	const contrast = marking ? useMyContrastColor(bgColor, theme, mode === 'dark') : null;
+        const bgColor = marking?.background_color;
+        const contrast = useMyContrastColor(bgColor, theme, mode === 'dark');
 
-	if (!marking) return null;
+        if (!marking) return null;
 
 	const markingImage = marking.image_remote_url ? { uri: marking.image_remote_url } : marking.image ? { uri: getImageUrl(String(marking.image)) } : null;
 	const textColor = color || contrast;


### PR DESCRIPTION
## Summary
- ensure MarkingIcon calls contrast hook consistently
- avoid hook usage inside loops in list-day-screen
- reject with Error objects during Directus bootstrap
- guard login screen text with boolean check
- simplify Details layout conditional

## Testing
- `npx eslint apps/frontend/app/components/MarkingIcon/index.tsx "apps/frontend/app/app/(monitor)/list-day-screen/index.tsx" apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/DirectusTestServerSetup.ts "apps/frontend/app/app/(auth)/login.tsx" apps/frontend/app/components/Details/index.tsx --fix` *(fails: ESLint: eslint-plugin-react missing)*
- `yarn test` *(fails: connect ENETUNREACH 185.232.0.200:443)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2517c908330bb03cb69ee2c5b9f