### PR TITLE
Fix food parser destructuring errors

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodParserInterface.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodParserInterface.ts
@@ -76,7 +76,7 @@ export class FoodParserHelper {
         ? foodoffer.foodoffer_category?.external_identifier || null
         : null;
 
-    const {id, user_created, user_updated, canteen, food, markings, date: _, environmental_impact, nutrition, prices, foodoffer_category, category, attribute_values, ...rest} = foodoffer;
+    const {id, user_created, user_updated, canteen, food, markings, date: _, foodoffer_category, category, ...rest} = foodoffer;
 
     const basicFoodofferData: FoodofferTypeWithBasicData = {
       ...rest,


### PR DESCRIPTION
## Summary
- adjust foodoffer destructuring to avoid referencing missing fields
- prevent name conflict with attribute_values while building parser data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693502e273d48330b1e38e981e8b3945)