### PR TITLE
Refactor LanguageCodes into shared common module

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -1,5 +1,7 @@
 import { PrimaryKey } from '@directus/types';
-import { CollectionNames, DatabaseTypes } from 'repo-depkit-common';
+import { CollectionNames, DatabaseTypes, LanguageCodes, LanguageCodesType } from 'repo-depkit-common';
+
+export { LanguageCodes, LanguageCodesType };
 
 import { MyDatabaseHelper } from './MyDatabaseHelper';
 
@@ -14,18 +16,6 @@ export type ExistingTranslation = {
   [key: string]: any;
 };
 type NewTranslationForCreation = Omit<ExistingTranslation, 'id'>;
-
-export class LanguageCodes {
-  public static readonly _codes = {
-    de: 'de-DE' as const,
-    en: 'en-US' as const,
-  };
-
-  static readonly DE = LanguageCodes._codes.de;
-  static readonly EN = LanguageCodes._codes.en;
-}
-
-export type LanguageCodesType = (typeof LanguageCodes._codes)[keyof typeof LanguageCodes._codes];
 
 export type TranslationBaseFields = {
   be_source_for_translations?: boolean | null;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationsBackend.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationsBackend.ts
@@ -1,12 +1,4 @@
-export class LanguageCodes {
-  public static readonly _codes = {
-    de: 'de-DE' as const,
-    en: 'en-US' as const,
-  };
-
-  static readonly DE = LanguageCodes._codes.de;
-  static readonly EN = LanguageCodes._codes.en;
-}
+export { LanguageCodes } from 'repo-depkit-common';
 
 export class TranslationsBackend {
   public static getTranslation(key: TranslationBackendKeys, language?: string): string {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -16,3 +16,4 @@ export * from './src/EmailHelper';
 export * from './src/EventHelper';
 export * from './src/form/FormHelperCommon';
 export * from './src/RatingHelper';
+export * from './src/LanguageCodes';

--- a/packages/common/src/LanguageCodes.ts
+++ b/packages/common/src/LanguageCodes.ts
@@ -1,0 +1,11 @@
+export class LanguageCodes {
+  public static readonly _codes = {
+    de: 'de-DE' as const,
+    en: 'en-US' as const,
+  };
+
+  static readonly DE = LanguageCodes._codes.de;
+  static readonly EN = LanguageCodes._codes.en;
+}
+
+export type LanguageCodesType = (typeof LanguageCodes._codes)[keyof typeof LanguageCodes._codes];


### PR DESCRIPTION
## Summary
- move the LanguageCodes definition into the shared repo-depkit-common package
- update translation helpers to consume the shared LanguageCodes export instead of duplicating definitions
- re-export LanguageCodes where previously available to maintain existing imports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b42d5a39483308499e7e41c750ffb)