### PR TITLE
chore: relocate sonarcloud report output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,7 @@ jobs:
       - name: "📥 Download SonarCloud reports"
         run: |
           SONAR_PROJECT=$(grep -E '^sonar.projectKey' sonar-project.properties | cut -d= -f2)
-          OUTPUT_DIR=reports
-          echo "Saving SonarCloud reports to $OUTPUT_DIR"
-          yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT" --output-dir "$OUTPUT_DIR"
+          yarn workspace sonarCloudReportDownloader start --token "$SONAR_TOKEN" --project "$SONAR_PROJECT"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: "💾 Commit reports"
@@ -107,9 +105,9 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-          if [ -d apps/sonarCloudReportDownloader/reports ]; then
-            echo "Committing reports from apps/sonarCloudReportDownloader/reports"
-            git add -f apps/sonarCloudReportDownloader/reports
+          if [ -d reports/sonarCloud ]; then
+            echo "Committing reports from reports/sonarCloud"
+            git add -f reports/sonarCloud
             if git diff --cached --quiet; then
               echo "No changes to commit"
             else
@@ -117,7 +115,7 @@ jobs:
               git push
             fi
           else
-            echo "No reports generated at apps/sonarCloudReportDownloader/reports, skipping commit"
+            echo "No reports generated at reports/sonarCloud, skipping commit"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/t
 .yarn/install-state.gz
 .pnp.*
 
-apps/sonarCloudReportDownloader/reports/
+reports/sonarCloud/

--- a/apps/sonarCloudReportDownloader/src/index.ts
+++ b/apps/sonarCloudReportDownloader/src/index.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import path from 'path';
+import { execSync } from 'child_process';
 
 interface Issue {
   key: string;
@@ -17,6 +18,17 @@ const qualityToReportName: Record<string, string> = {
   RELIABILITY: 'reliability',
   MAINTAINABILITY: 'maintainability',
 };
+
+function getRepoRoot(): string {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+  } catch {
+    console.warn('Could not determine git repository root. Using current directory.');
+    return process.cwd();
+  }
+}
+
+const repoRoot = getRepoRoot();
 
 const argv = yargs(hideBin(process.argv))
   .scriptName('sonar-report')
@@ -43,7 +55,7 @@ const argv = yargs(hideBin(process.argv))
   .option('output-dir', {
     alias: 'o',
     type: 'string',
-    default: './reports',
+    default: path.join(repoRoot, 'reports', 'sonarCloud'),
     describe: 'Output directory for reports',
   })
   .help()


### PR DESCRIPTION
## Summary
- resolve repo root dynamically to place SonarCloud reports under `reports/sonarCloud`
- simplify CI workflow by relying on tool's default output directory

## Testing
- `npx prettier apps/sonarCloudReportDownloader/src/index.ts .github/workflows/ci.yml --write`
- `npx eslint apps/sonarCloudReportDownloader/src/index.ts`
- `yarn test` *(fails: Failed to fetch or parse news page)*

------
https://chatgpt.com/codex/tasks/task_e_68c166c371d48330a2d4c3ae9b6e8113