### PR TITLE
Add debug update check logging

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -7,7 +7,7 @@ import { Languages, PriceGroupKey } from './types';
 import { AntDesign, Entypo, Feather, FontAwesome5, Ionicons, MaterialCommunityIcons, MaterialIcons, Octicons } from '@expo/vector-icons';
 import { isWeb } from '@/constants/Constants';
 import SettingsList from '@/components/SettingsList';
-import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
+import { type UpdateCheckResult, useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import NicknameSheet from '@/components/NicknameSheet/NicknameSheet';
 import ColorSchemeSheet from '@/components/ColorSchemeSheet/ColorSchemeSheet';
@@ -45,16 +45,17 @@ const Settings = () => {
 	const dispatch = useDispatch();
 	const canteenSheetRef = useRef<BottomSheet>(null);
 	const [isActive, setIsActive] = useState(false);
-	const { translate, setLanguageMode, language } = useLanguage();
-	const [nickname, setNickname] = useState<string>('');
-	const nicknameSheetRef = useRef<BottomSheet>(null);
-	const openNicknameSheet = () => nicknameSheetRef?.current?.expand();
-	const closeNicknameSheet = () => {
-		Keyboard.dismiss();
-		nicknameSheetRef?.current?.close();
-	};
-	const [selectedLanguage, setSelectedLanguage] = useState<string>('');
-	const drawerSheetRef = useRef<BottomSheet>(null);
+        const { translate, setLanguageMode, language } = useLanguage();
+        const [nickname, setNickname] = useState<string>('');
+        const nicknameSheetRef = useRef<BottomSheet>(null);
+        const openNicknameSheet = () => nicknameSheetRef?.current?.expand();
+        const closeNicknameSheet = () => {
+                Keyboard.dismiss();
+                nicknameSheetRef?.current?.close();
+        };
+        const [selectedLanguage, setSelectedLanguage] = useState<string>('');
+        const [updateCheckLog, setUpdateCheckLog] = useState<string | null>(null);
+        const drawerSheetRef = useRef<BottomSheet>(null);
 	const languageSheetRef = useRef<BottomSheet>(null);
 	const amountColumnSheetRef = useRef<BottomSheet>(null);
 	const firstDaySheetRef = useRef<BottomSheet>(null);
@@ -67,9 +68,9 @@ const Settings = () => {
 	const isRegisteredUser = UserHelper.isRegisteredUser(user);
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode } = useSelector((state: RootState) => state.settings);
-	const selectedCanteen = useSelectedCanteen();
-	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
-	const profileHelper = useMemo(() => new ProfileHelper(), []);
+        const selectedCanteen = useSelectedCanteen();
+        const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
+        const profileHelper = useMemo(() => new ProfileHelper(), []);
 
 	const languageCode = language;
 
@@ -197,9 +198,35 @@ const Settings = () => {
                 });
         };
 
-	const handleCheckForUpdates = () => {
-		manualCheck();
-	};
+        const formatUpdateLogMessage = useCallback(
+                (result: UpdateCheckResult) => {
+                        const statusLabels: Record<UpdateCheckResult['status'], string> = {
+                                available: translate(TranslationKeys.update_available),
+                                'up-to-date': translate(TranslationKeys.no_updates_available),
+                                skipped: translate(TranslationKeys.updates),
+                                error: translate(TranslationKeys.error),
+                        };
+                        const details = result.details ? ` - ${result.details}` : '';
+
+                        return `${statusLabels[result.status]}${details}`;
+                },
+                [translate]
+        );
+
+        const handleCheckForUpdates = async () => {
+                const result = await manualCheck();
+
+                if (debugMode) {
+                        const timestamp = new Date().toLocaleString();
+                        setUpdateCheckLog(`[${timestamp}] ${formatUpdateLogMessage(result)}`);
+                }
+        };
+
+        useEffect(() => {
+                if (!debugMode) {
+                        setUpdateCheckLog(null);
+                }
+        }, [debugMode]);
 
 	const changeLanguage = (language: { label?: string; flag?: string; value: any }) => {
 		setSelectedLanguage(language.value);
@@ -327,6 +354,24 @@ const Settings = () => {
                                                 {/* Terms & Conditions */}
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="file-document-check" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.terms_and_conditions_accepted_and_privacy_policy_read_at_date)} value={termsAndPrivacyConsentAcceptedDate} handleFunction={() => {}} groupPosition="bottom" />
                                         </View>
