### PR TITLE
Fix fork sync workflow trigger

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -76,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
         run: |
           echo "🚀 Triggering Combined CI workflow after successful sync..."
-          gh workflow run combined-ci.yml --ref master
+          gh workflow run ci.yml --ref master
           echo "✅ Combined CI workflow triggered!"
 
       - name: ⏭️ Skip Fork Sync - No Updates


### PR DESCRIPTION
## Summary
- update the sync-fork workflow to run the existing ci.yml pipeline after a successful fork sync

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf91baeb248330a8d4a9439b394b84