### PR TITLE
Share map link normalization with CustomMarkdown

### DIFF
--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -10,6 +10,8 @@ import { useTheme } from '@/hooks/useTheme';
 import { RootState } from '@/redux/reducer';
 import { UriScheme } from '@/constants/UriScheme';
 import { markdownContentPatterns } from '@/constants/MarkdownPatterns';
+import { resolveLocationHref } from '@/helper/MarkdownLinkHelper';
+import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
 
 const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColor, imageWidth, imageHeight }) => {
 	const { theme } = useTheme();
@@ -129,17 +131,20 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 						continue;
 					}
 
-					if (contentPatterns.link.test(trimmedForMatch)) {
-						flushTextContent();
-						const match = trimmedForMatch.match(contentPatterns.link);
-						stack[stack.length - 1].items.push({
-							type: 'link',
-							displayText: match?.[1],
-							url: match?.[2],
-							indent: indentLength,
-						});
-						continue;
-					}
+                                        if (contentPatterns.link.test(trimmedForMatch)) {
+                                                flushTextContent();
+                                                const match = trimmedForMatch.match(contentPatterns.link);
+                                                const rawUrl = match?.[2] || '';
+                                                const { resolvedHref } = resolveLocationHref(rawUrl);
+                                                const normalizedUrl = resolvedHref ?? rawUrl;
+                                                stack[stack.length - 1].items.push({
+                                                        type: 'link',
+                                                        displayText: match?.[1],
+                                                        url: normalizedUrl,
+                                                        indent: indentLength,
+                                                });
+                                                continue;
+                                        }
 
 					currentParagraph.push({
 						text: trimmedLine,
@@ -264,12 +269,22 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 							</View>
 						);
 
-					case 'link':
-						return (
-							<View key={`link-${level}-${index}`} style={{ marginLeft: calculateMarginLeft(level, item.indent || 0), marginBottom: 10 }}>
-								<RedirectButton type="link" label={item.displayText} onClick={() => Linking.openURL(item.url)} backgroundColor={backgroundColor || ''} color={contrastColor} />
-							</View>
-						);
+                                        case 'link':
+                                                return (
+                                                        <View key={`link-${level}-${index}`} style={{ marginLeft: calculateMarginLeft(level, item.indent || 0), marginBottom: 10 }}>
+                                                                <RedirectButton
+                                                                        type="link"
+                                                                        label={item.displayText || item.url}
+                                                                        onClick={() => {
+                                                                                if (item.url) {
+                                                                                        void CommonSystemActionHelper.openExternalURL(item.url, true);
+                                                                                }
+                                                                        }}
+                                                                        backgroundColor={backgroundColor || ''}
+                                                                        color={contrastColor}
+                                                                />
+                                                        </View>
+                                                );
 
 					case 'image':
 						return <ImageContent key={`image-${level}-${index}`} url={item.url} altText={item.altText} level={level} indent={item.indent || 0} />;

--- a/apps/frontend/app/constants/MarkdownPatterns.ts
+++ b/apps/frontend/app/constants/MarkdownPatterns.ts
@@ -7,9 +7,11 @@ type ContentPatterns = {
 	heading: RegExp;
 };
 
+const LINK_SCHEME_PATTERN = `(?:https?:\\/\\/|${UriScheme.GEO}|${UriScheme.MAPS}|${UriScheme.TEL})`;
+
 export const markdownContentPatterns: ContentPatterns = {
-	email: new RegExp(`\\[([^\\]]+)]\\((${UriScheme.MAILTO}[^\\)]+)\\)`),
-	link: /\[([^\]]+)]\((https?:\/\/[^\)]+)\)/,
-	image: /!\[([^\]]*)]\(([^)]+)\)/,
-	heading: /^#{1,6}\s*(.*)$/,
+        email: new RegExp(`\\[([^\\]]+)]\\((${UriScheme.MAILTO}[^\\)]+)\\)`),
+        link: new RegExp(`\\[([^\\]]+)]\\((${LINK_SCHEME_PATTERN}[^\\)]+)\\)`),
+        image: /!\[([^\]]*)]\(([^)]+)\)/,
+        heading: /^#{1,6}\s*(.*)$/,
 };

--- a/apps/frontend/app/helper/MarkdownLinkHelper.ts
+++ b/apps/frontend/app/helper/MarkdownLinkHelper.ts
@@ -1,0 +1,85 @@
+import { UriScheme } from '@/constants/UriScheme';
+import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
+
+const COORDINATE_PATTERN = /-?\d+(?:\.\d+)?/g;
+
+export type ResolvedLocationHref = {
+        resolvedHref?: string;
+        scheme: UriScheme | null;
+        coordinates: { latitude: number; longitude: number } | null;
+};
+
+export const parseCoordinatesFromUri = (uri: string, scheme: UriScheme) => {
+        if (!uri) {
+                return null;
+        }
+
+        const trimmedUri = uri.trim();
+        if (!trimmedUri.toLowerCase().startsWith(scheme)) {
+                return null;
+        }
+
+        const coordinateString = trimmedUri.slice(scheme.length);
+        const matches = coordinateString.match(COORDINATE_PATTERN);
+
+        if (!matches || matches.length < 2) {
+                return null;
+        }
+
+        const [latitudeRaw, longitudeRaw] = matches;
+        const latitude = parseFloat(latitudeRaw);
+        const longitude = parseFloat(longitudeRaw);
+
+        if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
+                return null;
+        }
+
+        return { latitude, longitude } as const;
+};
+
+export const resolveLocationHref = (href: string | null | undefined): ResolvedLocationHref => {
+        if (!href) {
+                return { resolvedHref: undefined, scheme: null, coordinates: null };
+        }
+
+        const trimmedHref = href.trim();
+        if (!trimmedHref) {
+                return { resolvedHref: undefined, scheme: null, coordinates: null };
+        }
+
+        const normalizedHref = trimmedHref.toLowerCase();
+        const isGeoLink = normalizedHref.startsWith(UriScheme.GEO);
+        const isMapsLink = normalizedHref.startsWith(UriScheme.MAPS);
+
+        let scheme: UriScheme | null = null;
+        if (isGeoLink) {
+                scheme = UriScheme.GEO;
+        } else if (isMapsLink) {
+                scheme = UriScheme.MAPS;
+        }
+
+        if (!scheme) {
+                return { resolvedHref: trimmedHref, scheme: null, coordinates: null };
+        }
+
+        const coordinatePayload = trimmedHref.slice(scheme.length).trim();
+        const coordinates = parseCoordinatesFromUri(trimmedHref, scheme);
+        if (coordinates) {
+                const mapsUrl = CommonSystemActionHelper.getGoogleMapsUrl(coordinates.latitude, coordinates.longitude);
+                return { resolvedHref: mapsUrl, scheme, coordinates };
+        }
+
+        if (coordinatePayload) {
+                const fallbackQuery = coordinatePayload.replace(/^[,\s]+|[,\s]+$/g, '');
+                if (fallbackQuery) {
+                        return {
+                                resolvedHref: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(fallbackQuery)}`,
+                                scheme,
+                                coordinates: null,
+                        };
+                }
+        }
+
+        return { resolvedHref: trimmedHref, scheme, coordinates: null };
+};
+


### PR DESCRIPTION
## Summary
- extract the location URI resolution helpers into a shared MarkdownLinkHelper module
- reuse the normalization logic in CustomMarkdown so wiki cards turn geo/maps links into actionable buttons
- widen the markdown link-matching regex to include geo, maps, and tel schemes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9429efc0833090f9974223493d05