### PR TITLE
Add collectible placements across app screens

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -10,7 +10,7 @@ import {
 	StyleSheet,
 } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { CampusSortOption, DatabaseTypes } from 'repo-depkit-common';
+import { CampusSortOption, CollectableAt, DatabaseTypes } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -39,6 +39,7 @@ import { RootState } from '@/redux/reducer';
 
 import IconButton from '@/components/UI/IconButton';
 import Button from '@/components/UI/Button';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 const ITEM_HEIGHT = 140;
 
@@ -405,12 +406,13 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 							renderItem={renderItem}
 							keyExtractor={keyExtractor}
 							numColumns={numColumns}
-							contentContainerStyle={{
-								marginTop: 20,
-							}}
-							ListHeaderComponent={ListHeaderComponent}
-							ListEmptyComponent={ListEmptyComponent}
-							refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+                                                        contentContainerStyle={{
+                                                                marginTop: 20,
+                                                        }}
+                                                        ListFooterComponent={<CollectibleSpot collectibleKey={CollectableAt.collectable_at_campus} />}
+                                                        ListHeaderComponent={ListHeaderComponent}
+                                                        ListEmptyComponent={ListEmptyComponent}
+                                                        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
 							removeClippedSubviews={false}
 							showsVerticalScrollIndicator={false}
 							onEndReachedThreshold={0.4}

--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -37,6 +37,14 @@ const CollectibleEventScreen = () => {
                 [activeCollectibleEvent]
         );
 
+        const maxCollectibleKeys = useMemo(
+                () =>
+                        activeCollectibleEvent
+                                ? COLLECTABLE_AT_FIELDS.filter(key => (activeCollectibleEvent as any)?.[key]).length
+                                : 0,
+                [activeCollectibleEvent]
+        );
+
         const [points, setPoints] = useState('');
         const [isLoading, setIsLoading] = useState(false);
         const [isSaving, setIsSaving] = useState(false);
@@ -76,13 +84,14 @@ const CollectibleEventScreen = () => {
         }, [loadParticipation]);
 
         useEffect(() => {
+                if (debugMode) return;
                 if (collectedCount > 0) {
                         const newValue = String(collectedCount);
                         if (newValue !== points) {
                                 setPoints(newValue);
                         }
                 }
-        }, [collectedCount, points]);
+        }, [collectedCount, debugMode, points]);
 
         const handleSave = async () => {
                 if (!activeCollectibleEvent?.id) {
@@ -162,6 +171,9 @@ const CollectibleEventScreen = () => {
                                                 keyboardType="numeric"
                                                 inputMode="numeric"
                                         />
+                                        <Text style={{ ...styles.info, color: theme.inactiveText, marginTop: 8 }}>
+                                                {collectedCount}/{maxCollectibleKeys || '∞'} {translate(TranslationKeys.collectible_event_collected)}
+                                        </Text>
                                 </View>
 
                                 <TouchableOpacity

--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -10,7 +10,7 @@ import Details from '@/components/Details';
 import Labels from '@/components/Labels';
 import { fetchFoodDetailsById, fetchFoodOffersDetailsById } from '@/redux/actions/FoodOffers/FoodOffers';
 import { excerpt, getImageUrl, getpreviousFeedback, numToOneDecimal } from '@/constants/HelperFunctions';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { CollectableAt, DatabaseTypes } from 'repo-depkit-common';
 import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
@@ -33,6 +33,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { handleFoodRating } from '@/helper/feedback';
 import { RootState } from '@/redux/reducer';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 const selectFoodState = (state: RootState) => state.food;
 
@@ -762,12 +763,13 @@ export default function FoodDetailsScreen() {
 								paddingHorizontal: isWeb ? (screenWidth > 1000 ? 20 : 0) : 10,
 							}}
 						>
-							{foodDetails?.id && renderContent(foodDetails)}
-						</View>
-					</View>
-					<PermissionModal isVisible={warning} setIsVisible={setWarning} />
-				</View>
-			</ScrollView>
+                                                        {foodDetails?.id && renderContent(foodDetails)}
+                                                </View>
+                                        </View>
+                                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_foodoffers_details} />
+                                        <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+                                </View>
+                        </ScrollView>
 			{isActive && (
 				<BaseBottomSheet
 					ref={notificationSheetRef}

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -10,7 +10,7 @@ import {
 	View,
 } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { DatabaseTypes, FoodSortOption, sortBySortField } from 'repo-depkit-common';
+import { CollectableAt, DatabaseTypes, FoodSortOption, sortBySortField } from 'repo-depkit-common';
 import styles from './styles';
 import {useTheme} from '@/hooks/useTheme';
 import {DrawerContentComponentProps, DrawerNavigationProp} from '@react-navigation/drawer';
@@ -62,6 +62,7 @@ import {TranslationKeys} from '@/locales/keys';
 
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import {RootState} from '@/redux/reducer';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
@@ -602,6 +603,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                                                 </Text>
                                         </View>
                                 )}
+                                <CollectibleSpot collectibleKey={CollectableAt.collectable_at_foodoffers} />
                                 <View style={{ height: 40 }} />
                         </>
                 );

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, Dimensions, RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ApartmentSortOption, DatabaseTypes } from 'repo-depkit-common';
+import { ApartmentSortOption, CollectableAt, DatabaseTypes } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -30,6 +30,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { RootState } from '@/redux/reducer';
 import { FlashList } from '@shopify/flash-list';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 const MIN_CARD_WIDTH = 280;
 
