### PR TITLE
Add reusable debug view component

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -30,6 +30,7 @@ import { ServerAPI } from '@/redux/actions';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import DebugView from '@/components/DebugView';
 
 enum BalanceStateLowerBound {
 	CONFIDENT = 10,
@@ -50,12 +51,20 @@ const AccountBalanceScreen = () => {
 	const [isNfcSupported, setIsNfcSupported] = useState(false);
 	const [isNfcEnabled, setIsNfcEnabled] = useState(false);
 	const [isActive, setIsActive] = useState(false);
-	const [autoPlay, setAutoPlay] = useState(appSettings?.animations_auto_start);
-	const animationRef = useRef<LottieView>(null);
+        const [autoPlay, setAutoPlay] = useState(appSettings?.animations_auto_start);
+        const animationRef = useRef<LottieView>(null);
         const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
         const [animationJson, setAmimationJson] = useState<any>(null);
         const [debugErrors, setDebugErrors] = useState<Array<{ timestamp: Date; error: string; source: string }>>([]);
         const { show: showModal, close: closeModal } = useMyScrollViewModal();
+
+        const debugLogMessages = useMemo(
+                () =>
+                        debugErrors.map(errorItem =>
+                                `${format(errorItem.timestamp, 'dd.MM.yyyy HH:mm:ss')} - ${errorItem.source}: ${errorItem.error}`
+                        ),
+                [debugErrors]
+        );
 
 	// Helper function to add errors to debug list
 	const addDebugError = useCallback((error: any, source: string) => {
@@ -70,9 +79,7 @@ const AccountBalanceScreen = () => {
 		]);
 	}, []);
 
-	console.log(profile)
-
-	useFocusEffect(
+        useFocusEffect(
 		useCallback(() => {
 			if (profile?.credit_balance) {
 				if (Number(profile?.credit_balance) >= BalanceStateLowerBound.CONFIDENT) {
@@ -348,71 +355,61 @@ const AccountBalanceScreen = () => {
 				</View>
 				<View style={styles.additionalInfoContainer}>{appSettings && appSettings?.balance_translations && <CustomMarkdown content={getTextFromTranslation(appSettings?.balance_translations, language) || ''} backgroundColor={balance_area_color} imageWidth={'100%'} imageHeight={400} />}</View>
 			</View>
-			<View style={styles.additionalInfoContainer}>
-				{/* Dev mode: Simulate NFC reads */}
-				{isDevMode && (
-					<View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 12 }}>
-						{[1, 5, 20].map(amount => (
-							<TouchableOpacity
-								key={`simulate-${amount}`}
-								style={{
-									paddingVertical: 8,
-									paddingHorizontal: 14,
-									borderRadius: 8,
-									borderWidth: 1,
-									borderColor: theme.screen.iconBg,
-									marginHorizontal: 6,
-								}}
-								onPress={async () => {
-									const mock: CardResponse = {
-										currentBalance: amount.toFixed(2),
-										currentBalanceRaw: null,
-										lastTransaction: undefined,
-										lastTransactionRaw: null,
-										chooseAppRaw: null,
-										tag: null,
-										readTime: new Date(),
-									};
-									try {
-										await callBack(mock);
-										toast(`Simulated NFC read: ${amount}€`, 'info');
-									} catch (e: any) {
-										console.error('Error in simulated read', e);
-										addDebugError(e, 'Simulated NFC Read');
-									}
-								}}
-							>
-								<Text style={{ color: theme.screen.text }}>{`Simulate ${amount}€`}</Text>
-							</TouchableOpacity>
-						))}
-					</View>
-				)}
-
-				{/* Debug Logs if isDevMode active*/}
-                                {isDevMode && debugErrors.length > 0 && (
-                                        <View style={{ marginTop: 20 }}>
-                                                <Text style={{ ...styles.label, color: theme.header.text }}>{translate(TranslationKeys.debugErrors)}:</Text>
-                                                {debugErrors.map((errorItem, index) => (
-                                                        <View key={index} style={{ marginVertical: 4 }}>
-								<Text style={{ ...styles.errorText, color: theme.header.text }}>{`${format(errorItem.timestamp, 'dd.MM.yyyy HH:mm:ss')} - ${errorItem.source}: ${errorItem.error}`}</Text>
-                                                        </View>
-                                                ))}
-                                        </View>
-                                )}
-                                {isDevMode && (
-                                        <View style={{ marginTop: 16 }}>
-                                                <TouchableOpacity
-                                                        style={{ ...styles.nfcButton, borderColor: theme.screen.iconBg }}
-                                                        onPress={showInstruction}
-                                                >
-                                                        <MaterialCommunityIcons name="cellphone-nfc" size={24} color={theme.screen.icon} />
-                                                        <Text style={{ ...styles.nfcLabel, color: theme.screen.text }}>
-                                                                {translate(TranslationKeys.showNfcInstruction)}
-                                                        </Text>
-                                                </TouchableOpacity>
-                                        </View>
-                                )}
-                        </View>
+			
+                        {isDevMode ? (
+                                <View style={styles.additionalInfoContainer}>
+                                        <DebugView
+                                                title={translate(TranslationKeys.debugErrors)}
+                                                logs={debugLogMessages}
+                                                actions={[
+                                                        {
+                                                                label: translate(TranslationKeys.showNfcInstruction),
+                                                                icon: 'cellphone-nfc',
+                                                                onPress: showInstruction,
+                                                                borderColor: theme.screen.iconBg,
+                                                                backgroundColor: theme.drawerBg,
+                                                        },
+                                                ]}
+                                        >
+                                                <View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 4 }}>
+                                                        {[1, 5, 20].map(amount => (
+                                                                <TouchableOpacity
+                                                                        key={`simulate-${amount}`}
+                                                                        style={{
+                                                                                paddingVertical: 8,
+                                                                                paddingHorizontal: 14,
+                                                                                borderRadius: 8,
+                                                                                borderWidth: 1,
+                                                                                borderColor: theme.screen.iconBg,
+                                                                                marginHorizontal: 6,
+                                                                                marginTop: 8,
+                                                                        }}
+                                                                        onPress={async () => {
+                                                                                const mock: CardResponse = {
+                                                                                        currentBalance: amount.toFixed(2),
+                                                                                        currentBalanceRaw: null,
+                                                                                        lastTransaction: undefined,
+                                                                                        lastTransactionRaw: null,
+                                                                                        chooseAppRaw: null,
+                                                                                        tag: null,
+                                                                                        readTime: new Date(),
+                                                                                };
+                                                                                try {
+                                                                                        await callBack(mock);
+                                                                                        toast(`Simulated NFC read: ${amount}€`, 'info');
+                                                                                } catch (e: any) {
+                                                                                        console.error('Error in simulated read', e);
+                                                                                        addDebugError(e, 'Simulated NFC Read');
+                                                                                }
+                                                                        }}
+                                                                >
+                                                                        <Text style={{ color: theme.screen.text }}>{`Simulate ${amount}€`}</Text>
+                                                                </TouchableOpacity>
+                                                        ))}
+                                                </View>
+                                        </DebugView>
+                                </View>
+                        ) : null}
                         <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_card_balance} />
                 </ScrollView>
         );

--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -23,139 +23,7 @@ import ModalComponent from '@/components/ModalSetting/ModalComponent';
 import MyMarkdown from '@/components/MyMarkdown';
 import { getCollectibleEventTranslation } from '@/helper/resourceHelper';
 import useRateAppModal from '@/hooks/useRateAppModal';
-
-type DebugSectionProps = {
-        activeCollectibleEvent: DatabaseTypes.CollectibleEvents;
-        theme: ReturnType<typeof useTheme>['theme'];
-        buttonColor: string;
-        resetCurrentCollectibles: () => void;
-        resetAllParticipations: () => void;
-        nextCollectibleKey?: CollectibleAt;
-        debugSpotLabel: string;
-        selectedLanguage?: string;
-        onOpenRateModal: () => void;
-};
-
-const getGroupPosition = (index: number, length: number) => {
-        if (length === 1) return 'single';
-        if (index === 0) return 'top';
-        if (index === length - 1) return 'bottom';
-        return 'middle';
-};
-
-const DebugSection: React.FC<DebugSectionProps> = ({
-        activeCollectibleEvent,
-        theme,
-        buttonColor,
-        resetCurrentCollectibles,
-        resetAllParticipations,
-        nextCollectibleKey,
-        debugSpotLabel,
-        selectedLanguage,
-        onOpenRateModal,
-}) => {
-        return (
-                <View style={{ marginTop: 16 }}>
-                        <Text style={{ ...styles.label, color: theme.screen.text, marginBottom: 8 }}>Debug</Text>
-                        <View style={{ marginTop: 12, gap: 8 }}>
-                                <TouchableOpacity
-                                        style={{
-                                                ...styles.button,
-                                                backgroundColor: buttonColor,
-                                                opacity: 0.9,
-                                        }}
-                                        onPress={resetCurrentCollectibles}
-                                >
-                                        <Text style={{ ...styles.buttonText, color: theme.dark }}>
-                                                Reset current event found collectible
-                                        </Text>
-                                </TouchableOpacity>
-
-                                <TouchableOpacity
-                                        style={{
-                                                ...styles.button,
-                                                backgroundColor: theme.warning,
-                                                opacity: 0.9,
-                                        }}
-                                        onPress={resetAllParticipations}
-                                >
-                                        <Text style={{ ...styles.buttonText, color: theme.dark }}>
-                                                Reset all event participations
-                                        </Text>
-                                </TouchableOpacity>
-
-                                <TouchableOpacity
-                                        style={{
-                                                ...styles.button,
-                                                backgroundColor: theme.drawerBg,
-                                                borderWidth: 1,
-                                                borderColor: theme.screen.icon,
-                                        }}
-                                        onPress={onOpenRateModal}
-                                >
-                                        <Text style={{ ...styles.buttonText, color: theme.screen.text }}>
-                                                Open rate prompt modal
-                                        </Text>
-                                </TouchableOpacity>
-                        </View>
-
-                        {nextCollectibleKey ? (
-                                <View style={{ marginTop: 12, gap: 8 }}>
-                                        <Text style={{ ...styles.label, color: theme.screen.text }}>{debugSpotLabel}</Text>
-                                        <CollectibleSpot collectibleKey={nextCollectibleKey} />
-                                </View>
-                        ) : null}
-
-                        {activeCollectibleEvent ? (
-                                <View style={{ marginTop: 12 }}>
-                                        <Text style={{ ...styles.info, color: theme.screen.text, marginBottom: 4 }}>
-                                                Event Details
-                                        </Text>
-                                        <SettingsList
-                                                key="event-id"
-                                                iconBgColor={theme.accent}
-                                                leftIcon={
-                                                        <MaterialCommunityIcons
-                                                                name="pound-box-outline"
-                                                                size={22}
-                                                                color={theme.screen.icon}
-                                                        />
-                                                }
-                                                label={`ID: ${activeCollectibleEvent.id}`}
-                                                groupPosition={getGroupPosition(0, 3) as any}
-                                        />
-                                        <SettingsList
-                                                key="event-alias"
-                                                iconBgColor={theme.accent}
-                                                leftIcon={
-                                                        <MaterialCommunityIcons
-                                                                name="label-outline"
-                                                                size={22}
-                                                                color={theme.screen.icon}
-                                                        />
-                                                }
-                                                label={`Alias: ${activeCollectibleEvent.alias || '-'}`}
-                                                groupPosition={getGroupPosition(1, 3) as any}
-                                        />
-
-                                        <SettingsList
-                                                key="language"
-                                                iconBgColor={theme.accent}
-                                                leftIcon={
-                                                        <MaterialCommunityIcons
-                                                                name="translate"
-                                                                size={22}
-                                                                color={theme.screen.icon}
-                                                        />
-                                                }
-                                                label={`Selected language: ${selectedLanguage || '-'}`}
-                                                groupPosition={getGroupPosition(2, 3) as any}
-                                        />
-                                </View>
-                        ) : null}
-                </View>
-        );
-};
+import DebugView from '@/components/DebugView';
 
 const CollectibleEventScreen = () => {
         useSetPageTitle(TranslationKeys.collectible_event);
@@ -599,42 +467,70 @@ const CollectibleEventScreen = () => {
                                 ) : null}
 
                                         {debugMode ? (
-                                                <DebugSection
-                                                        activeCollectibleEvent={activeCollectibleEvent}
-                                                        buttonColor={buttonColor}
-                                                        resetAllParticipations={resetAllParticipations}
-                                                        resetCurrentCollectibles={resetCurrentCollectibles}
-                                                        theme={theme}
-                                                        nextCollectibleKey={nextCollectibleKey}
-                                                        debugSpotLabel={translate(TranslationKeys.collectible_event_debug_spot)}
-                                                        selectedLanguage={languageForDirectusTranslation}
-                                                        onOpenRateModal={openRateAppModal}
-                                                />
-                                        ) : null}
-
-                                        {debugMode && debugLogs.length ? (
-                                                <View style={{ marginTop: 16 }}>
-                                                        <Text
-                                                                style={{
-                                                                        ...styles.label,
-                                                                        color: theme.screen.text,
-                                                                        marginBottom: 8,
-                                                                }}
-                                                        >
-                                                                Debug Logs
-                                                        </Text>
-                                                        <View style={{ gap: 6 }}>
-                                                                {debugLogs.map((log, index) => (
-                                                                        <Text
-                                                                                // eslint-disable-next-line react/no-array-index-key
-                                                                                key={`debug-log-${index}`}
-                                                                                style={{ color: theme.inactiveText }}
-                                                                        >
-                                                                                {log}
+                                                <DebugView
+                                                        title="Debug"
+                                                        logs={debugLogs}
+                                                        actions={[
+                                                                {
+                                                                        label: 'Reset current event found collectible',
+                                                                        onPress: resetCurrentCollectibles,
+                                                                        backgroundColor: buttonColor,
+                                                                        textColor: theme.dark,
+                                                                },
+                                                                {
+                                                                        label: 'Reset all event participations',
+                                                                        onPress: resetAllParticipations,
+                                                                        backgroundColor: theme.warning,
+                                                                        textColor: theme.dark,
+                                                                },
+                                                                {
+                                                                        label: 'Open rate prompt modal',
+                                                                        onPress: openRateAppModal,
+                                                                        backgroundColor: theme.drawerBg,
+                                                                        borderColor: theme.screen.iconBg,
+                                                                        textColor: theme.screen.text,
+                                                                },
+                                                        ]}
+                                                >
+                                                        {nextCollectibleKey ? (
+                                                                <View style={{ marginTop: 12 }}>
+                                                                        <Text style={{ ...styles.label, color: theme.screen.text }}>
+                                                                                {translate(TranslationKeys.collectible_event_debug_spot)}
                                                                         </Text>
-                                                                ))}
-                                                        </View>
-                                                </View>
+                                                                        <CollectibleSpot collectibleKey={nextCollectibleKey} />
+                                                                </View>
+                                                        ) : null}
+
+                                                        {activeCollectibleEvent ? (
+                                                                <View style={{ marginTop: 12 }}>
+                                                                        <Text style={{ ...styles.info, color: theme.screen.text, marginBottom: 4 }}>
+                                                                                Event Details
+                                                                        </Text>
+                                                                        <SettingsList
+                                                                                key="event-id"
+                                                                                iconBgColor={theme.accent}
+                                                                                leftIcon={<MaterialCommunityIcons name="pound-box-outline" size={22} color={theme.screen.icon} />}
+                                                                                label={`ID: ${activeCollectibleEvent.id}`}
+                                                                                groupPosition={getGroupPosition(0, 3) as any}
+                                                                        />
+                                                                        <SettingsList
+                                                                                key="event-alias"
+                                                                                iconBgColor={theme.accent}
+                                                                                leftIcon={<MaterialCommunityIcons name="label-outline" size={22} color={theme.screen.icon} />}
+                                                                                label={`Alias: ${activeCollectibleEvent.alias || '-'}`}
+                                                                                groupPosition={getGroupPosition(1, 3) as any}
+                                                                        />
+
+                                                                        <SettingsList
+                                                                                key="language"
+                                                                                iconBgColor={theme.accent}
+                                                                                leftIcon={<MaterialCommunityIcons name="translate" size={22} color={theme.screen.icon} />}
+                                                                                label={`Selected language: ${languageForDirectusTranslation || '-'}`}
+                                                                                groupPosition={getGroupPosition(2, 3) as any}
+                                                                        />
+                                                                </View>
+                                                        ) : null}
+                                                </DebugView>
                                         ) : null}
 
                                 {isLoading ? (

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -38,6 +38,7 @@ import { RootState } from '@/redux/reducer';
 import { ServerInfoHelper } from '@/helper/ServerInfoHelper';
 import { UserHelper } from '@/helper/UserHelper';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import DebugView from '@/components/DebugView';
 
 const Settings = () => {
 	useSetPageTitle(TranslationKeys.settings);
@@ -349,28 +350,42 @@ const Settings = () => {
 					</TouchableOpacity>
 					{isManagement && isDevMode && <Text style={{ ...styles.devModeText, color: theme.screen.text }}>{translate(TranslationKeys.developerModeActive)}</Text>}
                                         {isManagement && isDevMode && (
-                                                <View style={{ gap: 0 }}>
-                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={serverInfo?.info?.project?.project_name} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
-                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
-                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
-                                                        <SettingsList
-                                                                iconBgColor={primaryColor}
-                                                                leftIcon={<MaterialCommunityIcons name="bank-transfer" size={24} color={theme.screen.icon} />}
-                                                                label={translate(TranslationKeys.debug_mode)}
-                                                                value={debugMode ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
-                                                                rightElement={
-                                                                        <Switch
-                                                                                value={debugMode}
-                                                                                onValueChange={toggleDebugMode}
-                                                                                trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
-                                                                                thumbColor={theme.screen.icon}
-                                                                                ios_backgroundColor={theme.screen.iconBg}
-                                                                        />
-                                                                }
-                                                                handleFunction={toggleDebugMode}
-                                                                groupPosition="bottom"
-                                                        />
-                                                </View>
+                                                <DebugView
+                                                        title={translate(TranslationKeys.debug_mode)}
+                                                        logs={[
+                                                                `${translate(TranslationKeys.backend_server)}: ${
+                                                                        serverInfo?.info?.project?.project_name || '-'
+                                                                }`,
+                                                                `${translate(TranslationKeys.debug_mode)}: ${
+                                                                        debugMode
+                                                                                ? translate(TranslationKeys.checked)
+                                                                                : translate(TranslationKeys.unchecked)
+                                                                }`,
+                                                        ]}
+                                                >
+                                                        <View style={{ gap: 0 }}>
+                                                                <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={serverInfo?.info?.project?.project_name} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
+                                                                <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
+                                                                <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
+                                                                <SettingsList
+                                                                        iconBgColor={primaryColor}
+                                                                        leftIcon={<MaterialCommunityIcons name="bank-transfer" size={24} color={theme.screen.icon} />}
+                                                                        label={translate(TranslationKeys.debug_mode)}
+                                                                        value={debugMode ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
+                                                                        rightElement={
+                                                                                <Switch
+                                                                                        value={debugMode}
+                                                                                        onValueChange={toggleDebugMode}
+                                                                                        trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
+                                                                                        thumbColor={theme.screen.icon}
+                                                                                        ios_backgroundColor={theme.screen.iconBg}
+                                                                                />
+                                                                        }
+                                                                        handleFunction={toggleDebugMode}
+                                                                        groupPosition="bottom"
+                                                                />
+                                                        </View>
+                                                </DebugView>
                                         )}
                                         <SettingsList
                                                 iconBgColor={primaryColor}

--- a/apps/frontend/app/components/DebugView/index.tsx
+++ b/apps/frontend/app/components/DebugView/index.tsx
@@ -1,0 +1,127 @@
+import React, { ReactNode, useMemo } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+
+import { useTheme } from '@/hooks/useTheme';
+import styles from './styles';
+
+export type DebugLog = string | { message: string; timestamp?: string | Date };
+
+export type DebugAction = {
+        label: string;
+        onPress?: () => void;
+        icon?: keyof typeof MaterialCommunityIcons.glyphMap;
+        backgroundColor?: string;
+        borderColor?: string;
+        textColor?: string;
+        disabled?: boolean;
+};
+
+interface DebugViewProps {
+        title?: string;
+        logs?: DebugLog[];
+        actions?: DebugAction[];
+        isVisible?: boolean;
+        children?: ReactNode;
+}
+
+const DebugView: React.FC<DebugViewProps> = ({
+        title = 'Debug',
+        logs = [],
+        actions = [],
+        isVisible = true,
+        children,
+}) => {
+        const { theme } = useTheme();
+
+        const formattedLogs = useMemo(() => {
+                return logs
+                        ?.map(log => {
+                                if (typeof log === 'string') return log;
+
+                                const timestamp = log.timestamp
+                                        ? typeof log.timestamp === 'string'
+                                                ? log.timestamp
+                                                : log.timestamp.toLocaleString()
+                                        : null;
+
+                                return timestamp ? `${timestamp} - ${log.message}` : log.message;
+                        })
+                        .filter(Boolean);
+        }, [logs]);
+
+        if (!isVisible) return null;
+
+        return (
+                <View
+                        style={[
+                                styles.container,
+                                {
+                                        backgroundColor: theme.drawerBg,
+                                        borderColor: theme.screen.iconBg,
+                                },
+                        ]}
+                >
+                        <View style={styles.header}>
+                                <MaterialCommunityIcons name="bug-outline" size={18} color={theme.screen.icon} />
+                                <Text style={{ ...styles.title, color: theme.screen.text }}>{title}</Text>
+                        </View>
+
+                        {actions.length ? (
+                                <View style={styles.actionsContainer}>
+                                        {actions.map((action, index) => (
+                                                <TouchableOpacity
+                                                        key={`${action.label}-${index}`}
+                                                        onPress={action.onPress}
+                                                        disabled={action.disabled}
+                                                        style={[
+                                                                styles.actionButton,
+                                                                {
+                                                                        backgroundColor:
+                                                                                action.backgroundColor ?? theme.drawerHeading,
+                                                                        borderColor: action.borderColor ?? theme.screen.iconBg,
+                                                                        opacity: action.disabled ? 0.6 : 1,
+                                                                },
+                                                        ]}
+                                                >
+                                                        {action.icon ? (
+                                                                <MaterialCommunityIcons
+                                                                        name={action.icon}
+                                                                        size={18}
+                                                                        color={action.textColor ?? theme.screen.icon}
+                                                                        style={styles.actionIcon}
+                                                                />
+                                                        ) : null}
+                                                        <Text
+                                                                style={{
+                                                                        ...styles.actionLabel,
+                                                                        color: action.textColor ?? theme.screen.text,
+                                                                }}
+                                                        >
+                                                                {action.label}
+                                                        </Text>
+                                                </TouchableOpacity>
+                                        ))}
+                                </View>
+                        ) : null}
+
+                        {children}
+
+                        {formattedLogs?.length ? (
+                                <View style={styles.logsContainer}>
+                                        {formattedLogs.map((log, index) => (
+                                                <Text
+                                                        // eslint-disable-next-line react/no-array-index-key
+                                                        key={`${log}-${index}`}
+                                                        style={{ ...styles.logText, color: theme.inactiveText }}
+                                                >
+                                                        {log}
+                                                </Text>
+                                        ))}
+                                </View>
+                        ) : null}
+                </View>
+        );
+};
+
+export default DebugView;

--- a/apps/frontend/app/components/DebugView/styles.ts
+++ b/apps/frontend/app/components/DebugView/styles.ts
@@ -1,0 +1,54 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+        container: {
+                width: '100%',
+                borderWidth: 1,
+                borderRadius: 12,
+                padding: 12,
+                marginTop: 16,
+        },
+        header: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginBottom: 8,
+        },
+        title: {
+                fontSize: 16,
+                fontWeight: '600',
+                marginLeft: 8,
+        },
+        actionsContainer: {
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                marginTop: 4,
+                marginBottom: 8,
+        },
+        actionButton: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingVertical: 8,
+                paddingHorizontal: 12,
+                borderRadius: 10,
+                borderWidth: 1,
+                marginRight: 8,
+                marginTop: 8,
+        },
+        actionIcon: {
+                marginRight: 6,
+        },
+        actionLabel: {
+                fontSize: 14,
+                fontWeight: '500',
+        },
+        logsContainer: {
+                marginTop: 8,
+        },
+        logText: {
+                fontSize: 13,
+                fontFamily: 'monospace',
+                marginBottom: 4,
+        },
+});
+
+export default styles;


### PR DESCRIPTION
## Summary
- add shared DebugView component for displaying debug actions and logs
- integrate DebugView into account balance, collectible event, and settings screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69394dccaefc83309eb737091719a207)