### PR TITLE
Refactor ASC env setup into TS helper

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -5,6 +5,9 @@ inputs:
   EXPO_TOKEN:
     required: true
     description: Expo Access Token (für EAS CLI Login)
+  EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT:
+    required: false
+    description: Inhalt des Apple App Store Connect API Keys (.p8)
 
 runs:
   using: "composite"
@@ -44,6 +47,43 @@ runs:
     - name: 📦 Install dependencies
       run: yarn install --immutable
       shell: bash
+
+    - name: 🔐 Prepare Apple App Store Connect API key
+      if: inputs.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT != ''
+      shell: bash
+      env:
+        EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ inputs.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+      run: |
+        set -euo pipefail
+
+        ASC_KEY_DIR="$(mktemp -d)"
+        ASC_KEY_PATH="${ASC_KEY_DIR}/AuthKey.p8"
+
+        printf "%s" "$EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT" > "$ASC_KEY_PATH"
+
+        ASC_ENV_VARS=$(node - <<'EOF'
+        require('ts-node').register({
+          transpileOnly: true,
+          compilerOptions: { module: 'Node16', moduleResolution: 'node16' },
+        });
+
+        const { getEasSubmitEnvVariables } = require('./apps/frontend/scripts/getEasSubmitEnvVariables.ts');
+
+        const envVars = getEasSubmitEnvVariables();
+
+        for (const [key, value] of Object.entries(envVars)) {
+          if (!value) {
+            throw new Error(`Missing value for ${key}`);
+          }
+          console.log(`${key}=${value}`);
+        }
+        EOF
+        )
+
+        {
+          echo "EXPO_ASC_API_KEY_PATH=$ASC_KEY_PATH"
+          echo "$ASC_ENV_VARS"
+        } >> "$GITHUB_ENV"
 
     - name: 🛠️ Generate EAS config
       run: yarn workspace rocket-meals-scripts generate:eas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,7 @@ jobs:
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
       - name: "🛠️ Build and Submit iOS App"
         run: eas build --platform ios --non-interactive --auto-submit
         working-directory: ./apps/frontend/app

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -2,9 +2,14 @@
 import { ServerHelper } from 'repo-depkit-common';
 import {ImageSourcePropType} from "react-native";
 
+export const EXPO_ASC_KEY_ID = '39JT9543R7';
+export const EXPO_ASC_ISSUER_ID = 'a8db47e8-cb43-4861-b383-58ec4f9a9fc6';
+export const EXPO_APPLE_TEAM_ID = '6U99CRVHVR';
+export const EXPO_APPLE_TEAM_TYPE = 'IN_HOUSE';
+
 export type CustomerConfig = {
-	projectName: string;
-	projectSlug: string | undefined;
+        projectName: string;
+        projectSlug: string | undefined;
 	easUpdateId: string | undefined;
 	easProjectId: string | undefined;
 	appScheme: string | undefined;

--- a/apps/frontend/scripts/getEasSubmitEnvVariables.ts
+++ b/apps/frontend/scripts/getEasSubmitEnvVariables.ts
@@ -1,0 +1,17 @@
+import { EXPO_APPLE_TEAM_ID, EXPO_APPLE_TEAM_TYPE, EXPO_ASC_ISSUER_ID, EXPO_ASC_KEY_ID } from '../app/config';
+
+export type EasSubmitEnvVariables = {
+  EXPO_ASC_KEY_ID: string;
+  EXPO_ASC_ISSUER_ID: string;
+  EXPO_APPLE_TEAM_ID: string;
+  EXPO_APPLE_TEAM_TYPE: string;
+};
+
+export function getEasSubmitEnvVariables(): EasSubmitEnvVariables {
+  return {
+    EXPO_ASC_KEY_ID,
+    EXPO_ASC_ISSUER_ID,
+    EXPO_APPLE_TEAM_ID,
+    EXPO_APPLE_TEAM_TYPE,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable getEasSubmitEnvVariables helper to supply ASC env values from config
- update the setup-and-install action to rely on the helper instead of regex parsing and create the key after dependencies are installed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f005a8fa083309db3f8a4f6a03c9c)