### PR TITLE
Improve collectible event translation handling

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -21,7 +21,7 @@ import CustomMenuHeader from '@/components/CustomMenuHeader/CustomMenuHeader';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import ModalComponent from '@/components/ModalSetting/ModalComponent';
 import MyMarkdown from '@/components/MyMarkdown';
-import { getDirectusTranslation } from '@/helper/resourceHelper';
+import { getCollectibleEventTranslation } from '@/helper/resourceHelper';
 import useRateAppModal from '@/hooks/useRateAppModal';
 
 type DebugSectionProps = {
@@ -430,22 +430,13 @@ const CollectibleEventScreen = () => {
 
                 const translations =
                         (activeCollectibleEvent?.translations || []) as DatabaseTypes.CollectibleEventsTranslations[];
-                const title =
-                        getDirectusTranslation(
-                                { languageCode: languageForDirectusTranslation || '' },
-                                translations,
-                                'title',
-                                false,
-                                activeCollectibleEvent?.alias || ''
-                        ) || '';
-                const description =
-                        getDirectusTranslation(
-                                { languageCode: languageForDirectusTranslation || '' },
-                                translations,
-                                'description',
-                                false,
-                                activeCollectibleEvent?.description || ''
-                        ) || '';
+
+                const { title, description } = getCollectibleEventTranslation(
+                        translations,
+                        languageForDirectusTranslation || '',
+                        activeCollectibleEvent?.alias || '',
+                        activeCollectibleEvent?.description || ''
+                );
 
                 return (
                         <View style={styles.section}>

--- a/apps/frontend/app/helper/resourceHelper.tsx
+++ b/apps/frontend/app/helper/resourceHelper.tsx
@@ -128,13 +128,19 @@ const MISSING_TRANSLATION = 'Missing translation';
 export function getDirectusTranslation(params: any, translations: TranslationEntry[], field: string, ignoreFallbackLanguage?: boolean, fallback_text?: string | null): string {
 	const languageCode = params?.languageCode || FALLBACK_LANGUAGE_CODE_ENGLISH;
 
-	const translationDict = translations.reduce(
-		(acc, translation) => {
-			acc[translation.languages_code] = translation;
-			return acc;
-		},
-		{} as { [key: string]: TranslationEntry }
-	);
+        const translationDict = translations.reduce(
+                (acc, translation) => {
+                        acc[translation.languages_code] = translation;
+
+                        const [baseLanguageCode] = translation.languages_code?.split?.('-') || [];
+                        if (baseLanguageCode && !acc[baseLanguageCode]) {
+                                acc[baseLanguageCode] = translation;
+                        }
+
+                        return acc;
+                },
+                {} as { [key: string]: TranslationEntry }
+        );
 
 	const getTranslation = (dict: { [key: string]: TranslationEntry }, langCode: string, params?: any) => {
 		const languageKey = langCode?.split('-')[0];
@@ -199,16 +205,34 @@ export function getFoodName(food: string | DatabaseTypes.Foods | null | undefine
 }
 
 export const getNewsTranslationByLanguageCode = (translations: NewsTranslations[], languageCode: string): any => {
-	if (!translations || translations.length === 0) return '';
+        if (!translations || translations.length === 0) return '';
 
 	const translation = translations?.find(item => item.languages_code?.toString().split('-')[0] === languageCode);
 
-	if (translation) {
-		return {
-			title: translation.title,
-			content: translation.content,
-		};
-	}
+        if (translation) {
+                return {
+                        title: translation.title,
+                        content: translation.content,
+                };
+        }
+};
+
+export const getCollectibleEventTranslation = (
+        translations: DatabaseTypes.CollectibleEventsTranslations[] = [],
+        languageCode: string,
+        fallbackTitle?: string | null,
+        fallbackDescription?: string | null
+) => {
+        const title = getDirectusTranslation({ languageCode }, translations as any, 'title', false, fallbackTitle || '');
+        const description = getDirectusTranslation(
+                { languageCode },
+                translations as any,
+                'description',
+                false,
+                fallbackDescription || ''
+        );
+
+        return { title, description };
 };
 
 export const getBuildingTranslationByLanguageCode = (translations: BuildingsTranslations[], languageCode: string) => {


### PR DESCRIPTION
## Summary
- ensure getDirectusTranslation indexes base language codes for consistent fallback behavior
- add a reusable collectible event translation helper and use it in the event screen instead of manual language normalization

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938bbc7b12083308830501a7b23e53d)