### PR TITLE
Fix eating habits sorting for disliked markings

### DIFF
--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -287,10 +287,10 @@ export function sortByEatingHabits(foodOffers: DatabaseTypes.Foodoffers[], profi
       }
     }
 
-    if (isLiked) {
-      liked.push(offer);
-    } else if (isDisliked) {
+    if (isDisliked) {
       disliked.push(offer);
+    } else if (isLiked) {
+      liked.push(offer);
     } else {
       neutral.push(offer);
     }

--- a/packages/common/src/__tests__/SortingHelper.test.ts
+++ b/packages/common/src/__tests__/SortingHelper.test.ts
@@ -57,6 +57,20 @@ describe('SortingHelper', () => {
     expect(sorted.map((o: any) => o.id)).toEqual(['1', '3', '2']);
   });
 
+  test('sortByEatingHabits moves mixed liked and disliked offers to the end', () => {
+    const offers: any = [
+      { id: '1', markings: [{ markings_id: 'm1' }] },
+      { id: '2', markings: [{ markings_id: 'm1' }, { markings_id: 'm2' }] },
+      { id: '3', markings: [{ markings_id: 'm2' }] },
+    ];
+    const profile = [
+      { markings_id: 'm1', like: true },
+      { markings_id: 'm2', like: false },
+    ];
+    const sorted = sortByEatingHabits(offers, profile);
+    expect(sorted.map((o: any) => o.id)).toEqual(['1', '2', '3']);
+  });
+
   test('sortBySortField sorts numerically and keeps missing at end', () => {
     const items = [{ id: 'a', sort: 3 }, { id: 'b', sort: 1 }, { id: 'c' }];
     const sorted = sortBySortField(items);


### PR DESCRIPTION
## Summary
- prioritize disliked markings when sorting eating habits so meals with any disliked marking fall to the end
- add a regression test covering offers that contain both liked and disliked markings

## Testing
- yarn workspace repo-depkit-common test

------
https://chatgpt.com/codex/tasks/task_e_68d19337471c83309ded62ce1885c2dd