### PR TITLE
Fix dropdown bottom sheet visibility

### DIFF
--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -17,6 +17,7 @@ import ServerStatusLoader from '@/components/ServerStatusLoader/ServerStatusLoad
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { GluestackUIProvider } from '@gluestack-ui/themed';
 import { config } from '@gluestack-ui/config';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import ExpoUpdateLoader from '@/components/ExpoUpdateLoader/ExpoUpdateLoader';
 import ExpoUpdateChecker from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 
@@ -87,19 +88,21 @@ export default function Layout() {
 				<Provider store={configureStore}>
 					<GluestackUIProvider config={config}>
 						<PersistGate loading={null} persistor={persistor}>
-							<RootSiblingParent>
-								<ThemeProvider>
-									<ServerStatusLoader>
-										<ExpoUpdateChecker>
-											<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1, backgroundColor: theme.screen.iconBg }}>
-												<SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.iconBg }} edges={pathname?.includes('image-full-screen') ? ['bottom'] : ['top', 'bottom']}>
-													<Slot />
-												</SafeAreaView>
-											</KeyboardAvoidingView>
-										</ExpoUpdateChecker>
-									</ServerStatusLoader>
-								</ThemeProvider>
-							</RootSiblingParent>
+                                                        <RootSiblingParent>
+                                                                <BottomSheetModalProvider>
+                                                                        <ThemeProvider>
+                                                                                <ServerStatusLoader>
+                                                                                        <ExpoUpdateChecker>
+                                                                                                <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1, backgroundColor: theme.screen.iconBg }}>
+                                                                                                        <SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.iconBg }} edges={pathname?.includes('image-full-screen') ? ['bottom'] : ['top', 'bottom']}>
+                                                                                                                <Slot />
+                                                                                                        </SafeAreaView>
+                                                                                                </KeyboardAvoidingView>
+                                                                                        </ExpoUpdateChecker>
+                                                                                </ServerStatusLoader>
+                                                                        </ThemeProvider>
+                                                                </BottomSheetModalProvider>
+                                                        </RootSiblingParent>
 						</PersistGate>
 					</GluestackUIProvider>
 				</Provider>

--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -1,6 +1,11 @@
 import React, { forwardRef, useCallback, useMemo } from 'react';
 import { Dimensions, TouchableOpacity, View } from 'react-native';
-import BottomSheet, { BottomSheetBackdrop, type BottomSheetBackdropProps, type BottomSheetProps } from '@gorhom/bottom-sheet';
+import BottomSheet, {
+        BottomSheetBackdrop,
+        BottomSheetPortal,
+        type BottomSheetBackdropProps,
+        type BottomSheetProps,
+} from '@gorhom/bottom-sheet';
 import { AntDesign } from '@expo/vector-icons';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
@@ -32,18 +37,20 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 		[onClose, onChange]
 	);
 
-	return (
-		<BottomSheet ref={ref} snapPoints={snapPoints} enableDynamicSizing maxDynamicContentSize={MAX_HEIGHT} backdropComponent={renderBackdrop} backgroundStyle={backgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header, { backgroundColor: headerBg }]}>
-				<View style={styles.placeholder} />
-				<View style={[styles.handle, { backgroundColor: handleColor }]} />
-				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>
-					<AntDesign name="close" size={24} color={theme.sheet.closeIcon} />
-				</TouchableOpacity>
-			</View>
-			{children}
-		</BottomSheet>
-	);
+        return (
+                <BottomSheetPortal>
+                        <BottomSheet ref={ref} snapPoints={snapPoints} enableDynamicSizing maxDynamicContentSize={MAX_HEIGHT} backdropComponent={renderBackdrop} backgroundStyle={backgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
+                                <View style={[styles.header, { backgroundColor: headerBg }]}>
+                                        <View style={styles.placeholder} />
+                                        <View style={[styles.handle, { backgroundColor: handleColor }]} />
+                                        <TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>
+                                                <AntDesign name="close" size={24} color={theme.sheet.closeIcon} />
+                                        </TouchableOpacity>
+                                </View>
+                                {children}
+                        </BottomSheet>
+                </BottomSheetPortal>
+        );
 });
 
 export default BaseBottomSheet;


### PR DESCRIPTION
## Summary
- render the shared BaseBottomSheet component through BottomSheetPortal so dropdowns are not clipped by their parent views
- register BottomSheetModalProvider at the app layout level to support portal-based bottom sheets across the app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901dcd12a588330b22bb1992e3f7eea