### PR TITLE
Refactor form dropdown to use modal option picker

### DIFF
--- a/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
+++ b/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
@@ -1,122 +1,247 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Text, View } from 'react-native';
-import { Picker } from '@react-native-picker/picker';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import SingleLineInput from '@/components/SingleLineInput/SingleLineInput';
-
-const CUSTOM_OPTION_VALUE = '__custom__';
-const PLACEHOLDER_VALUE = '__placeholder__';
+import BaseBottomSheet from '@/components/BaseBottomSheet';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
 
 const ensureStringArray = (options: string[]): string[] => {
-	const uniqueValues = new Set<string>();
-	options.forEach(option => {
-		if (typeof option === 'string' && option.trim().length > 0) {
-			uniqueValues.add(option.trim());
-		}
-	});
-	return Array.from(uniqueValues);
+        const uniqueValues = new Set<string>();
+        options.forEach(option => {
+                if (typeof option === 'string' && option.trim().length > 0) {
+                        uniqueValues.add(option.trim());
+                }
+        });
+        return Array.from(uniqueValues);
 };
 
 type DropdownInputProps = {
-	id: string;
-	value: string | null | undefined;
-	onChange: (id: string, value: string, custom_type: string) => void;
-	error?: string;
-	isDisabled: boolean;
-	custom_type: string;
-	options?: string[];
-	prefix?: string | null;
-	suffix?: string | null;
+        id: string;
+        value: string | null | undefined;
+        onChange: (id: string, value: string, custom_type: string) => void;
+        error?: string;
+        isDisabled: boolean;
+        custom_type: string;
+        options?: string[];
+        prefix?: string | null;
+        suffix?: string | null;
 };
 
 const DropdownInput = ({ id, value, onChange, error, isDisabled, custom_type, options = [], prefix, suffix }: DropdownInputProps) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const { primaryColor } = useSelector((state: RootState) => state.settings);
 
-	const normalizedOptions = useMemo(() => ensureStringArray(options), [options]);
+        const normalizedOptions = useMemo(() => ensureStringArray(options), [options]);
 
-	const currentValue = typeof value === 'string' ? value : '';
-	const [showCustomInput, setShowCustomInput] = useState(() => {
-		if (currentValue.trim().length === 0) {
-			return false;
-		}
+        const currentValue = typeof value === 'string' ? value : '';
+        const [showCustomInput, setShowCustomInput] = useState(() => {
+                if (currentValue.trim().length === 0) {
+                        return false;
+                }
 
-		return !normalizedOptions.includes(currentValue);
-	});
+                return !normalizedOptions.includes(currentValue);
+        });
 
-	useEffect(() => {
-		if (currentValue.trim().length > 0) {
-			setShowCustomInput(!normalizedOptions.includes(currentValue));
-		} else if (normalizedOptions.includes(currentValue)) {
-			setShowCustomInput(false);
-		}
-	}, [currentValue, normalizedOptions]);
+        useEffect(() => {
+                if (currentValue.trim().length > 0) {
+                        setShowCustomInput(!normalizedOptions.includes(currentValue));
+                } else if (normalizedOptions.includes(currentValue)) {
+                        setShowCustomInput(false);
+                }
+        }, [currentValue, normalizedOptions]);
 
-	const valueMatchesOption = normalizedOptions.includes(currentValue);
-	const selectedValue = showCustomInput ? CUSTOM_OPTION_VALUE : valueMatchesOption ? currentValue : PLACEHOLDER_VALUE;
-	const isCustomSelected = showCustomInput;
+        const valueMatchesOption = normalizedOptions.includes(currentValue);
+        const isCustomSelected = showCustomInput;
+        const sheetRef = useRef<BottomSheet>(null);
 
-	const handlePickerChange = (itemValue: string) => {
-		if (itemValue === CUSTOM_OPTION_VALUE) {
-			setShowCustomInput(true);
-			const nextValue = currentValue && !normalizedOptions.includes(currentValue) ? currentValue : '';
-			onChange(id, nextValue, custom_type);
-			return;
-		}
+        const openSheet = useCallback(() => {
+                if (!isDisabled) {
+                        sheetRef.current?.expand();
+                }
+        }, [isDisabled]);
 
-		if (itemValue === PLACEHOLDER_VALUE) {
-			setShowCustomInput(false);
-			onChange(id, '', custom_type);
-			return;
-		}
+        const closeSheet = useCallback(() => {
+                sheetRef.current?.close();
+        }, []);
 
-		setShowCustomInput(false);
-		onChange(id, itemValue, custom_type);
-	};
+        const selectPlaceholder = useCallback(() => {
+                setShowCustomInput(false);
+                onChange(id, '', custom_type);
+                closeSheet();
+        }, [closeSheet, custom_type, id, onChange]);
 
