### PR TITLE
Fix NextDayTimeSheet keyboard overlap

### DIFF
--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, Text, TouchableOpacity, View } from 'react-native';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
@@ -54,33 +54,38 @@ const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({
 
 	const disableSave = !value || Boolean(error);
 
-	return (
-		<BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
-			<View style={styles.sheetHeader}>
-				<Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.foodoffers_next_day_time)}</Text>
-			</View>
-			<Text style={{ ...styles.description, color: theme.sheet.text, opacity: 0.75 }}>{translate(TranslationKeys.foodoffers_next_day_time_description)}</Text>
-			<View style={styles.inputContainer}>
-				<TimeInput id="foodoffers-next-day-threshold" value={value} onChange={handleChange} onError={handleError} error={error} isDisabled={false} custom_type="time" prefix={null} suffix={null} />
-			</View>
-			<View style={styles.buttonContainer}>
-				<TouchableOpacity onPress={closeSheet} style={{ ...styles.cancelButton, borderColor: primaryColor }}>
-					<Text style={{ ...styles.buttonText, color: theme.sheet.text }}>{translate(TranslationKeys.cancel)}</Text>
-				</TouchableOpacity>
-				<TouchableOpacity
-					onPress={handleSave}
-					style={{
-						...styles.saveButton,
-						backgroundColor: primaryColor,
-						opacity: disableSave ? 0.6 : 1,
-					}}
-					disabled={disableSave}
-				>
-					<Text style={{ ...styles.buttonText, color: contrastColor }}>{translate(TranslationKeys.save)}</Text>
-				</TouchableOpacity>
-			</View>
-		</BottomSheetView>
-	);
+        return (
+                <BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
+                        <KeyboardAvoidingView
+                                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                                style={styles.keyboardAvoidingView}
+                        >
+                                <View style={styles.sheetHeader}>
+                                        <Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.foodoffers_next_day_time)}</Text>
+                                </View>
+                                <Text style={{ ...styles.description, color: theme.sheet.text, opacity: 0.75 }}>{translate(TranslationKeys.foodoffers_next_day_time_description)}</Text>
+                                <View style={styles.inputContainer}>
+                                        <TimeInput id="foodoffers-next-day-threshold" value={value} onChange={handleChange} onError={handleError} error={error} isDisabled={false} custom_type="time" prefix={null} suffix={null} />
+                                </View>
+                                <View style={styles.buttonContainer}>
+                                        <TouchableOpacity onPress={closeSheet} style={{ ...styles.cancelButton, borderColor: primaryColor }}>
+                                                <Text style={{ ...styles.buttonText, color: theme.sheet.text }}>{translate(TranslationKeys.cancel)}</Text>
+                                        </TouchableOpacity>
+                                        <TouchableOpacity
+                                                onPress={handleSave}
+                                                style={{
+                                                        ...styles.saveButton,
+                                                        backgroundColor: primaryColor,
+                                                        opacity: disableSave ? 0.6 : 1,
+                                                }}
+                                                disabled={disableSave}
+                                        >
+                                                <Text style={{ ...styles.buttonText, color: contrastColor }}>{translate(TranslationKeys.save)}</Text>
+                                        </TouchableOpacity>
+                                </View>
+                        </KeyboardAvoidingView>
+                </BottomSheetView>
+        );
 };
 
 export default FoodOffersNextDayTimeSheet;

--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/styles.ts
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/styles.ts
@@ -1,20 +1,25 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	sheetView: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 16,
-		paddingBottom: 24,
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
+        sheetView: {
+                width: '100%',
+                height: '100%',
+                borderTopRightRadius: 28,
+                borderTopLeftRadius: 28,
+                padding: 16,
+                paddingBottom: 24,
+                alignItems: 'center',
+        },
+        keyboardAvoidingView: {
+                flex: 1,
+                width: '100%',
+                alignItems: 'center',
+        },
+        sheetHeader: {
+                width: '100%',
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
 	},
 	sheetHeading: {
 		fontFamily: 'Poppins_700Bold',


### PR DESCRIPTION
## Summary
- wrap the next-day time sheet content in a platform-aware KeyboardAvoidingView to prevent the keyboard from covering inputs
- add styling support for the new keyboard avoiding container

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68eba58620308330821a150807dc3f8f