### PR TITLE
Fix collectible event translations retrieval

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -393,7 +393,8 @@ const CollectibleEventScreen = () => {
                         return <Text style={{ ...styles.info, color: theme.screen.text }}>{translate(TranslationKeys.collectible_event_no_active)}</Text>;
                 }
 
-                const translations = (activeCollectibleEvent?.translations || []) as any[];
+                const translations =
+                        (activeCollectibleEvent?.translations || []) as DatabaseTypes.CollectibleEventsTranslations[];
                 const title =
                         getDirectusTranslation(
                                 { languageCode: language },

--- a/apps/frontend/app/redux/actions/CollectibleEvents/CollectibleEvents.ts
+++ b/apps/frontend/app/redux/actions/CollectibleEvents/CollectibleEvents.ts
@@ -9,7 +9,7 @@ export class CollectibleEventsHelper extends CollectionHelper<DatabaseTypes.Coll
 
         async fetchCollectibleEvents(queryOverride: any = {}) {
                 const defaultQuery = {
-                        fields: ['*, translations.*'],
+                        fields: ['*', 'translations.*'],
                         sort: ['sort'],
                         limit: 200,
                 };


### PR DESCRIPTION
## Summary
- request collectible event translations with proper field syntax so title and description data are returned
- type the collectible event screen translations array to match the translations collection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693899e6909c8330be81b424e872de51)