### PR TITLE
Refine AI food image generation workflow batching

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-image-ai-generation-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-image-ai-generation-hook/index.ts
@@ -1,0 +1,204 @@
+import { defineHook } from '@directus/extensions-sdk';
+import { CollectionNames, DatabaseTypes } from 'repo-depkit-common';
+import { WorkflowScheduleHelper } from '../workflows-runs-hook';
+import { SingleWorkflowRun } from '../workflows-runs-hook/WorkflowRunJobInterface';
+import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
+import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
+import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
+import { EnvVariableHelper } from '../helpers/EnvVariableHelper';
+import { ItemsServiceCreator } from '../helpers/ItemsServiceCreator';
+import { ImageSafeGeneratorFood } from '../helpers/ai/image/ImageSafeGeneratorFood';
+import { ModerationCheckChatGpt } from '../helpers/ai/moderation/ModerationCheckChatGpt';
+import { ImageRawGeneratorChatGpt } from '../helpers/ai/image/ImageRawGeneratorChatGpt';
+import { FilesServiceHelper, MyFileTypes } from '../helpers/FilesServiceHelper';
+
+const WORKFLOW_ID = 'food-image-ai-generation';
+
+function getFileId(image: DatabaseTypes.Foods['image']): string | undefined {
+  if (!image) {
+    return undefined;
+  }
+  if (typeof image === 'string') {
+    return image;
+  }
+  if (typeof image === 'object' && 'id' in image && typeof image.id === 'string') {
+    return image.id;
+  }
+  return undefined;
+}
+
+class FoodImageAiGenerationWorkflow extends SingleWorkflowRun {
+  getWorkflowId(): string {
+    return WORKFLOW_ID;
+  }
+
+  async runJob(context: WorkflowRunContext): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+    await context.logger.appendLog('Starting food image AI generation workflow');
+
+    try {
+      const appSettings = await context.myDatabaseHelper.getAppSettingsHelper().getAppSettings();
+      if (!appSettings?.foods_image_ai_generation_enabled) {
+        await context.logger.appendLog('AI image generation disabled in app settings');
+        return context.logger.getFinalLogWithStateAndParams({
+          state: WORKFLOW_RUN_STATE.SKIPPED,
+        });
+      }
+
+      const openAiToken = EnvVariableHelper.getOpenAiToken();
+      if (!openAiToken) {
+        await context.logger.appendLog('OPEN_AI_TOKEN environment variable is not configured');
+        return context.logger.getFinalLogWithStateAndParams({
+          state: WORKFLOW_RUN_STATE.FAILED,
+        });
+      }
+
+      const itemsServiceCreator = new ItemsServiceCreator(
+        context.myDatabaseHelper.apiContext,
+        context.myDatabaseHelper.eventContext
+      );
+      const foodsService = await itemsServiceCreator.getItemsService<DatabaseTypes.Foods>(CollectionNames.FOODS);
+      const foodsHelper = context.myDatabaseHelper.getFoodsHelper();
+      const missingImageFilter: any = {
+        _and: [
+          { image: { _null: true } },
+          { image_remote_url: { _null: true } },
+        ],
+      };
+      const totalFoodsToProcess = await foodsHelper.countItems({ filter: missingImageFilter });
+
+      if (!totalFoodsToProcess) {
+        await context.logger.appendLog('No foods without images found');
+        return context.logger.getFinalLogWithStateAndParams({
+          state: WORKFLOW_RUN_STATE.SUCCESS,
+        });
+      }
+
+      await context.logger.appendLog(`Found ${totalFoodsToProcess} foods without images`);
+
+      const moderationCheck = new ModerationCheckChatGpt({ apiKey: openAiToken });
+      const imageGenerator = new ImageRawGeneratorChatGpt({ apiKey: openAiToken });
+      const imageSafeGenerator = new ImageSafeGeneratorFood({
+        moderationCheck: moderationCheck,
+        imageGenerator: imageGenerator,
+      });
+      const filesHelper = context.myDatabaseHelper.getFilesHelper();
+      let generatedImages = 0;
+      let skippedFoods = 0;
+      let processedCount = 0;
+      const processedIds = new Set<string>();
+      const batchSize = 100;
+
+      while (true) {
+        const batchFilter = {
+          _and: [...missingImageFilter._and],
+        } as any;
+
+        if (processedIds.size > 0) {
+          batchFilter._and.push({ id: { _nin: Array.from(processedIds) } });
+        }
+
+        const foodsBatch = await foodsService.readByQuery({
+          filter: batchFilter,
+          fields: ['id'],
+          limit: batchSize,
+        });
+
+        if (!foodsBatch || foodsBatch.length === 0) {
+          break;
+        }
+
+        for (const batchFood of foodsBatch) {
+          const foodId = batchFood.id;
+          processedIds.add(foodId);
+          processedCount += 1;
+
+          try {
+            const food = await foodsService.readOne(foodId, {
+              fields: ['id', 'alias', 'image', 'image_remote_url'],
+            });
+
+            if (!food) {
+              skippedFoods += 1;
+              await context.logger.appendLog(
+                `Skipping food ${foodId} because it no longer exists (${processedCount}/${totalFoodsToProcess})`
+              );
+              continue;
+            }
+
+            const alias = typeof food.alias === 'string' ? food.alias.trim() : '';
+            const existingImageId = getFileId(food.image);
+            const hasRemoteUrl = typeof food.image_remote_url === 'string' && food.image_remote_url.length > 0;
+
+            if (existingImageId || hasRemoteUrl) {
+              skippedFoods += 1;
+              await context.logger.appendLog(
+                `Skipping food ${foodId} because an image already exists (${processedCount}/${totalFoodsToProcess})`
+              );
+              continue;
+            }
+
+            if (!alias) {
+              skippedFoods += 1;
+              await context.logger.appendLog(
+                `Skipping food ${foodId} because alias is missing (${processedCount}/${totalFoodsToProcess})`
+              );
+              continue;
+            }
+
+            const imageBuffer = await imageSafeGenerator.generateImage(alias);
+            const filename = `Foods ${foodId}`;
+            const fileId = await filesHelper.uploadOneFromBuffer(
+              imageBuffer,
+              filename,
+              MyFileTypes.PNG,
+              context.myDatabaseHelper
+            );
+            const fileIdString = String(fileId);
+
+            await foodsHelper.updateOne(foodId, {
+              image: fileIdString,
+              image_generated: true,
+            });
+
+            generatedImages += 1;
+            await context.logger.appendLog(
+              `Generated image for food ${foodId} (${processedCount}/${totalFoodsToProcess})`
+            );
+          } catch (err: any) {
+            const message = err?.message || String(err);
+            skippedFoods += 1;
+            await context.logger.appendLog(
+              `Failed to process food ${foodId}: ${message} (${processedCount}/${totalFoodsToProcess})`
+            );
+          }
+        }
+      }
+
+      await context.logger.appendLog(
+        `Finished food image generation. Generated images: ${generatedImages}. Skipped foods: ${skippedFoods}. Processed foods: ${processedCount}.`
+      );
+
+      return context.logger.getFinalLogWithStateAndParams({
+        state: WORKFLOW_RUN_STATE.SUCCESS,
+      });
+    } catch (err: any) {
+      const message = err?.message || String(err);
+      await context.logger.appendLog('Error: ' + message);
+      return context.logger.getFinalLogWithStateAndParams({
+        state: WORKFLOW_RUN_STATE.FAILED,
+      });
+    }
+  }
+}
+
+export default defineHook(async (registerFunctions, apiContext) => {
+  const { schedule } = registerFunctions;
+  const myDatabaseHelper = new MyDatabaseHelper(apiContext);
+
+  WorkflowScheduleHelper.registerScheduleToRunWorkflowRuns({
+    workflowRunInterface: new FoodImageAiGenerationWorkflow(),
+    myDatabaseHelper: myDatabaseHelper,
+    schedule: schedule,
+    cronOject: WorkflowScheduleHelper.EVERY_DAY_AT_4AM,
+  });
+});

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/EnvVariableHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/EnvVariableHelper.ts
@@ -77,6 +77,10 @@ export class EnvVariableHelper {
     return this.getEnvVariable('FOOD_IMAGE_SYNC_SWOSY_API_SERVER_URL');
   }
 
