### PR TITLE
Update foodoffers cache key to include canteen and date

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -81,7 +81,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { profile, user } = useSelector((state: RootState) => state.authReducer);
 	const selectedCanteen = useSelectedCanteen();
 		const kioskMode = useKioskMode();
-	const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, Record<string, DatabaseTypes.Foodoffers[]>>>({});
+        const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
 
@@ -310,43 +310,46 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		return '';
 	};
 
-	const fetchFoods = async () => {
-		try {
-			setLoading(true);
-			const canteenId = selectedCanteen?.id as string;
-			let foodOffers = prefetchedFoodOffers[canteenId]?.[selectedDate];
+        const getCacheKey = (canteenId: string, date: string) => {
+                return `${canteenId}_${format(new Date(date), 'dd.MM.yyyy')}`;
+        };
 
-			if (!foodOffers) {
-				const foodData = await fetchFoodOffersByCanteen(canteenId, selectedDate);
-				foodOffers = foodData?.data || [];
-			}
+        const getCachedOffers = (canteenId: string, date: string) => {
+                return prefetchedFoodOffers[getCacheKey(canteenId, date)];
+        };
 
-			setPrefetchedFoodOffers(prev => ({
-				...prev,
-				[canteenId]: {
-					...(prev[canteenId] || {}),
-					[selectedDate]: foodOffers,
-				},
-			}));
+        const fetchFoods = async () => {
+                try {
+                        setLoading(true);
+                        const canteenId = selectedCanteen?.id as string;
+                        let foodOffers = getCachedOffers(canteenId, selectedDate);
+
+                        if (!foodOffers) {
+                                const foodData = await fetchFoodOffersByCanteen(canteenId, selectedDate);
+                                foodOffers = foodData?.data || [];
+                        }
+
+                        setPrefetchedFoodOffers(prev => ({
+                                ...prev,
+                                [getCacheKey(canteenId, selectedDate)]: foodOffers,
+                        }));
 
 			// Prefetch next two days
 			for (let i = 1; i <= 2; i++) {
-				const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
-				if (!prefetchedFoodOffers[canteenId]?.[date]) {
-					fetchFoodOffersByCanteen(canteenId, date)
-						.then(res => {
-							const offers = res?.data || [];
-							setPrefetchedFoodOffers(p => ({
-								...p,
-								[canteenId]: {
-									...(p[canteenId] || {}),
-									[date]: offers,
-								},
-							}));
-						})
-						.catch(e => console.error('Error prefetching Food Offers:', e));
-				}
-			}
+                                const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
+                                const cacheKey = getCacheKey(canteenId, date);
+                                if (!prefetchedFoodOffers[cacheKey]) {
+                                        fetchFoodOffersByCanteen(canteenId, date)
+                                                .then(res => {
+                                                        const offers = res?.data || [];
+                                                        setPrefetchedFoodOffers(p => ({
+                                                                ...p,
+                                                                [cacheKey]: offers,
+                                                        }));
+                                                })
+                                                .catch(e => console.error('Error prefetching Food Offers:', e));
+                                }
+                        }
 
 			updateSort(sortBy as FoodSortOption, foodOffers);
 
@@ -371,17 +374,17 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		setRefreshing(false);
 	}, []);
 
-	const nextAvailableDate = useMemo(() => {
-		const canteenId = selectedCanteen?.id as string;
-		for (let i = 1; i <= 2; i++) {
-			const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
-			const offers = prefetchedFoodOffers[canteenId]?.[date];
-			if (offers && offers.length > 0) {
-				return date;
-			}
-		}
-		return null;
-	}, [prefetchedFoodOffers, selectedCanteen, selectedDate]);
+        const nextAvailableDate = useMemo(() => {
+                const canteenId = selectedCanteen?.id as string;
+                for (let i = 1; i <= 2; i++) {
+                        const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
+                        const offers = getCachedOffers(canteenId, date);
+                        if (offers && offers.length > 0) {
+                                return date;
+                        }
+                }
+                return null;
+        }, [prefetchedFoodOffers, selectedCanteen, selectedDate]);
 
 	const getWeekdayKey = (date: string) => {
 		const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -49,7 +49,7 @@ import CanteenFeedbackLabels from '@/components/CanteenFeedbackLabels/CanteenFee
 import {Tooltip, TooltipContent, TooltipText} from '@gluestack-ui/themed';
 import * as Notifications from 'expo-notifications';
 import {sortFoodOffers} from '@/helper/foodOfferSortHelper';
-import {addDays, format} from 'date-fns';
+import {addDays, format, parse} from 'date-fns';
 import {BusinessHoursHelper} from '@/redux/actions/BusinessHours/BusinessHours';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';
 import {PopupEventHelper} from '@/helper/PopupEventHelper';
@@ -134,7 +134,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const selectedCanteen = useSelectedCanteen();
 	useFoodOffersDefaultDate();
 	const kioskMode = useKioskMode();
-	const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, Record<string, DatabaseTypes.Foodoffers[]>>>({});
+        const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 	const { hasUnreadChats } = useChatUnreadStatus();
 	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
@@ -209,12 +209,26 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 return [...start, ...main, ...end] as DayItem[];
         }, [selectedCanteenFoodOffers, foodOffersInfoItems, selectedCanteen]);
 
