### PR TITLE
Refine rating helper usage

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-feedback-rating-calculate-hook/FoodRatingCalculator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-feedback-rating-calculate-hook/FoodRatingCalculator.ts
@@ -1,10 +1,10 @@
-import { DatabaseTypes } from 'repo-depkit-common';
+import { DatabaseTypes, RatingHelper } from 'repo-depkit-common';
 import { ApiContext } from '../helpers/ApiContext';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 
 export class FoodRatingCalculator {
-  static MAX_RATING_VALUE = 5;
-  static MIN_RATING_VALUE = 1;
+  static MAX_RATING_VALUE = RatingHelper.MAX_RATING;
+  static MIN_RATING_VALUE = RatingHelper.MIN_RATING;
 
   private readonly myDatabaseHelper: MyDatabaseHelper;
 
@@ -42,22 +42,12 @@ export class FoodRatingCalculator {
     return await foodsService.readOne(food_id);
   }
 
-  static getNumberIfValueInRatingRange(value: number | null | undefined) {
-    if (value === null || value === undefined) {
-      return null;
-    }
-    if (FoodRatingCalculator.MIN_RATING_VALUE <= value && value <= FoodRatingCalculator.MAX_RATING_VALUE) {
-      return value;
-    }
-    return null;
-  }
-
   static calculateFoodRating(food: Partial<DatabaseTypes.Foods>, food_feedbacks: Partial<DatabaseTypes.FoodsFeedbacks>[]) {
     let sum_rating_values = 0;
     let rating_amount = 0;
     for (let food_feedback of food_feedbacks) {
       let rating = food_feedback?.rating;
-      const valid_rating = FoodRatingCalculator.getNumberIfValueInRatingRange(rating);
+      const valid_rating = RatingHelper.getNumberIfValueInRatingRange(rating);
       if (valid_rating !== null) {
         sum_rating_values += valid_rating;
         rating_amount++;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-feedback-rating-calculate-hook/__tests__/TestFoodRatingCalculator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-feedback-rating-calculate-hook/__tests__/TestFoodRatingCalculator.ts
@@ -1,14 +1,14 @@
 // small jest test
 import { describe, expect, it } from '@jest/globals';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { DatabaseTypes, RatingHelper } from 'repo-depkit-common';
 import { FoodRatingCalculator } from '../FoodRatingCalculator';
 
 describe('FoodRatingCalculator Test', () => {
-  const RATING_VALUE_AVG = (FoodRatingCalculator.MAX_RATING_VALUE + FoodRatingCalculator.MIN_RATING_VALUE) / 2;
-  const RATING_VALUE_LOW = FoodRatingCalculator.MIN_RATING_VALUE;
-  const RATING_VALUE_HIGH = FoodRatingCalculator.MAX_RATING_VALUE;
-  const RATING_VALUE_INVALID_LOW = FoodRatingCalculator.MIN_RATING_VALUE - 1;
-  const RATING_VALUE_INVALID_HIGH = FoodRatingCalculator.MAX_RATING_VALUE + 1;
+  const RATING_VALUE_AVG = RatingHelper.RATING_VALUE_AVG;
+  const RATING_VALUE_LOW = RatingHelper.RATING_VALUE_LOW;
+  const RATING_VALUE_HIGH = RatingHelper.RATING_VALUE_HIGH;
+  const RATING_VALUE_INVALID_LOW = RatingHelper.RATING_VALUE_INVALID_LOW;
+  const RATING_VALUE_INVALID_HIGH = RatingHelper.RATING_VALUE_INVALID_HIGH;
 
   // Medium rating
   it('medium feedback rating', async () => {
@@ -200,16 +200,16 @@ describe('FoodRatingCalculator Test', () => {
 
   // check valid rating values
   it('valid rating values', async () => {
-    for (let i = FoodRatingCalculator.MIN_RATING_VALUE; i <= FoodRatingCalculator.MAX_RATING_VALUE; i++) {
-      const valid_rating = FoodRatingCalculator.getNumberIfValueInRatingRange(i);
+    for (let i = RatingHelper.MIN_RATING; i <= RatingHelper.MAX_RATING; i++) {
+      const valid_rating = RatingHelper.getNumberIfValueInRatingRange(i);
       expect(valid_rating).toBe(i);
     }
   });
 
   // check invalid rating values
   it('invalid rating values', async () => {
-    const invalid_rating_low = FoodRatingCalculator.getNumberIfValueInRatingRange(FoodRatingCalculator.MIN_RATING_VALUE - 1);
-    const invalid_rating_high = FoodRatingCalculator.getNumberIfValueInRatingRange(FoodRatingCalculator.MAX_RATING_VALUE + 1);
+    const invalid_rating_low = RatingHelper.getNumberIfValueInRatingRange(RatingHelper.MIN_RATING - 1);
+    const invalid_rating_high = RatingHelper.getNumberIfValueInRatingRange(RatingHelper.MAX_RATING + 1);
     expect(invalid_rating_low).toBe(null);
     expect(invalid_rating_high).toBe(null);
   });
@@ -218,7 +218,7 @@ describe('FoodRatingCalculator Test', () => {
   it('randomized feedback ratings', async () => {
     const amount_feedbacks = 100;
     const rating_values_valid_and_invalid: number[] = [];
-    for (let i = FoodRatingCalculator.MIN_RATING_VALUE - 5; i <= FoodRatingCalculator.MAX_RATING_VALUE + 5; i++) {
+    for (let i = RatingHelper.MIN_RATING - 5; i <= RatingHelper.MAX_RATING + 5; i++) {
       rating_values_valid_and_invalid.push(i);
     }
 
@@ -232,7 +232,7 @@ describe('FoodRatingCalculator Test', () => {
         rating: rating_value,
       });
 
-      const valid_rating = FoodRatingCalculator.getNumberIfValueInRatingRange(rating_value);
+      const valid_rating = RatingHelper.getNumberIfValueInRatingRange(rating_value);
       if (valid_rating !== null) {
         valid_rating_sum += valid_rating;
         valid_rating_amount++;

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -8,7 +8,7 @@ import { AntDesign, MaterialCommunityIcons, MaterialIcons } from '@expo/vector-i
 import { FoodItemProps } from './types';
 import { excerpt, getImageUrl, getpreviousFeedback, showFormatedPrice, showPrice } from '@/constants/HelperFunctions';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { DatabaseTypes, RatingHelper } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import { SET_MARKING_DETAILS, SET_SELECTED_FOOD_MARKINGS } from '@/redux/Types/types';
 import PermissionModal from '../PermissionModal/PermissionModal';
@@ -202,12 +202,12 @@ const FoodItem: React.FC<FoodItemProps> = memo(
 
                   <View style={styles.overlayActionsContainer}>
                     <TouchableOpacity style={styles.favContainer}>
-                      {previousFeedback?.rating === 5 ? (
+                      {RatingHelper.isMaxRating(previousFeedback?.rating) ? (
                         <TouchableOpacity onPress={() => updateRating(null)}>
                           <AntDesign name="star" size={20} color={foods_area_color} />
                         </TouchableOpacity>
                       ) : (
-                        <TouchableOpacity onPress={() => updateRating(5)}>
+                        <TouchableOpacity onPress={() => updateRating(RatingHelper.MAX_RATING)}>
                           <MaterialIcons name="star" size={20} color="white" />
                         </TouchableOpacity>
                       )}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -15,3 +15,4 @@ export * from './src/CronHelper';
 export * from './src/EmailHelper';
 export * from './src/EventHelper';
 export * from './src/form/FormHelperCommon';
+export * from './src/RatingHelper';

--- a/packages/common/src/RatingHelper.ts
+++ b/packages/common/src/RatingHelper.ts
@@ -1,0 +1,25 @@
+export class RatingHelper {
+  static readonly MAX_RATING = 5;
+  static readonly MIN_RATING = 1;
+  static readonly RATING_VALUE_AVG = (RatingHelper.MAX_RATING + RatingHelper.MIN_RATING) / 2;
+  static readonly RATING_VALUE_LOW = RatingHelper.MIN_RATING;
+  static readonly RATING_VALUE_HIGH = RatingHelper.MAX_RATING;
+  static readonly RATING_VALUE_INVALID_LOW = RatingHelper.MIN_RATING - 1;
+  static readonly RATING_VALUE_INVALID_HIGH = RatingHelper.MAX_RATING + 1;
+
+  static isMaxRating(value: number | null | undefined): boolean {
+    return RatingHelper.getNumberIfValueInRatingRange(value) === RatingHelper.MAX_RATING;
+  }
+
+  static getNumberIfValueInRatingRange(value: number | null | undefined): number | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (value < RatingHelper.MIN_RATING || value > RatingHelper.MAX_RATING) {
+      return null;
+    }
+
+    return value;
+  }
+}


### PR DESCRIPTION
## Summary
- add derived rating constants to the shared RatingHelper for reuse
- update backend rating calculations and tests to consume the shared helper directly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ab89b70d88330afa1c963fe1c31eb)