### PR TITLE
Fix duplicate header on collectible event screen

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -668,13 +668,8 @@ export default function Layout() {
                                 <Drawer.Screen
                                         name="collectible-event/index"
                                         options={{
-                                                header: () => (
-                                                        <CustomStackHeader
-                                                                label={translate(TranslationKeys.collectible_event)}
-                                                                key={'collectible_event'}
-                                                        />
-                                                ),
                                                 title: translate(TranslationKeys.collectible_event),
+                                                headerShown: false,
                                         }}
                                 />
                                 <Drawer.Screen


### PR DESCRIPTION
## Summary
- hide the drawer stack header for the collectible event screen to prevent a double header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693735800b208330afe7b0170e58cb65)