### PR TITLE
Remove panel styling from collectible event screen

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -286,7 +286,7 @@ const CollectibleEventScreen = () => {
                 const description = getDescriptionFromTranslation(activeCollectibleEvent.translations as any, language);
 
                 return (
-                        <View style={[styles.card, { backgroundColor: theme.background, borderColor: theme.screen.icon }]}>
+                        <View style={styles.section}>
                                 <Text style={{ ...styles.title, color: theme.screen.text }}>{title}</Text>
                                 {description ? (
                                         <Text style={{ ...styles.description, color: theme.inactiveText }}>{description}</Text>

--- a/apps/frontend/app/app/(app)/collectible-event/styles.ts
+++ b/apps/frontend/app/app/(app)/collectible-event/styles.ts
@@ -7,9 +7,7 @@ const styles = StyleSheet.create({
         content: {
                 padding: 16,
         },
-        card: {
-                borderRadius: 12,
-                padding: 16,
+        section: {
                 marginBottom: 16,
         },
         title: {


### PR DESCRIPTION
## Summary
- display the collectible event screen content without an additional panel container
- simplify styling by replacing the card layout with a basic section layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69370e0942888330ad7de241a21f9d04)