### PR TITLE
Refactor form generation parameter bundle

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
@@ -393,7 +393,11 @@ async function sendFormExtractMail(form: DatabaseTypes.Forms, formExtract: Datab
   let internalMyDatabaseHelper = myDatabaseHelper.cloneWithInternalServerMode();
   // we need the internal server mode to generate the pdf, as traefik does not route the request correctly
   // TODO: Fix traefik configuration or add server to extra_hosts in docker-compose
-  let pdfBuffer = await FormHelper.generatePdfFromForm(form, formExtractRelevantInformation, internalMyDatabaseHelper);
+  let pdfBuffer = await FormHelper.generatePdfFromForm({
+    form,
+    formExtractRelevantInformation,
+    myDatabaseHelperInterface: internalMyDatabaseHelper,
+  });
 
   console.log('recipient_emails: ');
   console.log(recipient_emails);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
@@ -27,7 +27,13 @@ type AddFormFieldParams = {
   suffix?: string;
   form_submission_id: string;
   index: number;
-}
+};
+
+export type FormGenerationParams = {
+  form: DatabaseTypes.Forms;
+  formExtractRelevantInformation: FormExtractRelevantInformation;
+  myDatabaseHelperInterface: MyDatabaseTestableHelperInterface;
+};
 
 export class FormHelper {
   private static readonly FORM_IMAGE_TRANSFORM_OPTIONS = DirectusFilesAssetHelper.PRESET_FILE_TRANSFORMATION_IMAGE_HD;
@@ -449,7 +455,8 @@ export class FormHelper {
     return pdfBuffer;
   }
 
-  public static async generateHtmlFromForm(form: DatabaseTypes.Forms, formExtractRelevantInformation: FormExtractRelevantInformation, myDatabaseHelperInterface: MyDatabaseTestableHelperInterface): Promise<string> {
+  public static async generateHtmlFromForm(params: FormGenerationParams): Promise<string> {
+    let { form, formExtractRelevantInformation, myDatabaseHelperInterface } = params;
     let markdownContent = await this.generateMarkdownContentFromForm(form, formExtractRelevantInformation, myDatabaseHelperInterface);
     let template = DEFAULT_HTML_TEMPLATE;
     let html = await HtmlGenerator.generateHtml(BaseGermanMarkdownTemplateHelper.getTemplateDataForMarkdownContent(markdownContent), myDatabaseHelperInterface, template);
@@ -457,8 +464,10 @@ export class FormHelper {
     return html;
   }
 
-  public static async generatePdfFromForm(form: DatabaseTypes.Forms, formExtractRelevantInformation: FormExtractRelevantInformation, myDatabaseHelperInterface: MyDatabaseTestableHelperInterface, requestOptions?: RequestOptions): Promise<Buffer> {
-    let html = await this.generateHtmlFromForm(form, formExtractRelevantInformation, myDatabaseHelperInterface);
+  public static async generatePdfFromForm(params: FormGenerationParams & { requestOptions?: RequestOptions }): Promise<Buffer> {
+    let { requestOptions, ...formGenerationParams } = params;
+    let { myDatabaseHelperInterface } = formGenerationParams;
+    let html = await this.generateHtmlFromForm(formGenerationParams);
     let pdfBuffer = await this.generatePdfFromHtml(html, myDatabaseHelperInterface, requestOptions);
     return pdfBuffer;
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/__tests__/TestFormPdfGenerator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/__tests__/TestFormPdfGenerator.ts
@@ -18,7 +18,12 @@ describe('Pdf Generator Test', () => {
       mockImageResolution: true, // mock image resolution to avoid loading real images
     };
 
-    let pdfBuffer = await FormHelper.generatePdfFromForm(testForm, testFormExtractRelevantInformation, myDatabaseTestableHelperInterface, requestOptions);
+    let pdfBuffer = await FormHelper.generatePdfFromForm({
+      form: testForm,
+      formExtractRelevantInformation: testFormExtractRelevantInformation,
+      myDatabaseHelperInterface: myDatabaseTestableHelperInterface,
+      requestOptions,
+    });
     expect(pdfBuffer).toBeTruthy();
     let savePath = TestArtifacts.saveTestArtifact(pdfBuffer, 'form/pdf/' + 'example-form' + '.pdf');
     expect(true).toBeTruthy();


### PR DESCRIPTION
## Summary
- extract shared form generation values into a new `FormGenerationParams` object
- update form helper methods and call sites to use the consolidated parameters when generating HTML and PDFs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b435dcf7c8330b6db6bcb6add5d76)