### PR TITLE
Make AI badge circular on food offer cards

### DIFF
--- a/apps/frontend/app/components/FoodItem/styles.ts
+++ b/apps/frontend/app/components/FoodItem/styles.ts
@@ -46,9 +46,9 @@ export default StyleSheet.create({
                 alignItems: 'center',
         },
         aiBadgeContainer: {
-                paddingHorizontal: 10,
-                paddingVertical: 6,
-                borderRadius: 12,
+                width: 35,
+                height: 35,
+                borderRadius: 50,
                 backgroundColor: 'rgba(0,0,0,0.6)',
                 justifyContent: 'center',
                 alignItems: 'center',
@@ -108,7 +108,8 @@ export default StyleSheet.create({
         aiGeneratedBadgeText: {
                 color: '#FFF',
                 fontSize: 12,
-                fontFamily: 'Poppins_600SemiBold',
+                fontFamily: 'Poppins_700Bold',
                 textTransform: 'uppercase',
+                textAlign: 'center',
         },
 });


### PR DESCRIPTION
## Summary
- update AI generated badge styling on food cards to be circular like quick action buttons
- adjust badge text styling for better alignment and emphasis

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eacafa21883308517c5b6d57c3b73)