### PR TITLE
Fix keyboard avoiding offsets for settings sheets

### DIFF
--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
@@ -58,7 +58,12 @@ const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({
 
 	return (
 		<BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
-			<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} keyboardVerticalOffset={bottomInset + 16} style={styles.keyboardAvoidingView} contentContainerStyle={styles.keyboardAvoidingContent}>
+                        <KeyboardAvoidingView
+                                behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+                                keyboardVerticalOffset={Platform.OS === 'ios' ? bottomInset : 0}
+                                style={styles.keyboardAvoidingView}
+                                contentContainerStyle={styles.keyboardAvoidingContent}
+                        >
 				<View style={styles.sheetHeader}>
 					<Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.foodoffers_next_day_time)}</Text>
 				</View>

--- a/apps/frontend/app/components/NicknameSheet/NicknameSheet.tsx
+++ b/apps/frontend/app/components/NicknameSheet/NicknameSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -9,43 +9,52 @@ import { NicknameSheetProps } from './types';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const NicknameSheet: React.FC<NicknameSheetProps> = ({ closeSheet, value, onChange, onSave, disableSave }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+        const { bottom: bottomInset } = useSafeAreaInsets();
+        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
-	return (
-		<BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
-			<View style={styles.sheetHeader}>
-				<View />
-				<Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.nickname)}</Text>
-			</View>
-			<TextInput
-				style={{
-					...styles.sheetInput,
-					color: theme.sheet.text,
-					backgroundColor: theme.sheet.inputBg,
-					borderColor: theme.sheet.inputBorder,
-				}}
-				placeholder={translate(TranslationKeys.nickname)}
-				placeholderTextColor={theme.sheet.placeholder}
-				cursorColor={theme.sheet.text}
-				selectionColor={primaryColor}
-				value={value}
-				onChangeText={onChange}
-			/>
-			<View style={styles.buttonContainer}>
-				<TouchableOpacity onPress={closeSheet} style={{ ...styles.cancelButton, borderColor: primaryColor }}>
-					<Text style={[styles.buttonText, { color: theme.screen.text }]}>{translate(TranslationKeys.cancel)}</Text>
-				</TouchableOpacity>
-				<TouchableOpacity onPress={onSave} disabled={disableSave} style={{ ...styles.saveButton, backgroundColor: primaryColor }}>
-					<Text style={[styles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.save)}</Text>
-				</TouchableOpacity>
-			</View>
-		</BottomSheetView>
-	);
+        return (
+                <BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
+                        <KeyboardAvoidingView
+                                behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+                                keyboardVerticalOffset={Platform.OS === 'ios' ? bottomInset : 0}
+                                style={styles.keyboardAvoidingView}
+                                contentContainerStyle={styles.keyboardAvoidingContent}
+                        >
+                                <View style={styles.sheetHeader}>
+                                        <View />
+                                        <Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.nickname)}</Text>
+                                </View>
+                                <TextInput
+                                        style={{
+                                                ...styles.sheetInput,
+                                                color: theme.sheet.text,
+                                                backgroundColor: theme.sheet.inputBg,
+                                                borderColor: theme.sheet.inputBorder,
+                                        }}
+                                        placeholder={translate(TranslationKeys.nickname)}
+                                        placeholderTextColor={theme.sheet.placeholder}
+                                        cursorColor={theme.sheet.text}
+                                        selectionColor={primaryColor}
+                                        value={value}
+                                        onChangeText={onChange}
+                                />
+                                <View style={styles.buttonContainer}>
+                                        <TouchableOpacity onPress={closeSheet} style={{ ...styles.cancelButton, borderColor: primaryColor }}>
+                                                <Text style={[styles.buttonText, { color: theme.screen.text }]}>{translate(TranslationKeys.cancel)}</Text>
+                                        </TouchableOpacity>
+                                        <TouchableOpacity onPress={onSave} disabled={disableSave} style={{ ...styles.saveButton, backgroundColor: primaryColor }}>
+                                                <Text style={[styles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.save)}</Text>
+                                        </TouchableOpacity>
+                                </View>
+                        </KeyboardAvoidingView>
+                </BottomSheetView>
+        );
 };
 
 export default NicknameSheet;

--- a/apps/frontend/app/components/NicknameSheet/styles.ts
+++ b/apps/frontend/app/components/NicknameSheet/styles.ts
@@ -1,20 +1,28 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	sheetView: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 20,
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
+        sheetView: {
+                width: '100%',
+                height: '100%',
+                borderTopRightRadius: 28,
+                borderTopLeftRadius: 28,
+                padding: 10,
+                paddingBottom: 20,
+                alignItems: 'center',
+        },
+        keyboardAvoidingView: {
+                flex: 1,
+                width: '100%',
+        },
+        keyboardAvoidingContent: {
+                flexGrow: 1,
+                alignItems: 'center',
+        },
+        sheetHeader: {
+                width: '100%',
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
 		borderTopRightRadius: 28,
 		borderTopLeftRadius: 28,
 	},


### PR DESCRIPTION
## Summary
- adjust the FoodOffers next-day threshold sheet keyboard offset to respect only the safe-area inset on iOS
- wrap the nickname sheet content in a keyboard avoiding view with matching safe-area styles so the keyboard no longer pushes it too high

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68ebca0acbf88330b8d1327a136ef402