### PR TITLE
Add debug collectible spot to collectible event screen

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -155,6 +155,15 @@ const CollectibleEventScreen = () => {
                 setVisibleHints(prev => ({ ...prev, [key]: !prev[key] }));
         }, []);
 
+        const handleDebugCollectibleTouch = useCallback(() => {
+                setPoints(prev => {
+                        const currentValue = Number.parseInt(prev || '0', 10);
+                        const nextValue = Number.isNaN(currentValue) ? 1 : currentValue + 1;
+
+                        return String(nextValue);
+                });
+        }, []);
+
         const loadParticipation = useCallback(async () => {
                 if (!activeCollectibleEvent?.id || !profile?.id) {
                         setParticipation(null);
@@ -477,9 +486,35 @@ const CollectibleEventScreen = () => {
         return (
                 <SafeAreaView style={[styles.container, { backgroundColor: theme.screen.background }]}>
                         <CustomMenuHeader label={translate(TranslationKeys.collectible_event)} />
-                        <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-                                {renderContent()}
-                        </ScrollView>
+                        <View style={styles.container}>
+                                <ScrollView
+                                        style={styles.container}
+                                        contentContainerStyle={[
+                                                styles.content,
+                                                debugMode ? styles.contentWithBottomPadding : undefined,
+                                        ]}
+                                >
+                                        {renderContent()}
+                                </ScrollView>
+
+                                {debugMode ? (
+                                        <TouchableOpacity
+                                                style={[
+                                                        styles.debugCollectibleSpot,
+                                                        { backgroundColor: buttonColor, borderColor: theme.screen.icon },
+                                                ]}
+                                                onPress={handleDebugCollectibleTouch}
+                                                activeOpacity={0.85}
+                                        >
+                                                <Text style={[styles.debugCollectibleSpotText, { color: theme.dark }]}>
+                                                        {translate(TranslationKeys.collectible_event_debug_spot)}
+                                                </Text>
+                                                <Text style={[styles.debugCollectibleSpotSubtext, { color: theme.dark }]}>
+                                                        {translate(TranslationKeys.collectible_event_points)}: {points || '0'}
+                                                </Text>
+                                        </TouchableOpacity>
+                                ) : null}
+                        </View>
                         <PermissionModal
                                 isVisible={isPermissionModalVisible}
                                 setIsVisible={setIsPermissionModalVisible}

--- a/apps/frontend/app/app/(app)/collectible-event/styles.ts
+++ b/apps/frontend/app/app/(app)/collectible-event/styles.ts
@@ -10,6 +10,9 @@ const styles = StyleSheet.create({
         section: {
                 marginBottom: 16,
         },
+        contentWithBottomPadding: {
+                paddingBottom: 120,
+        },
         title: {
                 fontSize: 20,
                 fontWeight: '700',
@@ -55,6 +58,30 @@ const styles = StyleSheet.create({
                 fontSize: 12,
                 lineHeight: 18,
                 marginTop: 12,
+        },
+        debugCollectibleSpot: {
+                position: 'absolute',
+                bottom: 16,
+                left: 16,
+                right: 16,
+                borderRadius: 12,
+                borderWidth: 1,
+                paddingVertical: 12,
+                paddingHorizontal: 16,
+                alignItems: 'center',
+                shadowColor: '#000',
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.1,
+                shadowRadius: 4,
+                elevation: 3,
+        },
+        debugCollectibleSpotText: {
+                fontSize: 16,
+                fontWeight: '700',
+        },
+        debugCollectibleSpotSubtext: {
+                fontSize: 14,
+                marginTop: 4,
         },
 });
 

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -196,6 +196,7 @@ export enum TranslationKeys {
         collectible_event_show_hint = 'collectible_event_show_hint',
         collectible_event_hint_prefix = 'collectible_event_hint_prefix',
         collectible_event_found_label = 'collectible_event_found_label',
+        collectible_event_debug_spot = 'collectible_event_debug_spot',
         create = 'create',
         delete = 'delete',
         account_delete = 'account_delete',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1979,6 +1979,16 @@
     "tr": "Found",
     "zh": "Found"
   },
+  "collectible_event_debug_spot": {
+    "de": "Debug-Collectible-Spot",
+    "en": "Debug collectible spot",
+    "ar": "Debug collectible spot",
+    "es": "Debug collectible spot",
+    "fr": "Debug collectible spot",
+    "ru": "Debug collectible spot",
+    "tr": "Debug collectible spot",
+    "zh": "Debug collectible spot"
+  },
   "create": {
     "de": "Erstellen",
     "en": "Create",


### PR DESCRIPTION
## Summary
- add a debug-only collectible spot at the bottom of the collectible event screen
- allow tapping the debug spot to increment the current points value
- add padding and translations to support the new debug spot label

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384d0148f883309a221ef6defa1b5b)