@@ -517,13 +518,14 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 							renderItem={renderItem}
 							keyExtractor={keyExtractor}
 							numColumns={numColumns}
-							contentContainerStyle={{
-								paddingHorizontal: 5,
-								paddingBottom: 20,
-							}}
-							ListHeaderComponent={ListHeaderComponent}
-							ListEmptyComponent={ListEmptyComponent}
-							refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+                                                        contentContainerStyle={{
+                                                                paddingHorizontal: 5,
+                                                                paddingBottom: 20,
+                                                        }}
+                                                        ListFooterComponent={<CollectibleSpot collectibleKey={CollectableAt.collectable_at_housing} />}
+                                                        ListHeaderComponent={ListHeaderComponent}
+                                                        ListEmptyComponent={ListEmptyComponent}
+                                                        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
 							removeClippedSubviews={false}
 							showsVerticalScrollIndicator={false}
 							onEndReachedThreshold={0.4}

--- a/apps/frontend/app/app/(app)/price-group/index.tsx
+++ b/apps/frontend/app/app/(app)/price-group/index.tsx
@@ -15,11 +15,12 @@ import { useFocusEffect } from 'expo-router';
 import { replaceLottieColors } from '@/helper/animationHelper';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { CollectableAt, DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { PriceGroupKey } from '@/app/(app)/settings/types';
 import { UserHelper } from '@/helper/UserHelper';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 const Index = () => {
 	useSetPageTitle(TranslationKeys.price_group);
@@ -153,10 +154,11 @@ const Index = () => {
 							color={selectedOption === option.id ? '#000000' : undefined}
 						/>
 					</TouchableOpacity>
-				))}
-			</View>
-		</View>
-	);
+                                ))}
+                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_price_group_selection} />
+                        </View>
+                </View>
+        );
 };
 
 export default Index;

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -33,10 +33,11 @@ import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { ServerAPI } from '@/redux/actions';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { CollectableAt, DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { ServerInfoHelper } from '@/helper/ServerInfoHelper';
 import { UserHelper } from '@/helper/UserHelper';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 const Settings = () => {
 	useSetPageTitle(TranslationKeys.settings);
@@ -373,9 +374,10 @@ const Settings = () => {
                                                         />
                                                 </>
                                         )}
-					<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="numeric" size={24} color={theme.screen.icon} />} label="Version" value={getVersionInternalForAppsettingsScreen().toString()} handleFunction={() => {}} />
-				</View>
-			</ScrollView>
+                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="numeric" size={24} color={theme.screen.icon} />} label="Version" value={getVersionInternalForAppsettingsScreen().toString()} handleFunction={() => {}} />
+                                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_settings} />
+                                </View>
+                        </ScrollView>
 			{isActive && (
 				<>
 					<BaseBottomSheet

--- a/apps/frontend/app/app/(app)/support-FAQ/index.tsx
+++ b/apps/frontend/app/app/(app)/support-FAQ/index.tsx
@@ -11,6 +11,8 @@ import { useSelector } from 'react-redux';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import { CollectableAt } from 'repo-depkit-common';
 
 const SupportFaq = () => {
 	useSetPageTitle(TranslationKeys.feedback_support_faq);
@@ -128,22 +130,23 @@ const SupportFaq = () => {
 							}}
 							groupPosition="middle"
 						/>
-						<SettingsList
-							iconBgColor={primaryColor}
-							leftIcon={<MaterialIcons name="apps" size={24} color={theme.screen.icon} />}
-							label={translate(TranslationKeys.software_name)}
-							value="Rocket Meals"
+                                                <SettingsList
+                                                        iconBgColor={primaryColor}
+                                                        leftIcon={<MaterialIcons name="apps" size={24} color={theme.screen.icon} />}
+                                                        label={translate(TranslationKeys.software_name)}
+                                                        value="Rocket Meals"
 							rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
 							handleFunction={() => {
 								openInBrowser('https://rocket-meals.de/homepage/');
 							}}
-							groupPosition="bottom"
-						/>
-					</View>
-				</View>
-			</ScrollView>
-		</View>
-	);
+                                                        groupPosition="bottom"
+                                                />
+                                        </View>
+                                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_faq} />
+                                </View>
+                        </ScrollView>
+                </View>
+        );
 };
 
 export default SupportFaq;

