### PR TITLE
Refactor management screen layout

### DIFF
--- a/apps/frontend/app/app/(app)/management/index.tsx
+++ b/apps/frontend/app/app/(app)/management/index.tsx
@@ -1,166 +1,158 @@
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import React from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
-import { Entypo, FontAwesome, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { FontAwesome, Ionicons, MaterialCommunityIcons, Octicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useDispatch } from 'react-redux';
 import { SET_DAY_PLAN, SET_FOOD_PLAN, SET_WEEK_PLAN } from '@/redux/Types/types';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
+import SettingsGroupTitle from '@/components/SettingsGroupTitle';
+import SettingsList from '@/components/SettingsList';
 
 const Index = () => {
 	useSetPageTitle(TranslationKeys.role_management);
 	const { translate } = useLanguage();
-	const { theme } = useTheme();
-	const dispatch = useDispatch();
+        const { theme } = useTheme();
+        const dispatch = useDispatch();
 
-	return (
-		<ScrollView
+        return (
+                <ScrollView
 			style={{
 				...styles.container,
 				backgroundColor: theme.screen.background,
 			}}
 			contentContainerStyle={{
-				...styles.contentContainer,
-				backgroundColor: theme.screen.background,
-			}}
-		>
+                                ...styles.contentContainer,
+                                backgroundColor: theme.screen.background,
+                        }}
+                >
                         <View style={{ ...styles.content }}>
-                                <Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.meal_guidance_system)}</Text>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                dispatch({
-                                                        type: SET_WEEK_PLAN,
-                                                        payload: {
-                                                                selectedCanteen: {},
-                                                                isAllergene: true,
-                                                        },
-                                                });
-                                                router.navigate('/foodPlanWeek');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <MaterialCommunityIcons name="calendar" color={theme.screen.icon} size={24} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.foodweekplan)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                dispatch({
-                                                        type: SET_DAY_PLAN,
-                                                        payload: {
-                                                                selectedCanteen: {},
-                                                                mealOfferCategory: '',
-                                                                isMenuCategory: true,
-                                                                nextFoodInterval: 10,
-                                                                refreshInterval: 300,
-                                                                isFullScreen: true,
-                                                                foodCategory: '',
-                                                                isMenuCategoryName: true,
-                                                        },
-                                                });
-                                                router.navigate('/foodPlanDay');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <MaterialCommunityIcons name="folder-image" color={theme.screen.icon} size={24} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.foodBigScreen)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                dispatch({
-                                                        type: SET_FOOD_PLAN,
-                                                        payload: {
-                                                                selectedCanteen: {},
-                                                                additionalSelectedCanteen: {},
-                                                                nextFoodInterval: 10,
-                                                                refreshInterval: 300,
-                                                        },
-                                                });
-                                                router.navigate('/foodPlanList');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <MaterialCommunityIcons name="view-list" color={theme.screen.icon} size={24} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.monitorDayPlan)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                router.navigate('/labels');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <Ionicons name="bag-add" size={24} color={theme.screen.icon} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.markings)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.forms)}</Text>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                router.navigate('/form-categories');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <FontAwesome name="list-alt" color={theme.screen.icon} size={22} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.form_categories)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.event_monitors)}</Text>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                router.navigate('/collectible-event-monitor');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <MaterialCommunityIcons name="trophy" color={theme.screen.icon} size={24} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.collectible_event_monitor)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.rss_feed)}</Text>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                router.navigate('/rss-feed-config');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <FontAwesome name="rss-square" color={theme.screen.icon} size={22} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.rss_feed)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
-                                <Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.statistiken)}</Text>
-                                <TouchableOpacity
-                                        style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }}
-                                        onPress={() => {
-                                                router.navigate('/statistics');
-                                        }}
-                                >
-                                        <View style={styles.col}>
-                                                <MaterialCommunityIcons name="calendar" color={theme.screen.icon} size={24} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.test_statistik)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
+                                <SettingsGroupTitle>{translate(TranslationKeys.meal_guidance_system)}</SettingsGroupTitle>
+                                <View style={styles.groupContainer}>
+                                        <SettingsList
+                                                leftIcon={<MaterialCommunityIcons name="calendar" size={24} />}
+                                                label={translate(TranslationKeys.foodweekplan)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        dispatch({
+                                                                type: SET_WEEK_PLAN,
+                                                                payload: {
+                                                                        selectedCanteen: {},
+                                                                        isAllergene: true,
+                                                                },
+                                                        });
+                                                        router.navigate('/foodPlanWeek');
+                                                }}
+                                                groupPosition="top"
+                                        />
+                                        <SettingsList
+                                                leftIcon={<MaterialCommunityIcons name="folder-image" size={24} />}
+                                                label={translate(TranslationKeys.foodBigScreen)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        dispatch({
+                                                                type: SET_DAY_PLAN,
+                                                                payload: {
+                                                                        selectedCanteen: {},
+                                                                        mealOfferCategory: '',
+                                                                        isMenuCategory: true,
+                                                                        nextFoodInterval: 10,
+                                                                        refreshInterval: 300,
+                                                                        isFullScreen: true,
+                                                                        foodCategory: '',
+                                                                        isMenuCategoryName: true,
+                                                                },
+                                                        });
+                                                        router.navigate('/foodPlanDay');
+                                                }}
+                                                groupPosition="middle"
+                                        />
+                                        <SettingsList
+                                                leftIcon={<MaterialCommunityIcons name="view-list" size={24} />}
+                                                label={translate(TranslationKeys.monitorDayPlan)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        dispatch({
+                                                                type: SET_FOOD_PLAN,
+                                                                payload: {
+                                                                        selectedCanteen: {},
+                                                                        additionalSelectedCanteen: {},
+                                                                        nextFoodInterval: 10,
+                                                                        refreshInterval: 300,
+                                                                },
+                                                        });
+                                                        router.navigate('/foodPlanList');
+                                                }}
+                                                groupPosition="middle"
+                                        />
+                                        <SettingsList
+                                                leftIcon={<Ionicons name="bag-add" size={24} />}
+                                                label={translate(TranslationKeys.markings)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        router.navigate('/labels');
+                                                }}
+                                                groupPosition="bottom"
+                                        />
+                                </View>
+
+                                <SettingsGroupTitle>{translate(TranslationKeys.forms)}</SettingsGroupTitle>
+                                <View style={styles.groupContainer}>
+                                        <SettingsList
+                                                leftIcon={<FontAwesome name="list-alt" size={22} />}
+                                                label={translate(TranslationKeys.form_categories)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        router.navigate('/form-categories');
+                                                }}
+                                                groupPosition="single"
+                                        />
+                                </View>
+
+                                <SettingsGroupTitle>{translate(TranslationKeys.event_monitors)}</SettingsGroupTitle>
+                                <View style={styles.groupContainer}>
+                                        <SettingsList
+                                                leftIcon={<MaterialCommunityIcons name="trophy" size={24} />}
+                                                label={translate(TranslationKeys.collectible_event_monitor)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        router.navigate('/collectible-event-monitor');
+                                                }}
+                                                groupPosition="single"
+                                        />
+                                </View>
+
+                                <SettingsGroupTitle>{translate(TranslationKeys.rss_feed)}</SettingsGroupTitle>
+                                <View style={styles.groupContainer}>
+                                        <SettingsList
+                                                leftIcon={<FontAwesome name="rss-square" size={22} />}
+                                                label={translate(TranslationKeys.rss_feed)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        router.navigate('/rss-feed-config');
+                                                }}
+                                                groupPosition="single"
+                                        />
+                                </View>
+
+                                <SettingsGroupTitle>{translate(TranslationKeys.statistiken)}</SettingsGroupTitle>
+                                <View style={styles.groupContainer}>
+                                        <SettingsList
+                                                leftIcon={<MaterialCommunityIcons name="calendar" size={24} />}
+                                                label={translate(TranslationKeys.test_statistik)}
+                                                rightIcon={<Octicons name="chevron-right" size={24} />}
+                                                onPress={() => {
+                                                        router.navigate('/statistics');
+                                                }}
+                                                groupPosition="single"
+                                        />
+                                </View>
                         </View>
