### PR TITLE
chore: add data clumps analysis workflow

### DIFF
--- a/.github/actions/analyse-data-clumps/action.yml
+++ b/.github/actions/analyse-data-clumps/action.yml
@@ -1,0 +1,25 @@
+name: Analyse Data Clumps
+description: Run data-clumps-doctor to analyse repository for data clumps
+
+runs:
+  using: "composite"
+  steps:
+    - name: Clone data-clumps-doctor
+      shell: bash
+      run: |
+        git clone https://github.com/NilsBaumgartner1994/data-clumps-doctor data-clumps-doctor
+    - name: Build data-clumps-doctor
+      shell: bash
+      run: |
+        cd data-clumps-doctor/analyse
+        npm ci
+        npm run build
+    - name: Run data-clumps analysis
+      shell: bash
+      run: |
+        mkdir -p reports/data-clumps-doctor
+        node data-clumps-doctor/analyse/build/ignoreCoverage/cli.js \
+          --source_type typescript \
+          --commit_selection current \
+          --output reports/data-clumps-doctor/data-clumps.json \
+          --path_to_project "$GITHUB_WORKSPACE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,44 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  data-clumps-report:
+    name: "🩺 Analyse Data Clumps"
+    runs-on: ubuntu-latest
+    needs: [sonarqube, check-repository]
+    if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
+    steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "⚙️ Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+      - name: "🩺 Run data-clumps-doctor"
+        uses: ./.github/actions/analyse-data-clumps
+      - name: "💾 Commit reports"
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+          if [ -d reports/data-clumps-doctor ]; then
+            echo "Committing reports from reports/data-clumps-doctor"
+            git add -f reports/data-clumps-doctor
+            if git diff --cached --quiet; then
+              echo "No changes to commit"
+            else
+              git commit -m "chore: update data clumps report [skip ci]"
+              git push
+            fi
+          else
+            echo "No reports generated at reports/data-clumps-doctor, skipping commit"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   backend-directus:
     name: "🔨 Directus Backend Build"
     runs-on: ubuntu-latest
@@ -243,7 +281,7 @@ jobs:
   push-changes:
     name: "📤 Push Changes"
     runs-on: ubuntu-latest
-    needs: [backend-directus, sonarcloud-report, check-repository]
+    needs: [backend-directus, sonarcloud-report, data-clumps-report, check-repository]
     if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
     steps:
       - name: "🔄 Checkout Repository"

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/t
 .pnp.*
 
 reports/sonarCloud/
+reports/data-clumps-doctor/


### PR DESCRIPTION
## Summary
- add composite action to analyze data clumps via data-clumps-doctor
- run data clumps analysis in CI and commit report
- ignore generated data clumps reports

## Testing
- `yarn lint && echo 'lint success'`
- `yarn test` *(fails: Failed to generate PDF)*

------
https://chatgpt.com/codex/tasks/task_e_68c176e593c48330ae50e40550aa341f