### PR TITLE
Fix GlobalModal visibility handling

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -21,6 +21,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const [content, setContent] = useState<ReactNode | null>(null);
         const [backgroundStyle, setBackgroundStyle] = useState<any>(null);
         const sheetRef = useRef<any>(null);
+        const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({
                 lastAction: null,
                 contentSet: false,
@@ -33,6 +34,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const open = (c: ReactNode, options?: { backgroundStyle?: any }) => {
                 setContent(c);
                 setBackgroundStyle(options?.backgroundStyle ?? null);
+                setIsVisible(true);
                 setDebug((prev) => ({
                         ...prev,
                         lastAction: 'open',
@@ -46,7 +48,10 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const close = () => {
                 sheetRef.current?.close?.();
                 setBackgroundStyle(null);
-                setTimeout(() => setContent(null), 200);
+                setTimeout(() => {
+                        setContent(null);
+                        setIsVisible(false);
+                }, 200);
                 setDebug((prev) => ({
                         ...prev,
                         lastAction: 'close',
@@ -73,29 +78,28 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         return (
                 <ModalContext.Provider value={{ open, close, debug }}>
                         {children}
-                        {content && (
-                                <View pointerEvents="box-none" style={styles.modalContainer}>
-                                        <BaseBottomSheet
-                                                ref={sheetRef}
-                                                index={0}
-                                                backgroundStyle={backgroundStyle}
-                                                enablePanDownToClose
-                                                onClose={() => {
-                                                        setContent(null);
-                                                        setBackgroundStyle(null);
-                                                        setDebug((prev) => ({
-                                                                ...prev,
-                                                                lastAction: 'close',
-                                                                contentSet: false,
-                                                                sheetRefReady: Boolean(sheetRef.current),
-                                                                closeInvocations: prev.closeInvocations + 1,
-                                                        }));
-                                                }}
-                                        >
-                                                {content}
-                                        </BaseBottomSheet>
-                                </View>
-                        )}
+                        <View pointerEvents="box-none" style={styles.modalContainer}>
+                                <BaseBottomSheet
+                                        ref={sheetRef}
+                                        index={isVisible ? 0 : -1}
+                                        backgroundStyle={backgroundStyle}
+                                        enablePanDownToClose
+                                        onClose={() => {
+                                                setContent(null);
+                                                setBackgroundStyle(null);
+                                                setIsVisible(false);
+                                                setDebug((prev) => ({
+                                                        ...prev,
+                                                        lastAction: 'close',
+                                                        contentSet: false,
+                                                        sheetRefReady: Boolean(sheetRef.current),
+                                                        closeInvocations: prev.closeInvocations + 1,
+                                                }));
+                                        }}
+                                >
+                                        {content}
+                                </BaseBottomSheet>
+                        </View>
                 </ModalContext.Provider>
         );
 };


### PR DESCRIPTION
## Summary
- keep the global modal bottom sheet mounted and toggle visibility via index to ensure it renders when opened
- track visibility state alongside content to reset background and debug data consistently on close

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c20bd4ac8330a6eea05cd1cd0c8d)