### PR TITLE
fix: remove redundant background color check

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -239,7 +239,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
 															}
 															style={{
 																...styles.categoryLogo,
-																backgroundColor: mark?.background_color && mark?.background_color,
+                                                                                                                               backgroundColor: mark?.background_color,
 																borderRadius: mark?.background_color ? 8 : mark.hide_border ? 5 : 0,
 															}}
 														/>


### PR DESCRIPTION
## Summary
- remove redundant background color conditional in FoodItem component

## Testing
- `yarn eslint apps/frontend/app/components/FoodItem/FoodItem.tsx` *(fails: ESLint couldn't find the plugin "eslint-plugin-react-native".)*
- `CI=true yarn test` *(incomplete: build process stalled during Directus extension build)*

------
https://chatgpt.com/codex/tasks/task_e_68c14e07d9c08330a44c0a36fe6ad24d