### PR TITLE
Include lifetimeSeconds in shared Apple secret credentials

### DIFF
--- a/apps/backend-sync/src/apple-secret-rotator/apple/generateAppleClientSecret.ts
+++ b/apps/backend-sync/src/apple-secret-rotator/apple/generateAppleClientSecret.ts
@@ -1,16 +1,10 @@
 import {generateAppleJWTShell} from "./generateAppleClientSecretShell";
+import type {AppleClientSecretCredentials} from "./types";
+export {AppleClientSecretCredentials} from "./types";
 
 export const APPLE_AUDIENCE = 'https://appleid.apple.com';
 const days = 90; // could be to the max of 180 days which Apple allows
 export const MAX_TOKEN_LIFETIME_SECONDS = 60 * 60 * 24 * days;
-
-export type AppleClientSecretConfig = {
-  teamId: string;
-  clientId: string;
-  keyId: string;
-  privateKey: string;
-  lifetimeSeconds?: number;
-};
 
 export type AppleClientSecretResult = {
   token: string;
@@ -63,17 +57,17 @@ export function decodeAppleClientSecretExpiry(token: string): number | null {
     return parseInt(exp.toString());
 }
 
-export function generateAppleClientSecret(config: AppleClientSecretConfig): AppleClientSecretResult {
-  const { teamId, clientId, keyId } = config;
+export function generateAppleClientSecret(config: AppleClientSecretCredentials): AppleClientSecretResult {
+  const { teamId, clientId, keyId, privateKey } = config;
   if (!teamId || !clientId || !keyId || !config.privateKey) {
     throw new Error('Missing configuration for Apple client secret generation.');
   }
 
   let result = generateAppleJWTShell({
-    teamId: config.teamId,
-    clientId: config.clientId,
-    keyId: config.keyId,
-    keyFileContent: config.privateKey,
+    teamId,
+    clientId,
+    keyId,
+    privateKey,
   })
 
   return {

--- a/apps/backend-sync/src/apple-secret-rotator/apple/generateAppleClientSecretShell.ts
+++ b/apps/backend-sync/src/apple-secret-rotator/apple/generateAppleClientSecretShell.ts
@@ -1,18 +1,12 @@
 // import child_process for execSync
 import {execSync} from 'child_process';
-
-interface AppleJWTParams {
-  teamId: string;
-  clientId: string;
-  keyId: string;
-  keyFileContent: string;
-}
+import {AppleClientSecretCredentials} from './types';
 
 /**
  * Generate Apple SSO JWT token
  */
-export function generateAppleJWTShell(params: AppleJWTParams) {
-  const { teamId, clientId, keyId, keyFileContent } = params;
+export function generateAppleJWTShell(params: AppleClientSecretCredentials) {
+  const { teamId, clientId, keyId, privateKey } = params;
 
   // Validate required parameters
   const missingParams: string[] = [];
@@ -20,7 +14,7 @@ export function generateAppleJWTShell(params: AppleJWTParams) {
   if (!teamId) missingParams.push('teamId');
   if (!clientId) missingParams.push('clientId');
   if (!keyId) missingParams.push('keyId');
-  if (!keyFileContent) {
+  if (!privateKey) {
     missingParams.push('keyFileContent or keyFilePath');
   }
 
@@ -52,7 +46,7 @@ export function generateAppleJWTShell(params: AppleJWTParams) {
   execSync(`chmod +x ${target}`);
 
   // Execute the shell script with parameters
-  let command = `${target} --team_id "${teamId}" --client_id "${clientId}" --key_id "${keyId}" --key_file_content '${keyFileContent}'`;
+  let command = `${target} --team_id "${teamId}" --client_id "${clientId}" --key_id "${keyId}" --key_file_content '${privateKey}'`;
 
   let token: string;
   try {

--- a/apps/backend-sync/src/apple-secret-rotator/apple/types.ts
+++ b/apps/backend-sync/src/apple-secret-rotator/apple/types.ts
@@ -1,0 +1,7 @@
+export type AppleClientSecretCredentials = {
+  teamId: string;
+  clientId: string;
+  keyId: string;
+  privateKey: string;
+  lifetimeSeconds?: number;
+};

--- a/apps/backend-sync/src/apple-secret-rotator/index.ts
+++ b/apps/backend-sync/src/apple-secret-rotator/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import {
-  AppleClientSecretConfig,
+  AppleClientSecretCredentials,
   decodeAppleClientSecretExpiry,
   generateAppleClientSecret,
   MAX_TOKEN_LIFETIME_SECONDS
@@ -11,7 +11,7 @@ const REFRESH_THRESHOLD_SECONDS = 60 * 60 * 24 * refreshIfExpiringWithinDays;
 
 const HOOK_NAME = 'apple-secret-rotator';
 
-export function buildConfigFromEnv(hostEnvFilePath: string): AppleClientSecretConfig | null {
+export function buildConfigFromEnv(hostEnvFilePath: string): AppleClientSecretCredentials | null {
   const teamId = getEnvValue(hostEnvFilePath, 'AUTH_APPLE_HOOK_APPLE_TEAM_ID');
   const clientId = getEnvValue(hostEnvFilePath, 'AUTH_APPLE_CLIENT_ID');
   const keyId = getEnvValue(hostEnvFilePath, 'AUTH_APPLE_HOOK_APPLE_KEY_ID');
@@ -78,7 +78,7 @@ function setEnvValue(hostEnvFilePath: string, key: string, value: string) {
   console.log("["+HOOK_NAME+"] Updated " + key + " in " + hostEnvFilePath);
 }
 
-async function refreshSecret(config: AppleClientSecretConfig, hostEnvFilePath: string) {
+async function refreshSecret(config: AppleClientSecretCredentials, hostEnvFilePath: string) {
   try {
     const result = generateAppleClientSecret(config);
     let token = result.token;
@@ -95,7 +95,7 @@ async function refreshSecret(config: AppleClientSecretConfig, hostEnvFilePath: s
   }
 }
 
-export async function ensureAppleClientSecret(config: AppleClientSecretConfig, hostEnvFilePath: string): Promise<{changed: boolean, reason?: string}> {
+export async function ensureAppleClientSecret(config: AppleClientSecretCredentials, hostEnvFilePath: string): Promise<{changed: boolean, reason?: string}> {
   if (!config) {
     console.warn('['+HOOK_NAME+'] Rotator disabled due to missing configuration.');
     return { changed: false, reason: 'missing_config' };


### PR DESCRIPTION
## Summary
- move optional lifetimeSeconds into the shared Apple client secret credentials type to remove the extra config interface
- update client secret generation and rotator utilities to rely on the unified credentials shape

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d93b4917c8330b7f633e5e2830455)