### PR TITLE
Add drawer opener to collectible screen

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -17,11 +17,9 @@ import CollectibleItem from '@/components/CollectibleItem';
 import useCollectibleDict from '@/hooks/useCollectibleDict';
 import PermissionModal from '@/components/PermissionModal/PermissionModal';
 import SettingsList from '@/components/SettingsList';
-import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { RESET_ALL_COLLECTIBLE_EVENT_DICTS, RESET_COLLECTIBLE_EVENT_DICT } from '@/redux/Types/types';
-import { DrawerNavigationProp } from '@react-navigation/drawer';
-import { useNavigation } from 'expo-router';
-import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
+import CustomMenuHeader from '@/components/CustomMenuHeader/CustomMenuHeader';
 
 type DebugSectionProps = {
         activeCollectibleEvent: DatabaseTypes.CollectibleEvents;
@@ -114,12 +112,11 @@ const CollectibleEventScreen = () => {
         const toast = useToast();
         const { translate, language } = useLanguage();
         const { profile, loggedIn } = useSelector((state: RootState) => state.authReducer);
-        const { primaryColor, debugMode, drawerPosition } = useSelector((state: RootState) => state.settings);
+        const { primaryColor, debugMode } = useSelector((state: RootState) => state.settings);
         const buttonColor = primaryColor || theme.primary;
         const { activeCollectibleEvent } = useActiveCollectibleEvent();
         const participantsHelper = useMemo(() => new CollectibleEventParticipantsHelper(), []);
         const { collectedCount, collectibleDict } = useCollectibleDict(activeCollectibleEvent?.id);
-        const drawerNavigation = useNavigation<DrawerNavigationProp<any>>();
 
         const activeCollectibleKeys = useMemo(
                 () =>
@@ -485,39 +482,7 @@ const CollectibleEventScreen = () => {
 
         return (
                 <SafeAreaView style={[styles.container, { backgroundColor: theme.screen.background }]}>
-                        <View style={{ ...styles.header, backgroundColor: theme.header.background }}>
-                                <View
-                                        style={[
-                                                styles.row,
-                                                {
-                                                        flexDirection: drawerPosition === 'right' ? 'row-reverse' : 'row',
-                                                },
-                                        ]}
-                                >
-                                        <Tooltip
-                                                placement="top"
-                                                trigger={triggerProps => (
-                                                        <TouchableOpacity
-                                                                {...triggerProps}
-                                                                onPress={() => drawerNavigation.toggleDrawer()}
-                                                                style={{ padding: 10 }}
-                                                        >
-                                                                <Ionicons name="menu" size={24} color={theme.header.text} />
-                                                        </TouchableOpacity>
-                                                )}
-                                        >
-                                                <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
-                                                        <TooltipText fontSize="$sm" color={theme.tooltip.text}>
-                                                                {translate(TranslationKeys.open_drawer)}
-                                                        </TooltipText>
-                                                </TooltipContent>
-                                        </Tooltip>
-
-                                        <Text style={{ ...styles.heading, color: theme.header.text }}>
-                                                {translate(TranslationKeys.collectible_event)}
-                                        </Text>
-                                </View>
-                        </View>
+                        <CustomMenuHeader label={translate(TranslationKeys.collectible_event)} />
                         <ScrollView style={styles.container} contentContainerStyle={styles.content}>
                                 {renderContent()}
                         </ScrollView>

--- a/apps/frontend/app/app/(app)/collectible-event/styles.ts
+++ b/apps/frontend/app/app/(app)/collectible-event/styles.ts
@@ -56,22 +56,6 @@ const styles = StyleSheet.create({
                 lineHeight: 18,
                 marginTop: 12,
         },
-        header: {
-                width: '100%',
-                height: 60,
-                justifyContent: 'center',
-                paddingHorizontal: 16,
-        },
-        row: {
-                width: '100%',
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 12,
-        },
-        heading: {
-                fontSize: 18,
-                fontWeight: '700',
-        },
 });
 
 export default styles;


### PR DESCRIPTION
## Summary
- add a header with a burger menu to the collectible event screen to open the drawer
- align the new header styling with existing app theming

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937306f838483308cb1ebac7dc2ddbd)