--- a/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
+++ b/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
@@ -9,12 +9,13 @@ import { isWeb } from '@/constants/Constants';
 import { SET_BUILDINGS, SET_CANTEENS, SET_SELECTED_CANTEEN } from '@/redux/Types/types';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { CollectableAt, DatabaseTypes } from 'repo-depkit-common';
 import { CanteenHelper } from '@/redux/actions';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import CanteenSelection from '../CanteenSelection/CanteenSelection';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeSheet }) => {
 	const { theme } = useTheme();
@@ -117,18 +118,19 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeShee
 					paddingTop: isWeb ? 10 : 0,
 				}}
 			></View>
-			<Text
-				style={{
-					...styles.sheetHeading,
-					fontSize: isWeb ? 40 : 32,
-					color: theme.sheet.text,
-				}}
-			>
-				{translate(TranslationKeys.canteen)}
-			</Text>
-			<CanteenSelection onSelectCanteen={handleSelectCanteen} />
-		</BottomSheetScrollView>
-	);
+                        <Text
+                                style={{
+                                        ...styles.sheetHeading,
+                                        fontSize: isWeb ? 40 : 32,
+                                        color: theme.sheet.text,
+                                }}
+                        >
+                                {translate(TranslationKeys.canteen)}
+                        </Text>
+                        <CanteenSelection onSelectCanteen={handleSelectCanteen} />
+                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_canteen_selection} />
+                </BottomSheetScrollView>
+        );
 };
 
 export default CanteenSelectionSheet;

