### PR TITLE
Add optional selected date handling for foodoffer navigation

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -44,7 +44,7 @@ const selectPreviousFeedback = createSelector(
 export default function FoodDetailsScreen() {
         useSetPageTitle(TranslationKeys.food_details);
 
-        const { id, foodId } = useLocalSearchParams();
+        const { id, foodId, selectedDate: selectedDateParam } = useLocalSearchParams();
         const offerId = Array.isArray(id) ? id[0] : id;
         const initialFoodId = Array.isArray(foodId) ? foodId[0] : foodId;
 
@@ -59,11 +59,25 @@ export default function FoodDetailsScreen() {
 	const profileHelper = useMemo(() => new ProfileHelper(), []);
 	const foodfeedbackHelper = useMemo(() => new FoodFeedbackHelper(), []);
 	const { foodAttributeGroups } = useSelector((state: RootState) => state.foodAttributes);
-	const { foodCategories, foodOfferCategories } = useSelector((state: RootState) => state.food);
-	const [pushTokenObj, requestDeviceNotificationPermission] = NotificationHelper.useNotificationPermission(profile);
-	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
-	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
-	const defaultImage = getImageUrl(String(appSettings.foods_placeholder_image)) || appSettings.foods_placeholder_image_remote_url || getImageUrl(serverInfo?.info?.project?.project_logo);
+        const { foodCategories, foodOfferCategories, selectedDate } = useSelector((state: RootState) => state.food);
+        const [pushTokenObj, requestDeviceNotificationPermission] = NotificationHelper.useNotificationPermission(profile);
+        const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
+        const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
+        const defaultImage = getImageUrl(String(appSettings.foods_placeholder_image)) || appSettings.foods_placeholder_image_remote_url || getImageUrl(serverInfo?.info?.project?.project_logo);
+
+        const normalizedSelectedDateFromParams = useMemo(() => {
+                const value = Array.isArray(selectedDateParam) ? selectedDateParam[0] : selectedDateParam;
+
+                if (!value || typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+                        return undefined;
+                }
+
+                const parsedDate = new Date(value);
+
+                return Number.isNaN(parsedDate.getTime()) ? undefined : value;
+        }, [selectedDateParam]);
+
+        const effectiveSelectedDate = normalizedSelectedDateFromParams || selectedDate;
 
 	const [warning, setWarning] = useState(false);
 	const selectedCanteen = useSelectedCanteen();
@@ -381,10 +395,10 @@ export default function FoodDetailsScreen() {
 		}
 	}, []);
 
-	const updateNotification = async () => {
-		if (!user?.id) {
-			setWarning(true);
-			return;
+        const updateNotification = async () => {
+                if (!user?.id) {
+                        setWarning(true);
+                        return;
 		}
 		if (isSmartPhone()) {
 			const result = await NotificationHelper.getDeviceNotificationPermission();
@@ -416,8 +430,23 @@ export default function FoodDetailsScreen() {
 
 	const themeStyles = {
 		backgroundColor: foods_area_color,
-		borderColor: foods_area_color,
-	};
+                borderColor: foods_area_color,
+        };
+
+        const handleNavigateBack = useCallback(() => {
+                const today = new Date().toISOString().split('T')[0];
+                const params =
+                        effectiveSelectedDate && effectiveSelectedDate !== today
+                                ? { selectedDate: effectiveSelectedDate }
+                                : undefined;
+
+                if (router.canGoBack()) {
+                        router.back();
+                        return;
+                }
+
+                router.navigate({ pathname: '/(app)/foodoffers', params });
+        }, [effectiveSelectedDate]);
 
 	return (
 		<SafeAreaView
@@ -437,18 +466,32 @@ export default function FoodDetailsScreen() {
 					backgroundColor: theme.screen.background,
 				}}
 			>
-				<View
-					style={{
-						width: '100%',
-						height: '100%',
-						alignItems: 'center',
-					}}
-				>
-					{isWeb ? (
-						<>
-							<View
-								style={{
-									...styles.featuredContainer,
+                                <View
+                                        style={{
+                                                width: '100%',
+                                                height: '100%',
+                                                alignItems: 'center',
+                                        }}
+                                >
+                                        <View style={styles.backButtonContainer}>
+                                                <TouchableOpacity
+                                                        onPress={handleNavigateBack}
+                                                        style={{
+                                                                ...styles.backButton,
+                                                                backgroundColor: theme.screen.iconBg,
+                                                        }}
+                                                >
+                                                        <MaterialIcons name="arrow-back" size={20} color={theme.screen.text} />
+                                                        <Text style={{ ...styles.backButtonText, color: theme.screen.text }}>
+                                                                {translate(TranslationKeys.navigate_back)}
+                                                        </Text>
+                                                </TouchableOpacity>
+                                        </View>
+                                        {isWeb ? (
+                                                <>
+                                                        <View
+                                                                style={{
+                                                                        ...styles.featuredContainer,
 									width: screenWidth > 1000 ? '80%' : '100%',
 									flexDirection: screenWidth > 1000 ? 'row' : 'column',
 								}}

--- a/apps/frontend/app/app/(app)/foodoffers/details/styles.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/details/styles.ts
@@ -8,17 +8,34 @@ export default StyleSheet.create({
 		alignItems: 'center',
 		paddingBottom: 20,
 	},
-	header: {
-		width: '100%',
-		height: 60,
-		justifyContent: 'center',
-		gap: 20,
-	},
-	headerRow: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		alignItems: 'center',
+        header: {
+                width: '100%',
+                height: 60,
+                justifyContent: 'center',
+                gap: 20,
+        },
+        backButtonContainer: {
+                width: '100%',
+                alignItems: 'flex-start',
+                marginBottom: 10,
+        },
+        backButton: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 8,
+                paddingHorizontal: 12,
+                paddingVertical: 8,
+                borderRadius: 12,
+        },
+        backButtonText: {
+                fontFamily: 'Poppins_500Medium',
+                fontSize: 14,
+        },
+        headerRow: {
+                width: '100%',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                alignItems: 'center',
 	},
 	col1: {
 		flexDirection: 'row',

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -17,7 +17,7 @@ import {DrawerContentComponentProps, DrawerNavigationProp} from '@react-navigati
 import {isWeb} from '@/constants/Constants';
 import FoodItem from '@/components/FoodItem/FoodItem';
 import FoodOfferInfoItem from '@/components/FoodOfferInfoItem/FoodOfferInfoItem';
-import {useFocusEffect, useNavigation, useRouter} from 'expo-router';
+import {useFocusEffect, useLocalSearchParams, useNavigation, useRouter} from 'expo-router';
 import {useDispatch, useSelector} from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import useKioskMode from '@/hooks/useKioskMode';
@@ -89,11 +89,12 @@ interface DayItem {
 
 
 const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
-	const dispatch = useDispatch();
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const router = useRouter();
-	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
+        const dispatch = useDispatch();
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const router = useRouter();
+        const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
+        const { selectedDate: selectedDateParam } = useLocalSearchParams();
 	const bottomSheetRef = useRef<BottomSheet>(null);
 	const eventSheetRef = useRef<BottomSheet>(null);
 	const businessHoursHelper = new BusinessHoursHelper();
@@ -131,16 +132,16 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { profile, user } = useSelector((state: RootState) => state.authReducer);
 	const { appElements } = useSelector((state: RootState) => state.appElements);
 	const { selectedCanteenFoodOffers, canteenFeedbackLabels } = useSelector((state: RootState) => state.canteenReducer);
-	const selectedCanteen = useSelectedCanteen();
-	useFoodOffersDefaultDate();
-	const kioskMode = useKioskMode();
+        const selectedCanteen = useSelectedCanteen();
+        useFoodOffersDefaultDate();
+        const kioskMode = useKioskMode();
         const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
-	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
+        const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 	const { hasUnreadChats } = useChatUnreadStatus();
 	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
 
 	const MIN_CARD_WIDTH = 280;
-	const numColumns = useMemo(() => {
+        const numColumns = useMemo(() => {
 		if (amountColumnsForcard && amountColumnsForcard > 0) {
 			return amountColumnsForcard;
 		}
@@ -148,8 +149,26 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		if (!listWidth) return 2;
 
 		const cols = Math.floor(listWidth / MIN_CARD_WIDTH);
-		return Math.max(2, cols);
-	}, [amountColumnsForcard, listWidth]);
+                return Math.max(2, cols);
+        }, [amountColumnsForcard, listWidth]);
+
+        const normalizedSelectedDateParam = useMemo(() => {
+                const paramValue = Array.isArray(selectedDateParam) ? selectedDateParam[0] : selectedDateParam;
+
+                if (!paramValue || typeof paramValue !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(paramValue)) {
+                        return null;
+                }
+
+                const parsedDate = new Date(paramValue);
+
+                return Number.isNaN(parsedDate.getTime()) ? null : paramValue;
+        }, [selectedDateParam]);
+
+        useEffect(() => {
+                if (normalizedSelectedDateParam && normalizedSelectedDateParam !== selectedDate) {
+                        dispatch({ type: SET_SELECTED_DATE, payload: normalizedSelectedDateParam });
+                }
+        }, [dispatch, normalizedSelectedDateParam, selectedDate]);
 
 	const cardWidth = useMemo(() => {
 		if (!listWidth || !numColumns) return undefined;

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -43,6 +43,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
     const foodItem = food as DatabaseTypes.Foods;
     const { language, serverInfo, appSettings, primaryColor } = useSelector((state: RootState) => state.settings);
     const { user, profile, isManagement } = useSelector((state: RootState) => state.authReducer);
+    const { selectedDate } = useSelector((state: RootState) => state.food);
 
     const previousFeedback = useSelector(state => selectPreviousFeedback(state as RootState, foodItem.id));
     const markings = useSelector(selectMarkings);
@@ -100,9 +101,19 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       [toast]
     );
 
-    const handleNavigation = useCallback((id: string, foodId: string) => {
-      router.push({ pathname: '/(app)/foodoffers/details', params: { id, foodId } });
-    }, []);
+    const handleNavigation = useCallback(
+      (id: string, foodId: string) => {
+        const today = new Date().toISOString().split('T')[0];
+        const params: Record<string, string> = { id, foodId };
+
+        if (selectedDate && selectedDate !== today) {
+          params.selectedDate = selectedDate;
+        }
+
+        router.push({ pathname: '/(app)/foodoffers/details', params });
+      },
+      [selectedDate]
+    );
 
     const handleOpenSheet = useCallback(() => {
       dispatch({ type: SET_SELECTED_FOOD_MARKINGS, payload: dislikedMarkings });


### PR DESCRIPTION
## Summary
- add support for reading an optional selectedDate parameter on the foodoffers page
- forward the selected date when navigating to foodoffer details to preserve list context
- provide a back navigation button on the details screen that falls back to the foodoffers list with the correct date

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea72ff238833087f61feb68eda682)