### PR TITLE
Refactor translator to abstract base class

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/DeepLTranslator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/DeepLTranslator.ts
@@ -1,34 +1,18 @@
-import deepl, { SourceLanguageCode, TargetLanguageCode, Translator } from 'deepl-node';
-import { MyTranslatorInterface } from './MyTranslatorInterface';
+import deepl, { SourceLanguageCode, TargetLanguageCode, Translator as DeepLTranslatorClient } from 'deepl-node';
+import { Translator } from './Translator';
+import { TranslatorSettings } from './TranslatorSettings';
+import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 
-export class DeepLTranslator implements MyTranslatorInterface {
-  private readonly translator: Translator;
+export class DeepLTranslator extends Translator {
+  private translator: DeepLTranslatorClient | undefined;
 
-  constructor(auth_key: string) {
-    this.translator = new deepl.Translator(auth_key);
+  constructor(translatorSettings: TranslatorSettings, myDatabaseHelper: MyDatabaseHelper) {
+    super(translatorSettings, myDatabaseHelper);
   }
 
-  async init() {
-    /**
-        console.log("Initializing DeepL Translator");
-        const sourceLanguages = await this.translator.getSourceLanguages();
-        console.log("Source Languages: ");
-        for (let i = 0; i < sourceLanguages.length; i++) {
-            const lang = sourceLanguages[i];
-            console.log(`${lang.name} (${lang.code})`); // Example: 'English (en)'
-        }
+  async translateImplementation(text: string, source_language: string, destination_language: string) {
+    if (!this.translator) return null;
 
-        console.log("");
-        const targetLanguages = await this.translator.getTargetLanguages();
-        console.log("Target Languages: ");
-        for (let i = 0; i < targetLanguages.length; i++) {
-            const lang = targetLanguages[i];
-            console.log(`${lang.name} (${lang.code}) supports formality`);
-        }
-         */
-  }
-
-  async translate(text: string, source_language: string, destination_language: string) {
     let translationResponse = null;
     let sourceLanguageCode = this.getDeepLLanguageCodeSource(source_language);
     let destinationLanguageCode = this.getDeepLLanguageCodeTarget(destination_language);
@@ -53,13 +37,81 @@ export class DeepLTranslator implements MyTranslatorInterface {
     return translationResponse;
   }
 
+  async reloadAuthKeyImplementation(auth_key: string) {
+    this.translator = new deepl.Translator(auth_key);
+    await this.initTranslator();
+  }
+
+  async getExtraImplementation() {
+    if (!this.translator) return { extra: '' };
+
+    const sourceLanguages = await this.translator.getSourceLanguages();
+    const targetLanguages = await this.translator.getTargetLanguages();
+
+    let extraObj = {
+      sourceLanguages: sourceLanguages,
+      targetLanguages: targetLanguages,
+    };
+    const extra = JSON.stringify(extraObj, null, 2);
+
+    return {
+      extra: extra || '',
+    };
+  }
+
+  async getUsageImplementation() {
+    if (!this.translator) return { used: 0, limit: 0 };
+
+    //console.log("DeepL Translator get Usage");
+    const usage = await this.translator.getUsage();
+    if (usage.anyLimitReached()) {
+      //console.log('Translation limit exceeded.');
+    }
+    const characterUsage = usage?.character; // {"character":{"count":0,"limit":500000}}
+
+    return {
+      used: characterUsage?.count || 0,
+      limit: characterUsage?.limit || 0,
+    };
+  }
+
+  /**
+   * Private Methods
+   */
+
+  private async initTranslator() {
+    /**
+        console.log("Initializing DeepL Translator");
+        const sourceLanguages = await this.translator.getSourceLanguages();
+        console.log("Source Languages: ");
+        for (let i = 0; i < sourceLanguages.length; i++) {
+            const lang = sourceLanguages[i];
+            console.log(`${lang.name} (${lang.code})`); // Example: 'English (en)'
+        }
+
+        console.log("");
+        const targetLanguages = await this.translator.getTargetLanguages();
+        console.log("Target Languages: ");
+        for (let i = 0; i < targetLanguages.length; i++) {
+            const lang = targetLanguages[i];
+            console.log(`${lang.name} (${lang.code}) supports formality`);
+        }
+         */
+  }
+
   private replaceAll(str: string, find: string, replace: string) {
     // use regex where find is replaced with replace globally and multiple times
     // find could be a special character like * which needs to be escaped
     return str.replace(new RegExp(find.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'), replace);
   }
 
-  async translateRaw(text: string, source_language_code: SourceLanguageCode, destination_language_code: TargetLanguageCode) {
+  private async translateRaw(
+    text: string,
+    source_language_code: SourceLanguageCode,
+    destination_language_code: TargetLanguageCode,
+  ) {
+    if (!this.translator) return null;
+
     //copy text string to another variable
     let textToTranslate: string = text;
 
@@ -92,48 +144,15 @@ export class DeepLTranslator implements MyTranslatorInterface {
     return translation;
   }
 
-  async getExtra() {
-    const sourceLanguages = await this.translator.getSourceLanguages();
-    const targetLanguages = await this.translator.getTargetLanguages();
-
-    let extraObj = {
-      sourceLanguages: sourceLanguages,
-      targetLanguages: targetLanguages,
-    };
-    const extra = JSON.stringify(extraObj, null, 2);
-
-    return {
-      extra: extra || '',
-    };
-  }
-
-  async getUsage() {
-    //console.log("DeepL Translator get Usage");
-    const usage = await this.translator.getUsage();
-    if (usage.anyLimitReached()) {
-      //console.log('Translation limit exceeded.');
-    }
-    const characterUsage = usage?.character; // {"character":{"count":0,"limit":500000}}
-
-    return {
-      used: characterUsage?.count || 0,
-      limit: characterUsage?.limit || 0,
-    };
-  }
-
-  /**
-   * Private Methods
-   */
-
-  getDeepLLanguageCodeSource(directus_language_code: string) {
+  private getDeepLLanguageCodeSource(directus_language_code: string) {
     return this.getDeepLLanguageCode(directus_language_code) as SourceLanguageCode;
   }
 
-  getDeepLLanguageCodeTarget(directus_language_code: string) {
+  private getDeepLLanguageCodeTarget(directus_language_code: string) {
     return this.getDeepLLanguageCode(directus_language_code) as TargetLanguageCode;
   }
 
-  getDeepLLanguageCode(directus_language_code: string) {
+  private getDeepLLanguageCode(directus_language_code: string) {
     /** directus_language_code
      * e.g. "en-US" -> "en"
      */

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/MyTranslatorInterface.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/MyTranslatorInterface.ts
@@ -1,9 +1,0 @@
-export interface MyTranslatorInterface {
-  init(): Promise<void>;
-
-  translate(text: string, source_language: string, destination_language: string): Promise<any>;
-
-  getUsage(): Promise<any>;
-
-  getExtra(): Promise<any>;
-}

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/Translator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/Translator.ts
@@ -1,13 +1,11 @@
-import { DeepLTranslator } from './DeepLTranslator';
-import { MyTranslatorInterface } from './MyTranslatorInterface';
 import { TranslatorSettings } from './TranslatorSettings';
 import { EnvVariableHelper } from '../helpers/EnvVariableHelper';
 import { MyDatabaseHelper } from '../helpers/MyDatabaseHelper';
 
-export class Translator {
+export abstract class Translator {
   private readonly logger: any;
   translatorSettings: TranslatorSettings;
-  private translatorImplementation: undefined | MyTranslatorInterface;
+  private initialized = false;
 
   constructor(translatorSettings: TranslatorSettings, myDatabaseHelper: MyDatabaseHelper) {
     this.logger = myDatabaseHelper?.apiContext?.logger;
@@ -25,18 +23,20 @@ export class Translator {
     try {
       //console.log("Auth Key found");
       await this.reloadAuthKey(auth_key);
+      this.initialized = true;
       let correctObj = await this.getSettingsAuthKeyCorrectObject();
       await this.setSettings(correctObj);
     } catch (error: any) {
       console.log('Error Initializing Translatior');
       console.log(error.toString());
       await this.setSettings(this.getSettingsAuthKeyErrorObject(error));
+      this.initialized = false;
     }
   }
 
   async translate(text: string, source_language: string, destination_language: string) {
-    if (!this.translatorImplementation) return null;
-    const translation = await this.translatorImplementation.translate(text, source_language, destination_language);
+    if (!this.initialized) return null;
+    const translation = await this.translateImplementation(text, source_language, destination_language);
     await this.reloadUsage(); //update usage stats
     return translation;
   }
@@ -64,8 +64,7 @@ export class Translator {
 
   async reloadAuthKey(auth_key: string) {
     //console.log("Reload AuthKey");
-    this.translatorImplementation = new DeepLTranslator(auth_key);
-    await this.translatorImplementation.init();
+    await this.reloadAuthKeyImplementation(auth_key);
     await this.reloadUsage();
   }
 
@@ -82,13 +81,11 @@ export class Translator {
   }
 
   async getUsage() {
-    if (!this.translatorImplementation) return { used: 0, limit: 0 };
-    return await this.translatorImplementation.getUsage();
+    return await this.getUsageImplementation();
   }
 
   async getExtra() {
-    if (!this.translatorImplementation) return { extra: '' };
-    return await this.translatorImplementation.getExtra();
+    return await this.getExtraImplementation();
   }
 
   async setSettings(newSettings: any) {
@@ -98,4 +95,16 @@ export class Translator {
   async getAuthKey() {
     return await this.translatorSettings.getAuthKey();
   }
+
+  abstract translateImplementation(
+    text: string,
+    source_language: string,
+    destination_language: string,
+  ): Promise<any>;
+
+  abstract reloadAuthKeyImplementation(auth_key: string): Promise<void>;
+
+  abstract getUsageImplementation(): Promise<any>;
+
+  abstract getExtraImplementation(): Promise<any>;
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/index.ts
@@ -1,6 +1,6 @@
 import { defineHook } from '@directus/extensions-sdk';
 
-import { Translator } from './Translator';
+import { DeepLTranslator } from './DeepLTranslator';
 import { TranslatorSettings } from './TranslatorSettings';
 import { DirectusCollectionTranslator } from './DirectusCollectionTranslator.js';
 import { EventHelper } from '../helpers/EventHelper';
@@ -17,7 +17,7 @@ const DEV_MODE = false;
 
 async function getAndInitItemsServiceCreatorAndTranslatorSettingsAndTranslatorAndSchema(myDatabaseHelper: MyDatabaseHelper) {
   let translatorSettings = new TranslatorSettings(myDatabaseHelper);
-  let translator = new Translator(translatorSettings, myDatabaseHelper);
+  let translator = new DeepLTranslator(translatorSettings, myDatabaseHelper);
   await translator.init();
   return {
     translatorSettings: translatorSettings,
@@ -153,7 +153,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(scheduleNameAutoTran
 
     try {
       let translatorSettings = new TranslatorSettings(myDatabaseHelper);
-      let translator = new Translator(translatorSettings, myDatabaseHelper);
+      let translator = new DeepLTranslator(translatorSettings, myDatabaseHelper);
       await translator.init();
 
       registerCollectionAutoTranslation(filter, apiContext);


### PR DESCRIPTION
## Summary
- convert Translator to an abstract base class that delegates translation logic to implementations
- update DeepL translator to extend the abstract base and provide implementation-specific methods
- remove unused translator interface and adjust hook wiring to instantiate the concrete translator

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b44ac923c8330b3af8c4ef20152f6)