### PR TITLE
Update latlon markdown buttons to use navigate icon

### DIFF
--- a/apps/frontend/app/helper/SystemActionHelper.ts
+++ b/apps/frontend/app/helper/SystemActionHelper.ts
@@ -21,19 +21,23 @@ const ANDROID_PARAM_NEW_ACTIVITY = {
 };
 
 export class CommonSystemActionHelper {
-	static async openExternalURL(url: string, newWindow = false) {
-		if (isMobile) {
-			await Linking.openURL(url);
-		} else {
-			let target = '_self';
-			if (newWindow) {
-				target = '_blank';
-			}
-			await window.open(url, target);
-		}
-	}
+        static async openExternalURL(url: string, newWindow = false) {
+                if (isMobile) {
+                        await Linking.openURL(url);
+                } else {
+                        let target = '_self';
+                        if (newWindow) {
+                                target = '_blank';
+                        }
+                        await window.open(url, target);
+                }
+        }
 
-	// static async openMaps(location: LocationType, useGoogleMaps?: boolean) {
+        static getGoogleMapsUrl(latitude: number, longitude: number) {
+                return `https://www.google.com/maps?q=${latitude},${longitude}`;
+        }
+
+        // static async openMaps(location: LocationType, useGoogleMaps?: boolean) {
 	// 	const latitude = location?.latitude;
 	// 	const longitude = location?.longitude;
 


### PR DESCRIPTION
## Summary
- switch the markdown renderer's latlon button to reuse the navigate icon used in building details

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68de32ea1904833086e4b41a22ba0c76