### PR TITLE
feat(frontend): show chat initial message

### DIFF
--- a/apps/frontend/app/app/(app)/chats/details/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/details/index.tsx
@@ -45,7 +45,10 @@ const ChatDetailsScreen = () => {
 		fetchMsgs();
 	}, [chat_id]);
 
-	const chatTitle = chats.find(c => c.id === chat_id)?.alias || 'Chat';
+        const chat = chats.find(c => c.id === chat_id);
+        const chatTitle = chat?.alias || 'Chat';
+        const chatInitialMessage = (chat as { initial_message?: string } | undefined)?.initial_message;
+        const initialMessage = typeof chatInitialMessage === 'string' ? chatInitialMessage.trim() : undefined;
 
 	const sortedMessages = [...messages].sort((a, b) => {
 		const da = a.date_created || a.date_updated || '';
@@ -109,9 +112,33 @@ const ChatDetailsScreen = () => {
 		);
 	};
 
-	return (
-		<View style={[styles.container, { backgroundColor: theme.screen.background }]}>
-			<FlatList data={sortedMessages} keyExtractor={item => item.id} renderItem={renderItem} contentContainerStyle={styles.list} inverted />
+        const renderInitialMessage = () => {
+                if (!initialMessage) {
+                        return null;
+                }
+
+                const bgColor = theme.card.background;
+                const textColor = myContrastColor(bgColor, theme, mode === 'dark');
+
+                return (
+                        <View style={styles.initialMessageWrapper}>
+                                <View style={[styles.bubble, styles.initialMessageBubble, { backgroundColor: bgColor }]}>
+                                        <MyMarkdown content={initialMessage} textColor={textColor} />
+                                </View>
+                        </View>
+                );
+        };
+
+        return (
+                <View style={[styles.container, { backgroundColor: theme.screen.background }]}>        
+                        <FlatList
+                                data={sortedMessages}
+                                keyExtractor={item => item.id}
+                                renderItem={renderItem}
+                                contentContainerStyle={styles.list}
+                                inverted
+                                ListFooterComponent={renderInitialMessage()}
+                        />
 			{showOldMessageNotice && (
 				<View style={styles.oldMessageContainer}>
 					<Text style={[styles.oldMessageText, { color: theme.screen.text }]}>{translate(TranslationKeys.chat_last_message_unanswered)}</Text>

--- a/apps/frontend/app/app/(app)/chats/details/styles.ts
+++ b/apps/frontend/app/app/(app)/chats/details/styles.ts
@@ -8,19 +8,26 @@ export default StyleSheet.create({
 		padding: 20,
 		gap: 2,
 	},
-	messageItem: {
-		maxWidth: '80%',
-		gap: 4,
-	},
-	bubble: {
-		padding: 10,
-		borderRadius: 3,
-	},
-	timestamp: {
-		fontSize: 12,
-		fontFamily: 'Poppins_400Regular',
-		marginTop: 2,
-	},
+        messageItem: {
+                maxWidth: '80%',
+                gap: 4,
+        },
+        bubble: {
+                padding: 10,
+                borderRadius: 3,
+        },
+        initialMessageWrapper: {
+                alignItems: 'center',
+                marginBottom: 12,
+        },
+        initialMessageBubble: {
+                alignSelf: 'center',
+        },
+        timestamp: {
+                fontSize: 12,
+                fontFamily: 'Poppins_400Regular',
+                marginTop: 2,
+        },
 	inputContainer: {
 		flexDirection: 'row',
 		alignItems: 'flex-end',


### PR DESCRIPTION
## Summary
- render a chat's initial message as a centered bubble above the conversation
- add supporting styles for the neutral initial message bubble

## Testing
- yarn lint *(fails: script "eslint" not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d3ede83c8330a3eaff062239c7b1)