+        const getCacheKey = (canteenId: string, date: string) => {
+                return `${canteenId}_${format(new Date(date), 'dd.MM.yyyy')}`;
+        };
+
+        const getCachedOffers = (canteenId: string, date: string) => {
+                return prefetchedFoodOffers[getCacheKey(canteenId, date)];
+        };
+
         const cachedFoodOfferDates = useMemo(() => {
                 const canteenId = selectedCanteen?.id;
                 if (!canteenId) return [];
 
-                const dates = Object.keys(prefetchedFoodOffers[canteenId] || {});
-                return dates.sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
+                const dates = Object.keys(prefetchedFoodOffers)
+                        .filter(key => key.startsWith(`${canteenId}_`))
+                        .map(key => key.replace(`${canteenId}_`, ''))
+                        .map(date => parse(date, 'dd.MM.yyyy', new Date()))
+                        .filter(date => !Number.isNaN(date.getTime()))
+                        .sort((a, b) => a.getTime() - b.getTime())
+                        .map(date => format(date, 'yyyy-MM-dd'));
+                return dates;
         }, [prefetchedFoodOffers, selectedCanteen]);
 
         const cachedFoodOfferDateLabels = useMemo(
@@ -405,30 +419,31 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const fetchFoods = async (forceFetch = false) => {
 		try {
 			setLoading(true);
-			const canteenId = selectedCanteen?.id as string;
-			if (!canteenId || !selectedDate) {
-				setLoading(false);
-				return;
-			}
+                        const canteenId = selectedCanteen?.id as string;
+                        if (!canteenId || !selectedDate) {
+                                setLoading(false);
+                                return;
+                        }
 
-			let foodOffers = prefetchedFoodOffers[canteenId]?.[selectedDate];
-			if (!foodOffers || forceFetch) {
-				const foodData = await fetchFoodOffersByCanteen(canteenId, selectedDate);
-				foodOffers = foodData?.data || [];
-			}
+                        let foodOffers = getCachedOffers(canteenId, selectedDate);
+                        if (!foodOffers || forceFetch) {
+                                const foodData = await fetchFoodOffersByCanteen(canteenId, selectedDate);
+                                foodOffers = foodData?.data || [];
+                        }
 
-			setPrefetchedFoodOffers(prev => ({ ...prev, [canteenId]: { ...(prev[canteenId] || {}), [selectedDate]: foodOffers } }));
+                        setPrefetchedFoodOffers(prev => ({ ...prev, [getCacheKey(canteenId, selectedDate)]: foodOffers }));
 
 			for (let i = 1; i <= 2; i++) {
-				const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
-				if (!prefetchedFoodOffers[canteenId]?.[date]) {
-					fetchFoodOffersByCanteen(canteenId, date)
-						.then(res => {
-							const offers = res?.data || [];
-							setPrefetchedFoodOffers(p => ({ ...p, [canteenId]: { ...(p[canteenId] || {}), [date]: offers } }));
-							try {
-								offers.slice(0, 6).forEach((o: any) => {
-									const img = o?.food?.image_remote_url || o?.food?.image;
+                                const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
+                                const cacheKey = getCacheKey(canteenId, date);
+                                if (!prefetchedFoodOffers[cacheKey]) {
+                                        fetchFoodOffersByCanteen(canteenId, date)
+                                                .then(res => {
+                                                        const offers = res?.data || [];
+                                                        setPrefetchedFoodOffers(p => ({ ...p, [cacheKey]: offers }));
+                                                        try {
+                                                                offers.slice(0, 6).forEach((o: any) => {
+                                                                        const img = o?.food?.image_remote_url || o?.food?.image;
 									if (img) Image.prefetch(img).catch(() => { });
 								});
 							} catch (e) { }
@@ -480,15 +495,15 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	);
 	const canteenFeedbackLabelsExist = canteenFeedbackLabels?.length > 0;
 
-	const nextAvailableDate = useMemo(() => {
-		const canteenId = selectedCanteen?.id as string;
-		for (let i = 1; i <= 2; i++) {
-			const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
-			const offers = prefetchedFoodOffers[canteenId]?.[date];
-			if (offers && offers.length > 0) return date;
-		}
-		return null;
-	}, [prefetchedFoodOffers, selectedCanteen, selectedDate]);
+        const nextAvailableDate = useMemo(() => {
+                const canteenId = selectedCanteen?.id as string;
+                for (let i = 1; i <= 2; i++) {
+                        const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
+                        const offers = getCachedOffers(canteenId, date);
+                        if (offers && offers.length > 0) return date;
+                }
+                return null;
+        }, [prefetchedFoodOffers, selectedCanteen, selectedDate]);
 
 	const getWeekdayKey = (date: string) => {
 		const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];


### PR DESCRIPTION
## Summary
- use a composite cache key of `<canteen_id>_<dd.MM.yyyy>` for local foodoffers data in both foodoffers views
- update cached date handling to derive readable dates from the new key format
- continue prefetching and lookup logic through the new composite key helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de07645fc8330864b5fa14c523b9f)