### PR TITLE
Add icon generation to setup and install workflow

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -48,3 +48,38 @@ runs:
     - name: 🛠️ Generate EAS config
       run: yarn workspace rocket-meals-scripts generate:eas
       shell: bash
+
+    - name: 🖼️ Generate customer icons
+      shell: bash
+      working-directory: ./apps/frontend
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y imagemagick
+
+        ICON_PATH=$(node - <<'EOF'
+        require('ts-node').register({
+                transpileOnly: true,
+                compilerOptions: { module: 'Node16', moduleResolution: 'node16' },
+        });
+
+        const { getCustomerConfig } = require('./app/config.ts');
+        const config = getCustomerConfig();
+
+        console.log(config.images.icon_logo_source_path);
+        EOF
+        )
+
+        COMPANY_PATH=$(node - <<'EOF'
+        require('ts-node').register({
+                transpileOnly: true,
+                compilerOptions: { module: 'Node16', moduleResolution: 'node16' },
+        });
+
+        const { getCustomerConfig } = require('./app/config.ts');
+        const config = getCustomerConfig();
+
+        console.log(config.images.company_logo_source_path);
+        EOF
+        )
+
+        ./generateIcons.sh "./app/${ICON_PATH}" "./app/${COMPANY_PATH}" "./app/assets/images/"


### PR DESCRIPTION
## Summary
- install ImageMagick and invoke the frontend generateIcons.sh script during setup
- pull icon and company logo paths from the customer config to drive icon generation

## Testing
- not run (CI only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ec4cd4d9083309bab7928ed0c5dc0)