### PR TITLE
Prevent account balance modal close loop

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -57,6 +57,7 @@ const AccountBalanceScreen = () => {
         const [animationJson, setAmimationJson] = useState<any>(null);
         const [debugErrors, setDebugErrors] = useState<Array<{ timestamp: Date; error: string; source: string }>>([]);
         const { show: showModal, close: closeModal } = useMyScrollViewModal();
+        const closeInstructionRef = useRef(closeModal);
 
         const debugLogMessages = useMemo(
                 () =>
@@ -210,9 +211,13 @@ const AccountBalanceScreen = () => {
                 );
         }, [isActive, showModal, theme.screen.text, theme.sheet.sheetBg, translate]);
 
-        const hideInstruction = useCallback(() => {
-                closeModal();
+        useEffect(() => {
+                closeInstructionRef.current = closeModal;
         }, [closeModal]);
+
+        const hideInstruction = useCallback(() => {
+                closeInstructionRef.current();
+        }, []);
 
 	const onReadNfcPress = async () => {
 		await myCardReader.readCard(callBack, showInstruction, hideInstruction, translate(TranslationKeys.nfcInstructionRead));
@@ -283,9 +288,9 @@ const AccountBalanceScreen = () => {
 
         useEffect(() => {
                 if (!isActive) {
-                        hideInstruction();
+                        closeInstructionRef.current();
                 }
-        }, [hideInstruction, isActive]);
+        }, [isActive]);
 
 	const renderLottie = useMemo(() => {
 		if (animationJson) {

--- a/apps/frontend/app/components/GlobalModal/useModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useModal.tsx
@@ -1,16 +1,19 @@
-import { ReactNode } from 'react';
+import { ReactNode, useCallback } from 'react';
 import { useModalContext } from './ModalProvider';
 
 export const useModal = () => {
         const { open, close, debug } = useModalContext();
 
-        const show = (content: ReactNode, options?: { backgroundStyle?: any }) => {
-                open(content, options);
-        };
+        const show = useCallback(
+                (content: ReactNode, options?: { backgroundStyle?: any }) => {
+                        open(content, options);
+                },
+                [open]
+        );
 
-        const closeModal = () => {
+        const closeModal = useCallback(() => {
                 close();
-        };
+        }, [close]);
 
         return { show, close: closeModal, debug };
 };


### PR DESCRIPTION
## Summary
- keep the account balance modal close handler in a ref so dependency changes do not retrigger closes
- only close the instruction modal on focus loss rather than whenever the close callback identity changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693953804f9c8330b36d0cbf8ce60637)