### PR TITLE
Enhance rate app modal actions

### DIFF
--- a/apps/frontend/app/hooks/useRateAppModal.tsx
+++ b/apps/frontend/app/hooks/useRateAppModal.tsx
@@ -1,17 +1,29 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import * as StoreReview from 'expo-store-review';
+import { Ionicons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
 
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { TranslationKeys } from '@/locales/keys';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
+import { myContrastColor } from '@/helper/ColorHelper';
+import { RootState } from '@/redux/reducer';
+import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
 import styles from '@/app/(app)/collectible-event/styles';
 
 const useRateAppModal = (buttonColorOverride?: string) => {
         const { show, close } = useMyScrollViewModal();
         const { translate } = useLanguage();
         const { theme } = useTheme();
+        const { appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+
+        const rateButtonColor = buttonColorOverride || theme.primary;
+        const rateButtonTextColor = useMemo(
+                () => myContrastColor(rateButtonColor, theme, mode === 'dark'),
+                [mode, rateButtonColor, theme]
+        );
 
         const handleRateApp = useCallback(async () => {
                 try {
@@ -26,7 +38,20 @@ const useRateAppModal = (buttonColorOverride?: string) => {
                 }
         }, [close]);
 
-        const openRateAppModal = useCallback(() => {
+        const openRateAppModal = useCallback(async () => {
+                let canRate = false;
+
+                try {
+                        const [isAvailable, hasAction] = await Promise.all([
+                                StoreReview.isAvailableAsync(),
+                                typeof StoreReview.hasAction === 'function' ? StoreReview.hasAction() : Promise.resolve(false),
+                        ]);
+
+                        canRate = isAvailable && !hasAction;
+                } catch (error) {
+                        console.log('Error checking review availability', error);
+                }
+
                 show(
                         {
                                 children: (
@@ -51,17 +76,19 @@ const useRateAppModal = (buttonColorOverride?: string) => {
                                                         {translate(TranslationKeys.collectible_event_rate_app_prompt)}
                                                 </Text>
 
-                                                <TouchableOpacity
-                                                        style={{
-                                                                ...styles.button,
-                                                                backgroundColor: buttonColorOverride || theme.primary,
-                                                        }}
-                                                        onPress={handleRateApp}
-                                                >
-                                                        <Text style={{ ...styles.buttonText, color: theme.dark }}>
-                                                                {translate(TranslationKeys.rate_now)}
-                                                        </Text>
-                                                </TouchableOpacity>
+                                                {canRate && (
+                                                        <TouchableOpacity
+                                                                style={{
+                                                                        ...styles.button,
+                                                                        backgroundColor: rateButtonColor,
+                                                                }}
+                                                                onPress={handleRateApp}
+                                                        >
+                                                                <Text style={{ ...styles.buttonText, color: rateButtonTextColor }}>
+                                                                        {translate(TranslationKeys.rate_now)}
+                                                                </Text>
+                                                        </TouchableOpacity>
+                                                )}
 
                                                 <TouchableOpacity
                                                         style={{ ...styles.button, backgroundColor: theme.drawerBg }}
@@ -71,19 +98,90 @@ const useRateAppModal = (buttonColorOverride?: string) => {
                                                                 {translate(TranslationKeys.rate_later)}
                                                         </Text>
                                                 </TouchableOpacity>
+
+                                                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                                                        <TouchableOpacity
+                                                                style={{
+                                                                        ...styles.button,
+                                                                        flex: 1,
+                                                                        marginTop: 0,
+                                                                        marginRight: 12,
+                                                                        flexDirection: 'row',
+                                                                        alignItems: 'center',
+                                                                        justifyContent: 'center',
+                                                                        backgroundColor: theme.card.background,
+                                                                        borderWidth: 1,
+                                                                        borderColor: theme.screen.iconBg,
+                                                                }}
+                                                                onPress={() => {
+                                                                        if (appSettings?.app_stores_url_to_google) {
+                                                                                CommonSystemActionHelper.openExternalURL(
+                                                                                        appSettings?.app_stores_url_to_google,
+                                                                                        true
+                                                                                );
+                                                                        }
+                                                                }}
+                                                        >
+                                                                <Ionicons
+                                                                        name="logo-google-playstore"
+                                                                        size={20}
+                                                                        color={theme.screen.icon}
+                                                                        style={{ marginRight: 8 }}
+                                                                />
+                                                                <Text style={{ ...styles.buttonText, color: theme.screen.text }}>
+                                                                        Google Play Store
+                                                                </Text>
+                                                        </TouchableOpacity>
+
+                                                        <TouchableOpacity
+                                                                style={{
+                                                                        ...styles.button,
+                                                                        flex: 1,
+                                                                        marginTop: 0,
+                                                                        flexDirection: 'row',
+                                                                        alignItems: 'center',
+                                                                        justifyContent: 'center',
+                                                                        backgroundColor: theme.card.background,
+                                                                        borderWidth: 1,
+                                                                        borderColor: theme.screen.iconBg,
+                                                                }}
+                                                                onPress={() => {
+                                                                        if (appSettings?.app_stores_url_to_apple) {
+                                                                                CommonSystemActionHelper.openExternalURL(
+                                                                                        appSettings?.app_stores_url_to_apple,
+                                                                                        true
+                                                                                );
+                                                                        }
+                                                                }}
+                                                        >
+                                                                <Ionicons
+                                                                        name="logo-apple"
+                                                                        size={20}
+                                                                        color={theme.screen.icon}
+                                                                        style={{ marginRight: 8 }}
+                                                                />
+                                                                <Text style={{ ...styles.buttonText, color: theme.screen.text }}>
+                                                                        App Store
+                                                                </Text>
+                                                        </TouchableOpacity>
+                                                </View>
                                         </View>
                                 ),
                         },
                         { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
                 );
         }, [
-                buttonColorOverride,
+                appSettings?.app_stores_url_to_apple,
+                appSettings?.app_stores_url_to_google,
                 close,
                 handleRateApp,
+                rateButtonColor,
+                rateButtonTextColor,
                 show,
-                theme.dark,
+                theme.card.background,
                 theme.drawerBg,
-                theme.primary,
+                theme.screen.icon,
+                theme.screen.iconBg,
                 theme.screen.text,
                 theme.sheet?.sheetBg,
                 translate,


### PR DESCRIPTION
## Summary
- hide the rate action when reviews are unavailable or already handled and use contrast-aware text coloring
- add platform store shortcut buttons with platform icons linking to configured app store pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392d3d25748330ae0d24c04229e75d)