### PR TITLE
Update collectible screen hints and status icons

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -419,42 +419,29 @@ const CollectibleEventScreen = () => {
                                                                 const isHintVisible = isCollected || visibleHints[key];
                                                                 const hintText = `${translate(TranslationKeys.collectible_event_hint_prefix)} ${key}`;
 
+                                                                const iconBgColor = isCollected ? '#2DBE62' : '#F7D21F';
+                                                                const labelText = isHintVisible
+                                                                        ? key
+                                                                        : translate(TranslationKeys.collectible_event_show_hint);
+                                                                const valueText = isCollected
+                                                                        ? undefined
+                                                                        : isHintVisible
+                                                                                ? hintText
+                                                                                : undefined;
+
                                                                 return (
                                                                         <SettingsList
                                                                                 key={`progress-${key}`}
-                                                                                iconBgColor={buttonColor}
+                                                                                iconBgColor={iconBgColor}
                                                                                 leftIcon={
                                                                                         <MaterialCommunityIcons
-                                                                                                name={
-                                                                                                        isCollected
-                                                                                                                ? 'trophy-outline'
-                                                                                                                : 'lightbulb-on-outline'
-                                                                                                }
+                                                                                                name={isCollected ? 'check' : 'lightbulb-on-outline'}
                                                                                                 size={22}
                                                                                                 color={theme.screen.icon}
                                                                                         />
                                                                                 }
-                                                                                label={
-                                                                                        isHintVisible
-                                                                                                ? key
-                                                                                                : translate(TranslationKeys.collectible_event_show_hint)
-                                                                                }
-                                                                                value={
-                                                                                        isCollected
-                                                                                                ? translate(TranslationKeys.collectible_event_found_label)
-                                                                                                : isHintVisible
-                                                                                                        ? hintText
-                                                                                                        : translate(TranslationKeys.collectible_event_show_hint)
-                                                                                }
-                                                                                rightIcon={
-                                                                                        isCollected ? (
-                                                                                                <MaterialCommunityIcons
-                                                                                                        name="check"
-                                                                                                        size={22}
-                                                                                                        color={theme.screen.icon}
-                                                                                                />
-                                                                                        ) : undefined
-                                                                                }
+                                                                                label={labelText}
+                                                                                value={valueText}
                                                                                 onPress={
                                                                                         isCollected || isHintVisible
                                                                                                 ? undefined


### PR DESCRIPTION
## Summary
- show the hint prompt only once for uncollected collectibles
- replace the trophy icon with a green check and adjust icon background colors
- remove the redundant "found" label from the collectible progress list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372f6ae50883308ec702fdb7238910)