### PR TITLE
Add detailed error info to collectible participation toasts

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -338,7 +338,15 @@ const CollectibleEventScreen = () => {
                 } catch (error) {
                         console.error('Error saving collectible event participation:', error);
                         appendDebugLog(`Failed to save participation: ${String(error)}`);
-                        toast(translate(TranslationKeys.collectible_event_save_error), 'error');
+                        const errorDetails = (() => {
+                                try {
+                                        return JSON.stringify(error, null, 2);
+                                } catch (jsonError) {
+                                        console.error('Failed to stringify error:', jsonError);
+                                        return String(error);
+                                }
+                        })();
+                        toast(`${translate(TranslationKeys.collectible_event_save_error)}\n${errorDetails}`, 'error');
                 } finally {
                         setIsSaving(false);
                 }

--- a/apps/frontend/app/components/CollectibleItem/index.tsx
+++ b/apps/frontend/app/components/CollectibleItem/index.tsx
@@ -112,7 +112,15 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
                         }
                 } catch (error) {
                         console.error('Error saving collectible event participation:', error);
-                        toast(translate(TranslationKeys.collectible_event_save_error), 'error');
+                        const errorDetails = (() => {
+                                try {
+                                        return JSON.stringify(error, null, 2);
+                                } catch (jsonError) {
+                                        console.error('Failed to stringify error:', jsonError);
+                                        return String(error);
+                                }
+                        })();
+                        toast(`${translate(TranslationKeys.collectible_event_save_error)}\n${errorDetails}`, 'error');
                 } finally {
                         setIsSaving(false);
                 }


### PR DESCRIPTION
## Summary
- include JSON-formatted error details in collectible participation save toasts
- log stringify failures while keeping existing debug logging

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939db4c07888330b1b4aee88f064021)