### PR TITLE
Fix FoodParserHelper test data to match types

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/__tests__/FoodParserHelper.test.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/__tests__/FoodParserHelper.test.ts
@@ -9,7 +9,6 @@ const baseFoodofferInformationForParser: FoodoffersTypeForParser = {
     price_employee: 4.5,
     price_guest: 6,
     price_student: 3.5,
-    prices: '{}',
     foodoffer_components: [],
   },
   attribute_values: [],


### PR DESCRIPTION
## Summary
- remove unsupported prices field from FoodParserHelper test fixture to align with FoodoffersTypeForParser

## Testing
- yarn workspace directus-extension-rocket-meals-bundle testOnly --watch=false --runTestsByPath src/food-sync-hook/__tests__/FoodParserHelper.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353da3bdc083308c40d5ca983840e7)