### PR TITLE
Fix EventHelper DatabaseTypes import

### DIFF
--- a/packages/common/src/EventHelper.ts
+++ b/packages/common/src/EventHelper.ts
@@ -1,4 +1,4 @@
-import { DatabaseTypes } from './databaseTypes/types';
+import * as DatabaseTypes from './databaseTypes/types';
 
 export type PopupEventPlatformKey = 'show_on_ios' | 'show_on_android' | 'show_on_web';
 


### PR DESCRIPTION
## Summary
- fix EventHelper to import database types via namespace import

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924376803188330bbf4af74ae398f76)