### PR TITLE
Adjust version row grouping in settings

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -349,7 +349,7 @@ const Settings = () => {
 					</TouchableOpacity>
 					{isManagement && isDevMode && <Text style={{ ...styles.devModeText, color: theme.screen.text }}>{translate(TranslationKeys.developerModeActive)}</Text>}
                                         {isManagement && isDevMode && (
-                                                <>
+                                                <View style={{ gap: 0 }}>
                                                         <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={serverInfo?.info?.project?.project_name} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
                                                         <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
                                                         <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
@@ -370,9 +370,16 @@ const Settings = () => {
                                                                 handleFunction={toggleDebugMode}
                                                                 groupPosition="bottom"
                                                         />
-                                                </>
+                                                </View>
                                         )}
-                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="numeric" size={24} color={theme.screen.icon} />} label="Version" value={getVersionInternalForAppsettingsScreen().toString()} handleFunction={() => {}} />
+                                        <SettingsList
+                                                iconBgColor={primaryColor}
+                                                leftIcon={<MaterialCommunityIcons name="numeric" size={24} color={theme.screen.icon} />}
+                                                label="Version"
+                                                value={getVersionInternalForAppsettingsScreen().toString()}
+                                                handleFunction={() => {}}
+                                                groupPosition="single"
+                                        />
                                         <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings} />
                                 </View>
                         </ScrollView>


### PR DESCRIPTION
## Summary
- set the version settings row to use the single group position so it retains both top and bottom rounding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938a26888648330aa6e1f861bc1f59b)