### PR TITLE
ci: cancel previous runs on branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, master, dev]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-repository:
     name: "🔍 Check Repository"


### PR DESCRIPTION
## Summary
- ensure only the most recent CI run executes per branch

## Testing
- `yarn prettier .github/workflows/ci.yml --check`


------
https://chatgpt.com/codex/tasks/task_e_68c14e5b90408330865489d42e9067eb