### PR TITLE
Allow latlon markdown links and log rendered anchors

### DIFF
--- a/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -35,7 +35,22 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 	const theme = selectedTheme === 'systematic' ? (colorScheme === 'dark' ? darkTheme : lightTheme) : selectedTheme === 'dark' ? darkTheme : lightTheme;
 
 	const { width } = useWindowDimensions();
-	const md = new MarkdownIt({ html: true });
+        const md = new MarkdownIt({ html: true });
+
+        const defaultValidateLink = md.validateLink.bind(md);
+        md.validateLink = (url: string | null | undefined) => {
+                if (!url) {
+                        return false;
+                }
+
+                const normalizedUrl = url.toLowerCase();
+
+                if (normalizedUrl.startsWith('latlon:')) {
+                        return true;
+                }
+
+                return defaultValidateLink(url);
+        };
 
 	let sourceContent = content || '';
 	const option_find_linebreaks = true;
@@ -110,8 +125,14 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 				iconLeft = <Ionicons name="navigate" size={24} color={contrastColor} />;
 			}
 
-			return <ProjectButton text={text} onPress={handlePress} iconLeft={iconLeft} />;
-		},
+                        console.log('[MyMarkdown] Rendering link', {
+                                href,
+                                finalHref,
+                                text,
+                        });
+
+                        return <ProjectButton text={text} onPress={handlePress} iconLeft={iconLeft} />;
+                },
 		sub: (props: any) => {
 			const { data } = props.tnode;
 			const text = data || props.children[0]?.data;


### PR DESCRIPTION
## Summary
- allow the markdown renderer to pass through custom `latlon:` links by customizing link validation
- add console logging to show the original and resolved href for rendered anchors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6e6fc768833089af64ab71fb0945