### PR TITLE
Add data clumps badge generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,18 @@ jobs:
           node-version: "22.16.0"
       - name: "🩺 Run data-clumps-doctor"
         uses: ./.github/actions/analyse-data-clumps
+      - name: "📁 Prepare badge directory"
+        run: mkdir -p reports/data-clumps-doctor/badges
+      - name: "📊 Extract data clumps count"
+        id: data-clumps-count
+        run: echo "count=$(jq '.report_summary.amount_data_clumps' reports/data-clumps-doctor/data-clumps.json)" >> "$GITHUB_OUTPUT"
+      - name: "🏷️ Generate data clumps badge"
+        uses: emibcn/badge-action@v2.0.2
+        with:
+          label: "data clumps"
+          status: ${{ steps.data-clumps-count.outputs.count }}
+          color: "blue,555,daf"
+          path: "reports/data-clumps-doctor/badges/data-clumps.svg"
       - name: "💾 Commit reports"
         run: |
           git config user.name "github-actions"


### PR DESCRIPTION
## Summary
- generate data clumps badge from report
- commit badge into report folder
- run data clumps analysis only on upstream repository

## Testing
- `CI=1 yarn test` *(hangs: Yarn completes with warnings, process did not exit)*

------
https://chatgpt.com/codex/tasks/task_e_68c180897a30833087f3ddf06f876a8a