### PR TITLE
Add client-side dependency handling for form field visibility

### DIFF
--- a/packages/common/src/databaseTypes/types.ts
+++ b/packages/common/src/databaseTypes/types.ts
@@ -1362,6 +1362,8 @@ export type FormFields = {
   sort?: number | null;
   status: string;
   translations: any[] | FormFieldsTranslations[];
+  visibility_depends_on_referenced_field?: string | FormFields | null;
+  visibility_depends_on_referenced_value_equals?: string | null;
   user_created?: string | DirectusUsers | null;
   user_updated?: string | DirectusUsers | null;
   value_prefix?: string | null;


### PR DESCRIPTION
## Summary
- add utility helpers to evaluate form field dependencies and normalize values on the client
- hide form submission fields unless their referenced field currently matches the required value
- extend the shared FormFields type with the new visibility dependency properties

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690093b225d483308a0fd1850b785396