### PR TITLE
Handle base language fallback for Directus translations

### DIFF
--- a/apps/frontend/app/helper/resourceHelper.tsx
+++ b/apps/frontend/app/helper/resourceHelper.tsx
@@ -137,19 +137,20 @@ export function getDirectusTranslation(params: any, translations: TranslationEnt
 	);
 
 	const getTranslation = (dict: { [key: string]: TranslationEntry }, langCode: string, params?: any) => {
-		const translationEntry = dict[langCode];
+		const languageKey = langCode?.split('-')[0];
+		const translationEntry = dict[langCode] || dict[languageKey];
 		if (!translationEntry) return null;
 
-                                let translation = translationEntry[field];
-                if (params) {
-                        Object.keys(params).forEach(key => {
-                                translation = StringHelper.replaceAllWithOptions({
-                                        str: translation,
-                                        find: `%${key}`,
-                                        replace: params[key],
-                                });
-                        });
-                }
+		let translation = translationEntry[field];
+		if (params) {
+			Object.keys(params).forEach(key => {
+				translation = StringHelper.replaceAllWithOptions({
+					str: translation,
+					find: `%${key}`,
+					replace: params[key],
+				});
+			});
+		}
 		return translation;
 	};
 

--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -22,19 +22,20 @@ export function getDirectusTranslation(params: any, translations: TranslationEnt
   );
 
   const getTranslation = (dict: { [key: string]: TranslationEntry }, langCode: string, params?: any) => {
-    const translationEntry = dict[langCode];
+    const languageKey = langCode?.split('-')[0];
+    const translationEntry = dict[langCode] || dict[languageKey];
     if (!translationEntry) return null;
 
-  let translation = translationEntry[field];
-  if (params) {
-    Object.keys(params).forEach(key => {
-      translation = StringHelper.replaceAllWithOptions({
-        str: translation,
-        find: `%${key}`,
-        replace: params[key],
+    let translation = translationEntry[field];
+    if (params) {
+      Object.keys(params).forEach(key => {
+        translation = StringHelper.replaceAllWithOptions({
+          str: translation,
+          find: `%${key}`,
+          replace: params[key],
+        });
       });
-    });
-  }
+    }
     return translation;
   };
 


### PR DESCRIPTION
## Summary
- add base language lookup when resolving Directus translations to handle language codes with region suffixes
- align translation handling in shared common helper and frontend helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938b85c48f48330b317c93fb3efa8a2)