### PR TITLE
Move debug toggle below WebP setting

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -326,30 +326,11 @@ const Settings = () => {
                                                 {/* Terms & Conditions */}
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="file-document-check" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.terms_and_conditions_accepted_and_privacy_policy_read_at_date)} value={termsAndPrivacyConsentAcceptedDate} handleFunction={() => {}} groupPosition="bottom" />
                                         </View>
-                                        {isManagement && (
-                                                <SettingsList
-                                                        iconBgColor={primaryColor}
-                                                        leftIcon={<MaterialCommunityIcons name="bank-transfer" size={24} color={theme.screen.icon} />}
-                                                        label={translate(TranslationKeys.debug_mode)}
-                                                        value={debugMode ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
-                                                        rightElement={
-                                                                <Switch
-                                                                        value={debugMode}
-                                                                        onValueChange={toggleDebugMode}
-                                                                        trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
-                                                                        thumbColor={theme.screen.icon}
-                                                                        ios_backgroundColor={theme.screen.iconBg}
-                                                                />
-                                                        }
-                                                        handleFunction={toggleDebugMode}
-                                                        groupPosition="single"
-                                                />
-                                        )}
                                         <TouchableOpacity
                                                 style={styles.footer}
                                                 onPress={() => {
                                                         if (isManagement) {
-								dispatch({ type: UPDATE_DEVELOPER_MODE, payload: false });
+                                                                dispatch({ type: UPDATE_DEVELOPER_MODE, payload: false });
 								dispatch({ type: UPDATE_MANAGEMENT, payload: false });
 							} else {
 								dispatch({ type: UPDATE_DEVELOPER_MODE, payload: true });
@@ -368,13 +349,30 @@ const Settings = () => {
 						<Text style={{ ...styles.heading, color: theme.drawerHeading }}>{ServerInfoHelper.getServerName(serverInfo)}</Text>
 					</TouchableOpacity>
 					{isManagement && isDevMode && <Text style={{ ...styles.devModeText, color: theme.screen.text }}>{translate(TranslationKeys.developerModeActive)}</Text>}
-					{isManagement && isDevMode && (
-						<>
-							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={serverInfo?.info?.project?.project_name} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
-							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
-							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="bottom" />
-						</>
-					)}
+                                        {isManagement && isDevMode && (
+                                                <>
+                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={serverInfo?.info?.project?.project_name} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
+                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
+                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
+                                                        <SettingsList
+                                                                iconBgColor={primaryColor}
+                                                                leftIcon={<MaterialCommunityIcons name="bank-transfer" size={24} color={theme.screen.icon} />}
+                                                                label={translate(TranslationKeys.debug_mode)}
+                                                                value={debugMode ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
+                                                                rightElement={
+                                                                        <Switch
+                                                                                value={debugMode}
+                                                                                onValueChange={toggleDebugMode}
+                                                                                trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
+                                                                                thumbColor={theme.screen.icon}
+                                                                                ios_backgroundColor={theme.screen.iconBg}
+                                                                        />
+                                                                }
+                                                                handleFunction={toggleDebugMode}
+                                                                groupPosition="bottom"
+                                                        />
+                                                </>
+                                        )}
 					<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="numeric" size={24} color={theme.screen.icon} />} label="Version" value={getVersionInternalForAppsettingsScreen().toString()} handleFunction={() => {}} />
 				</View>
 			</ScrollView>


### PR DESCRIPTION
## Summary
- relocate the debug mode toggle to follow the WebP setting in management view
- adjust grouping so WebP stays middle and debug toggle is bottom of management developer options

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc6f9955c83309abc361dfd9cb2b6)