### PR TITLE
Fix collectible event monitor hook import

### DIFF
--- a/apps/frontend/app/app/(monitor)/collectible-event-monitor/index.tsx
+++ b/apps/frontend/app/app/(monitor)/collectible-event-monitor/index.tsx
@@ -4,7 +4,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { TranslationKeys } from '@/locales/keys';
-import { useActiveCollectibleEvent } from '@/hooks/useActiveCollectibleEvent';
+import useActiveCollectibleEvent from '@/hooks/useActiveCollectibleEvent';
 import { useLanguage } from '@/hooks/useLanguage';
 
 const CollectibleEventMonitor = () => {


### PR DESCRIPTION
## Summary
- switch collectible event monitor to use the default active collectible event hook export

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a765db34833086be062b69dd650e)