### PR TITLE
Use MyScrollViewModal for Expo update checker

### DIFF
--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, AppState, AppStateStatus, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import * as Updates from 'expo-updates';
-import ModalSheet from '../BaseBottomModal';
+import { useModal } from '@/components/GlobalModal/useModal';
 import usePlatformHelper from '@/helper/platformHelper';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { isInExpoGo } from '@/helper/DeviceRuntimeHelper';
+import MyScrollViewModal from '../MyScrollViewModal';
 
 interface ExpoUpdateCheckerProps {
 	children?: ReactNode;
@@ -24,37 +25,60 @@ const UpdateCheckerContext = createContext<UpdateCheckerContextType | null>(null
 const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 	const appState = useRef<AppStateStatus>(AppState.currentState);
 	const { isSmartPhone } = usePlatformHelper();
-	const { translate } = useLanguage();
-	const { theme } = useTheme();
-	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+        const { translate } = useLanguage();
+        const { theme } = useTheme();
+        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+        const { show, close } = useModal();
+        const [updating, setUpdating] = useState(false);
 
-	const [modalVisible, setModalVisible] = useState(false);
-	const [updating, setUpdating] = useState(false);
-	const [updateAvailable, setUpdateAvailable] = useState(false);
-	const [titleKey, setTitleKey] = useState<TranslationKeys>(TranslationKeys.update_available);
-	const [messageKey, setMessageKey] = useState<TranslationKeys>(TranslationKeys.update_available_message);
+        const showUpdateModal = (hasUpdate: boolean, title: TranslationKeys, message: TranslationKeys) => {
+                show(
+                        <MyScrollViewModal
+                                title={translate(title)}
+                                closeSheet={close}
+                                showsVerticalScrollIndicator={false}
+                        >
+                                <View style={{ padding: 20 }}>
+                                        <Text style={{ color: theme.screen.text, textAlign: 'center' }}>{translate(message)}</Text>
+                                </View>
+                                <View style={modalStyles.buttonContainer}>
+                                        <TouchableOpacity onPress={close} style={[modalStyles.cancelButton, { borderColor: primaryColor }]}>
+                                                <Text style={[modalStyles.buttonText, { color: theme.screen.text }]}>
+                                                        {translate(hasUpdate ? TranslationKeys.cancel : TranslationKeys.okay)}
+                                                </Text>
+                                        </TouchableOpacity>
+                                        {hasUpdate && (
+                                                <TouchableOpacity onPress={applyUpdate} style={[modalStyles.saveButton, { backgroundColor: primaryColor }]}>
+                                                        {updating ? (
+                                                                <ActivityIndicator color={contrastColor} />
+                                                        ) : (
+                                                                <Text style={[modalStyles.buttonText, { color: contrastColor }]}>
+                                                                        {translate(TranslationKeys.to_update)}
+                                                                </Text>
+                                                        )}
+                                                </TouchableOpacity>
+                                        )}
+                                </View>
+                        </MyScrollViewModal>,
+                        { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } },
+                );
+        };
 
 	const checkForUpdates = async (showUpToDate = false) => {
 		if (!isSmartPhone()) return;
 		if (isInExpoGo()) return;
 		try {
-			const update = await Updates.checkForUpdateAsync();
-			if (update.isAvailable) {
-				setUpdateAvailable(true);
-				setTitleKey(TranslationKeys.update_available);
-				setMessageKey(TranslationKeys.update_available_message);
-				setModalVisible(true);
-			} else if (showUpToDate) {
-				setUpdateAvailable(false);
-				setTitleKey(TranslationKeys.updates);
-				setMessageKey(TranslationKeys.no_updates_available);
-				setModalVisible(true);
-			}
-		} catch (e) {
-			console.error('Error while checking updates', e);
-		}
-	};
+                        const update = await Updates.checkForUpdateAsync();
+                        if (update.isAvailable) {
+                                showUpdateModal(true, TranslationKeys.update_available, TranslationKeys.update_available_message);
+                        } else if (showUpToDate) {
+                                showUpdateModal(false, TranslationKeys.updates, TranslationKeys.no_updates_available);
+                        }
+                } catch (e) {
+                        console.error('Error while checking updates', e);
+                }
+        };
 
 	useEffect(() => {
 		if (!isSmartPhone()) return;
@@ -70,37 +94,18 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 	}, []);
 
 	const applyUpdate = async () => {
-		try {
-			setUpdating(true);
-			await Updates.fetchUpdateAsync();
-			await Updates.reloadAsync();
-		} catch (e) {
-			console.error('Error while applying updates', e);
-		}
-	};
+                try {
+                        setUpdating(true);
+                        await Updates.fetchUpdateAsync();
+                        await Updates.reloadAsync();
+                } catch (e) {
+                        console.error('Error while applying updates', e);
+                } finally {
+                        setUpdating(false);
+                }
+        };
 
-	return (
-		<UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>
-			{children}
-			{modalVisible && (
-				<ModalSheet visible={modalVisible} onClose={() => setModalVisible(false)} title={translate(titleKey)}>
-					<View style={{ padding: 20 }}>
-						<Text style={{ color: theme.screen.text, textAlign: 'center' }}>{translate(messageKey)}</Text>
-					</View>
-					<View style={modalStyles.buttonContainer}>
-						<TouchableOpacity onPress={() => setModalVisible(false)} style={[modalStyles.cancelButton, { borderColor: primaryColor }]}>
-							<Text style={[modalStyles.buttonText, { color: theme.screen.text }]}>{translate(updateAvailable ? TranslationKeys.cancel : TranslationKeys.okay)}</Text>
-						</TouchableOpacity>
-						{updateAvailable && (
-							<TouchableOpacity onPress={applyUpdate} style={[modalStyles.saveButton, { backgroundColor: primaryColor }]}>
-								{updating ? <ActivityIndicator color={contrastColor} /> : <Text style={[modalStyles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.to_update)}</Text>}
-							</TouchableOpacity>
-						)}
-					</View>
-				</ModalSheet>
-			)}
-		</UpdateCheckerContext.Provider>
-	);
+        return <UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>{children}</UpdateCheckerContext.Provider>;
 };
 
 export const useExpoUpdateChecker = () => {


### PR DESCRIPTION
## Summary
- switch Expo update checker to use the global modal hook with MyScrollViewModal
- display update availability messages in the shared scrollable modal with existing actions
- reset updating state after attempting to apply updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d9af88cc83309db8322853851504)