### PR TITLE
Align CollectibleEvents import with database type usage

### DIFF
--- a/packages/common/src/CollectibleEvents.ts
+++ b/packages/common/src/CollectibleEvents.ts
@@ -1,4 +1,4 @@
-import { DatabaseTypes } from './databaseTypes/types';
+import * as DatabaseTypes from './databaseTypes/types';
 
 export const COLLECTABLE_AT_FIELDS: (keyof DatabaseTypes.CollectibleEvents)[] = [
   'collectable_at_campus',


### PR DESCRIPTION
## Summary
- import collectible event types via the DatabaseTypes namespace for consistency
- keep collectable field list keyed to DatabaseTypes.CollectibleEvents

## Testing
- yarn workspace rocket-meals-scripts generate:eas


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c7d198008330a290643dbb08442e)