### PR TITLE
Fix GlobalModal visibility handling when reopening sheets

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -75,6 +75,19 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 return () => clearTimeout(t);
         }, [content]);
 
+        // Also react to visibility changes in case the content does not change (e.g., re-open same modal)
+        useEffect(() => {
+                if (isVisible) {
+                        sheetRef.current?.expand?.();
+                        setDebug((prev) => ({
+                                ...prev,
+                                sheetRefReady: Boolean(sheetRef.current),
+                        }));
+                } else {
+                        sheetRef.current?.close?.();
+                }
+        }, [isVisible]);
+
         return (
                 <ModalContext.Provider value={{ open, close, debug }}>
                         {children}


### PR DESCRIPTION
## Summary
- ensure the global modal bottom sheet expands whenever it becomes visible, even if the content instance stays the same
- close the sheet via its ref when visibility resets so modal state stays in sync

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c6076f1c8330a316e608aba5eb77)