### PR TITLE
Add collectable flags for collectible events contexts

### DIFF
--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_canteen_selection.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_canteen_selection.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_canteen_selection",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_canteen_selection",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 6,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_canteen_selection",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_card_reader.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_card_reader.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_card_reader",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_card_reader",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 8,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_card_reader",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_food_details.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_food_details.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_food_details",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_food_details",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 2,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_food_details",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_foodoffers.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_foodoffers.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_foodoffers",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_foodoffers",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 1,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_foodoffers",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_marking_modal.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_marking_modal.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_marking_modal",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_marking_modal",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 5,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_marking_modal",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_marking_settings.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_marking_settings.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_marking_settings",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_marking_settings",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 4,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_marking_settings",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_price_setting.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_price_setting.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_price_setting",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_price_setting",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 7,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_price_setting",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_settings.json
+++ b/data/directus-sync-data/configuration/directus-config/snapshot/fields/collectible_events/collectable_at_settings.json
@@ -1,0 +1,45 @@
+{
+  "collection": "collectible_events",
+  "field": "collectable_at_settings",
+  "type": "boolean",
+  "meta": {
+    "collection": "collectible_events",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "collectable_at_settings",
+    "group": "collectible_settings",
+    "hidden": false,
+    "interface": "boolean",
+    "note": null,
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 3,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "collectable_at_settings",
+    "table": "collectible_events",
+    "data_type": "boolean",
+    "default_value": true,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/packages/common/src/databaseTypes/types.ts
+++ b/packages/common/src/databaseTypes/types.ts
@@ -485,6 +485,14 @@ export type CollectibleEventParticipants = {
 
 export type CollectibleEvents = {
   alias?: string | null;
+  collectable_at_card_reader?: boolean | null;
+  collectable_at_canteen_selection?: boolean | null;
+  collectable_at_food_details?: boolean | null;
+  collectable_at_foodoffers?: boolean | null;
+  collectable_at_marking_modal?: boolean | null;
+  collectable_at_marking_settings?: boolean | null;
+  collectable_at_price_setting?: boolean | null;
+  collectable_at_settings?: boolean | null;
   collectible_image?: string | DirectusFiles | null;
   collectible_settings: string;
   date_created?: string | null;


### PR DESCRIPTION
## Summary
- add boolean flags to `collectible_events` to configure collectability in food offers, details, settings, marking, canteen selection, price settings, and card reader surfaces
- expose the new fields in the generated `CollectibleEvents` TypeScript definition

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936913ad2248330919339fa27333687)