### PR TITLE
Refactor timer print methods to use options object

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -547,7 +547,7 @@ export class ParseSchedule {
         foodsDict[foodId] = foodWithTranslations;
       }
       index++;
-      myTimer.printElapsedTimeAndEstimatedTimeRemaining(index, amount);
+      myTimer.printElapsedTimeAndEstimatedTimeRemaining({ progress: index, total: amount });
     }
 
     myTimer.printElapsedTime();
@@ -621,7 +621,10 @@ export class ParseSchedule {
         await this.updateFoodTranslations(foundFoodWithTranslations, foodsInformationForParser);
 
         amountCompleted++;
-        myTimer.printElapsedTimeAndEstimatedTimeRemaining(amountCompleted, foodsInformationForParserList.length);
+        myTimer.printElapsedTimeAndEstimatedTimeRemaining({
+          progress: amountCompleted,
+          total: foodsInformationForParserList.length,
+        });
       }
     }
 
@@ -810,7 +813,12 @@ export class ParseSchedule {
       await myFoodOffersService.createManyItems(batch, {
         disableEventEmit: disableEventEmit,
       });
-      myTimer.printElapsedTimeAndEstimatedTimeRemaining(batchIndex, amountOfBatches, null, 'Total amount of food offers: ' + foodoffersToCreate.length);
+      myTimer.printElapsedTimeAndEstimatedTimeRemaining({
+        progress: batchIndex,
+        total: amountOfBatches,
+        prefix: null,
+        suffix: 'Total amount of food offers: ' + foodoffersToCreate.length,
+      });
       batchIndex++;
     }
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyTimer.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyTimer.ts
@@ -35,6 +35,13 @@ export class MyTimers<T extends string> {
   }
 }
 
+type TimerProgressOptions = {
+  progress: number;
+  total: number;
+  prefix?: string | null;
+  suffix?: string | null;
+};
+
 export class MyTimer {
   public startTime: number = 0;
   public endTime: number = 0;
@@ -97,8 +104,7 @@ export class MyTimer {
     return estimatedTime;
   }
 
-  public printEstimatedTimeRemaining(progress: number, total: number, prefix?: string | null, suffix?: string | null) {
-    let remaining = total - progress;
+  public printEstimatedTimeRemaining({ progress, total, prefix, suffix }: TimerProgressOptions) {
     let estimatedTime = this.getEstimatedTimeRemaining(progress, total);
     let estimatedTimeStr = this.formatTimeToString(estimatedTime);
     prefix = prefix ? `${prefix}: ` : '';
@@ -114,7 +120,7 @@ export class MyTimer {
     return `${progressStr}/${totalStr}`;
   }
 
-  public printElapsedTimeAndEstimatedTimeRemaining(progress: number, total: number, prefix?: string | null, suffix?: string | null) {
+  public printElapsedTimeAndEstimatedTimeRemaining({ progress, total, prefix, suffix }: TimerProgressOptions) {
     const elapsed = this.getElapsedTime();
     const estimatedTime = this.getEstimatedTimeRemaining(progress, total);
     const elapsedStr = this.formatTimeToString(elapsed);


### PR DESCRIPTION
## Summary
- add a TimerProgressOptions object to group shared parameters for timer output methods
- update MyTimer printing helpers to accept the new options object
- adjust ParseSchedule timer calls to match the refactored API

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b43207c1c83308a08303ef572d2ef)