### PR TITLE
fix(ci): serialize report job pushes

### DIFF
--- a/.github/actions/analyse-data-clumps/action.yml
+++ b/.github/actions/analyse-data-clumps/action.yml
@@ -7,18 +7,18 @@ runs:
     - name: Clone data-clumps-doctor
       shell: bash
       run: |
-        git clone https://github.com/NilsBaumgartner1994/data-clumps-doctor data-clumps-doctor
+        git clone https://github.com/NilsBaumgartner1994/data-clumps-doctor "$RUNNER_TEMP/data-clumps-doctor"
     - name: Build data-clumps-doctor
       shell: bash
       run: |
-        cd data-clumps-doctor/analyse
+        cd "$RUNNER_TEMP/data-clumps-doctor/analyse"
         npm ci
         npm run build
     - name: Run data-clumps analysis
       shell: bash
       run: |
         mkdir -p reports/data-clumps-doctor
-        node data-clumps-doctor/analyse/build/ignoreCoverage/cli.js \
+        node "$RUNNER_TEMP/data-clumps-doctor/analyse/build/ignoreCoverage/cli.js" \
           --source_type typescript \
           --commit_selection current \
           --output reports/data-clumps-doctor/data-clumps.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
   sonarcloud-report:
     name: "📥 Download SonarCloud Report"
     runs-on: ubuntu-latest
-    needs: [sonarqube, check-repository]
+    needs: [sonarqube, data-clumps-report, check-repository]
     if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
     steps:
       - name: "🔄 Checkout Repository"
@@ -123,7 +123,7 @@ jobs:
   data-clumps-report:
     name: "🩺 Analyse Data Clumps"
     runs-on: ubuntu-latest
-    needs: [sonarqube, check-repository]
+    needs: [lint, check-repository]
     if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
     steps:
       - name: "🔄 Checkout Repository"


### PR DESCRIPTION
## Summary
- ensure `data-clumps-report` runs after lint and before sonarcloud reports
- avoid concurrent report pushes on the same branch
- prevent data-clumps analysis from scanning its own tool source

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable}}' .github/actions/analyse-data-clumps/action.yml .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c179fa20948330b55273b7d1f84655