### PR TITLE
Add scripts workspace entry to root package

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -44,3 +44,7 @@ runs:
     - name: 📦 Install dependencies
       run: yarn install --immutable
       shell: bash
+
+    - name: 🛠️ Generate EAS config
+      run: yarn workspace rocket-meals-scripts generate:eas
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ data/database_file_uploads/
 
 # Ignore all ios generated files
 apps/frontend/app/ios
+apps/frontend/app/eas.json
 
 # Ignore all android generated files
 apps/frontend/app/android

--- a/apps/frontend/app/eas.template.json
+++ b/apps/frontend/app/eas.template.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "preview": {
+      "android": {
+        "buildType": "apk"
+      },
+      "node": "22.16.0"
+    },
+    "previewApk": {
+      "android": {
+        "buildType": "apk"
+      },
+      "channel": "preview",
+      "node": "22.16.0"
+    },
+    "preview2": {
+      "android": {
+        "gradleCommand": ":app:assembleRelease"
+      },
+      "node": "22.16.0"
+    },
+    "preview3": {
+      "developmentClient": true,
+      "node": "22.16.0"
+    },
+    "preview4": {
+      "distribution": "internal",
+      "node": "22.16.0"
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "autoIncrement": false,
+      "channel": "production",
+      "node": "22.16.0"
+    }
+  },
+  "submit": {
+    "production": {
+      "android": {
+        "track": "production"
+      },
+      "ios": {
+        "appleId": "nils@baumgartner-software.de",
+        "ascAppId": "6483930801",
+        "appleTeamId": "6U99CRVHVR"
+      }
+    }
+  }
+}

--- a/apps/scripts/generate-eas-config.ts
+++ b/apps/scripts/generate-eas-config.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { getCustomerConfig } from '../frontend/app/config';
+
+const TEMPLATE_FILE = path.resolve(__dirname, '../frontend/app/eas.template.json');
+const TARGET_FILE = path.resolve(__dirname, '../frontend/app/eas.json');
+
+type SubmitConfig = {
+        production?: {
+                ios?: IosSubmitConfig;
+        } & Record<string, unknown>;
+} & Record<string, unknown>;
+
+type EasConfig = {
+        submit?: SubmitConfig;
+} & Record<string, unknown>;
+
+type IosSubmitConfig = {
+        ascAppId?: string;
+} & Record<string, unknown>;
+
+function loadTemplate(): EasConfig {
+        if (!fs.existsSync(TEMPLATE_FILE)) {
+                throw new Error(`EAS template not found at ${TEMPLATE_FILE}`);
+        }
+
+        const contents = fs.readFileSync(TEMPLATE_FILE, 'utf8');
+        return JSON.parse(contents);
+}
+
+function getIosSubmitConfig(config: EasConfig): IosSubmitConfig {
+        const submit = config.submit;
+        if (!submit || typeof submit !== 'object') {
+                throw new Error('The EAS template does not contain submit configuration.');
+        }
+
+        const production = submit.production;
+        if (!production || typeof production !== 'object') {
+                throw new Error('The EAS template does not contain submit.production configuration.');
+        }
+
+        const ios = production.ios;
+        if (!ios || typeof ios !== 'object') {
+                throw new Error('The EAS template does not contain submit.production.ios configuration.');
+        }
+
+        return ios;
+}
+
+function updateAscAppId(config: EasConfig, appleAppId?: string) {
+        const iosSubmitConfig = getIosSubmitConfig(config);
+
+        if (appleAppId) {
+                iosSubmitConfig.ascAppId = appleAppId;
+        } else {
+                delete iosSubmitConfig.ascAppId;
+        }
+}
+
+function persistConfig(config: EasConfig) {
+        const serialized = JSON.stringify(config, null, 2);
+        fs.writeFileSync(TARGET_FILE, `${serialized}\n`, 'utf8');
+}
+
+function main() {
+        const template = loadTemplate();
+        const { appleAppId } = getCustomerConfig();
+
+        updateAscAppId(template, appleAppId);
+        persistConfig(template);
+        console.log(`EAS config generated at ${TARGET_FILE}`);
+}
+
+void main();

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rocket-meals-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "generate:eas": "ts-node --project ./tsconfig.json ./generate-eas-config.ts"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/scripts/tsconfig.json
+++ b/apps/scripts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "workspaces": [
     "apps/frontend/app",
     "apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle",
+    "apps/scripts",
     "apps/*",
     "packages/*"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -23022,6 +23022,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"rocket-meals-scripts@workspace:apps/scripts":
+  version: 0.0.0-use.local
+  resolution: "rocket-meals-scripts@workspace:apps/scripts"
+  dependencies:
+    ts-node: "npm:^10.9.2"
+    typescript: "npm:~5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "rollup-plugin-esbuild@npm:6.2.1":
   version: 6.2.1
   resolution: "rollup-plugin-esbuild@npm:6.2.1"


### PR DESCRIPTION
## Summary
- include `apps/scripts` in the root workspace list so Yarn treats the new helper package as part of the monorepo

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691899a9d9cc83309da041d1b8f14386)