### PR TITLE
Improve collectible hint labels readability

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -535,10 +535,13 @@ const CollectibleEventScreen = () => {
                                                         {activeCollectibleKeys.map((key, index) => {
                                                                 const isCollected = Boolean(collectibleDict?.[key]);
                                                                 const isHintVisible = isCollected || visibleHints[key];
+                                                                const formattedLabel = key
+                                                                        .replace(/^collectible_at_?/, '')
+                                                                        .replace(/_/g, ' ');
 
                                                                 const iconBgColor = isCollected ? '#2DBE62' : '#F7D21F';
                                                                 const labelText = isHintVisible
-                                                                        ? key
+                                                                        ? formattedLabel
                                                                         : translate(TranslationKeys.collectible_event_show_hint);
 
                                                                 return (


### PR DESCRIPTION
## Summary
- format collectible event hint labels to drop the `collectible_at` prefix and replace underscores with spaces for readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69389dca6dfc8330bfbde815bacfd496)