### PR TITLE
Improve wiki markdown rendering behavior

### DIFF
--- a/apps/frontend/app/components/CustomCollapsible/CustomCollapsible.tsx
+++ b/apps/frontend/app/components/CustomCollapsible/CustomCollapsible.tsx
@@ -9,8 +9,8 @@ import { useSelector } from 'react-redux';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { RootState } from '@/redux/reducer';
 
-const CustomCollapsible: React.FC<CustomCollapsibleProps> = ({ headerText, children, customColor = '' }) => {
-	const [collapsed, setCollapsed] = useState(true);
+const CustomCollapsible: React.FC<CustomCollapsibleProps> = ({ headerText, children, customColor = '', startCollapsed = false }) => {
+        const [collapsed, setCollapsed] = useState(startCollapsed);
 	const { theme } = useTheme();
 	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const resolvedColor = customColor || primaryColor;

--- a/apps/frontend/app/components/CustomCollapsible/types.ts
+++ b/apps/frontend/app/components/CustomCollapsible/types.ts
@@ -1,6 +1,7 @@
 export interface CustomCollapsibleProps {
-	headerText: string;
-	children: React.ReactNode;
-	customColor?: string;
-	//   containerStyle?: StyleProp<ViewStyle>;
+        headerText: string;
+        children: React.ReactNode;
+        customColor?: string;
+        startCollapsed?: boolean;
+        //   containerStyle?: StyleProp<ViewStyle>;
 }

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -23,116 +23,170 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 		};
 
 		if (content) {
-			const rawText = content;
-			const lines = rawText.split('\n').filter((line: string) => line.trim() !== '');
+                        const rawText = content;
+                        const lines = rawText.split('\n');
 
-			const contrastColor = myContrastColor(backgroundColor || primaryColor, theme, mode === 'dark');
-			// Process content into a structured format
-			const processContent = (lines: string[]) => {
-				const result: any[] = [];
-				let stack = [{ level: 0, items: result }];
-				let currentText = '';
+                        const contrastColor = myContrastColor(backgroundColor || primaryColor, theme, mode === 'dark');
+                        // Process content into a structured format
+                        const processContent = (lines: string[]) => {
+                                const result: any[] = [];
+                                const stack: Array<{ level: number; items: any[] }> = [{ level: 0, items: result }];
+                                let currentParagraph: Array<{ text: string; indent: number }> = [];
 
-				const flushTextContent = () => {
-					if (currentText.trim()) {
-						stack[stack.length - 1].items.push({
-							type: 'text',
-							content: currentText.trim(),
-						});
-						currentText = '';
-					}
-				};
+                                const flushTextContent = () => {
+                                        if (currentParagraph.length) {
+                                                const minIndent = Math.min(...currentParagraph.map(item => item.indent));
+                                                const textContent = currentParagraph.map(item => item.text).join('\n');
+                                                stack[stack.length - 1].items.push({
+                                                        type: 'text',
+                                                        content: textContent,
+                                                        indent: Number.isFinite(minIndent) ? minIndent : 0,
+                                                });
+                                                currentParagraph = [];
+                                        }
+                                };
 
-				lines.forEach(line => {
-					// Check for headings first
-					const headingMatch = line.match(contentPatterns.heading);
-					if (headingMatch) {
-						flushTextContent();
+                                for (let i = 0; i < lines.length; i += 1) {
+                                        const line = lines[i];
+                                        const normalizedLine = line.replace(/\t/g, '    ');
+                                        const indentLength = normalizedLine.match(/^\s*/)?.[0].length ?? 0;
+                                        const trimmedLine = line.trim();
 
-						const level = headingMatch[0].match(/#/g)?.length || 1;
-						const headerText = headingMatch[1].trim();
+                                        const headingMatch = trimmedLine.match(contentPatterns.heading);
+                                        if (headingMatch) {
+                                                flushTextContent();
 
-						// Close previous sections at this level or higher
-						while (stack.length > 1 && stack[stack.length - 1].level >= level) {
-							stack.pop();
-						}
+                                                const level = headingMatch[0].match(/#/g)?.length || 1;
+                                                const headerText = headingMatch[1].trim();
 
-						const newSection = {
-							type: 'collapsible',
-							header: headerText,
-							items: [],
-							level,
-						};
+                                                if (level === 1) {
+                                                        while (stack.length > 1) {
+                                                                stack.pop();
+                                                        }
 
-						stack[stack.length - 1].items.push(newSection);
-						stack.push({ level, items: newSection.items });
-						return;
-					}
+                                                        stack[stack.length - 1].items.push({
+                                                                type: 'heading',
+                                                                content: headerText,
+                                                                level,
+                                                        });
+                                                        continue;
+                                                }
 
-					// Check for other content types
-					if (contentPatterns.image.test(line)) {
-						flushTextContent();
-						const match = line.match(contentPatterns.image);
-						stack[stack.length - 1].items.push({
-							type: 'image',
-							altText: match?.[1] || '',
-							url: match?.[2] || '',
-						});
-					} else if (contentPatterns.email.test(line)) {
-						flushTextContent();
-						const match = line.match(contentPatterns.email);
-						stack[stack.length - 1].items.push({
-							type: 'email',
-							displayText: match?.[1],
-							email: match?.[2],
-						});
-					} else if (contentPatterns.link.test(line)) {
-						flushTextContent();
-						const match = line.match(contentPatterns.link);
-						stack[stack.length - 1].items.push({
-							type: 'link',
-							displayText: match?.[1],
-							url: match?.[2],
-						});
-					} else {
-						currentText += `${line}\n`;
-					}
-				});
+                                                while (stack.length > 1 && stack[stack.length - 1].level >= level) {
+                                                        stack.pop();
+                                                }
 
-				flushTextContent();
-				return result;
-			};
+                                                let startCollapsed = false;
+                                                for (let lookahead = i + 1; lookahead < lines.length; lookahead += 1) {
+                                                        const lookLine = lines[lookahead];
+                                                        if (lookLine.trim() === '') {
+                                                                continue;
+                                                        }
+                                                        const lookNormalized = lookLine.replace(/\t/g, '    ');
+                                                        const lookIndent = lookNormalized.match(/^\s*/)?.[0].length ?? 0;
+                                                        startCollapsed = lookIndent > 0;
+                                                        break;
+                                                }
 
-			// Component for rendering text with proper formatting
-			const TextContent = ({ text, level }: { text: string; level: number }) => (
-				<Text
-					style={{
-						fontSize: 16,
-						fontFamily: 'Poppins_400Regular',
-						color: theme.screen.text,
-						marginLeft: level * 16,
-						lineHeight: 24,
-					}}
-				>
-					{text}
-				</Text>
-			);
+                                                const newSection = {
+                                                        type: 'collapsible',
+                                                        header: headerText,
+                                                        items: [],
+                                                        level,
+                                                        startCollapsed,
+                                                };
 
-			// Component for rendering images
-			const ImageContent = ({ url, altText, level }: { url: string; altText: string; level: number }) => {
-				const [error, setError] = useState(false);
+                                                stack[stack.length - 1].items.push(newSection);
+                                                stack.push({ level, items: newSection.items });
+                                                continue;
+                                        }
 
-				return (
-					<View
-						style={{
-							width: '100%',
-							alignItems: 'center',
-							marginLeft: level * 16,
-							marginVertical: 10,
-							borderRadius: 8,
-							overflow: 'hidden',
-							marginTop: 20,
-						}}
+                                        if (trimmedLine === '') {
+                                                flushTextContent();
+                                                stack[stack.length - 1].items.push({ type: 'emptyLine' });
+                                                continue;
+                                        }
+
+                                        const trimmedForMatch = trimmedLine;
+
+                                        if (contentPatterns.image.test(trimmedForMatch)) {
+                                                flushTextContent();
+                                                const match = trimmedForMatch.match(contentPatterns.image);
+                                                stack[stack.length - 1].items.push({
+                                                        type: 'image',
+                                                        altText: match?.[1] || '',
+                                                        url: match?.[2] || '',
+                                                        indent: indentLength,
+                                                });
+                                                continue;
+                                        }
+
+                                        if (contentPatterns.email.test(trimmedForMatch)) {
+                                                flushTextContent();
+                                                const match = trimmedForMatch.match(contentPatterns.email);
+                                                stack[stack.length - 1].items.push({
+                                                        type: 'email',
+                                                        displayText: match?.[1],
+                                                        email: match?.[2],
+                                                        indent: indentLength,
+                                                });
+                                                continue;
+                                        }
+
+                                        if (contentPatterns.link.test(trimmedForMatch)) {
+                                                flushTextContent();
+                                                const match = trimmedForMatch.match(contentPatterns.link);
+                                                stack[stack.length - 1].items.push({
+                                                        type: 'link',
+                                                        displayText: match?.[1],
+                                                        url: match?.[2],
+                                                        indent: indentLength,
+                                                });
+                                                continue;
+                                        }
+
+                                        currentParagraph.push({
+                                                text: trimmedLine,
+                                                indent: indentLength,
+                                        });
+                                }
+
+                                flushTextContent();
+                                return result;
+                        };
+
+                        const calculateMarginLeft = (level: number, indent = 0) => level * 16 + indent * 4;
+
+                        // Component for rendering text with proper formatting
+                        const TextContent = ({ text, level, indent }: { text: string; level: number; indent: number }) => (
+                                <Text
+                                        style={{
+                                                fontSize: 16,
+                                                fontFamily: 'Poppins_400Regular',
+                                                color: theme.screen.text,
+                                                marginLeft: calculateMarginLeft(level, indent),
+                                                lineHeight: 24,
+                                        }}
+                                >
+                                        {text}
+                                </Text>
+                        );
+
+                        // Component for rendering images
+                        const ImageContent = ({ url, altText, level, indent }: { url: string; altText: string; level: number; indent: number }) => {
+                                const [error, setError] = useState(false);
+
+                                return (
+                                        <View
+                                                style={{
+                                                        width: '100%',
+                                                        alignItems: 'center',
+                                                        marginLeft: calculateMarginLeft(level, indent),
+                                                        marginVertical: 10,
+                                                        borderRadius: 8,
+                                                        overflow: 'hidden',
+                                                        marginTop: 20,
+                                                }}
 					>
 						{error ? (
 							<View
@@ -184,36 +238,81 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 			// Main renderer for content items
 			const renderContentItem = (item: any, level: number, index: number) => {
 				switch (item.type) {
-					case 'text':
-						return <TextContent key={`text-${level}-${index}`} text={item.content} level={level} />;
+                                        case 'heading':
+                                                return (
+                                                        <Text
+                                                                key={`heading-${level}-${index}`}
+                                                                style={{
+                                                                        fontSize: 24,
+                                                                        fontFamily: 'Poppins_600SemiBold',
+                                                                        color: theme.screen.text,
+                                                                        marginTop: level === 0 ? 0 : 12,
+                                                                        marginBottom: 12,
+                                                                        marginLeft: calculateMarginLeft(level, 0),
+                                                                }}
+                                                        >
+                                                                {item.content}
+                                                        </Text>
+                                                );
 
-					case 'email':
-						return (
-							<View key={`email-${level}-${index}`} style={{ marginLeft: level * 16, marginBottom: 10 }}>
-								<RedirectButton type="email" label={item.displayText} onClick={() => Linking.openURL(`mailto:${item.email}`)} backgroundColor={backgroundColor || ''} color={contrastColor} />
-							</View>
-						);
+                                        case 'emptyLine':
+                                                return <View key={`empty-${level}-${index}`} style={{ height: 16 }} />;
 
-					case 'link':
-						return (
-							<View key={`link-${level}-${index}`} style={{ marginLeft: level * 16, marginBottom: 10 }}>
-								<RedirectButton type="link" label={item.displayText} onClick={() => Linking.openURL(item.url)} backgroundColor={backgroundColor || ''} color={contrastColor} />
-							</View>
-						);
+                                        case 'text':
+                                                return (
+                                                        <TextContent
+                                                                key={`text-${level}-${index}`}
+                                                                text={item.content}
+                                                                level={level}
+                                                                indent={item.indent || 0}
+                                                        />
+                                                );
 
-					case 'image':
-						return <ImageContent key={`image-${level}-${index}`} url={item.url} altText={item.altText} level={level} />;
+                                        case 'email':
+                                                return (
+                                                        <View
+                                                                key={`email-${level}-${index}`}
+                                                                style={{ marginLeft: calculateMarginLeft(level, item.indent || 0), marginBottom: 10 }}
+                                                        >
+                                                                <RedirectButton type="email" label={item.displayText} onClick={() => Linking.openURL(`mailto:${item.email}`)} backgroundColor={backgroundColor || ''} color={contrastColor} />
+                                                        </View>
+                                                );
 
-					case 'collapsible':
-						return (
-							<View key={`collapsible-${level}-${index}`} style={{ marginTop: level > 0 ? 5 : 10 }}>
-								<CustomCollapsible headerText={item.header} customColor={backgroundColor || ''}>
-									{renderContent(item.items, level + 1)}
-								</CustomCollapsible>
-							</View>
-						);
+                                        case 'link':
+                                                return (
+                                                        <View
+                                                                key={`link-${level}-${index}`}
+                                                                style={{ marginLeft: calculateMarginLeft(level, item.indent || 0), marginBottom: 10 }}
+                                                        >
+                                                                <RedirectButton type="link" label={item.displayText} onClick={() => Linking.openURL(item.url)} backgroundColor={backgroundColor || ''} color={contrastColor} />
+                                                        </View>
+                                                );
 
-					default:
+                                        case 'image':
+                                                return (
+                                                        <ImageContent
+                                                                key={`image-${level}-${index}`}
+                                                                url={item.url}
+                                                                altText={item.altText}
+                                                                level={level}
+                                                                indent={item.indent || 0}
+                                                        />
+                                                );
+
+                                        case 'collapsible':
+                                                return (
+                                                        <View key={`collapsible-${level}-${index}`} style={{ marginTop: level > 0 ? 5 : 10 }}>
+                                                                <CustomCollapsible
+                                                                        headerText={item.header}
+                                                                        customColor={backgroundColor || ''}
+                                                                        startCollapsed={item.startCollapsed}
+                                                                >
+                                                                        {renderContent(item.items, level + 1)}
+                                                                </CustomCollapsible>
+                                                        </View>
+                                                );
+
+                                        default:
 						return null;
 				}
 			};


### PR DESCRIPTION
## Summary
- preserve blank lines and indentation cues when parsing wiki markdown so collapsible content defaults reflect the authored structure
- render top-level headings as standard text while keeping nested items indented and spaced consistently
- add support for configuring the initial collapsed state of custom collapsible cards

## Testing
- yarn lint *(fails: script "eslint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd9d605548330a03124f5f9d86c8b