+                                        {debugMode && updateCheckLog && (
+                                                <View
+                                                        style={[
+                                                                styles.debugUpdateLogContainer,
+                                                                {
+                                                                        borderColor: theme.screen.icon,
+                                                                        backgroundColor: theme.screen.background,
+                                                                },
+                                                        ]}
+                                                >
+                                                        <Text style={{ ...styles.debugUpdateLogTitle, color: theme.screen.text }}>
+                                                                {translate(TranslationKeys.CHECK_FOR_APP_UPDATES)}
+                                                        </Text>
+                                                        <Text style={{ ...styles.debugUpdateLogText, color: theme.screen.text }}>
+                                                                {updateCheckLog}
+                                                        </Text>
+                                                </View>
+                                        )}
                                         <TouchableOpacity
                                                 style={styles.footer}
                                                 onPress={() => {

--- a/apps/frontend/app/app/(app)/settings/styles.ts
+++ b/apps/frontend/app/app/(app)/settings/styles.ts
@@ -168,8 +168,23 @@ export default StyleSheet.create({
 		width: 72,
 		height: 72,
 	},
-	devModeText: {
-		fontSize: 16,
-		fontFamily: 'Poppins_400Regular',
-	},
+        devModeText: {
+                fontSize: 16,
+                fontFamily: 'Poppins_400Regular',
+        },
+        debugUpdateLogContainer: {
+                padding: 12,
+                borderRadius: 12,
+                borderWidth: 1,
+                marginTop: 10,
+        },
+        debugUpdateLogTitle: {
+                fontSize: 16,
+                fontFamily: 'Poppins_700Bold',
+                marginBottom: 4,
+        },
+        debugUpdateLogText: {
+                fontSize: 12,
+                fontFamily: 'Poppins_400Regular',
+        },
 });

--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -12,12 +12,17 @@ import { myContrastColor } from '@/helper/ColorHelper';
 import { isInExpoGo } from '@/helper/DeviceRuntimeHelper';
 
 interface ExpoUpdateCheckerProps {
-	children?: ReactNode;
+        children?: ReactNode;
 }
 
 interface UpdateCheckerContextType {
-	manualCheck: () => void;
+        manualCheck: () => Promise<UpdateCheckResult>;
 }
+
+export type UpdateCheckResult = {
+        status: 'available' | 'up-to-date' | 'skipped' | 'error';
+        details?: string;
+};
 
 const UpdateCheckerContext = createContext<UpdateCheckerContextType | null>(null);
 
@@ -35,26 +40,38 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 	const [titleKey, setTitleKey] = useState<TranslationKeys>(TranslationKeys.update_available);
 	const [messageKey, setMessageKey] = useState<TranslationKeys>(TranslationKeys.update_available_message);
 
-	const checkForUpdates = async (showUpToDate = false) => {
-		if (!isSmartPhone()) return;
-		if (isInExpoGo()) return;
-		try {
-			const update = await Updates.checkForUpdateAsync();
-			if (update.isAvailable) {
-				setUpdateAvailable(true);
-				setTitleKey(TranslationKeys.update_available);
-				setMessageKey(TranslationKeys.update_available_message);
-				setModalVisible(true);
-			} else if (showUpToDate) {
-				setUpdateAvailable(false);
-				setTitleKey(TranslationKeys.updates);
-				setMessageKey(TranslationKeys.no_updates_available);
-				setModalVisible(true);
-			}
-		} catch (e) {
-			console.error('Error while checking updates', e);
-		}
-	};
+        const checkForUpdates = async (showUpToDate = false): Promise<UpdateCheckResult> => {
+                if (!isSmartPhone())
+                        return { status: 'skipped', details: 'Update checks are only supported on smartphones.' };
+                if (isInExpoGo())
+                        return { status: 'skipped', details: 'Update checks are not available inside Expo Go.' };
+                try {
+                        const update = await Updates.checkForUpdateAsync();
+                        if (update.isAvailable) {
+                                setUpdateAvailable(true);
+                                setTitleKey(TranslationKeys.update_available);
+                                setMessageKey(TranslationKeys.update_available_message);
+                                setModalVisible(true);
+                                return { status: 'available', details: translate(TranslationKeys.update_available) };
+                        } else if (showUpToDate) {
+                                setUpdateAvailable(false);
+                                setTitleKey(TranslationKeys.updates);
+                                setMessageKey(TranslationKeys.no_updates_available);
+                                setModalVisible(true);
+                                return {
+                                        status: 'up-to-date',
+                                        details: translate(TranslationKeys.no_updates_available),
+                                };
+                        }
+                        return { status: 'skipped', details: translate(TranslationKeys.no_updates_available) };
+                } catch (e) {
+                        console.error('Error while checking updates', e);
+                        return {
+                                status: 'error',
+                                details: e instanceof Error ? e.message : String(e),
+                        };
+                }
+        };
 
 	useEffect(() => {
 		if (!isSmartPhone()) return;
@@ -69,19 +86,19 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 		};
 	}, []);
 
-	const applyUpdate = async () => {
-		try {
-			setUpdating(true);
-			await Updates.fetchUpdateAsync();
-			await Updates.reloadAsync();
+        const applyUpdate = async () => {
+                try {
+                        setUpdating(true);
+                        await Updates.fetchUpdateAsync();
+                        await Updates.reloadAsync();
 		} catch (e) {
 			console.error('Error while applying updates', e);
 		}
-	};
+        };
 
-	return (
-		<UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>
-			{children}
+        return (
+                <UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>
+                        {children}
 			{modalVisible && (
 				<ModalSheet visible={modalVisible} onClose={() => setModalVisible(false)} title={translate(titleKey)}>
 					<View style={{ padding: 20 }}>


### PR DESCRIPTION
## Summary
- return structured results from the Expo update checker so manual checks can provide feedback
- surface manual update check logs in the settings screen when debug mode is enabled
- style the update check log container to match the settings layout

## Testing
- yarn lint *(fails: Expo lint expects an `eslint` script in this workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937364049f8833095dcf382d997e42e)