### PR TITLE
Add PDF generation interface for shared signatures

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
@@ -1,6 +1,7 @@
 import { FormExtractFormAnswer, FormExtractFormAnswerValueFileSingle, FormExtractFormAnswerValueFileSingleOrString, FormExtractRelevantInformation, FormExtractRelevantInformationSingle } from '../../forms-sync-hook';
 import { BaseGermanMarkdownTemplateHelper, DEFAULT_HTML_TEMPLATE, HtmlGenerator } from '../html/HtmlGenerator';
-import { PdfGeneratorHelper, RequestOptions } from '../pdf/PdfGeneratorHelper';
+import { PdfGeneratorHelper } from '../pdf/PdfGeneratorHelper';
+import { RequestOptions } from '../pdf/PdfGeneratorInterfaces';
 import { DirectusFilesAssetHelper } from '../DirectusFilesAssetHelper';
 import { MarkdownHelper } from '../html/MarkdownHelper';
 import { MyDatabaseTestableHelperInterface } from '../MyDatabaseHelperInterface';

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PdfGeneratorHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PdfGeneratorHelper.ts
@@ -5,25 +5,9 @@
 // html2pdf.js only works in the browser
 
 import { PuppeteerGenerator } from './PuppeteerGenerator';
+import { HtmlPdfGeneratorInterface, PdfGeneratorOptions, RequestOptions } from './PdfGeneratorInterfaces';
 
-export type PdfGeneratorOptions = {
-  format?: 'A3' | 'A4' | 'A5' | 'Legal' | 'Letter' | 'Tabloid';
-  landscape?: boolean;
-  printBackground?: boolean;
-  margin?: {
-    top?: string;
-    bottom?: string;
-    left?: string;
-    right?: string;
-  };
-};
-
-export type RequestOptions = {
-  bearerToken?: string | null | undefined;
-  mockImageResolution?: boolean; // if true, images are mocked with a placeholder image
-};
-
-export class PdfGeneratorHelper {
+export class PdfGeneratorHelper implements HtmlPdfGeneratorInterface {
   /** Returns the default PDF generation options */
   public static getDefaultPdfGeneratorOptions(): PdfGeneratorOptions {
     return {
@@ -40,8 +24,20 @@ export class PdfGeneratorHelper {
   }
 
   /** Generates a PDF from the provided HTML string */
-  public static async generatePdfFromHtml(html: string, requestOptions: RequestOptions, options?: PdfGeneratorOptions): Promise<Buffer> {
+  public static async generatePdfFromHtml(
+    html: string,
+    requestOptions: RequestOptions,
+    options?: PdfGeneratorOptions
+  ): Promise<Buffer> {
     options = { ...this.getDefaultPdfGeneratorOptions(), ...options };
     return await PuppeteerGenerator.generatePdfFromHtmlPuppeteer(html, requestOptions, options);
+  }
+
+  public async generatePdfFromHtml(
+    html: string,
+    requestOptions: RequestOptions,
+    options?: PdfGeneratorOptions
+  ): Promise<Buffer> {
+    return await PdfGeneratorHelper.generatePdfFromHtml(html, requestOptions, options);
   }
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PdfGeneratorInterfaces.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PdfGeneratorInterfaces.ts
@@ -1,0 +1,24 @@
+export type PdfGeneratorOptions = {
+  format?: 'A3' | 'A4' | 'A5' | 'Legal' | 'Letter' | 'Tabloid';
+  landscape?: boolean;
+  printBackground?: boolean;
+  margin?: {
+    top?: string;
+    bottom?: string;
+    left?: string;
+    right?: string;
+  };
+};
+
+export type RequestOptions = {
+  bearerToken?: string | null | undefined;
+  mockImageResolution?: boolean; // if true, images are mocked with a placeholder image
+};
+
+export interface HtmlPdfGeneratorInterface {
+  generatePdfFromHtml(
+    html: string,
+    requestOptions: RequestOptions,
+    options?: PdfGeneratorOptions
+  ): Promise<Buffer>;
+}

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PuppeteerGenerator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PuppeteerGenerator.ts
@@ -1,8 +1,8 @@
-import { PdfGeneratorOptions, RequestOptions } from './PdfGeneratorHelper';
+import { HtmlPdfGeneratorInterface, PdfGeneratorOptions, RequestOptions } from './PdfGeneratorInterfaces';
 import { default as puppeteerCore } from 'puppeteer-core';
 import { EnvVariableHelper } from '../EnvVariableHelper';
 
-export class PuppeteerGenerator {
+export class PuppeteerGenerator implements HtmlPdfGeneratorInterface {
   public static PuppeteerCore: any = puppeteerCore;
   public static PuppeteerForJest: any = undefined;
 
@@ -24,7 +24,11 @@ export class PuppeteerGenerator {
    * rocket-meals-directus-2         |     at async Promise.all (index 1)
    */
 
-  static async generatePdfFromHtmlPuppeteer(html: string, requestOptions: RequestOptions, options: PdfGeneratorOptions): Promise<Buffer> {
+  static async generatePdfFromHtmlPuppeteer(
+    html: string,
+    requestOptions: RequestOptions,
+    options?: PdfGeneratorOptions
+  ): Promise<Buffer> {
     let browser;
     let puppeteer = PuppeteerGenerator.getPuppeteerLib();
 
@@ -151,5 +155,13 @@ export class PuppeteerGenerator {
         await browser.close();
       }
     }
+  }
+
+  public async generatePdfFromHtml(
+    html: string,
+    requestOptions: RequestOptions,
+    options?: PdfGeneratorOptions
+  ): Promise<Buffer> {
+    return await PuppeteerGenerator.generatePdfFromHtmlPuppeteer(html, requestOptions, options);
   }
 }


### PR DESCRIPTION
## Summary
- add a shared HTML-to-PDF generator interface with common options and request parameters
- implement the interface in PdfGeneratorHelper and PuppeteerGenerator while keeping existing functionality
- update imports to reference the shared types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b421ad78c8330aececa362fbec864)