### PR TITLE
ci: colorize data clumps badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,12 +143,23 @@ jobs:
       - name: "📊 Extract data clumps count"
         id: data-clumps-count
         run: echo "count=$(jq '.report_summary.amount_data_clumps' reports/data-clumps-doctor/data-clumps.json)" >> "$GITHUB_OUTPUT"
+      - name: "🎨 Determine badge color"
+        id: badge-color
+        run: |
+          count=${{ steps.data-clumps-count.outputs.count }}
+          if [ "$count" -le 10 ]; then
+            echo "color=08A008" >> "$GITHUB_OUTPUT"
+          elif [ "$count" -le 100 ]; then
+            echo "color=FE7D37" >> "$GITHUB_OUTPUT"
+          else
+            echo "color=F85149" >> "$GITHUB_OUTPUT"
+          fi
       - name: "🏷️ Generate data clumps badge"
         uses: emibcn/badge-action@v2.0.2
         with:
           label: "data clumps"
           status: ${{ steps.data-clumps-count.outputs.count }}
-          color: "blue,555,daf"
+          color: ${{ steps.badge-color.outputs.color }}
           path: "reports/data-clumps-doctor/badges/data-clumps.svg"
       - name: "💾 Commit reports"
         run: |


### PR DESCRIPTION
## Summary
- colorize data clumps badge using solid colors based on count thresholds

## Testing
- `npx prettier .github/workflows/ci.yml --check`
- `CI=1 yarn app-backend-test 2>&1 | tail -n 20` *(fails: Error generating PDF due to missing libatk-1.0.so.0; ENETUNREACH when fetching news; tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c18bd0e5e48330bd332c4c8cbfb88a