--- a/apps/frontend/app/components/CollectibleItem/CollectibleSpot.tsx
+++ b/apps/frontend/app/components/CollectibleItem/CollectibleSpot.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View } from 'react-native';
+import { CollectableAt } from 'repo-depkit-common';
+
+import CollectibleItem from './index';
+
+type CollectibleSpotProps = {
+        collectibleKey: CollectableAt;
+};
+
+const CollectibleSpot: React.FC<CollectibleSpotProps> = ({ collectibleKey }) => {
+        return (
+                <View style={{ alignItems: 'center', marginVertical: 20 }}>
+                        <CollectibleItem collectibleKey={collectibleKey} />
+                </View>
+        );
+};
+
+export default CollectibleSpot;

--- a/apps/frontend/app/components/Details/index.tsx
+++ b/apps/frontend/app/components/Details/index.tsx
@@ -10,6 +10,8 @@ import { DetailsProps } from './types';
 import AttributeItem from './AttributeItem';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import { CollectableAt } from 'repo-depkit-common';
 
 const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 	const { translate } = useLanguage();
@@ -51,10 +53,11 @@ const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 						</View>
 					);
 				})
-			)}
-			<FoodLabelingInfo textStyle={styles.body1} backgroundColor={foods_area_color} />
-		</View>
-	);
+                        )}
+                        <FoodLabelingInfo textStyle={styles.body1} backgroundColor={foods_area_color} />
+                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_foodoffer_details_nutritions} />
+                </View>
+        );
 };
 
 export default Details;

--- a/apps/frontend/app/components/Labels/index.tsx
+++ b/apps/frontend/app/components/Labels/index.tsx
@@ -6,12 +6,13 @@ import styles from './styles';
 import FoodLabelingInfo from '../FoodLabelingInfo';
 import MarkingLabels from '../MarkingLabels/MarkingLabels';
 import { getFoodOffer } from '@/constants/HelperFunctions';
-import { DatabaseTypes, sortMarkingsByGroup } from 'repo-depkit-common';
+import { CollectableAt, DatabaseTypes, sortMarkingsByGroup } from 'repo-depkit-common';
 import { createSelector } from 'reselect';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 interface LabelsProps {
         foodDetails: any;
@@ -80,13 +81,14 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 		<View style={styles.container}>
 			<Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.markings)}</Text>
 
-			{foodMarkings?.map((marking: DatabaseTypes.Markings) => (
-				<MarkingLabels key={marking.id} markingId={marking.id} handleMenuSheet={handleMenuSheet} />
-			))}
+                        {foodMarkings?.map((marking: DatabaseTypes.Markings) => (
+                                <MarkingLabels key={marking.id} markingId={marking.id} handleMenuSheet={handleMenuSheet} />
+                        ))}
 
-			<FoodLabelingInfo textStyle={styles.body} backgroundColor={foods_area_color} />
-		</View>
-	);
+                        <FoodLabelingInfo textStyle={styles.body} backgroundColor={foods_area_color} />
+                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_foodoffer_details_markings} />
+                </View>
+        );
 };
 
 export default Labels;

--- a/apps/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
+++ b/apps/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
@@ -1,21 +1,24 @@
 import React, { forwardRef } from 'react';
 import type BottomSheet from '@gorhom/bottom-sheet';
+import { CollectableAt } from 'repo-depkit-common';
 import BaseBottomSheet from '../BaseBottomSheet';
 import MenuSheet from '../MenuSheet/MenuSheet';
 import { useTheme } from '@/hooks/useTheme';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 export interface MarkingBottomSheetProps {
 	onClose: () => void;
 }
 
 const MarkingBottomSheet = forwardRef<BottomSheet, MarkingBottomSheetProps>(({ onClose }, ref) => {
-	const { theme } = useTheme();
+        const { theme } = useTheme();
 
-	return (
-		<BaseBottomSheet ref={ref} index={-1} backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }} enablePanDownToClose handleComponent={null} onClose={onClose}>
-			<MenuSheet closeSheet={onClose} />
-		</BaseBottomSheet>
-	);
+        return (
+                <BaseBottomSheet ref={ref} index={-1} backgroundStyle={{ backgroundColor: theme.sheet.sheetBg }} enablePanDownToClose handleComponent={null} onClose={onClose}>
+                        <MenuSheet closeSheet={onClose} />
+                        <CollectibleSpot collectibleKey={CollectableAt.collectable_at_marking_details} />
+                </BaseBottomSheet>
+        );
 });
 
 export default MarkingBottomSheet;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -189,6 +189,7 @@ export enum TranslationKeys {
         collectible_event_load_error = 'collectible_event_load_error',
         collectible_event_loading_participation = 'collectible_event_loading_participation',
         collectible_event_login_required = 'collectible_event_login_required',
+        collectible_event_collected = 'collectible_event_collected',
         create = 'create',
         delete = 'delete',
         account_delete = 'account_delete',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1909,6 +1909,16 @@
     "tr": "Puan kaydetmek için lütfen giriş yapın.",
     "zh": "请登录以保存积分。"
   },
