### PR TITLE
Add tests for NumberHelper formatting and truncation

### DIFF
--- a/packages/common/src/__tests__/NumberHelper.test.ts
+++ b/packages/common/src/__tests__/NumberHelper.test.ts
@@ -1,0 +1,26 @@
+import { NumberHelper, StringHelper } from 'repo-depkit-common';
+
+describe('NumberHelper.toFixedNoRounding', () => {
+  it('truncates fractional part without rounding', () => {
+    expect(NumberHelper.toFixedNoRounding(123.4567, 2)).toBe('123.45');
+  });
+
+  it('pads fractional part with zeros when necessary', () => {
+    expect(NumberHelper.toFixedNoRounding(12, 3)).toBe('12.000');
+  });
+});
+
+describe('NumberHelper.formatNumber', () => {
+  it('returns placeholder when value is null', () => {
+    expect(NumberHelper.formatNumber(null, 'kg', true)).toBe(`?${StringHelper.NONBREAKING_SPACE}kg`);
+  });
+
+  it('formats number without rounding when roundUpOrDown is false', () => {
+    expect(NumberHelper.formatNumber(12.3456, null, false, ',', null, 2)).toBe('12,34');
+  });
+
+  it('applies rounding, thousands separator and unit when requested', () => {
+    const result = NumberHelper.formatNumber(1234.556, 'm', true, ',', '.', 2);
+    expect(result).toBe(`1.234,56${StringHelper.NONBREAKING_SPACE}m`);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering NumberHelper truncation helper
- verify NumberHelper.formatNumber behavior for null, truncation, and thousands separation

## Testing
- yarn workspace repo-depkit-common test

------
https://chatgpt.com/codex/tasks/task_e_68d862aa119883308315ef902d1e6b27