### PR TITLE
Add rate prompt modal hook and debug tools

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, SafeAreaView, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { COLLECTABLE_AT_FIELDS, CollectibleAt, DatabaseTypes } from 'repo-depkit-common';
-import * as StoreReview from 'expo-store-review';
 
 import useActiveCollectibleEvent from '@/hooks/useActiveCollectibleEvent';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -23,7 +22,7 @@ import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import ModalComponent from '@/components/ModalSetting/ModalComponent';
 import MyMarkdown from '@/components/MyMarkdown';
 import { getDirectusTranslation } from '@/helper/resourceHelper';
-import { useModal } from '@/components/GlobalModal/useModal';
+import useRateAppModal from '@/hooks/useRateAppModal';
 
 type DebugSectionProps = {
         activeCollectibleEvent: DatabaseTypes.CollectibleEvents;
@@ -33,6 +32,8 @@ type DebugSectionProps = {
         resetAllParticipations: () => void;
         nextCollectibleKey?: CollectibleAt;
         debugSpotLabel: string;
+        selectedLanguage?: string;
+        onOpenRateModal: () => void;
 };
 
 const getGroupPosition = (index: number, length: number) => {
@@ -50,6 +51,8 @@ const DebugSection: React.FC<DebugSectionProps> = ({
         resetAllParticipations,
         nextCollectibleKey,
         debugSpotLabel,
+        selectedLanguage,
+        onOpenRateModal,
 }) => {
         return (
                 <View style={{ marginTop: 16 }}>
@@ -80,6 +83,20 @@ const DebugSection: React.FC<DebugSectionProps> = ({
                                                 Reset all event participations
                                         </Text>
                                 </TouchableOpacity>
+
+                                <TouchableOpacity
+                                        style={{
+                                                ...styles.button,
+                                                backgroundColor: theme.drawerBg,
+                                                borderWidth: 1,
+                                                borderColor: theme.screen.icon,
+                                        }}
+                                        onPress={onOpenRateModal}
+                                >
+                                        <Text style={{ ...styles.buttonText, color: theme.screen.text }}>
+                                                Open rate prompt modal
+                                        </Text>
+                                </TouchableOpacity>
                         </View>
 
                         {nextCollectibleKey ? (
@@ -105,7 +122,7 @@ const DebugSection: React.FC<DebugSectionProps> = ({
                                                         />
                                                 }
                                                 label={`ID: ${activeCollectibleEvent.id}`}
-                                                groupPosition={getGroupPosition(0, 2) as any}
+                                                groupPosition={getGroupPosition(0, 3) as any}
                                         />
                                         <SettingsList
                                                 key="event-alias"
@@ -118,7 +135,21 @@ const DebugSection: React.FC<DebugSectionProps> = ({
                                                         />
                                                 }
                                                 label={`Alias: ${activeCollectibleEvent.alias || '-'}`}
-                                                groupPosition={getGroupPosition(1, 2) as any}
+                                                groupPosition={getGroupPosition(1, 3) as any}
+                                        />
+
+                                        <SettingsList
+                                                key="language"
+                                                iconBgColor={theme.accent}
+                                                leftIcon={
+                                                        <MaterialCommunityIcons
+                                                                name="translate"
+                                                                size={22}
+                                                                color={theme.screen.icon}
+                                                        />
+                                                }
+                                                label={`Selected language: ${selectedLanguage || '-'}`}
+                                                groupPosition={getGroupPosition(2, 3) as any}
                                         />
                                 </View>
                         ) : null}
@@ -136,13 +167,13 @@ const CollectibleEventScreen = () => {
         const { profile, loggedIn } = useSelector((state: RootState) => state.authReducer);
         const { primaryColor, debugMode } = useSelector((state: RootState) => state.settings);
         const buttonColor = primaryColor || theme.primary;
+        const { openRateAppModal } = useRateAppModal(buttonColor);
         const { activeCollectibleEvent } = useActiveCollectibleEvent();
         const participantsHelper = useMemo(() => new CollectibleEventParticipantsHelper(), []);
         const { collectedCount, collectibleDict } = useCollectibleDict(activeCollectibleEvent?.id);
         const [debugLogs, setDebugLogs] = useState<string[]>([]);
         const previousCollectedCountRef = useRef<number | null>(null);
         const previousEventIdRef = useRef<string | number | null>(null);
-        const hasShownReviewPromptRef = useRef<Record<string | number, boolean>>({});
 
         const appendDebugLog = useCallback((message: string, errorObject?: unknown) => {
                 const timestamp = new Date().toLocaleTimeString();
@@ -207,8 +238,6 @@ const CollectibleEventScreen = () => {
         const [pointsDraft, setPointsDraft] = useState('');
         const [isPointsModalVisible, setIsPointsModalVisible] = useState(false);
 
-        const { show: showModal, close: closeModal } = useModal();
-
         const openPointsModal = useCallback(() => setIsPointsModalVisible(true), []);
         const closePointsModal = useCallback(() => setIsPointsModalVisible(false), []);
 
@@ -234,22 +263,8 @@ const CollectibleEventScreen = () => {
                         appendDebugLog(`Points increased from ${previousValue} to ${currentCount}`);
                 }
 
-                const maxCollectibles = activeCollectibleKeys.length;
-                const hasCollectedAll = maxCollectibles > 0 && currentCount === maxCollectibles;
-                const eventId = activeCollectibleEvent?.id;
-
-                if (
-                        hasCollectedAll &&
-                        currentCount > previousValue &&
-                        eventId &&
-                        !hasShownReviewPromptRef.current[eventId]
-                ) {
-                        hasShownReviewPromptRef.current = { ...hasShownReviewPromptRef.current, [eventId]: true };
-                        openRateAppModal();
-                }
-
                 previousCollectedCountRef.current = currentCount;
-        }, [activeCollectibleEvent?.id, activeCollectibleKeys.length, appendDebugLog, collectedCount, debugMode, openRateAppModal]);
+        }, [appendDebugLog, collectedCount, debugMode]);
 
         const loadParticipation = useCallback(async () => {
                 if (!activeCollectibleEvent?.id || !profile?.id) {
@@ -403,64 +418,6 @@ const CollectibleEventScreen = () => {
                 setPoints(pointsDraft);
                 closePointsModal();
         }, [closePointsModal, pointsDraft]);
-
-        const handleRateApp = useCallback(async () => {
-                try {
-                        const isAvailable = await StoreReview.isAvailableAsync();
-                        if (isAvailable) {
-                                await StoreReview.requestReview();
-                        }
-                } catch (error) {
-                        console.log('Error requesting review', error);
-                } finally {
-                        closeModal();
-                }
-        }, [closeModal]);
-
-        const openRateAppModal = useCallback(() => {
-                showModal(
-                        <View style={{ padding: 24, gap: 12 }}>
-                                <Text
-                                        style={{
-                                                ...styles.title,
-                                                color: theme.screen.text,
-                                                textAlign: 'center',
-                                        }}
-                                >
-                                        {translate(TranslationKeys.collectible_event_congratulations_title)}
-                                </Text>
-
-                                <Text
-                                        style={{
-                                                ...styles.label,
-                                                color: theme.screen.text,
-                                                textAlign: 'center',
-                                        }}
-                                >
-                                        {translate(TranslationKeys.collectible_event_rate_app_prompt)}
-                                </Text>
-
-                                <TouchableOpacity
-                                        style={{ ...styles.button, backgroundColor: buttonColor }}
-                                        onPress={handleRateApp}
-                                >
-                                        <Text style={{ ...styles.buttonText, color: theme.dark }}>
-                                                {translate(TranslationKeys.rate_now)}
-                                        </Text>
-                                </TouchableOpacity>
-
-                                <TouchableOpacity
-                                        style={{ ...styles.button, backgroundColor: theme.drawerBg }}
-                                        onPress={closeModal}
-                                >
-                                        <Text style={{ ...styles.buttonText, color: theme.screen.text }}>
-                                                {translate(TranslationKeys.rate_later)}
-                                        </Text>
-                                </TouchableOpacity>
-                        </View>,
-                        { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
-                );
-        }, [buttonColor, closeModal, handleRateApp, showModal, theme.dark, theme.drawerBg, theme.screen.text, theme.sheet?.sheetBg, translate]);
 
         const renderContent = () => {
                 if (!activeCollectibleEvent) {
@@ -655,6 +612,8 @@ const CollectibleEventScreen = () => {
                                                         theme={theme}
                                                         nextCollectibleKey={nextCollectibleKey}
                                                         debugSpotLabel={translate(TranslationKeys.collectible_event_debug_spot)}
+                                                        selectedLanguage={language}
+                                                        onOpenRateModal={openRateAppModal}
                                                 />
                                         ) : null}
 

--- a/apps/frontend/app/components/CollectibleItem/index.tsx
+++ b/apps/frontend/app/components/CollectibleItem/index.tsx
@@ -13,6 +13,7 @@ import useToast from '@/hooks/useToast';
 import { TranslationKeys } from '@/locales/keys';
 import { useLanguage } from '@/hooks/useLanguage';
 import MyImage from '../MyImage';
+import useRateAppModal from '@/hooks/useRateAppModal';
 
 type CollectibleKey = (typeof COLLECTABLE_AT_FIELDS)[number];
 
@@ -36,6 +37,8 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
         const { profile, loggedIn } = useSelector((state: RootState) => state.authReducer);
         const { primaryColor: projectColor } = useSelector((state: RootState) => state.settings);
         const [isSaving, setIsSaving] = useState(false);
+
+        const { openRateAppModal } = useRateAppModal(projectColor || theme.primary);
 
         const { collectibleDict, setCollectibleKey, collectedCount } = useCollectibleDict(activeCollectibleEvent?.id);
         const participantsHelper = useMemo(() => new CollectibleEventParticipantsHelper(), []);
@@ -76,6 +79,10 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
                         `${translate(TranslationKeys.collectible_event_collected)} ${updatedCount}/${maxCollectibleKeys || '∞'}`,
                         'success'
                 );
+
+                if (maxCollectibleKeys > 0 && updatedCount === maxCollectibleKeys) {
+                        openRateAppModal();
+                }
 
                 if (!loggedIn || !profile?.id) {
                         return;

--- a/apps/frontend/app/hooks/useRateAppModal.tsx
+++ b/apps/frontend/app/hooks/useRateAppModal.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import * as StoreReview from 'expo-store-review';
+
+import { useModal } from '@/components/GlobalModal/useModal';
+import { TranslationKeys } from '@/locales/keys';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import styles from '@/app/(app)/collectible-event/styles';
+
+const useRateAppModal = (buttonColorOverride?: string) => {
+        const { show, close } = useModal();
+        const { translate } = useLanguage();
+        const { theme } = useTheme();
+
+        const handleRateApp = useCallback(async () => {
+                try {
+                        const isAvailable = await StoreReview.isAvailableAsync();
+                        if (isAvailable) {
+                                await StoreReview.requestReview();
+                        }
+                } catch (error) {
+                        console.log('Error requesting review', error);
+                } finally {
+                        close();
+                }
+        }, [close]);
+
+        const openRateAppModal = useCallback(() => {
+                show(
+                        <View style={{ padding: 24, gap: 12 }}>
+                                <Text
+                                        style={{
+                                                ...styles.title,
+                                                color: theme.screen.text,
+                                                textAlign: 'center',
+                                        }}
+                                >
+                                        {translate(TranslationKeys.collectible_event_congratulations_title)}
+                                </Text>
+
+                                <Text
+                                        style={{
+                                                ...styles.label,
+                                                color: theme.screen.text,
+                                                textAlign: 'center',
+                                        }}
+                                >
+                                        {translate(TranslationKeys.collectible_event_rate_app_prompt)}
+                                </Text>
+
+                                <TouchableOpacity
+                                        style={{ ...styles.button, backgroundColor: buttonColorOverride || theme.primary }}
+                                        onPress={handleRateApp}
+                                >
+                                        <Text style={{ ...styles.buttonText, color: theme.dark }}>
+                                                {translate(TranslationKeys.rate_now)}
+                                        </Text>
+                                </TouchableOpacity>
+
+                                <TouchableOpacity
+                                        style={{ ...styles.button, backgroundColor: theme.drawerBg }}
+                                        onPress={close}
+                                >
+                                        <Text style={{ ...styles.buttonText, color: theme.screen.text }}>
+                                                {translate(TranslationKeys.rate_later)}
+                                        </Text>
+                                </TouchableOpacity>
+                        </View>,
+                        { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
+                );
+        }, [
+                buttonColorOverride,
+                close,
+                handleRateApp,
+                show,
+                theme.dark,
+                theme.drawerBg,
+                theme.primary,
+                theme.screen.text,
+                theme.sheet?.sheetBg,
+                translate,
+        ]);
+
+        return { openRateAppModal };
+};
+
+export default useRateAppModal;


### PR DESCRIPTION
## Summary
- add a reusable rate app modal hook and use it when collectibles are completed
- show the selected language and provide a debug button to open the rate prompt on the collectible event screen
- simplify debug logging while keeping manual point editing intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ae0d16e88330bfeb4ee3eb4e2784)