### PR TITLE
Restore rating button visibility on food cards

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -200,23 +200,25 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                     </TouchableOpacity>
                   )}
 
-                  <TouchableOpacity style={styles.favContainer}>
-                    {previousFeedback?.rating === 5 ? (
-                      <TouchableOpacity onPress={() => updateRating(null)}>
-                        <AntDesign name="star" size={20} color={foods_area_color} />
-                      </TouchableOpacity>
-                    ) : (
-                      <TouchableOpacity onPress={() => updateRating(5)}>
-                        <MaterialIcons name="star" size={20} color="white" />
+                  <View style={styles.overlayActionsContainer}>
+                    <TouchableOpacity style={styles.favContainer}>
+                      {previousFeedback?.rating === 5 ? (
+                        <TouchableOpacity onPress={() => updateRating(null)}>
+                          <AntDesign name="star" size={20} color={foods_area_color} />
+                        </TouchableOpacity>
+                      ) : (
+                        <TouchableOpacity onPress={() => updateRating(5)}>
+                          <MaterialIcons name="star" size={20} color="white" />
+                        </TouchableOpacity>
+                      )}
+                    </TouchableOpacity>
+
+                    {dislikedMarkings.length > 0 && (
+                      <TouchableOpacity style={styles.favContainerWarn} onPress={handleOpenSheet}>
+                        <MaterialIcons name="warning" size={20} color={foods_area_color} />
                       </TouchableOpacity>
                     )}
-                  </TouchableOpacity>
-
-                  {dislikedMarkings.length > 0 && (
-                    <TouchableOpacity style={styles.favContainerWarn} onPress={handleOpenSheet}>
-                      <MaterialIcons name="warning" size={20} color={foods_area_color} />
-                    </TouchableOpacity>
-                  )}
+                  </View>
 
                   <View style={styles.categoriesContainer}>
                     {markingsData?.map(mark =>

--- a/apps/frontend/app/components/FoodItem/styles.ts
+++ b/apps/frontend/app/components/FoodItem/styles.ts
@@ -29,9 +29,25 @@ export default StyleSheet.create({
                 justifyContent: 'center',
                 alignItems: 'center',
         },
-	categoriesContainer: {
-		gap: 5,
-		width: 35,
+        favContainer: {
+                width: 35,
+                height: 35,
+                borderRadius: 50,
+                backgroundColor: 'rgba(0,0,0,0.45)',
+                justifyContent: 'center',
+                alignItems: 'center',
+        },
+        favContainerWarn: {
+                width: 35,
+                height: 35,
+                borderRadius: 50,
+                backgroundColor: 'rgba(255, 255, 255, 0.85)',
+                justifyContent: 'center',
+                alignItems: 'center',
+        },
+        categoriesContainer: {
+                gap: 5,
+                width: 35,
 		height: 80,
 		position: 'absolute',
 		top: 10,


### PR DESCRIPTION
## Summary
- wrap food card rating and warning buttons in the overlay container so they render on the image
- add dedicated styles for the rating and warning action buttons to keep them visible

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aaf7429b483309864e36a9e2f9fba)