### PR TITLE
Add guard to modal close to avoid redundant invocations

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -46,6 +46,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         };
 
         const close = () => {
+                if (!isVisible) return;
+
                 sheetRef.current?.close?.();
                 setBackgroundStyle(null);
                 setTimeout(() => {


### PR DESCRIPTION
## Summary
- add a visibility guard to the global modal close handler to avoid repeated close invocations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939500c1fd0833088bf590b1affad91)