### PR TITLE
Adjust Next Day TimeSheet default and add reset control

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -354,7 +354,7 @@ const Settings = () => {
 					{isManagement && isDevMode && (
 						<>
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={serverInfo?.info?.project?.project_name} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
-							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '23:59').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
+                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="bottom" />
 						</>
 					)}

--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/index.tsx
@@ -12,7 +12,7 @@ import { TimeInput } from '@/components/DateTimeInputs';
 import styles from './styles';
 import { FoodOffersNextDayTimeSheetProps } from './types';
 
-const DEFAULT_THRESHOLD = '23:59';
+const DEFAULT_THRESHOLD = '18:00';
 
 const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({ closeSheet, initialValue, onSave }) => {
 	const { theme } = useTheme();
@@ -21,11 +21,11 @@ const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({
 	const { bottom: bottomInset } = useSafeAreaInsets();
 	const contrastColor = useMemo(() => myContrastColor(primaryColor, theme, mode === 'dark'), [mode, primaryColor, theme]);
 
-	const [value, setValue] = useState(initialValue ?? DEFAULT_THRESHOLD);
+	const [value, setValue] = useState(initialValue || DEFAULT_THRESHOLD);
 	const [error, setError] = useState('');
 
 	useEffect(() => {
-		setValue(initialValue ?? DEFAULT_THRESHOLD);
+		setValue(initialValue || DEFAULT_THRESHOLD);
 		setError('');
 	}, [initialValue]);
 
@@ -54,7 +54,12 @@ const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({
 		onSave(sanitizedValue);
 	}, [onSave, translate, value]);
 
+	const handleReset = useCallback(() => {
+		onSave(null);
+	}, [onSave]);
+
 	const disableSave = !value || Boolean(error);
+	const disableReset = !initialValue && value === DEFAULT_THRESHOLD;
 
 	return (
 		<BottomSheetView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
@@ -67,16 +72,37 @@ const FoodOffersNextDayTimeSheet: React.FC<FoodOffersNextDayTimeSheetProps> = ({
 					<TimeInput id="foodoffers-next-day-threshold" value={value} onChange={handleChange} onError={handleError} error={error} isDisabled={false} custom_type="time" prefix={null} suffix={null} />
 				</View>
 				<View style={styles.buttonContainer}>
-					<TouchableOpacity onPress={closeSheet} style={{ ...styles.cancelButton, borderColor: primaryColor }}>
+					<TouchableOpacity
+						onPress={closeSheet}
+						style={[styles.buttonBase, styles.secondaryButton, { borderColor: primaryColor, marginRight: 12 }]}
+					>
 						<Text style={{ ...styles.buttonText, color: theme.sheet.text }}>{translate(TranslationKeys.cancel)}</Text>
 					</TouchableOpacity>
 					<TouchableOpacity
+						onPress={handleReset}
+						style={[
+							styles.buttonBase,
+							styles.secondaryButton,
+							{
+								borderColor: primaryColor,
+								marginRight: 12,
+								opacity: disableReset ? 0.6 : 1,
+							},
+						]}
+						disabled={disableReset}
+					>
+						<Text style={{ ...styles.buttonText, color: theme.sheet.text }}>{translate(TranslationKeys.reset)}</Text>
+					</TouchableOpacity>
+					<TouchableOpacity
 						onPress={handleSave}
-						style={{
-							...styles.saveButton,
-							backgroundColor: primaryColor,
-							opacity: disableSave ? 0.6 : 1,
-						}}
+						style={[
+							styles.buttonBase,
+							styles.primaryButton,
+							{
+								backgroundColor: primaryColor,
+								opacity: disableSave ? 0.6 : 1,
+							},
+						]}
 						disabled={disableSave}
 					>
 						<Text style={{ ...styles.buttonText, color: contrastColor }}>{translate(TranslationKeys.save)}</Text>

--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/styles.ts
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/styles.ts
@@ -41,28 +41,22 @@ export default StyleSheet.create({
 		marginTop: 20,
 	},
 	buttonContainer: {
-		width: '70%',
+		width: '100%',
 		flexDirection: 'row',
 		justifyContent: 'space-between',
 		marginTop: 28,
 	},
-	cancelButton: {
+	buttonBase: {
 		flex: 1,
 		height: 50,
 		justifyContent: 'center',
 		alignItems: 'center',
 		borderRadius: 50,
+	},
+	secondaryButton: {
 		borderWidth: 1,
-		marginRight: 10,
 	},
-	saveButton: {
-		flex: 1,
-		height: 50,
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderRadius: 50,
-		marginLeft: 10,
-	},
+	primaryButton: {},
 	buttonText: {
 		fontSize: 16,
 		fontFamily: 'Poppins_700Bold',

--- a/apps/frontend/app/components/FoodOffersNextDayTimeSheet/types.ts
+++ b/apps/frontend/app/components/FoodOffersNextDayTimeSheet/types.ts
@@ -1,5 +1,5 @@
 export interface FoodOffersNextDayTimeSheetProps {
-	closeSheet: () => void;
-	initialValue?: string | null;
-	onSave: (value: string) => void;
+        closeSheet: () => void;
+        initialValue?: string | null;
+        onSave: (value: string | null) => void;
 }

--- a/apps/frontend/app/hooks/useFoodOffersDefaultDate.ts
+++ b/apps/frontend/app/hooks/useFoodOffersDefaultDate.ts
@@ -3,14 +3,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { SET_SELECTED_DATE } from '@/redux/Types/types';
 
-const DEFAULT_THRESHOLD = '23:59';
+const DEFAULT_THRESHOLD = '18:00';
 
 const formatDate = (date: Date) => date.toISOString().split('T')[0];
 
 const parseThreshold = (value: string) => {
 	const match = /^(\d{2}):(\d{2})$/.exec(value || '');
 	if (!match) {
-		return { hours: 23, minutes: 59 };
+		return { hours: 18, minutes: 0 };
 	}
 
 	const hours = Math.min(23, Math.max(0, Number(match[1])));

--- a/apps/frontend/app/redux/Types/stateTypes.ts
+++ b/apps/frontend/app/redux/Types/stateTypes.ts
@@ -49,7 +49,7 @@ export interface SettingsState {
 	nickNameLocal: string;
 	amountColumnsForcard: number;
 	useWebpForAssets: boolean;
-	foodOffersNextDayThreshold: string;
+	foodOffersNextDayThreshold: string | null;
 }
 
 export interface FoodState {

--- a/apps/frontend/app/redux/reducer/settingsReducer.ts
+++ b/apps/frontend/app/redux/reducer/settingsReducer.ts
@@ -18,7 +18,7 @@ const initialState = {
 	nickNameLocal: '',
 	amountColumnsForcard: 0,
 	useWebpForAssets: true,
-	foodOffersNextDayThreshold: '23:59',
+	foodOffersNextDayThreshold: null,
 };
 
 const settingReducer = (state = initialState, actions: any) => {


### PR DESCRIPTION
## Summary
- change the food offers next day threshold default to 18:00 when no value is stored and update reducer/types accordingly
- refresh the settings screen and sheet to respect the new default and allow clearing the threshold via a reset button with shared button styling

## Testing
- yarn lint apps/frontend *(fails: Couldn't find the node_modules state file - running an install might help)*

------
https://chatgpt.com/codex/tasks/task_e_68ec678833d08330b0289ba8e14accc7