### PR TITLE
Fix collectible event screen title translation crash

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -9,7 +9,6 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { useDispatch, useSelector } from 'react-redux';
-import { getDirectusTranslation } from '@/helper/resourceHelper';
 import useToast from '@/hooks/useToast';
 import styles from './styles';
 import { CollectibleEventParticipantsHelper } from '@/redux/actions/CollectibleEvents/CollectibleEventParticipants';
@@ -131,7 +130,7 @@ const CollectibleEventScreen = () => {
         const dispatch = useDispatch();
         const { theme } = useTheme();
         const toast = useToast();
-        const { translate, language } = useLanguage();
+        const { translate } = useLanguage();
         const { profile, loggedIn } = useSelector((state: RootState) => state.authReducer);
         const { primaryColor, debugMode } = useSelector((state: RootState) => state.settings);
         const buttonColor = primaryColor || theme.primary;
@@ -393,20 +392,8 @@ const CollectibleEventScreen = () => {
                         return <Text style={{ ...styles.info, color: theme.screen.text }}>{translate(TranslationKeys.collectible_event_no_active)}</Text>;
                 }
 
-                const title = getDirectusTranslation(
-                        { languageCode: language },
-                        activeCollectibleEvent.translations as any,
-                        'title',
-                        false,
-                        activeCollectibleEvent.alias || ''
-                );
-                const description = getDirectusTranslation(
-                        { languageCode: language },
-                        activeCollectibleEvent.translations as any,
-                        'description',
-                        true,
-                        ''
-                );
+                const title = activeCollectibleEvent?.title || activeCollectibleEvent?.alias || '';
+                const description = activeCollectibleEvent?.description || '';
 
                 return (
                         <View style={styles.section}>


### PR DESCRIPTION
## Summary
- remove Directus translation usage for collectible event title and description
- use stored title/alias and description fields directly to avoid crashes

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69388dc0c2bc83308adc397c2df90251)