### PR TITLE
feat(ci): extract data clumps badge generation

### DIFF
--- a/.github/actions/generate-data-clumps-badge/action.yml
+++ b/.github/actions/generate-data-clumps-badge/action.yml
@@ -1,0 +1,36 @@
+name: Generate Data Clumps Badge
+description: Create badge from data-clumps-doctor report
+inputs:
+  directory:
+    description: Path to directory containing data-clumps.json (and where badge will be stored)
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare badge directory
+      shell: bash
+      run: mkdir -p "${{ inputs.directory }}/badges"
+    - name: Extract data clumps count
+      id: data-clumps-count
+      shell: bash
+      run: |
+        echo "count=$(jq '.report_summary.amount_data_clumps' \"${{ inputs.directory }}/data-clumps.json\")" >> "$GITHUB_OUTPUT"
+    - name: Determine badge color
+      id: badge-color
+      shell: bash
+      run: |
+        count="${{ steps.data-clumps-count.outputs.count }}"
+        if [ "$count" -le 10 ]; then
+          echo "color=08A008" >> "$GITHUB_OUTPUT"
+        elif [ "$count" -le 100 ]; then
+          echo "color=FE7D37" >> "$GITHUB_OUTPUT"
+        else
+          echo "color=F85149" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Generate badge
+      uses: emibcn/badge-action@v2.0.2
+      with:
+        label: data clumps
+        status: ${{ steps.data-clumps-count.outputs.count }}
+        color: ${{ steps.badge-color.outputs.color }}
+        path: "${{ inputs.directory }}/badges/data-clumps.svg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,29 +138,10 @@ jobs:
           node-version: "22.16.0"
       - name: "🩺 Run data-clumps-doctor"
         uses: ./.github/actions/analyse-data-clumps
-      - name: "📁 Prepare badge directory"
-        run: mkdir -p reports/data-clumps-doctor/badges
-      - name: "📊 Extract data clumps count"
-        id: data-clumps-count
-        run: echo "count=$(jq '.report_summary.amount_data_clumps' reports/data-clumps-doctor/data-clumps.json)" >> "$GITHUB_OUTPUT"
-      - name: "🎨 Determine badge color"
-        id: badge-color
-        run: |
-          count=${{ steps.data-clumps-count.outputs.count }}
-          if [ "$count" -le 10 ]; then
-            echo "color=08A008" >> "$GITHUB_OUTPUT"
-          elif [ "$count" -le 100 ]; then
-            echo "color=FE7D37" >> "$GITHUB_OUTPUT"
-          else
-            echo "color=F85149" >> "$GITHUB_OUTPUT"
-          fi
       - name: "🏷️ Generate data clumps badge"
-        uses: emibcn/badge-action@v2.0.2
+        uses: ./.github/actions/generate-data-clumps-badge
         with:
-          label: "data clumps"
-          status: ${{ steps.data-clumps-count.outputs.count }}
-          color: ${{ steps.badge-color.outputs.color }}
-          path: "reports/data-clumps-doctor/badges/data-clumps.svg"
+          directory: "reports/data-clumps-doctor"
       - name: "💾 Commit reports"
         run: |
           git config user.name "github-actions"


### PR DESCRIPTION
## Summary
- extract data clumps badge generation into reusable action
- call action from ci workflow

## Testing
- `yarn test` (fails: Failed to fetch or parse news page: connect ENETUNREACH 185.232.0.200:443 - Local (0.0.0.0:0))

------
https://chatgpt.com/codex/tasks/task_e_68c18ed77cb08330a792dee2e15edc31