### PR TITLE
Handle unknown workflow result hashes safely

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/itemServiceHelpers/WorkflowsRunHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/itemServiceHelpers/WorkflowsRunHelper.ts
@@ -70,7 +70,8 @@ export class WorkflowsRunHelper extends ItemsServiceHelper<DatabaseTypes.Workflo
         //console.log("workflowRuns: ")
         //console.log(workflowRuns);
         let workflowRun = workflowRuns[0];
-        return new WorkflowResultHash(workflowRun?.result_hash);
+        const resultHash = typeof workflowRun?.result_hash === 'string' ? workflowRun.result_hash : null;
+        return new WorkflowResultHash(resultHash);
       })
       .catch(async (exception: any) => {
         //console.log("getPreviousResultHash workflowRuns readByQuery Error");


### PR DESCRIPTION
## Summary
- normalize workflow run result_hash to a string or null before creating WorkflowResultHash instances to satisfy typing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c045971c83308aa91b97fb6956dd)