### PR TITLE
Refactor translation helper contexts

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -536,7 +536,13 @@ export class ParseSchedule {
   }
 
   async updateFoodTranslations(foundFoodWithTranslations: DatabaseTypes.Foods, foodsInformationForParser: FoodsInformationTypeForParser) {
-    await TranslationHelper.updateItemTranslationsForItemWithTranslationsFetched<DatabaseTypes.Foods, DatabaseTypes.FoodsTranslations>(foundFoodWithTranslations, foodsInformationForParser.translations, 'foods_id', CollectionNames.FOODS, this.context.myDatabaseHelper);
+    await TranslationHelper.updateItemTranslationsForItemWithTranslationsFetched<DatabaseTypes.Foods, DatabaseTypes.FoodsTranslations>({
+      itemWithTranslations: foundFoodWithTranslations,
+      translationsFromParsing: foodsInformationForParser.translations,
+      items_primary_field_in_translation_table: 'foods_id',
+      itemsTablename: CollectionNames.FOODS,
+      myDatabaseHelper: this.context.myDatabaseHelper,
+    });
   }
 
   async getOrCreateFoodsOnlyWithTranslations(foodsInformationForParserList: FoodsInformationTypeForParser[]) {
@@ -876,6 +882,12 @@ export class ParseSchedule {
   }
 
   async updateMarkingTranslations(marking: DatabaseTypes.Markings, markingJSON: MarkingsTypeForParser) {
-    await TranslationHelper.updateItemTranslations<DatabaseTypes.Markings, DatabaseTypes.MarkingsTranslations>(marking, markingJSON.translations, 'markings_id', CollectionNames.MARKINGS, this.context.myDatabaseHelper);
+    await TranslationHelper.updateItemTranslations<DatabaseTypes.Markings, DatabaseTypes.MarkingsTranslations>({
+      item: marking,
+      translationsFromParsing: markingJSON.translations,
+      items_primary_field_in_translation_table: 'markings_id',
+      itemsTablename: CollectionNames.MARKINGS,
+      myDatabaseHelper: this.context.myDatabaseHelper,
+    });
   }
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -40,6 +40,37 @@ type NonRelationFields = (typeof NonRelationFieldsArray)[number];
 
 export type TranslationRelationField<E> = Exclude<keyof E, NonRelationFields> & string;
 
+type TranslationUpdateBaseContext<E extends ExistingTranslation> = {
+  translationsFromParsing: TranslationsFromParsingType;
+  items_primary_field_in_translation_table: TranslationRelationField<E>;
+};
+
+type TranslationUpdateContextWithFetchedTranslations<
+  T extends ItemWithExistingTranslations,
+  E extends ExistingTranslation,
+> = TranslationUpdateBaseContext<E> & {
+  itemWithTranslations: T;
+  itemsTablename: CollectionNames;
+  myDatabaseHelper: MyDatabaseHelper;
+};
+
+type TranslationUpdateContextWithItem<
+  T extends ItemWithExistingTranslations,
+  E extends ExistingTranslation,
+> = TranslationUpdateBaseContext<E> & {
+  item: T;
+  itemsTablename: CollectionNames;
+  myDatabaseHelper: MyDatabaseHelper;
+};
+
+type TranslationUpdateInformationContext<
+  T extends ItemWithExistingTranslations,
+  E extends ExistingTranslation,
+> = TranslationUpdateBaseContext<E> & {
+  itemWithTranslations: T;
+  item: T;
+};
+
 export class TranslationHelper {
   static LANGUAGE_CODE_DE: LanguageCodesType = LanguageCodes.DE;
   static LANGUAGE_CODE_EN: LanguageCodesType = LanguageCodes.EN;
@@ -76,15 +107,23 @@ export class TranslationHelper {
     T extends ItemWithExistingTranslations, // T must have an id and translations field
     E extends ExistingTranslation, // the collection of the related translations
   >(
-    itemWithTranslations: T, // the item we want to update the translations for
-    translationsFromParsing: TranslationsFromParsingType, // the translations we got from the parser
-    items_primary_field_in_translation_table: TranslationRelationField<E>, // the primary field (to our item) in the translation table, e.g. "food_id" when translating foods
-    itemsTablename: CollectionNames, // the name of the table of our item
-    myDatabaseHelper: MyDatabaseHelper
+    context: TranslationUpdateContextWithFetchedTranslations<T, E>
   ) {
+    const {
+      itemWithTranslations,
+      translationsFromParsing,
+      items_primary_field_in_translation_table,
+      itemsTablename,
+      myDatabaseHelper,
+    } = context;
     const specificItemServiceReader = await myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
     if (!!itemWithTranslations) {
-      const { updateObject: updateObject, updateNeeded: updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations(itemWithTranslations, itemWithTranslations, translationsFromParsing, items_primary_field_in_translation_table);
+      const { updateObject: updateObject, updateNeeded: updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations({
+        itemWithTranslations,
+        item: itemWithTranslations,
+        translationsFromParsing,
+        items_primary_field_in_translation_table,
+      });
 
       if (updateNeeded) {
         //const createTranslations = updateObject.translations.create;
@@ -127,28 +166,29 @@ export class TranslationHelper {
     T extends ItemWithExistingTranslations, // T must have an id and translations field
     E extends ExistingTranslation, // the collection of the related translations
   >(
-    item: T, // the item we want to update the translations for
-    translationsFromParsing: TranslationsFromParsingType, // the translations we got from the parser
-    items_primary_field_in_translation_table: TranslationRelationField<E>, // the primary field (to our item) in the translation table, e.g. "food_id" when translating foods
-    itemsTablename: CollectionNames, // the name of the table of our item
-    myDatabaseHelper: MyDatabaseHelper
+    context: TranslationUpdateContextWithItem<T, E>
   ) {
+    const { item, translationsFromParsing, items_primary_field_in_translation_table, itemsTablename, myDatabaseHelper } = context;
     const specificItemServiceReader = await myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
     let itemWithTranslations = await specificItemServiceReader.readOne(item?.id, {
       ...TranslationHelper.QUERY_FIELDS_FOR_ALL_FIELDS_AND_FOR_TRANSLATION_FETCHING,
     }); // Bottleneck HERE. Takes on average 1.0s
-    return TranslationHelper.updateItemTranslationsForItemWithTranslationsFetched(itemWithTranslations, translationsFromParsing, items_primary_field_in_translation_table, itemsTablename, myDatabaseHelper);
+    return TranslationHelper.updateItemTranslationsForItemWithTranslationsFetched({
+      itemWithTranslations,
+      translationsFromParsing,
+      items_primary_field_in_translation_table,
+      itemsTablename,
+      myDatabaseHelper,
+    });
   }
 
   static async _getUpdateInformationForTranslations<
     T extends ItemWithExistingTranslations, // T must have an id and translations field
     E extends ExistingTranslation, // the collection of the related translations
   >(
-    itemWithTranslations: T, // the item we want to update the translations for
-    item: T, // the item we want to update the translations for
-    translationsFromParsing: TranslationsFromParsingType, // the translations we got from the parser
-    items_primary_field_in_translation_table: TranslationRelationField<E> // the primary field (to our item) in the translation table, e.g. "food_id" when translating foods
+    context: TranslationUpdateInformationContext<T, E>
   ) {
+    const { itemWithTranslations, item, translationsFromParsing, items_primary_field_in_translation_table } = context;
     /** translationsFromParsing is an object with the following structure:
          {
          [LanguageCodes.DE]: {


### PR DESCRIPTION
## Summary
- refactor translation helper methods to accept structured context objects and reduce parameter clumps
- update food and marking translation callers to use the new context-based signatures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d62e2e9908330b960e41c27ea1f50)