### PR TITLE
refactor workflow jobs to accept shared run context

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/cashregister-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/cashregister-hook/ParseSchedule.ts
@@ -1,28 +1,23 @@
 import { TimerHelper } from '../helpers/TimerHelper';
-import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { CashregistersTransactionsForParser, CashregisterTransactionParserInterface } from './CashregisterTransactionParserInterface';
 import { DatabaseTypes } from 'repo-depkit-common';
-import { WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 
 export class ParseSchedule {
-  private readonly workflowRun: DatabaseTypes.WorkflowsRuns;
-  private readonly logger: WorkflowRunLogger;
-  private readonly myDatabaseHelper: MyDatabaseHelper;
+  private readonly context: WorkflowRunContext;
   private readonly parser: CashregisterTransactionParserInterface;
 
-  constructor(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger, parser: CashregisterTransactionParserInterface) {
-    this.myDatabaseHelper = myDatabaseHelper;
-    this.workflowRun = workflowRun;
-    this.logger = logger;
+  constructor(context: WorkflowRunContext, parser: CashregisterTransactionParserInterface) {
+    this.context = context;
     this.parser = parser;
   }
 
   async parse(): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
     try {
-      await this.logger.appendLog('Starting cashregister parsing');
+      await this.context.logger.appendLog('Starting cashregister parsing');
 
-      await this.logger.appendLog('Parsing cashregister transactions');
+      await this.context.logger.appendLog('Parsing cashregister transactions');
       let transactions = await this.parser.getTransactionsList();
 
       let totalTransactionsToCheck = transactions.length;
@@ -35,14 +30,14 @@ export class ParseSchedule {
       // DEBUG: DELETE ALL TRANSACTIONS
       let clearAllData = false;
       if (clearAllData) {
-        await this.myDatabaseHelper.getCashregisterHelper().deleteAllTransactions();
+        await this.context.myDatabaseHelper.getCashregisterHelper().deleteAllTransactions();
       }
 
       myTimer.start();
 
       for (let i = 0; i < totalTransactionsToCheck; i++) {
         //console.log("Transaction parsing progress: " + i + "/" + totalTransactionsToCheck);
-        await this.logger.appendLog('Transaction parsing progress: ' + i + '/' + totalTransactionsToCheck);
+        await this.context.logger.appendLog('Transaction parsing progress: ' + i + '/' + totalTransactionsToCheck);
         let transaction = transactions[i];
         if (!transaction) {
           continue;
@@ -56,7 +51,9 @@ export class ParseSchedule {
         //console.log("cached_cashregister_id: "+cached_cashregister_id);
         if (cached_cashregister_id === undefined) {
           //console.log("findOrCreateCashregister");
-          let cashRegister = await this.myDatabaseHelper.getCashregisterHelper().findOrCreateCashregister(cashregister_external_id);
+          let cashRegister = await this.context.myDatabaseHelper.getCashregisterHelper().findOrCreateCashregister(
+            cashregister_external_id
+          );
           if (!!cashRegister) {
             //console.log("cashRegister found: "+cashRegister.id);
             cached_cashregister_id = cashRegister?.id;
@@ -79,22 +76,22 @@ export class ParseSchedule {
         myTimer.setCurrentCount(i);
         let timerInformation = myTimer.calcTimeSpent();
         let totalTimeInformation = timerInformation.totalTimeInformation;
-        await this.logger.appendLog('Time spent: ' + totalTimeInformation);
+          await this.context.logger.appendLog('Time spent: ' + totalTimeInformation);
       }
 
-      await this.logger.appendLog('Finished');
-      return this.logger.getFinalLogWithStateAndParams({
+      await this.context.logger.appendLog('Finished');
+      return this.context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.SUCCESS,
       });
     } catch (err: any) {
-      await this.logger.appendLog('Error: ' + err.toString());
-      return this.logger.getFinalLogWithStateAndParams({
+      await this.context.logger.appendLog('Error: ' + err.toString());
+      return this.context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }
   }
 
   async findOrCreateCashregisterTransaction(transaction: CashregistersTransactionsForParser, cashregister_id: string) {
-    return await this.myDatabaseHelper.getCashregisterHelper().findOrCreateCashregisterTransaction(transaction, cashregister_id);
+    return await this.context.myDatabaseHelper.getCashregisterHelper().findOrCreateCashregisterTransaction(transaction, cashregister_id);
   }
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/cashregister-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/cashregister-hook/index.ts
@@ -4,7 +4,8 @@ import { defineHook } from '@directus/extensions-sdk';
 import { EnvVariableHelper, SyncForCustomerEnum } from '../helpers/EnvVariableHelper';
 import { CashregisterTransactionParserInterface } from './CashregisterTransactionParserInterface';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
-import { SingleWorkflowRun, WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { CronObject, WorkflowScheduleHelper, WorkflowScheduler } from '../workflows-runs-hook';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
@@ -21,16 +22,16 @@ class CashRegisterWorkflow extends SingleWorkflowRun {
     return 'cashregister-parse';
   }
 
-  async runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
-    await logger.appendLog('Starting cashregister parsing');
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting cashregister parsing');
 
-    const parseSchedule = new ParseSchedule(workflowRun, myDatabaseHelper, logger, this.usedParser);
+    const parseSchedule = new ParseSchedule(context, this.usedParser);
 
     try {
       return await parseSchedule.parse();
     } catch (err: any) {
-      await logger.appendLog('Error: ' + err.toString());
-      return logger.getFinalLogWithStateAndParams({
+      await context.logger.appendLog('Error: ' + err.toString());
+      return context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-notify-schedule-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-notify-schedule-hook/index.ts
@@ -2,7 +2,8 @@ import { defineHook } from '@directus/extensions-sdk';
 import { NotifySchedule } from './NotifySchedule';
 import { WorkflowScheduleHelper } from '../workflows-runs-hook';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
-import { SingleWorkflowRun, WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 
@@ -11,16 +12,16 @@ class FoodNotifyWorkflow extends SingleWorkflowRun {
     return 'food-notify';
   }
 
-  async runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
-    await logger.appendLog('Starting food parsing');
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting food parsing');
 
     try {
-      const notifySchedule = new NotifySchedule(workflowRun, myDatabaseHelper, logger);
+      const notifySchedule = new NotifySchedule(context);
       let aboutMealsInDays = 1;
       return await notifySchedule.notify(aboutMealsInDays);
     } catch (err: any) {
-      await logger.appendLog('Error: ' + err.toString());
-      return logger.getFinalLogWithStateAndParams({
+      await context.logger.appendLog('Error: ' + err.toString());
+      return context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/WorkflowRunContext.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/WorkflowRunContext.ts
@@ -1,0 +1,16 @@
+import { DatabaseTypes } from 'repo-depkit-common';
+import { MyDatabaseHelper } from './MyDatabaseHelper';
+import { WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+
+/**
+ * Bundles commonly used objects when running a workflow.
+ */
+export class WorkflowRunContext {
+  constructor(
+    public readonly workflowRun: DatabaseTypes.WorkflowsRuns,
+    public readonly myDatabaseHelper: MyDatabaseHelper,
+    public readonly logger: WorkflowRunLogger
+  ) {}
+}
+
+export type WorkflowRunDependencies = WorkflowRunContext;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/housing-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/housing-sync-hook/index.ts
@@ -5,7 +5,8 @@ import { EnvVariableHelper, SyncForCustomerEnum } from '../helpers/EnvVariableHe
 import { ApartmentParserInterface } from './ApartmentParserInterface';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { WorkflowScheduleHelper } from '../workflows-runs-hook';
-import { SingleWorkflowRun, WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 
@@ -21,14 +22,14 @@ class HousingSyncWorkflow extends SingleWorkflowRun {
     return 'housing-sync';
   }
 
-  async runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
-    await logger.appendLog('Starting sync housing parsing');
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting sync housing parsing');
     try {
-      const parseSchedule = new ApartmentsParseSchedule(workflowRun, myDatabaseHelper, logger, this.parserInterface);
+      const parseSchedule = new ApartmentsParseSchedule(context, this.parserInterface);
       return await parseSchedule.parse();
     } catch (err: any) {
-      await logger.appendLog('Error: ' + err.toString());
-      return logger.getFinalLogWithStateAndParams({
+      await context.logger.appendLog('Error: ' + err.toString());
+      return context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/index.ts
@@ -7,7 +7,8 @@ import { StudentenwerkHannoverNews_Parser } from './hannover/StudentenwerkHannov
 import { StudentenwerkOsnabrueckNews_Parser } from './osnabrueck/StudentenwerkOsnabrueckNews_Parser';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { WorkflowScheduleHelper } from '../workflows-runs-hook';
-import { SingleWorkflowRun, WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 
@@ -23,14 +24,14 @@ class NewsParseWorkflow extends SingleWorkflowRun {
     return 'news-sync';
   }
 
-  async runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
-    await logger.appendLog('Starting sync news parsing');
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting sync news parsing');
     try {
-      const parseSchedule = new NewsParseSchedule(workflowRun, myDatabaseHelper, logger, this.newsParserInterface);
+      const parseSchedule = new NewsParseSchedule(context, this.newsParserInterface);
       return await parseSchedule.parse();
     } catch (err: any) {
-      await logger.appendLog('Error: ' + err.toString());
-      return logger.getFinalLogWithStateAndParams({
+      await context.logger.appendLog('Error: ' + err.toString());
+      return context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/utilization-canteen-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/utilization-canteen-hook/index.ts
@@ -2,7 +2,8 @@ import { ParseSchedule } from './ParseSchedule';
 import { defineHook } from '@directus/extensions-sdk';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { WorkflowScheduleHelper } from '../workflows-runs-hook';
-import { SingleWorkflowRun, WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 
@@ -11,15 +12,15 @@ class UtilizationCanteenCalculationWorkflow extends SingleWorkflowRun {
     return 'utilization-canteen-calculation';
   }
 
-  async runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
-    await logger.appendLog('Starting utilization canteen calculation');
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting utilization canteen calculation');
 
     try {
-      const parseSchedule = new ParseSchedule(workflowRun, myDatabaseHelper, logger);
+      const parseSchedule = new ParseSchedule(context);
       return await parseSchedule.parse();
     } catch (err: any) {
-      await logger.appendLog('Error: ' + err.toString());
-      return logger.getFinalLogWithStateAndParams({
+      await context.logger.appendLog('Error: ' + err.toString());
+      return context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
@@ -8,7 +8,8 @@ import { StudentenwerkOsnabrueckWashingmachineParser } from './osnabrueck/Studen
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { WorkflowScheduleHelper } from '../workflows-runs-hook';
 import { RegisterFunctions } from '@directus/extensions';
-import { SingleWorkflowRun, WorkflowRunLogger } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 
 function registerWashingmachinesFilterUpdate(apiContext: any, registerFunctions: RegisterFunctions) {
@@ -91,15 +92,15 @@ class WashingmachinesWorkflow extends SingleWorkflowRun {
     return 'washingmachines-parse';
   }
 
-  async runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
-    await logger.appendLog('Starting washingmachine parsing');
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting washingmachine parsing');
 
-    const parseSchedule = new WashingmachineParseSchedule(workflowRun, myDatabaseHelper, logger, this.usedParser);
+    const parseSchedule = new WashingmachineParseSchedule(context, this.usedParser);
     try {
       return await parseSchedule.parse();
     } catch (err: any) {
-      await logger.appendLog('Error: ' + err.toString());
-      return logger.getFinalLogWithStateAndParams({
+      await context.logger.appendLog('Error: ' + err.toString());
+      return context.logger.getFinalLogWithStateAndParams({
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/WorkflowRunJobInterface.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/WorkflowRunJobInterface.ts
@@ -1,6 +1,7 @@
 import { DatabaseTypes } from 'repo-depkit-common';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 
 export type ResultHandleWorkflowRunsWantToRun = {
   errorMessage: string | undefined;
@@ -59,7 +60,7 @@ export interface WorkflowRunJobInterface {
 
   handleWorkflowRunsWantToRun(modifiableInput: Partial<DatabaseTypes.WorkflowsRuns>, workflowruns: Partial<DatabaseTypes.WorkflowsRuns>[], alreadyRunningWorkflowruns: DatabaseTypes.WorkflowsRuns[]): ResultHandleWorkflowRunsWantToRun;
 
-  runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>>;
+  runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>>;
 }
 
 /**
@@ -104,7 +105,7 @@ export abstract class SingleWorkflowRun implements WorkflowRunJobInterface {
    * but they are left abstract so subclasses must implement them.
    */
   abstract getWorkflowId(): string;
-  abstract runJob(workflowRun: DatabaseTypes.WorkflowsRuns, myDatabaseHelper: MyDatabaseHelper, logger: WorkflowRunLogger): Promise<Partial<DatabaseTypes.WorkflowsRuns>>;
+  abstract runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>>;
 
   getDeleteFailedWorkflowRunsAfterDays(): number | undefined {
     return undefined;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
@@ -5,6 +5,7 @@ import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 import { ActionInitFilterEventHelper } from '../helpers/ActionInitFilterEventHelper';
 import { PrimaryKey, ScheduleHandler } from '@directus/types';
 import { WorkflowRunJobInterface, WorkflowRunLogger } from './WorkflowRunJobInterface';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 
 const SCHEDULE_NAME = 'workflows_hook';
@@ -307,9 +308,10 @@ async function handleActionRunningCreatedOrUpdatedWorkflow(payload: Partial<Data
 
             let result: Partial<DatabaseTypes.WorkflowsRuns> = workflowRun;
             let logger = new WorkflowRunLogger(workflowRun, myDatabaseHelper);
+            const context = new WorkflowRunContext(workflowRun, myDatabaseHelper, logger);
             try {
               //console.log("About to run job for workflowRun: "+workflowRun.id);
-              result = await workflowRunJobInterface.runJob(workflowRun, myDatabaseHelper, logger);
+              result = await workflowRunJobInterface.runJob(context);
             } catch (e: any) {
               console.log('Error while running workflow: ' + e.message);
               result = logger.getFinalLogWithStateAndParams({


### PR DESCRIPTION
## Summary
- remove `WorkflowParseSchedule` helper and drop inheritance from parse schedules
- have each parse schedule hold a `WorkflowRunContext` instance directly

## Testing
- `yarn app-backend-test` *(fails: Failed to fetch or parse news page: connect ENETUNREACH 185.232.0.200:443 - Local (0.0.0.0:0))*

------
https://chatgpt.com/codex/tasks/task_e_68c1c41f9214833099d9e0e21ca4c92b