### PR TITLE
Refactor feedback date filter handling

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-feedback-report-schedule/ReportGenerator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-feedback-report-schedule/ReportGenerator.ts
@@ -524,7 +524,7 @@ export class ReportGenerator {
       },
     };
 
-    let filterDateUpdatedFeedbackLabelEntries: Filter[] = ReportGenerator.getFilterDateUpdatedForReportFeedbackPeriodDays(startDate, endDate);
+    let filterDateUpdatedFeedbackLabelEntries: Filter[] = this.buildFeedbackDateFilters(startDate, endDate);
 
     let labels_counted_as_list: ReportFoodEntryLabelType[] = [];
 
@@ -606,6 +606,13 @@ export class ReportGenerator {
     ];
   }
 
+  private buildFeedbackDateFilters(startDate: Date | null, endDate: Date | null): Filter[] {
+    if (startDate != null && endDate != null) {
+      return ReportGenerator.getFilterDateUpdatedForReportFeedbackPeriodDays(startDate, endDate);
+    }
+    return [];
+  }
+
   async getAllFoodFeedbacksWithCommentsForFood(food_id: string, startDate: Date | null, endDate: Date | null) {
     let itemService = this.myDatabaseHelper.getFoodFeedbacksHelper();
 
@@ -620,14 +627,8 @@ export class ReportGenerator {
           _nnull: true,
         },
       },
+      ...this.buildFeedbackDateFilters(startDate, endDate),
     ];
-
-    if (startDate != null && endDate != null) {
-      let filterDateUpdated = ReportGenerator.getFilterDateUpdatedForReportFeedbackPeriodDays(startDate, endDate);
-      if (filterDateUpdated) {
-        filter.push(...filterDateUpdated);
-      }
-    }
 
     let feedbacksWithCommentsAndCanteenObject = await itemService.readByQuery({
       filter: {


### PR DESCRIPTION
## Summary
- extract a helper to build feedback date filters for reports
- reuse the shared helper in comment and label feedback queries to reduce duplication

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc910d3808330817b2913876f87b4)