### PR TITLE
Align calendar modal arrows with foodoffers header

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { CalendarSheetProps, Direction } from './types';
 import MyScrollViewModal from '@/components/MyScrollViewModal';
 import { isWeb } from '@/constants/Constants';
-import { AntDesign } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons';
 import { Calendar, LocaleConfig } from 'react-native-calendars';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -98,7 +98,7 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
                             }}
                             onPress={() => navigateMonth(direction === 'left' ? 'prev' : 'next')}
                         >
-                            <AntDesign name={direction === 'left' ? 'arrowleft' : 'arrowright'} size={20} color={contrastColor} />
+                            <Entypo name={direction === 'left' ? 'chevron-left' : 'chevron-right'} size={20} color={contrastColor} />
                         </TouchableOpacity>
                     )}
                     onMonthChange={(month: any) => {


### PR DESCRIPTION
## Summary
- update calendar modal navigation arrows to use the same chevron icons as the foodoffers header controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db76f1af483308d8831643c7c2d57)