### PR TITLE
Organize form submissions into grouped aliases

### DIFF
--- a/apps/frontend/app/app/(app)/form-submissions/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submissions/index.tsx
@@ -1,5 +1,5 @@
 import { ActivityIndicator, Dimensions, FlatList, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { Entypo, FontAwesome, Ionicons } from '@expo/vector-icons';
@@ -18,6 +18,20 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 
+type FormSubmissionListRow =
+        | {
+                        type: 'header';
+                        id: string;
+                        title: string;
+                }
+        | {
+                        type: 'item';
+                        id: string;
+                        title: string;
+                        submission: DatabaseTypes.FormSubmissions;
+                        depth: number;
+                };
+
 const Index = () => {
 	useSetPageTitle(TranslationKeys.select_a_form_submission);
 	const { translate } = useLanguage();
@@ -29,9 +43,94 @@ const Index = () => {
 	const [isActive, setIsActive] = useState(false);
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const formsSubmissionsHelper = new FormsSubmissionsHelper();
-	const [formSubmissions, setFormSubmissions] = useState<DatabaseTypes.FormSubmissions[]>([]);
-	const [selectedOption, setSelectedOption] = useState<string>('draft');
-	const { drawerPosition } = useSelector((state: RootState) => state.settings);
+        const [formSubmissions, setFormSubmissions] = useState<DatabaseTypes.FormSubmissions[]>([]);
+        const [selectedOption, setSelectedOption] = useState<string>('draft');
+        const { drawerPosition } = useSelector((state: RootState) => state.settings);
+
+        const listData = useMemo<FormSubmissionListRow[]>(() => {
+                if (!formSubmissions || formSubmissions.length === 0) {
+                        return [];
+                }
+
+                const grouped = new Map<
+                        string,
+                        {
+                                firstIndex: number;
+                                children: Array<{
+                                        submission: DatabaseTypes.FormSubmissions;
+                                        title: string;
+                                        depth: number;
+                                }>;
+                        }
+                >();
+                const singles: Array<{ order: number; row: FormSubmissionListRow }> = [];
+
+                formSubmissions.forEach((submission, index) => {
+                        const alias = submission.alias || '';
+                        const segments = alias.split('/').filter(Boolean);
+
+                        if (segments.length > 1) {
+                                const parent = segments[0];
+                                const childTitle = segments.slice(1).join('/');
+
+                                if (!grouped.has(parent)) {
+                                        grouped.set(parent, {
+                                                firstIndex: index,
+                                                children: [],
+                                        });
+                                }
+
+                                grouped.get(parent)?.children.push({
+                                        submission,
+                                        title: childTitle || alias,
+                                        depth: Math.max(segments.length - 1, 1),
+                                });
+                        } else {
+                                singles.push({
+                                        order: index,
+                                        row: {
+                                                type: 'item',
+                                                id: submission.id.toString(),
+                                                title: alias,
+                                                submission,
+                                                depth: 0,
+                                        },
+                                });
+                        }
+                });
+
+                const combined: Array<{ order: number; rows: FormSubmissionListRow[] }> = singles.map(single => ({
+                        order: single.order,
+                        rows: [single.row],
+                }));
+
+                grouped.forEach((value, key) => {
+                        const sanitizedId = key.replace(/\s+/g, '-').replace(/\//g, '-');
+                        const rows: FormSubmissionListRow[] = [
+                                {
+                                        type: 'header',
+                                        id: `header-${sanitizedId}`,
+                                        title: key,
+                                },
+                                ...value.children.map(child => ({
+                                        type: 'item',
+                                        id: child.submission.id.toString(),
+                                        title: child.title,
+                                        submission: child.submission,
+                                        depth: child.depth,
+                                })),
+                        ];
+
+                        combined.push({
+                                order: value.firstIndex,
+                                rows,
+                        });
+                });
+
+                combined.sort((a, b) => a.order - b.order);
+
+                return combined.flatMap(entry => entry.rows);
+        }, [formSubmissions]);
 
 	const openFilterSheet = () => {
 		sheetRef.current?.expand();
@@ -98,26 +197,44 @@ const Index = () => {
 		return () => subscription?.remove();
 	}, []);
 
-	const renderItem = ({ item }: { item: DatabaseTypes.FormSubmissions }) => {
-		return (
-			<TouchableOpacity
-				style={{
-					...styles.formCategory,
-					backgroundColor: theme.screen.iconBg,
-				}}
-				key={item.id}
-				onPress={() => {
-					router.push({
-						pathname: '/form-submission',
-						params: { form_submission_id: item?.id },
-					});
-				}}
-			>
-				<Text style={{ ...styles.body, color: theme.screen.text }}>{item.alias}</Text>
-				<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-			</TouchableOpacity>
-		);
-	};
+        const renderItem = useCallback(
+                ({ item }: { item: FormSubmissionListRow }) => {
+                        if (item.type === 'header') {
+                                return (
+                                        <View
+                                                style={{
+                                                        ...styles.groupHeader,
+                                                        backgroundColor: theme.screen.iconBg,
+                                                        borderColor: theme.screen.placeholder,
+                                                }}
+                                        >
+                                                <Text style={{ ...styles.groupHeaderText, color: theme.screen.text }}>{item.title}</Text>
+                                        </View>
+                                );
+                        }
+
+                        return (
+                                <TouchableOpacity
+                                        style={{
+                                                ...styles.formCategory,
+                                                backgroundColor: theme.screen.iconBg,
+                                                marginLeft: item.depth > 0 ? item.depth * 12 : 0,
+                                                paddingLeft: item.depth > 0 ? 20 + item.depth * 4 : 10,
+                                        }}
+                                        onPress={() => {
+                                                router.push({
+                                                        pathname: '/form-submission',
+                                                        params: { form_submission_id: item?.submission?.id },
+                                                });
+                                        }}
+                                >
+                                        <Text style={{ ...styles.body, color: theme.screen.text }}>{item.title || item.submission?.alias}</Text>
+                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
+                                </TouchableOpacity>
+                        );
+                },
+                [router, theme.screen.icon, theme.screen.iconBg, theme.screen.placeholder, theme.screen.text]
+        );
 
 	return (
 		<View
@@ -235,8 +352,13 @@ const Index = () => {
 							<ActivityIndicator size={30} color={theme.screen.text} />
 						</View>
 					) : formSubmissions?.length > 0 ? (
-						<FlatList data={formSubmissions} keyExtractor={item => item.id.toString()} renderItem={renderItem} contentContainerStyle={{ paddingBottom: 10 }} />
-					) : (
+                                                <FlatList
+                                                        data={listData}
+                                                        keyExtractor={item => item.id}
+                                                        renderItem={renderItem}
+                                                        contentContainerStyle={{ paddingBottom: 10 }}
+                                                />
+                                        ) : (
 						<View style={{ padding: 20, alignItems: 'center' }}>
 							<Text style={{ color: theme.screen.text, fontSize: 16 }}>{translate(TranslationKeys.no_data_found)}</Text>
 						</View>

--- a/apps/frontend/app/app/(app)/form-submissions/styles.ts
+++ b/apps/frontend/app/app/(app)/form-submissions/styles.ts
@@ -95,14 +95,28 @@ export default StyleSheet.create({
 		alignItems: 'center',
 		gap: 10,
 	},
-	body: {
-		maxWidth: '90%',
-		fontSize: 16,
-		fontFamily: 'Poppins_400Regular',
-	},
-	sheetBackground: {
-		borderTopRightRadius: 30,
-		borderTopLeftRadius: 30,
-	},
+        body: {
+                maxWidth: '90%',
+                fontSize: 16,
+                fontFamily: 'Poppins_400Regular',
+        },
+        groupHeader: {
+                width: '100%',
+                borderRadius: 10,
+                paddingVertical: 8,
+                paddingHorizontal: 14,
+                marginTop: 12,
+                marginBottom: 4,
+                borderWidth: 1,
+        },
+        groupHeaderText: {
+                fontSize: 14,
+                fontFamily: 'Poppins_600SemiBold',
+                textTransform: 'uppercase',
+        },
+        sheetBackground: {
+                borderTopRightRadius: 30,
+                borderTopLeftRadius: 30,
+        },
 	dummy: {},
 });


### PR DESCRIPTION
## Summary
- group form submissions by the first segment of their alias and build a hierarchical data set for the list
- render headers for each alias group and indent nested submissions to mimic subfolders
- add styles for the new group headers so grouped aliases are visually separated

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f600e5c3c883308fecf5b1910e5143