+  static getOpenAiToken() {
+    return this.getEnvVariable('OPEN_AI_TOKEN');
+  }
+
   static getMarkingSyncMode() {
     return this.getEnvVariable('MARKING_SYNC_MODE'); // Options: "TL1CSV", "TL1WEB", "SWOSY"
   }

--- a/packages/common/src/databaseTypes/types.ts
+++ b/packages/common/src/databaseTypes/types.ts
@@ -102,6 +102,7 @@ export type AppSettings = {
   foods_placeholder_image?: string | DirectusFiles | null;
   foods_placeholder_image_remote_url?: string | null;
   foods_placeholder_image_thumb_hash?: string | null;
+  foods_image_ai_generation_enabled?: boolean | null;
   foods_ratings_amount_display?: boolean | null;
   foods_ratings_average_display?: boolean | null;
   foods_ratings_type?: string | null;
@@ -1063,6 +1064,7 @@ export type Foods = {
   image?: string | DirectusFiles | null;
   image_remote_url?: string | null;
   image_thumb_hash?: string | null;
+  image_generated?: boolean | null;
   markings: any[] | FoodsMarkings[];
   rating_amount?: number | null;
   rating_amount_legacy?: number | null;


### PR DESCRIPTION
## Summary
- adjust the AI food image generation workflow to process only foods missing both image sources, mark generated items, and log progress while batching requests in groups of 100
- treat disabled app settings as skipped workflow runs and upload generated files under the "Foods <id>" naming scheme
- update the shared database type definition to include the `image_generated` flag

## Testing
- CI=1 yarn app-backend-test *(fails: external news fetch blocked by ENETUNREACH; Puppeteer PDF generation cannot launch browser due to missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6909f7a17fc08330888ac4826207a949