### PR TITLE
Add chat conversation state hook

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/package.json
@@ -55,6 +55,11 @@
       },
       {
         "type": "hook",
+        "name": "chat-conversation-state-hook",
+        "source": "src/chat-conversation-state-hook/index.ts"
+      },
+      {
+        "type": "hook",
         "name": "cashregister-hook",
         "source": "src/cashregister-hook/index.ts"
       },

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/chat-conversation-state-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/chat-conversation-state-hook/index.ts
@@ -1,0 +1,114 @@
+import { defineHook } from '@directus/extensions-sdk';
+import { Accountability } from '@directus/types';
+import {
+  ChatConversationState,
+  CollectionNames,
+  DatabaseTypes,
+} from 'repo-depkit-common';
+import { DatabaseInitializedCheck } from '../helpers/DatabaseInitializedCheck';
+import { ItemsServiceHelper } from '../helpers/ItemsServiceHelper';
+import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
+
+const HOOK_NAME = 'chat_conversation_state';
+const REQUIRED_COLLECTIONS: CollectionNames[] = [
+  CollectionNames.CHAT_MESSAGES,
+  CollectionNames.CHATS,
+  CollectionNames.USERS,
+];
+
+function isAdminAccountability(accountability?: Accountability | null): boolean {
+  if (!accountability) {
+    return false;
+  }
+
+  if (accountability.admin === true) {
+    return true;
+  }
+
+  return (accountability as { adminAccess?: boolean }).adminAccess === true;
+}
+
+async function isAdminUser(userId: string, myDatabaseHelper: MyDatabaseHelper): Promise<boolean> {
+  try {
+    const usersHelper = myDatabaseHelper.getUsersHelper();
+    const user = await usersHelper.readOne(userId, {
+      fields: [
+        'id',
+        'policies.policy.admin_access',
+        'policies.directus_policies_id.admin_access',
+      ],
+    });
+
+    const policies = (user?.policies || []) as unknown[];
+
+    return policies.some(policyEntry => {
+      if (typeof policyEntry !== 'object' || policyEntry === null) {
+        return false;
+      }
+
+      const access = policyEntry as {
+        policy?: DatabaseTypes.DirectusPolicies | { admin_access?: boolean };
+        directus_policies_id?: DatabaseTypes.DirectusPolicies | { admin_access?: boolean };
+      };
+
+      const policy = access.policy || access.directus_policies_id;
+      return policy?.admin_access === true;
+    });
+  } catch (error) {
+    console.error(`${HOOK_NAME}: Failed to resolve admin access for user ${userId}`, error);
+    return false;
+  }
+}
+
+export default defineHook(async ({ action }, apiContext) => {
+  const tablesExist = await DatabaseInitializedCheck.checkTablesExist(
+    HOOK_NAME,
+    apiContext,
+    REQUIRED_COLLECTIONS
+  );
+
+  if (!tablesExist) {
+    return;
+  }
+
+  action(CollectionNames.CHAT_MESSAGES + '.items.create', async (meta, eventContext) => {
+    const messageId = meta?.key as string | undefined;
+    if (!messageId) {
+      return;
+    }
+
+    const myDatabaseHelper = new MyDatabaseHelper(apiContext, eventContext);
+    const chatMessagesHelper = new ItemsServiceHelper<DatabaseTypes.ChatMessages>(
+      myDatabaseHelper,
+      CollectionNames.CHAT_MESSAGES
+    );
+    const chatsHelper = new ItemsServiceHelper<DatabaseTypes.Chats>(
+      myDatabaseHelper,
+      CollectionNames.CHATS
+    );
+
+    const message = await chatMessagesHelper.readOne(messageId, {
+      fields: ['id', 'chat', 'user_created'],
+    });
+
+    const chatId = message?.chat as string | undefined;
+    if (!chatId) {
+      return;
+    }
+
+    let messageFromAdmin = isAdminAccountability(eventContext?.accountability || null);
+
+    if (!messageFromAdmin) {
+      const creatorId = message?.user_created as string | undefined;
+      if (creatorId) {
+        messageFromAdmin = await isAdminUser(creatorId, myDatabaseHelper);
+      }
+    }
+
+    const conversationState = messageFromAdmin
+      ? ChatConversationState.WAITING_FOR_USER
+      : ChatConversationState.WAITING_FOR_SUPPORT;
+
+    await chatsHelper.updateOne(chatId, { conversation_state: conversationState });
+  });
+});

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -10,3 +10,4 @@ export * from './src/SortingHelper';
 export * from './src/SortingEnums';
 export * from './src/ServerHelper';
 export * from './src/FormCommonHelper';
+export * from './src/ChatConversationState';

--- a/packages/common/src/ChatConversationState.ts
+++ b/packages/common/src/ChatConversationState.ts
@@ -1,0 +1,5 @@
+export enum ChatConversationState {
+  WAITING_FOR_USER = 'waiting_for_user',
+  WAITING_FOR_SUPPORT = 'waiting_for_support',
+  RESOLVED = 'resolved',
+}

--- a/packages/common/src/databaseTypes/CollectionNames.ts
+++ b/packages/common/src/databaseTypes/CollectionNames.ts
@@ -39,6 +39,8 @@ export enum CollectionNames {
   WASHINGMACHINES = 'washingmachines',
   WASHINGMACHINES_JOBS = 'washingmachines_jobs',
   NEWS = 'news',
+  CHATS = 'chats',
+  CHAT_MESSAGES = 'chat_messages',
   LANGUAGES = 'languages',
   PROFILES = 'profiles',
   UTILIZATION_GROUPS = 'utilizations_groups',

--- a/packages/common/src/databaseTypes/types.ts
+++ b/packages/common/src/databaseTypes/types.ts
@@ -1,3 +1,5 @@
+import { ChatConversationState } from '../ChatConversationState';
+
 export type Apartments = {
   available_from?: string | null;
   building?: string | Buildings | null;
@@ -451,6 +453,7 @@ export type Chats = {
   date_updated?: string | null;
   foods_feedback?: string | FoodsFeedbacks | null;
   id: string;
+  conversation_state?: ChatConversationState | null;
   linked_entities: string;
   messages: any[] | ChatMessages[];
   participants: any[] | ChatsParticipants[];


### PR DESCRIPTION
## Summary
- add a chat conversation state enum and expose it via the common package
- register collection names for chats and chat messages
- add an action hook that updates the chat conversation state based on the author of a new message

## Testing
- yarn --cwd apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d5fea4288330ab3a729e71f2c288)