-		</ScrollView>
-	);
+                </ScrollView>
+        );
 };
 
 export default Index;

--- a/apps/frontend/app/app/(app)/management/styles.ts
+++ b/apps/frontend/app/app/(app)/management/styles.ts
@@ -1,40 +1,16 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	container: {
-		flex: 1,
-	},
-	contentContainer: {
-		// flex: 1,
-	},
-	content: {
-		width: '100%',
-		height: '100%',
-		padding: 20,
-	},
-	heading: {
-		fontSize: 24,
-		fontFamily: 'Poppins_700Bold',
-		marginVertical: 10,
-	},
-	listItem: {
-		width: '100%',
-		flexDirection: 'row',
-		alignItems: 'center',
-		justifyContent: 'space-between',
-		borderRadius: 10,
-		padding: 10,
-		marginVertical: 10,
-	},
-	col: {
-		maxWidth: '70%',
-		flexDirection: 'row',
-		alignItems: 'center',
-		gap: 10,
-	},
-	body: {
-		fontSize: 16,
-		fontFamily: 'Poppins_400Regular',
-	},
-	dummy: {},
+        container: {
+                flex: 1,
+        },
+        contentContainer: {
+        },
+        content: {
+                width: '100%',
+                padding: 20,
+        },
+        groupContainer: {
+                gap: 0,
+        },
 });


### PR DESCRIPTION
## Summary
- restructure the management screen to use SettingsList rows with grouped sections similar to the settings screen
- update styling to support grouped settings presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a57a55c48330a6d804231918186c)