### PR TITLE
fix: guard optional chaining in frontend

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -239,8 +239,8 @@ export default function FoodDetailsScreen() {
 	const getFoodDetails = async () => {
 		try {
 			const foodData = await fetchFoodOffersDetailsById(id.toString());
-			if (foodData && foodData.data) {
-				const { food, attribute_values, foodoffer_category } = foodData?.data;
+                        if (foodData && foodData.data) {
+                                const { food, attribute_values, foodoffer_category } = foodData?.data ?? {};
 
 				const translation = food?.translations?.find((val: FoodsTranslations) => String(val?.languages_code)?.split('-')[0] === languageCode);
 				setFoodDetails({

--- a/apps/frontend/app/app/(app)/form-categories/index.tsx
+++ b/apps/frontend/app/app/(app)/form-categories/index.tsx
@@ -73,13 +73,13 @@ const Index = () => {
 							formCategories?.map((category, index) => {
 								let IconComponent: any = null;
 								let iconName = '';
-								if (category?.icon_expo) {
-									const [library, name] = category?.icon_expo?.split(':');
-									if (iconLibraries[library]) {
-										IconComponent = iconLibraries[library];
-										iconName = name;
-									}
-								}
+                                                                if (category?.icon_expo) {
+                                                                        const [library, name] = category?.icon_expo?.split(':') ?? [];
+                                                                        if (iconLibraries[library]) {
+                                                                                IconComponent = iconLibraries[library];
+                                                                                iconName = name;
+                                                                        }
+                                                                }
 								return (
 									<TouchableOpacity
 										style={{

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -608,13 +608,13 @@ const Index = () => {
 									const isDisabled = answer?.form_field?.is_disabled || false;
 									let IconComponent: any = null;
 									let iconName = '';
-									if (answer?.form_field?.icon_expo) {
-										const [library, name] = answer?.form_field?.icon_expo?.split(':');
-										if (iconLibraries[library]) {
-											IconComponent = iconLibraries[library];
-											iconName = name;
-										}
-									}
+                                                                        if (answer?.form_field?.icon_expo) {
+                                                                                const [library, name] = answer?.form_field?.icon_expo?.split(':') ?? [];
+                                                                                if (iconLibraries[library]) {
+                                                                                        IconComponent = iconLibraries[library];
+                                                                                        iconName = name;
+                                                                                }
+                                                                        }
 
 									return (
 										<View

--- a/apps/frontend/app/app/(app)/forms/index.tsx
+++ b/apps/frontend/app/app/(app)/forms/index.tsx
@@ -74,13 +74,13 @@ const Index = () => {
 							forms?.map((form, index) => {
 								let IconComponent: any = null;
 								let iconName = '';
-								if (form?.icon_expo) {
-									const [library, name] = form?.icon_expo?.split(':');
-									if (iconLibraries[library]) {
-										IconComponent = iconLibraries[library];
-										iconName = name;
-									}
-								}
+                                                                if (form?.icon_expo) {
+                                                                        const [library, name] = form?.icon_expo?.split(':') ?? [];
+                                                                        if (iconLibraries[library]) {
+                                                                                IconComponent = iconLibraries[library];
+                                                                                iconName = name;
+                                                                        }
+                                                                }
 								return (
 									<TouchableOpacity
 										style={{

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -859,8 +859,8 @@ const Index = () => {
 														);
 													}
 
-													const { number_value } = attr?.value;
-													const { prefix, suffix } = attr?.value?.food_attribute || {};
+                                                                                                        const { number_value } = attr?.value ?? {};
+                                                                                                        const { prefix, suffix } = attr?.value?.food_attribute ?? {};
 
 													if (number_value === undefined || number_value === null) {
 														return (

--- a/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
@@ -151,12 +151,13 @@ const CourseTimetable: React.FC<CourseTimetableProps> = ({ events, openSheet, se
 		openSheet();
 	};
 
-	const reorderedDays = useMemo(() => {
-		const firstDayIndex = days?.findIndex(day => day.id.toLocaleLowerCase() === firstDayOfTheWeek.id);
-		console.log('firstDayIndex', firstDayOfTheWeek);
-		if (firstDayIndex === -1) return days; // Fallback if the firstDayOfTheWeek is invalid
-		return [...days?.slice(firstDayIndex), ...days?.slice(0, firstDayIndex)];
-	}, [firstDayOfTheWeek]);
+        const reorderedDays = useMemo(() => {
+                if (!days) return [];
+                const firstDayIndex = days.findIndex(day => day.id.toLocaleLowerCase() === firstDayOfTheWeek.id);
+                console.log('firstDayIndex', firstDayOfTheWeek);
+                if (firstDayIndex === -1) return days; // Fallback if the firstDayOfTheWeek is invalid
+                return [...days.slice(firstDayIndex), ...days.slice(0, firstDayIndex)];
+        }, [days, firstDayOfTheWeek]);
 
 	console.log('Events', events);
 	console.log('reorderedDays', reorderedDays);


### PR DESCRIPTION
## Summary
- ensure optional chaining expressions fall back to safe defaults
- handle undefined arrays and objects before property access

## Testing
- `yarn lint`
- `CI=1 yarn test` *(fails: Error generating PDF: Failed to launch the browser process; Failed to fetch or parse news page: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c1356dc2508330bfe7454533cb11be