### PR TITLE
Update collectible event preview and notice

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -294,9 +294,9 @@ const CollectibleEventScreen = () => {
 
                                 {debugMode && sampleCollectibleKey ? (
                                         <View style={{ alignItems: 'center', marginTop: 16 }}>
-                                                <CollectibleItem collectibleKey={sampleCollectibleKey} hideOnCollect={false} />
+                                                <CollectibleItem collectibleKey={sampleCollectibleKey} hideOnCollect={false} isPreview />
                                                 <Text style={{ color: theme.inactiveText, marginTop: 8 }}>
-                                                        Debug Collectible Item Preview
+                                                        {translate(TranslationKeys.collectible_event_preview_label)}
                                                 </Text>
                                         </View>
                                 ) : null}
@@ -361,6 +361,10 @@ const CollectibleEventScreen = () => {
 
                                         <Text style={{ ...styles.info, color: theme.inactiveText, marginTop: 8 }}>
                                                 {collectedCount}/{maxCollectibleKeys || '∞'} {translate(TranslationKeys.collectible_event_collected)}
+                                        </Text>
+
+                                        <Text style={{ ...styles.notice, color: theme.inactiveText }}>
+                                                {translate(TranslationKeys.collectible_event_data_notice)}
                                         </Text>
                                 </View>
 

--- a/apps/frontend/app/app/(app)/collectible-event/styles.ts
+++ b/apps/frontend/app/app/(app)/collectible-event/styles.ts
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
         card: {
                 borderRadius: 12,
                 padding: 16,
-                borderWidth: 1,
                 marginBottom: 16,
         },
         title: {
@@ -53,6 +52,11 @@ const styles = StyleSheet.create({
                 flexDirection: 'row',
                 alignItems: 'center',
                 marginTop: 8,
+        },
+        notice: {
+                fontSize: 12,
+                lineHeight: 18,
+                marginTop: 12,
         },
 });
 

--- a/apps/frontend/app/components/CollectibleItem/index.tsx
+++ b/apps/frontend/app/components/CollectibleItem/index.tsx
@@ -21,9 +21,10 @@ type CollectibleKey = (typeof COLLECTABLE_AT_FIELDS)[number];
 type CollectibleItemProps = {
         collectibleKey: CollectibleKey;
         hideOnCollect?: boolean;
+        isPreview?: boolean;
 };
 
-const CollectibleItem: React.FC<CollectibleItemProps> = ({ collectibleKey, hideOnCollect = true }) => {
+const CollectibleItem: React.FC<CollectibleItemProps> = ({ collectibleKey, hideOnCollect = true, isPreview }) => {
         const { theme } = useTheme();
         const toast = useToast();
         const { translate } = useLanguage();
@@ -114,9 +115,9 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({ collectibleKey, hideO
         return (
                 <TouchableOpacity
                         style={[styles.container, { borderColor: theme.screen.icon, backgroundColor: theme.screen.background }]}
-                        onPress={handleCollect}
-                        disabled={isSaving}
-                        activeOpacity={0.8}
+                        onPress={isPreview ? undefined : handleCollect}
+                        disabled={isSaving || isPreview}
+                        activeOpacity={isPreview ? 1 : 0.8}
                 >
                         <Image source={imageSource} resizeMode="contain" style={styles.image} />
                         {isCollected ? <View style={[styles.collectedOverlay, { backgroundColor: theme.primary }]} /> : null}

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -190,6 +190,8 @@ export enum TranslationKeys {
         collectible_event_loading_participation = 'collectible_event_loading_participation',
         collectible_event_login_required = 'collectible_event_login_required',
         collectible_event_collected = 'collectible_event_collected',
+        collectible_event_preview_label = 'collectible_event_preview_label',
+        collectible_event_data_notice = 'collectible_event_data_notice',
         create = 'create',
         delete = 'delete',
         account_delete = 'account_delete',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1919,6 +1919,26 @@
     "tr": "toplandı",
     "zh": "已收集"
   },
+  "collectible_event_preview_label": {
+    "de": "Zu sammelnde Objekte",
+    "en": "Items to collect",
+    "ar": "عناصر لجمعها",
+    "es": "Objetos para coleccionar",
+    "fr": "Éléments à collecter",
+    "ru": "Предметы для сбора",
+    "tr": "Toplanacak öğeler",
+    "zh": "待收集的物品"
+  },
+  "collectible_event_data_notice": {
+    "de": "Die Angabe deiner Daten ist freiwillig. Es gelten die Teilnahmebedingungen.",
+    "en": "Providing your data is voluntary. The terms and conditions apply.",
+    "ar": "تقديم بياناتك اختياري. تنطبق الشروط والأحكام.",
+    "es": "Proporcionar tus datos es voluntario. Se aplican los términos y condiciones.",
+    "fr": "Fournir vos données est volontaire. Les conditions générales s'appliquent.",
+    "ru": "Предоставление данных добровольно. Применяются условия и положения.",
+    "tr": "Verilerinizi sağlamak isteğe bağlıdır. Şartlar ve koşullar geçerlidir.",
+    "zh": "提供您的数据是自愿的。适用条款和条件。"
+  },
   "create": {
     "de": "Erstellen",
     "en": "Create",


### PR DESCRIPTION
## Summary
- make the collectible event preview non-interactive and rename the label
- remove the card border and add a voluntary data notice to the collectible event form

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69370223b1788330b78f756f7a78cb03)