### PR TITLE
Exclude CO2 ratings from Hannover food IDs

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/hannover/FoodTL1ParserHannover.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/hannover/FoodTL1ParserHannover.ts
@@ -113,6 +113,17 @@ export class FoodTL1ParserHannover extends FoodTL1Parser {
     return combined_marking_ids_as_string;
   }
 
+  /**
+   * Schmidt 05.12.2025 E-Mail
+   * CO2 Bewertung Kennzeichnungen sollen nicht zur Food Id Bildung beitragen
+   * @param markingExternalIdentifiers
+   */
+  private filterMarkingsNotImportantForFoodID(markingExternalIdentifiers: string[]): string[] {
+    return markingExternalIdentifiers.filter(marking => {
+      return !marking.startsWith(FoodTL1ParserHannover.CO2_BEWERTUNG_PREFIX_IDENTIFIER);
+    });
+  }
+
   static getHannoverFoodIdByRecipeIdsAndMarkings(recipe_ids: string[] | number[], marking_ids: string[]) {
     let sorted_recipe_ids = FoodTL1Parser.getSortedRecipeIdFromListOfRecipeIds(recipe_ids);
     let combined_marking_ids_as_string = FoodTL1ParserHannover.getCombinedSortedMarkingsExternalIdentifiersAsString(marking_ids);
@@ -139,7 +150,9 @@ export class FoodTL1ParserHannover extends FoodTL1Parser {
     }
     let total_marking_external_identifier_list = this._getMarkingsExternalIdentifiersFromRawFoodoffer(firstRawTL1Foodoffer);
 
-    let food_id = FoodTL1ParserHannover.getHannoverFoodIdByRecipeIdsAndMarkings(recipe_ids, total_marking_external_identifier_list);
+    let filtered_marking_identifiers_for_food_id = this.filterMarkingsNotImportantForFoodID(total_marking_external_identifier_list);
+
+    let food_id = FoodTL1ParserHannover.getHannoverFoodIdByRecipeIdsAndMarkings(recipe_ids, filtered_marking_identifiers_for_food_id);
 
     return food_id;
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/hannover/__tests__/TestFoodTL1ParserHannover.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/hannover/__tests__/TestFoodTL1ParserHannover.ts
@@ -116,6 +116,19 @@ describe('FoodTL1ParserHannover Test', () => {
     }
   });
 
+  it('CO2 rating markings are ignored for food id creation', async () => {
+    const co2RatingIdentifier = FoodTL1ParserHannover.getCO2RatingMarkingExternalIdentifier('A');
+    let foodOfferJson = await getFoodoffersJson(FoodTL1Parser_RawReportTestReaderHannover.getSavedRawReportWithCO2RatingValues());
+    expect(!!foodOfferJson).toBe(true);
+    expect(foodOfferJson.length).toBeGreaterThan(0);
+
+    for (let foodOffer of foodOfferJson) {
+      expect(foodOffer.marking_external_identifiers).toEqual(expect.arrayContaining([co2RatingIdentifier]));
+      expect(foodOffer.food_id).not.toContain(FoodTL1ParserHannover.CO2_BEWERTUNG_PREFIX_IDENTIFIER);
+      expect(foodOffer.food_id).not.toContain(co2RatingIdentifier);
+    }
+  });
+
   it('Markings use correctly additional field for vegan (x)', async () => {
     const marking_external_identifiers = ['4', '20', '20A', '20C', '25', '99', 'x'];
     let findFoodId = generateFoodId([800562, 802726, 801834, 801454], marking_external_identifiers);


### PR DESCRIPTION
## Summary
- add filtering to ignore CO2 rating markings when generating Hannover food IDs while retaining markings elsewhere
- include documentation note and ensure CO2 rating handling is still present in markings
- add regression test verifying CO2 rating markings do not alter food ID composition

## Testing
- not run (yarn/npm unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f0c3b830833099ffffdd6cf23b72)