### PR TITLE
Handle missing translation language keys

### DIFF
--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -15,14 +15,19 @@ export function getDirectusTranslation(params: any, translations: TranslationEnt
 
   const translationDict = translations.reduce(
     (acc, translation) => {
-      acc[translation.languages_code] = translation;
+      if (translation.languages_code) {
+        acc[translation.languages_code] = translation;
+      }
       return acc;
     },
     {} as { [key: string]: TranslationEntry }
   );
 
-  const getTranslation = (dict: { [key: string]: TranslationEntry }, langCode: string, params?: any) => {
-    const languageKey = langCode?.split('-')[0];
+  const getTranslation = (dict: { [key: string]: TranslationEntry }, langCode: string | null | undefined, params?: any) => {
+    if (!langCode) return null;
+    const languageKey = langCode.split('-')[0];
+    if (!languageKey) return null;
+
     const translationEntry = dict[langCode] || dict[languageKey];
     if (!translationEntry) return null;
 


### PR DESCRIPTION
## Summary
- skip translations missing a language code to avoid undefined dictionary keys
- guard against empty language keys when deriving translation lookups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c0708a108330b20c53e44bc2cdd6)