### PR TITLE
refactor: replace async forEach in schedule parser

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -757,7 +757,7 @@ export class ParseSchedule {
     }
 
     const foodoffersToCreate: Partial<DatabaseTypes.Foodoffers>[] = [];
-    foodofferListForParser.forEach(async (foodofferForParser, index) => {
+    for (const [index, foodofferForParser] of foodofferListForParser.entries()) {
       const canteen = dictCanteenExternalIdentifierToCanteen[foodofferForParser.canteen_external_identifier];
       const canteenFound = !!canteen;
 
@@ -789,7 +789,7 @@ export class ParseSchedule {
       } else {
         await this.logger.appendLog('Error Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - canteenFound: ' + canteenFound + ' - markingsAllFound: ' + markingsAllFound + ' - foodFound: ' + foodFound);
       }
-    });
+    }
 
     const batchSize = 10;
 


### PR DESCRIPTION
## Summary
- avoid returning promises from forEach callback in ParseSchedule

## Testing
- `yarn lint`
- `CI=1 yarn test`
- `npx tsc -p apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c14e24796c8330bbeb2664e1f1aedc