+  "collectible_event_collected": {
+    "de": "gesammelt",
+    "en": "collected",
+    "ar": "تم جمعها",
+    "es": "recogidos",
+    "fr": "collectés",
+    "ru": "собрано",
+    "tr": "toplandı",
+    "zh": "已收集"
+  },
   "create": {
     "de": "Erstellen",
     "en": "Create",

--- a/packages/common/src/CollectibleEvents.ts
+++ b/packages/common/src/CollectibleEvents.ts
@@ -1,15 +1,29 @@
 import * as DatabaseTypes from './databaseTypes/types';
 
+export enum CollectableAt {
+  collectable_at_campus = 'collectable_at_campus',
+  collectable_at_canteen_selection = 'collectable_at_canteen_selection',
+  collectable_at_faq = 'collectable_at_faq',
+  collectable_at_foodoffer_details_markings = 'collectable_at_foodoffer_details_markings',
+  collectable_at_foodoffer_details_nutritions = 'collectable_at_foodoffer_details_nutritions',
+  collectable_at_foodoffers = 'collectable_at_foodoffers',
+  collectable_at_foodoffers_details = 'collectable_at_foodoffers_details',
+  collectable_at_housing = 'collectable_at_housing',
+  collectable_at_marking_details = 'collectable_at_marking_details',
+  collectable_at_price_group_selection = 'collectable_at_price_group_selection',
+  collectable_at_settings = 'collectable_at_settings',
+}
+
 export const COLLECTABLE_AT_FIELDS: (keyof DatabaseTypes.CollectibleEvents)[] = [
-  'collectable_at_campus',
-  'collectable_at_canteen_selection',
-  'collectable_at_faq',
-  'collectable_at_foodoffer_details_markings',
-  'collectable_at_foodoffer_details_nutritions',
-  'collectable_at_foodoffers',
-  'collectable_at_foodoffers_details',
-  'collectable_at_housing',
-  'collectable_at_marking_details',
-  'collectable_at_price_group_selection',
-  'collectable_at_settings',
+  CollectableAt.collectable_at_campus,
+  CollectableAt.collectable_at_canteen_selection,
+  CollectableAt.collectable_at_faq,
+  CollectableAt.collectable_at_foodoffer_details_markings,
+  CollectableAt.collectable_at_foodoffer_details_nutritions,
+  CollectableAt.collectable_at_foodoffers,
+  CollectableAt.collectable_at_foodoffers_details,
+  CollectableAt.collectable_at_housing,
+  CollectableAt.collectable_at_marking_details,
+  CollectableAt.collectable_at_price_group_selection,
+  CollectableAt.collectable_at_settings,
 ];


### PR DESCRIPTION
## Summary
- allow manual point entry in collectible events debug mode with clearer collected progress label
- add reusable collectible spot component and embed it across screens matching collectable locations
- localize collected label for collectible event progress
- expose CollectableAt enum from repo-depkit-common and adopt it across collectible placements

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ef3c98b88330b12ef4c75e3635c6)