### PR TITLE
Ensure rate app modal opens after completing collectibles

### DIFF
--- a/apps/frontend/app/components/CollectibleItem/index.tsx
+++ b/apps/frontend/app/components/CollectibleItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 import { DatabaseTypes, COLLECTABLE_AT_FIELDS } from 'repo-depkit-common';
 import { useSelector } from 'react-redux';
@@ -41,6 +41,8 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
         const { openRateAppModal } = useRateAppModal(projectColor || theme.primary);
 
         const { collectibleDict, setCollectibleKey, collectedCount } = useCollectibleDict(activeCollectibleEvent?.id);
+        const collectedCountRef = useRef(collectedCount);
+        const hasCompletedCollectionRef = useRef(false);
         const participantsHelper = useMemo(() => new CollectibleEventParticipantsHelper(), []);
 
         const maxCollectibleKeys = useMemo(
@@ -63,6 +65,24 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
                 return null;
         }
 
+        useEffect(() => {
+                if (!maxCollectibleKeys) return;
+
+                const hasCompletedCollection =
+                        collectedCount === maxCollectibleKeys && collectedCountRef.current < maxCollectibleKeys;
+
+                if (hasCompletedCollection && !hasCompletedCollectionRef.current) {
+                        hasCompletedCollectionRef.current = true;
+                        openRateAppModal();
+                }
+
+                if (collectedCount < maxCollectibleKeys) {
+                        hasCompletedCollectionRef.current = false;
+                }
+
+                collectedCountRef.current = collectedCount;
+        }, [collectedCount, maxCollectibleKeys, openRateAppModal]);
+
         const handleCollect = async () => {
                 if (!activeCollectibleEvent?.id || isCollected) {
                         return;
@@ -79,10 +99,6 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
                         `${translate(TranslationKeys.collectible_event_collected)} ${updatedCount}/${maxCollectibleKeys || '∞'}`,
                         'success'
                 );
-
-                if (maxCollectibleKeys > 0 && updatedCount === maxCollectibleKeys) {
-                        openRateAppModal();
-                }
 
                 if (!loggedIn || !profile?.id) {
                         return;


### PR DESCRIPTION
## Summary
- add completion tracking for collectibles to trigger the rate app modal when the final item is collected
- prevent duplicate prompts by remembering prior completion state and resetting when progress drops

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939732b9d2c8330a3411a5ad69b594a)