### PR TITLE
Normalize workflow result hash objects

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/itemServiceHelpers/WorkflowsRunHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/itemServiceHelpers/WorkflowsRunHelper.ts
@@ -4,14 +4,34 @@ import { WorkflowRunLogger } from '../../workflows-runs-hook/WorkflowRunJobInter
 import { WORKFLOW_RUN_STATE } from './WorkflowsRunEnum';
 
 export class WorkflowResultHash {
-  private readonly result_hash: string | null | undefined;
+  private readonly result_hash: Record<string, unknown> | Array<unknown> | null;
 
-  constructor(result_hash: string | null | undefined) {
-    this.result_hash = result_hash;
+  constructor(result_hash: unknown) {
+    this.result_hash = WorkflowResultHash.convertToObject(result_hash);
+  }
+
+  private static convertToObject(result_hash: unknown): Record<string, unknown> | Array<unknown> | null {
+    if (result_hash === null || result_hash === undefined) {
+      return null;
+    }
+
+    if (typeof result_hash === 'string') {
+      try {
+        return JSON.parse(result_hash);
+      } catch {
+        return { value: result_hash };
+      }
+    }
+
+    if (typeof result_hash === 'object') {
+      return result_hash as Record<string, unknown> | Array<unknown>;
+    }
+
+    return { value: result_hash };
   }
 
   public isSame(otherResultHash: WorkflowResultHash) {
-    return this.result_hash === otherResultHash.result_hash;
+    return JSON.stringify(this.result_hash) === JSON.stringify(otherResultHash.result_hash);
   }
 
   public getHash() {


### PR DESCRIPTION
## Summary
- normalize workflow result hash values by parsing strings into objects and wrapping non-object values
- ensure workflow result hash comparisons operate on serialized object representations

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c34c1a6883309347ad36f9724ff0)