### PR TITLE
Add scroll support to course timetable screen

### DIFF
--- a/apps/frontend/app/app/(app)/course-timetable/index.tsx
+++ b/apps/frontend/app/app/(app)/course-timetable/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Linking, Platform, Text, TouchableOpacity, View } from 'react-native';
+import { Linking, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useFocusEffect } from 'expo-router';
 import TimeTableData from '@/constants/TimeTable';
@@ -137,53 +137,55 @@ const TimetableScreen = () => {
 		});
 	};
 
-	return (
-		<View style={{ ...styles.container, backgroundColor: theme.screen.background }}>
-			<TouchableOpacity
-				style={{
-					...styles.createButton,
-					backgroundColor: course_timetable_area_color,
-				}}
-				onPress={openSheet}
-			>
-				<FontAwesome name="calendar-plus-o" size={20} color={contrastColor} />
-				<View>
-					<Text style={{ ...styles.createButtonText, color: contrastColor }}>{`${translate(TranslationKeys.event)} ${translate(TranslationKeys.create)}`}</Text>
-				</View>
-			</TouchableOpacity>
-                        {events && events?.length > 0 ? (
-                                <CourseTimetable events={events} openSheet={openSheet} setIsUpdate={setIsUpdate} setTimeTableData={setTimeTableData} setSelectedEventId={setSelectedEventId} />
-                        ) : (
-                                <View style={styles.noEventsContainer}>
-                                        <Text
-						style={{
-							...styles.body,
-							color: theme.sheet.text,
-						}}
-					>
-						{parseMarkdown(text)}
-                                        </Text>
-                                        {link && <RedirectButton label={label} type="link" backgroundColor={course_timetable_area_color} color={contrastColor} onClick={() => handleOpenInBrowser(link)} />}
-                                </View>
-                        )}
-                        <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_course_timetable} />
+        return (
+                <View style={{ ...styles.container, backgroundColor: theme.screen.background }}>
+                        <ScrollView contentContainerStyle={styles.contentContainer} showsVerticalScrollIndicator={false}>
+                                <TouchableOpacity
+                                        style={{
+                                                ...styles.createButton,
+                                                backgroundColor: course_timetable_area_color,
+                                        }}
+                                        onPress={openSheet}
+                                >
+                                        <FontAwesome name="calendar-plus-o" size={20} color={contrastColor} />
+                                        <View>
+                                                <Text style={{ ...styles.createButtonText, color: contrastColor }}>{`${translate(TranslationKeys.event)} ${translate(TranslationKeys.create)}`}</Text>
+                                        </View>
+                                </TouchableOpacity>
+                                {events && events?.length > 0 ? (
+                                        <CourseTimetable events={events} openSheet={openSheet} setIsUpdate={setIsUpdate} setTimeTableData={setTimeTableData} setSelectedEventId={setSelectedEventId} />
+                                ) : (
+                                        <View style={styles.noEventsContainer}>
+                                                <Text
+                                                        style={{
+                                                                ...styles.body,
+                                                                color: theme.sheet.text,
+                                                        }}
+                                                >
+                                                        {parseMarkdown(text)}
+                                                </Text>
+                                                {link && <RedirectButton label={label} type="link" backgroundColor={course_timetable_area_color} color={contrastColor} onClick={() => handleOpenInBrowser(link)} />}
+                                        </View>
+                                )}
+                                <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_course_timetable} />
+                        </ScrollView>
                         {isActive && (
                                 <BaseBottomSheet
                                         ref={bottomSheetRef}
-					index={-1}
-					backgroundStyle={{
-						...styles.sheetBackground,
-						backgroundColor: theme.sheet.sheetBg,
-					}}
-					enablePanDownToClose
-					handleComponent={null}
-					onClose={closeSheet}
-				>
-					<CourseBottomSheet timeTableData={timeTableData} closeSheet={closeSheet} isUpdate={isUpdate} selectedEventId={selectedEventId} />
-				</BaseBottomSheet>
-			)}
-		</View>
-	);
+                                        index={-1}
+                                        backgroundStyle={{
+                                                ...styles.sheetBackground,
+                                                backgroundColor: theme.sheet.sheetBg,
+                                        }}
+                                        enablePanDownToClose
+                                        handleComponent={null}
+                                        onClose={closeSheet}
+                                >
+                                        <CourseBottomSheet timeTableData={timeTableData} closeSheet={closeSheet} isUpdate={isUpdate} selectedEventId={selectedEventId} />
+                                </BaseBottomSheet>
+                        )}
+                </View>
+        );
 };
 
 export default TimetableScreen;

--- a/apps/frontend/app/app/(app)/course-timetable/styles.ts
+++ b/apps/frontend/app/app/(app)/course-timetable/styles.ts
@@ -1,10 +1,14 @@
 import { Dimensions, StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	container: {
-		flex: 1,
-		paddingTop: 50,
-	},
+        container: {
+                flex: 1,
+                paddingTop: 50,
+        },
+        contentContainer: {
+                flexGrow: 1,
+                paddingBottom: 20,
+        },
 	createButton: {
 		maxWidth: 300,
 		height: 50,


### PR DESCRIPTION
## Summary
- wrap course timetable screen content in a ScrollView to enable scrolling when content is long
- add scroll container padding to maintain spacing for course timetable view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693845cb69108330a0670e543e06e4b5)