### PR TITLE
Handle missing overlapping event in repeat hook

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/collectible-events-repeat-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/collectible-events-repeat-hook/index.ts
@@ -124,8 +124,10 @@ class CollectibleEventsRepeatWorkflow extends SingleWorkflowRun {
       });
 
       if (overlappingEvents.length > 0) {
+        const overlappingEvent = overlappingEvents[0];
+
         await context.logger.appendLog(
-          `Skipping event ${event.id} due to overlap with current year event ${overlappingEvents[0].id}`
+          `Skipping event ${event.id} due to overlap with current year event ${overlappingEvent?.id}`
         );
         continue;
       }


### PR DESCRIPTION
## Summary
- guard overlapping event logging in collectible events repeat hook to avoid undefined access

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382f7859fc8330b242471bbd930555)