### PR TITLE
Format collectible hint labels

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -40,6 +40,14 @@ const getGroupPosition = (index: number, length: number) => {
         return 'middle';
 };
 
+const formatCollectibleLabel = (key: string) =>
+        key
+                .replace(/^collectible_at_/, '')
+                .split('_')
+                .filter(Boolean)
+                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                .join(' ');
+
 const DebugSection: React.FC<DebugSectionProps> = ({
                                                            activeCollectibleEvent,
                                                            theme,
@@ -481,7 +489,7 @@ const CollectibleEventScreen = () => {
 
                                                         const iconBgColor = isCollected ? '#2DBE62' : '#F7D21F';
                                                         const labelText = isHintVisible
-                                                            ? key
+                                                            ? formatCollectibleLabel(key)
                                                             : translate(TranslationKeys.collectible_event_show_hint);
 
                                                         return (


### PR DESCRIPTION
## Summary
- format collectible hint labels by removing the `collectible_at_` prefix, replacing underscores with spaces, and capitalizing words
- apply the formatted label when showing hints on the collectible event screen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c4ec0c50833089171e24827bc197)