### PR TITLE
Add collectible event data to privacy view

### DIFF
--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -38,11 +38,12 @@ const parseMarkdown = (text: string, theme: any) => {
 const DataAccess = ({ onOpenBottomSheet }: any) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
-	const { user, profile } = useSelector((state: RootState) => state.authReducer);
-	const { primaryColor } = useSelector((state: RootState) => state.settings);
-	const { canteens, buildings, selectedCanteenFoodOffers, canteenFoodOffers, businessHours, canteenFeedbackLabels, ownCanteenFeedBackLabelEntries } = useSelector((state: RootState) => state.canteenReducer);
+        const { user, profile } = useSelector((state: RootState) => state.authReducer);
+        const { primaryColor } = useSelector((state: RootState) => state.settings);
+        const { collectibleEvents } = useSelector((state: RootState) => state.collectibleEvents ?? {});
+        const { canteens, buildings, selectedCanteenFoodOffers, canteenFoodOffers, businessHours, canteenFeedbackLabels, ownCanteenFeedBackLabelEntries } = useSelector((state: RootState) => state.canteenReducer);
 
-	const { foodFeedbackLabels, ownFoodFeedbacks, ownfoodFeedbackLabelEntries, markings, selectedFoodMarkings, foodCategories, foodOfferCategories, markingDetails } = useSelector((state: RootState) => state.food);
+        const { foodFeedbackLabels, ownFoodFeedbacks, ownfoodFeedbackLabelEntries, markings, selectedFoodMarkings, foodCategories, foodOfferCategories, markingDetails } = useSelector((state: RootState) => state.food);
 
 	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
 
@@ -84,10 +85,19 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
 		},
 		{ label: 'Markings', value: markings },
 		{ label: 'Selected Food Markings', value: selectedFoodMarkings },
-		{ label: 'Food Categories', value: foodCategories },
-		{ label: 'FoodOffer Categories', value: foodOfferCategories },
-		{ label: 'MarkingDetails', value: markingDetails },
-	];
+                { label: 'Food Categories', value: foodCategories },
+                { label: 'FoodOffer Categories', value: foodOfferCategories },
+                { label: 'MarkingDetails', value: markingDetails },
+                { label: 'Collectible Events', value: collectibleEvents },
+                ...(profile?.collectible_event_participants
+                        ? [
+                                  {
+                                          label: 'Collectible Event Participations',
+                                          value: profile?.collectible_event_participants,
+                                  },
+                          ]
+                        : []),
+        ];
 
 	return (
 		<View style={{ ...styles.container, backgroundColor: theme.screen.background }}>

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -39,7 +39,7 @@ export function getMajorVersion() {
 }
 
 export function getVersionPatch() {
-	return 0;
+        return 1;
 }
 
 export function getVersionInternalForAppsettingsScreen() {


### PR DESCRIPTION
## Summary
- surface collectible events and participations in the data access device data list
- bump the frontend config patch version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d3b5c38c833096a3a39527adacd3)