### PR TITLE
Add collectible preview for event screen

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -13,7 +13,6 @@ import { getDescriptionFromTranslation, getTitleFromTranslation } from '@/helper
 import useToast from '@/hooks/useToast';
 import styles from './styles';
 import { CollectibleEventParticipantsHelper } from '@/redux/actions/CollectibleEvents/CollectibleEventParticipants';
-import CollectibleItem from '@/components/CollectibleItem';
 import useCollectibleDict from '@/hooks/useCollectibleDict';
 import PermissionModal from '@/components/PermissionModal/PermissionModal';
 import SettingsList from '@/components/SettingsList';
@@ -402,11 +401,11 @@ const CollectibleEventScreen = () => {
                                         <Text style={{ ...styles.description, color: theme.inactiveText }}>{description}</Text>
                                 ) : null}
 
-                                {debugMode && sampleCollectibleKey ? (
+                                {sampleCollectibleKey ? (
                                         <View style={{ alignItems: 'center', marginTop: 16 }}>
-                                                <CollectibleItem collectibleKey={sampleCollectibleKey} hideOnCollect={false} isPreview />
-                                                <Text style={{ color: theme.inactiveText, marginTop: 8 }}>
-                                                        {translate(TranslationKeys.collectible_event_preview_label)}
+                                                <CollectibleSpot collectibleKey={sampleCollectibleKey} isPreview />
+                                                <Text style={{ color: theme.inactiveText, marginTop: 8, textAlign: 'center' }}>
+                                                        {translate(TranslationKeys.collectible_event_collectible_preview_label)}
                                                 </Text>
                                         </View>
                                 ) : null}

--- a/apps/frontend/app/components/CollectibleItem/CollectibleSpot.tsx
+++ b/apps/frontend/app/components/CollectibleItem/CollectibleSpot.tsx
@@ -6,12 +6,17 @@ import CollectibleItem from './index';
 
 type CollectibleSpotProps = {
         collectibleKey: CollectibleAt;
+        isPreview?: boolean;
 };
 
-const CollectibleSpot: React.FC<CollectibleSpotProps> = ({ collectibleKey }) => {
+const CollectibleSpot: React.FC<CollectibleSpotProps> = ({ collectibleKey, isPreview }) => {
         return (
                 <View style={{ alignItems: 'center', marginVertical: 20 }}>
-                        <CollectibleItem collectibleKey={collectibleKey} />
+                        <CollectibleItem
+                                collectibleKey={collectibleKey}
+                                hideOnCollect={isPreview ? false : undefined}
+                                isPreview={isPreview}
+                        />
                 </View>
         );
 };

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -197,6 +197,7 @@ export enum TranslationKeys {
         collectible_event_hint_prefix = 'collectible_event_hint_prefix',
         collectible_event_found_label = 'collectible_event_found_label',
         collectible_event_debug_spot = 'collectible_event_debug_spot',
+        collectible_event_collectible_preview_label = 'collectible_event_collectible_preview_label',
         create = 'create',
         delete = 'delete',
         account_delete = 'account_delete',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1989,6 +1989,16 @@
     "tr": "Debug collectible spot",
     "zh": "Debug collectible spot"
   },
+  "collectible_event_collectible_preview_label": {
+    "de": "So sieht das zu sammelnde Objekt aus.",
+    "en": "This is what the collectible looks like.",
+    "ar": "This is what the collectible looks like.",
+    "es": "Así es como se ve el objeto coleccionable.",
+    "fr": "Voici à quoi ressemble l'objet à collectionner.",
+    "ru": "Так выглядит собираемый объект.",
+    "tr": "Koleksiyon objesi böyle görünüyor.",
+    "zh": "收集物品看起来是这样的。"
+  },
   "create": {
     "de": "Erstellen",
     "en": "Create",


### PR DESCRIPTION
## Summary
- show the collectible preview on the event screen even outside debug mode
- add translation for the preview hint and allow CollectibleSpot to render preview items

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938634f8f9c8330ae6568ea43a5687d)