### PR TITLE
Render collectible event description with markdown

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -22,6 +22,7 @@ import CustomMenuHeader from '@/components/CustomMenuHeader/CustomMenuHeader';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import useMyModal from '@/hooks/useMyModal';
 import ModalComponent from '@/components/ModalSetting/ModalComponent';
+import MyMarkdown from '@/components/MyMarkdown/MyMarkdown';
 
 type DebugSectionProps = {
         activeCollectibleEvent: DatabaseTypes.CollectibleEvents;
@@ -398,7 +399,9 @@ const CollectibleEventScreen = () => {
                         <View style={styles.section}>
                                 <Text style={{ ...styles.title, color: theme.screen.text }}>{title}</Text>
                                 {description ? (
-                                        <Text style={{ ...styles.description, color: theme.inactiveText }}>{description}</Text>
+                                        <View style={{ marginTop: 4 }}>
+                                                <MyMarkdown content={description} textColor={theme.inactiveText} />
+                                        </View>
                                 ) : null}
 
                                 {sampleCollectibleKey ? (


### PR DESCRIPTION
## Summary
- render collectible event descriptions using the existing markdown component to support formatted text

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693867093c4c8330886e828aa96ef83f)