### PR TITLE
Refine collectible event points display

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -175,7 +175,6 @@ const CollectibleEventScreen = () => {
             [activeCollectibleEvent]
         );
 
-        const [points, setPoints] = useState('');
         const [email, setEmail] = useState('');
         const [phoneNumber, setPhoneNumber] = useState('');
         const [isLoading, setIsLoading] = useState(false);
@@ -212,7 +211,6 @@ const CollectibleEventScreen = () => {
         const loadParticipation = useCallback(async () => {
                 if (!activeCollectibleEvent?.id || !profile?.id) {
                         setParticipation(null);
-                        setPoints('');
                         setEmail('');
                         setPhoneNumber('');
                         return;
@@ -227,12 +225,10 @@ const CollectibleEventScreen = () => {
                         );
                         if (existing) {
                                 setParticipation(existing);
-                                setPoints(existing.points ? String(existing.points) : '');
                                 setEmail(existing.email ?? '');
                                 setPhoneNumber(existing.phone_number ?? '');
                         } else {
                                 setParticipation(null);
-                                setPoints('');
                                 setEmail('');
                                 setPhoneNumber('');
                         }
@@ -252,13 +248,6 @@ const CollectibleEventScreen = () => {
         useEffect(() => {
                 setVisibleHints({});
         }, [activeCollectibleEvent?.id]);
-
-        useEffect(() => {
-                const newValue = String(collectedCount);
-                if (newValue !== points) {
-                        setPoints(newValue);
-                }
-        }, [collectedCount, points]);
 
         const handleSave = async () => {
                 if (!activeCollectibleEvent?.id) {
@@ -289,7 +278,6 @@ const CollectibleEventScreen = () => {
                             : await participantsHelper.createItem(payload);
 
                         setParticipation(updated as DatabaseTypes.CollectibleEventParticipants);
-                        setPoints((updated as DatabaseTypes.CollectibleEventParticipants)?.points || pointsToSave);
                         setEmail((updated as DatabaseTypes.CollectibleEventParticipants)?.email || email);
                         setPhoneNumber((updated as DatabaseTypes.CollectibleEventParticipants)?.phone_number || phoneNumber);
                         toast(translate(TranslationKeys.collectible_event_save_success), 'success');
@@ -308,7 +296,6 @@ const CollectibleEventScreen = () => {
                 }
 
                 dispatch({ type: RESET_COLLECTIBLE_EVENT_DICT, payload: { eventId: activeCollectibleEvent.id } });
-                setPoints('0');
                 toast(translate(TranslationKeys.reset), 'success');
 
                 if (loggedIn && profile?.id) {
@@ -335,7 +322,6 @@ const CollectibleEventScreen = () => {
         const resetAllParticipations = useCallback(async () => {
                 dispatch({ type: RESET_ALL_COLLECTIBLE_EVENT_DICTS });
                 setParticipation(null);
-                setPoints('');
                 setEmail('');
                 setPhoneNumber('');
 
@@ -374,32 +360,19 @@ const CollectibleEventScreen = () => {
                                     </Text>
                             </View>
 
-                            <DebugView>
-                                    <View style={{ marginTop: 16, gap: 12 }}>
-                                            <SettingsList
-                                                leftIcon={<MaterialCommunityIcons name="counter" size={22} color={theme.screen.icon} />}
-                                                label={translate(TranslationKeys.collectible_event_points)}
-                                                groupPosition="single"
-                                                showSeparator={false}
-                                                rightElement={
-                                                        <TextInput
-                                                            style={{
-                                                                    ...styles.settingsInput,
-                                                                    color: theme.screen.text,
-                                                                    backgroundColor: theme.drawerBg,
-                                                                    borderColor: theme.screen.icon,
-                                                            }}
-                                                            value={points}
-                                                            onChangeText={setPoints}
-                                                            placeholder={translate(TranslationKeys.enter_number)}
-                                                            placeholderTextColor={theme.screen.placeholder}
-                                                            keyboardType="numeric"
-                                                            inputMode="numeric"
-                                                        />
-                                                }
-                                            />
-                                    </View>
-                            </DebugView>
+                            <View style={{ marginTop: 16, gap: 12 }}>
+                                    <SettingsList
+                                        leftIcon={<MaterialCommunityIcons name="counter" size={22} color={theme.screen.icon} />}
+                                        label={translate(TranslationKeys.collectible_event_points)}
+                                        groupPosition="single"
+                                        showSeparator={false}
+                                        rightElement={
+                                                <Text style={{ color: theme.screen.text }}>
+                                                        {collectedCount}/{maxCollectibleKeys || '∞'}
+                                                </Text>
+                                        }
+                                    />
+                            </View>
 
                             <View style={{ marginTop: 16 }}>
                                     <Text style={{ ...styles.label, color: theme.screen.text }}>


### PR DESCRIPTION
## Summary
- remove the debug-only wrapper around the collectible event points row and show the current progress inline
- simplify collectible participation handling by removing the manual points input

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c57b86d483309053436f7caf63f3)