-	return (
-		<View style={styles.container}>
-			<View style={styles.inputContainer}>
-				{prefix && (
-					<View style={[styles.prefixSuffix, styles.prefixSuffixLeft, { backgroundColor: theme.screen.iconBg, borderColor: theme.screen.iconBg }]}>
-						<Text style={[styles.prefixSuffixLabel, { color: theme.screen.text }]}>{prefix}</Text>
-					</View>
-				)}
-				<View
-					style={[
-						styles.pickerWrapper,
-						{
-							backgroundColor: theme.screen.inputBg,
-							borderColor: theme.screen.iconBg,
-						},
-						prefix || suffix ? styles.pickerWrapperWithAffix : styles.pickerWrapperFull,
-					]}
-				>
-					<Picker enabled={!isDisabled} selectedValue={selectedValue} onValueChange={handlePickerChange} style={[styles.picker, { color: theme.screen.text }]} dropdownIconColor={theme.screen.text}>
-						<Picker.Item label={translate(TranslationKeys.enter_custom_value)} value={CUSTOM_OPTION_VALUE} />
-						<Picker.Item label={translate(TranslationKeys.select)} value={PLACEHOLDER_VALUE} />
-						{normalizedOptions.map(option => (
-							<Picker.Item key={option} label={option} value={option} />
-						))}
-					</Picker>
-				</View>
-				{suffix && (
-					<View style={[styles.prefixSuffix, styles.prefixSuffixRight, { backgroundColor: theme.screen.iconBg, borderColor: theme.screen.iconBg }]}>
-						<Text style={[styles.prefixSuffixLabel, { color: theme.screen.text }]}>{suffix}</Text>
-					</View>
-				)}
-			</View>
-			{isCustomSelected && (
-				<View style={styles.customInputContainer}>
-					<SingleLineInput id={id} value={currentValue} onChange={onChange} error={error || ''} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />
-				</View>
-			)}
-			{Boolean(error) && <Text style={styles.errorText}>{error}</Text>}
-		</View>
-	);
+        const selectCustom = useCallback(() => {
+                setShowCustomInput(true);
+                const nextValue = currentValue && !normalizedOptions.includes(currentValue) ? currentValue : '';
+                onChange(id, nextValue, custom_type);
+                closeSheet();
+        }, [closeSheet, currentValue, custom_type, normalizedOptions, id, onChange]);
+
+        const selectOption = useCallback(
+                (option: string) => {
+                        setShowCustomInput(false);
+                        onChange(id, option, custom_type);
+                        closeSheet();
+                },
+                [closeSheet, custom_type, id, onChange]
+        );
+
+        const placeholderLabel = translate(TranslationKeys.select);
+        const customLabel = translate(TranslationKeys.enter_custom_value);
+
+        const trimmedValue = currentValue.trim();
+        const displayValue = showCustomInput ? trimmedValue : valueMatchesOption ? currentValue : trimmedValue;
+        const labelToShow = displayValue.length > 0 ? displayValue : showCustomInput ? customLabel : placeholderLabel;
+        const isPlaceholderDisplay = displayValue.length === 0;
+
+        return (
+                <View style={styles.container}>
+                        <View style={styles.inputContainer}>
+                                {prefix && (
+                                        <View style={[styles.prefixSuffix, styles.prefixSuffixLeft, { backgroundColor: theme.screen.iconBg, borderColor: theme.screen.iconBg }]}>
+                                                <Text style={[styles.prefixSuffixLabel, { color: theme.screen.text }]}>{prefix}</Text>
+                                        </View>
+                                )}
+                                <TouchableOpacity
+                                        style={[
+                                                styles.selectorButton,
+                                                {
+                                                        backgroundColor: theme.screen.inputBg,
+                                                        borderColor: theme.screen.iconBg,
+                                                        opacity: isDisabled ? 0.6 : 1,
+                                                },
+                                                prefix && styles.selectorButtonWithPrefix,
+                                                suffix && styles.selectorButtonWithSuffix,
+                                        ]}
+                                        activeOpacity={0.7}
+                                        onPress={openSheet}
+                                        disabled={isDisabled}
+                                >
+                                        <Text
+                                                style={[
+                                                        styles.selectorText,
+                                                        {
+                                                                color: isPlaceholderDisplay ? theme.screen.placeholder : theme.screen.text,
+                                                        },
+                                                        isPlaceholderDisplay && styles.placeholderText,
+                                                ]}
+                                                numberOfLines={1}
+                                                ellipsizeMode="tail"
+                                        >
+                                                {labelToShow}
+                                        </Text>
+                                        <MaterialCommunityIcons name="chevron-down" size={22} color={theme.screen.icon} style={styles.chevronIcon} />
+                                </TouchableOpacity>
+                                {suffix && (
+                                        <View style={[styles.prefixSuffix, styles.prefixSuffixRight, { backgroundColor: theme.screen.iconBg, borderColor: theme.screen.iconBg }]}>
+                                                <Text style={[styles.prefixSuffixLabel, { color: theme.screen.text }]}>{suffix}</Text>
+                                        </View>
+                                )}
+                        </View>
+                        {isCustomSelected && (
+                                <View style={styles.customInputContainer}>
+                                        <SingleLineInput id={id} value={currentValue} onChange={onChange} error={error || ''} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />
+                                </View>
+                        )}
+                        {Boolean(error) && <Text style={styles.errorText}>{error}</Text>}
+                        <BaseBottomSheet ref={sheetRef} enablePanDownToClose onClose={closeSheet}>
+                                <BottomSheetScrollView style={{ backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.sheetContent}>
+                                        <Text style={[styles.sheetHeading, { color: theme.sheet.text }]}>{placeholderLabel}</Text>
+                                        <View style={styles.optionsList}>
+                                                <TouchableOpacity
+                                                        style={[
+                                                                styles.optionRow,
+                                                                {
+                                                                        backgroundColor: !isCustomSelected && trimmedValue.length === 0 ? primaryColor : theme.screen.iconBg,
+                                                                },
+                                                        ]}
+                                                        onPress={selectPlaceholder}
+                                                >
+                                                        <Text
+                                                                style={[
+                                                                        styles.optionLabel,
+                                                                        {
+                                                                                color: !isCustomSelected && trimmedValue.length === 0 ? theme.activeText : theme.screen.text,
+                                                                        },
+                                                                ]}
+                                                        >
+                                                                {placeholderLabel}
+                                                        </Text>
+                                                        <MaterialCommunityIcons
+                                                                name={!isCustomSelected && trimmedValue.length === 0 ? 'checkbox-marked' : 'checkbox-blank-outline'}
+                                                                size={24}
+                                                                color={!isCustomSelected && trimmedValue.length === 0 ? theme.activeText : theme.screen.icon}
+                                                        />
+                                                </TouchableOpacity>
+                                                <TouchableOpacity
+                                                        style={[
+                                                                styles.optionRow,
+                                                                {
+                                                                        backgroundColor: isCustomSelected ? primaryColor : theme.screen.iconBg,
+                                                                },
+                                                        ]}
+                                                        onPress={selectCustom}
+                                                >
+                                                        <Text
+                                                                style={[
+                                                                        styles.optionLabel,
+                                                                        {
+                                                                                color: isCustomSelected ? theme.activeText : theme.screen.text,
+                                                                        },
+                                                                ]}
+                                                        >
+                                                                {customLabel}
+                                                        </Text>
+                                                        <MaterialCommunityIcons
+                                                                name={isCustomSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
+                                                                size={24}
+                                                                color={isCustomSelected ? theme.activeText : theme.screen.icon}
+                                                        />
+                                                </TouchableOpacity>
+                                                {normalizedOptions.map(option => {
+                                                        const isSelected = !isCustomSelected && currentValue === option;
+                                                        return (
+                                                                <TouchableOpacity
+                                                                        key={option}
+                                                                        style={[
+                                                                                styles.optionRow,
+                                                                                {
+                                                                                        backgroundColor: isSelected ? primaryColor : theme.screen.iconBg,
+                                                                                },
+                                                                        ]}
+                                                                        onPress={() => selectOption(option)}
+                                                                >
+                                                                        <Text
+                                                                                style={[
+                                                                                        styles.optionLabel,
+                                                                                        {
+                                                                                                color: isSelected ? theme.activeText : theme.screen.text,
+                                                                                        },
+                                                                                ]}
+                                                                        >
+                                                                                {option}
+                                                                        </Text>
+                                                                        <MaterialCommunityIcons
+                                                                                name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
+                                                                                size={24}
+                                                                                color={isSelected ? theme.activeText : theme.screen.icon}
+                                                                        />
+                                                                </TouchableOpacity>
+                                                        );
+                                                })}
+                                        </View>
+                                </BottomSheetScrollView>
+                        </BaseBottomSheet>
+                </View>
+        );
 };
 
 export default DropdownInput;

--- a/apps/frontend/app/components/DropdownInput/styles.ts
+++ b/apps/frontend/app/components/DropdownInput/styles.ts
@@ -1,56 +1,99 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	container: {
-		width: '100%',
-	},
-	inputContainer: {
-		width: '100%',
-		flexDirection: 'row',
-		alignItems: 'center',
-	},
-	pickerWrapper: {
-		borderWidth: 1,
-		borderRadius: 10,
-	},
-	pickerWrapperFull: {
-		flex: 1,
-		width: '100%',
-	},
-	pickerWrapperWithAffix: {
-		flex: 1,
-	},
-	picker: {
-		width: '100%',
-		height: 50,
-	},
-	prefixSuffix: {
-		height: 50,
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderWidth: 1,
-		borderColor: '#3A3A3A',
-		paddingHorizontal: 12,
-	},
-	prefixSuffixLeft: {
-		borderTopLeftRadius: 10,
-		borderBottomLeftRadius: 10,
-	},
-	prefixSuffixRight: {
-		borderTopRightRadius: 10,
-		borderBottomRightRadius: 10,
-	},
-	prefixSuffixLabel: {
-		fontSize: 16,
-		fontFamily: 'Poppins_400Regular',
-	},
-	customInputContainer: {
-		marginTop: 10,
-	},
-	errorText: {
-		marginTop: 6,
-		fontSize: 12,
-		fontFamily: 'Poppins_400Regular',
-		color: '#ff4d4f',
-	},
+        container: {
+                width: '100%',
+        },
+        inputContainer: {
+                width: '100%',
+                flexDirection: 'row',
+                alignItems: 'center',
+        },
+        selectorButton: {
+                flex: 1,
+                borderWidth: 1,
+                borderRadius: 10,
+                height: 50,
+                paddingHorizontal: 12,
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+        },
+        selectorButtonWithPrefix: {
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                borderLeftWidth: 0,
+        },
+        selectorButtonWithSuffix: {
+                borderTopRightRadius: 0,
+                borderBottomRightRadius: 0,
+                borderRightWidth: 0,
+        },
+        selectorText: {
+                flex: 1,
+                fontSize: 16,
+                fontFamily: 'Poppins_400Regular',
+        },
+        placeholderText: {
+                opacity: 0.7,
+        },
+        chevronIcon: {
+                marginLeft: 12,
+        },
+        prefixSuffix: {
+                height: 50,
+                justifyContent: 'center',
+                alignItems: 'center',
+                borderWidth: 1,
+                borderColor: '#3A3A3A',
+                paddingHorizontal: 12,
+        },
+        prefixSuffixLeft: {
+                borderTopLeftRadius: 10,
+                borderBottomLeftRadius: 10,
+        },
+        prefixSuffixRight: {
+                borderTopRightRadius: 10,
+                borderBottomRightRadius: 10,
+        },
+        prefixSuffixLabel: {
+                fontSize: 16,
+                fontFamily: 'Poppins_400Regular',
+        },
+        customInputContainer: {
+                marginTop: 10,
+        },
+        errorText: {
+                marginTop: 6,
+                fontSize: 12,
+                fontFamily: 'Poppins_400Regular',
+                color: '#ff4d4f',
+        },
+        sheetContent: {
+                paddingHorizontal: 20,
+                paddingBottom: 24,
+        },
+        sheetHeading: {
+                fontSize: 24,
+                fontFamily: 'Poppins_600SemiBold',
+                textAlign: 'center',
+                marginBottom: 16,
+        },
+        optionsList: {
+                paddingBottom: 8,
+        },
+        optionRow: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingHorizontal: 16,
+                paddingVertical: 14,
+                borderRadius: 12,
+                marginBottom: 10,
+        },
+        optionLabel: {
+                flex: 1,
+                fontSize: 16,
+                fontFamily: 'Poppins_400Regular',
+        },
 });


### PR DESCRIPTION
## Summary
- replace the form dropdown picker with a modal bottom sheet selector similar to the theme settings experience
- restyle the dropdown trigger and option rows to match the modal-based interaction while keeping prefix/suffix support

## Testing
- yarn lint *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68f7334ea56483309016cf1ae9539b71