### PR TITLE
Add AI badge for generated food images

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -224,6 +224,17 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                       )}
                     </TouchableOpacity>
 
+                    {foodItem?.image_generated && (
+                      <TouchableOpacity
+                        style={styles.aiBadgeContainer}
+                        onPress={() => handleMenuSheet('aiGeneratedInfo')}
+                      >
+                        <Text style={styles.aiGeneratedBadgeText}>
+                          {translate(TranslationKeys.ai_generated_badge_label)}
+                        </Text>
+                      </TouchableOpacity>
+                    )}
+
                     {dislikedMarkings.length > 0 && (
                       <TouchableOpacity style={styles.favContainerWarn} onPress={handleOpenSheet}>
                         <MaterialIcons name="warning" size={20} color={foods_area_color} />

--- a/apps/frontend/app/components/FoodItem/styles.ts
+++ b/apps/frontend/app/components/FoodItem/styles.ts
@@ -45,6 +45,14 @@ export default StyleSheet.create({
                 justifyContent: 'center',
                 alignItems: 'center',
         },
+        aiBadgeContainer: {
+                paddingHorizontal: 10,
+                paddingVertical: 6,
+                borderRadius: 12,
+                backgroundColor: 'rgba(0,0,0,0.6)',
+                justifyContent: 'center',
+                alignItems: 'center',
+        },
         categoriesContainer: {
                 gap: 5,
                 width: 35,


### PR DESCRIPTION
## Summary
- show a KI/AI badge on food offer cards when the image is AI generated
- open the AI generated image info sheet when the badge is tapped
- add styling for the new badge under the quick action controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea99fd9fc8330b88be636e80e88da)