### PR TITLE
Fix keyboard offset in next day time sheet

### DIFF
--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { KeyboardAvoidingView, Platform, Text, TouchableOpacity, View } from 'react-native';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useSelector } from 'react-redux';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RootState } from '@/redux/reducer';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -14,9 +15,10 @@ import { FoodOffersNextDayTimeSheetProps } from './types';
 const DEFAULT_THRESHOLD = '23:59';
 
 const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({ closeSheet, initialValue, onSave }) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const { bottom: bottomInset } = useSafeAreaInsets();
 	const contrastColor = useMemo(() => myContrastColor(primaryColor, theme, mode === 'dark'), [mode, primaryColor, theme]);
 
 	const [value, setValue] = useState(initialValue ?? DEFAULT_THRESHOLD);
@@ -56,7 +58,12 @@ const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({
 
 	return (
 		<BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
-			<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.keyboardAvoidingView}>
+                        <KeyboardAvoidingView
+                                behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+                                keyboardVerticalOffset={bottomInset + 16}
+                                style={styles.keyboardAvoidingView}
+                                contentContainerStyle={styles.keyboardAvoidingContent}
+                        >
 				<View style={styles.sheetHeader}>
 					<Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.foodoffers_next_day_time)}</Text>
 				</View>

--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/styles.ts
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/styles.ts
@@ -10,11 +10,14 @@ export default StyleSheet.create({
 		paddingBottom: 24,
 		alignItems: 'center',
 	},
-	keyboardAvoidingView: {
-		flex: 1,
-		width: '100%',
-		alignItems: 'center',
-	},
+        keyboardAvoidingView: {
+                flex: 1,
+                width: '100%',
+        },
+        keyboardAvoidingContent: {
+                flexGrow: 1,
+                alignItems: 'center',
+        },
 	sheetHeader: {
 		width: '100%',
 		flexDirection: 'row',


### PR DESCRIPTION
## Summary
- adjust the next day time sheet keyboard avoiding behavior to respect safe area insets
- update styles so the keyboard avoiding view keeps the content centered without shifting too high

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebb30cbcd08330adbe639b08d9b5b5