### PR TITLE
Limit collectible participant update payloads

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -317,19 +317,23 @@ const CollectibleEventScreen = () => {
 
                 setIsSaving(true);
                 try {
-                        const payload: Partial<DatabaseTypes.CollectibleEventParticipants> = {
-                                points: pointsToSave,
-                                email: email?.trim() || null,
-                                phone_number: phoneNumber?.trim() || null,
-                                data: collectibleDict,
-                                profile: profile.id,
-                                collectible_event: activeCollectibleEvent.id,
-                                status: 'published',
-                        };
+                const updatePayload: Partial<DatabaseTypes.CollectibleEventParticipants> = {
+                        points: pointsToSave,
+                        email: email?.trim() || null,
+                        phone_number: phoneNumber?.trim() || null,
+                        data: collectibleDict,
+                };
 
-                        const updated = participation?.id
-                            ? await participantsHelper.updateItem(participation.id, payload)
-                            : await participantsHelper.createItem(payload);
+                const createPayload: Partial<DatabaseTypes.CollectibleEventParticipants> = {
+                        ...updatePayload,
+                        profile: profile.id,
+                        collectible_event: activeCollectibleEvent.id,
+                        status: 'published',
+                };
+
+                const updated = participation?.id
+                    ? await participantsHelper.updateItem(participation.id, updatePayload)
+                    : await participantsHelper.createItem(createPayload);
 
                         setParticipation(updated as DatabaseTypes.CollectibleEventParticipants);
                         setEmail((updated as DatabaseTypes.CollectibleEventParticipants)?.email || email);

--- a/apps/frontend/app/components/CollectibleItem/index.tsx
+++ b/apps/frontend/app/components/CollectibleItem/index.tsx
@@ -92,13 +92,17 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
 
                 setIsSaving(true);
                 try {
-                        const payload: Partial<DatabaseTypes.CollectibleEventParticipants> = {
-                                points: String(updatedCount),
-                                data: updatedData,
-                                profile: profile.id,
-                                collectible_event: activeCollectibleEvent.id,
-                                status: 'published',
-                        };
+                const updatePayload: Partial<DatabaseTypes.CollectibleEventParticipants> = {
+                        points: String(updatedCount),
+                        data: updatedData,
+                };
+
+                const createPayload: Partial<DatabaseTypes.CollectibleEventParticipants> = {
+                        ...updatePayload,
+                        profile: profile.id,
+                        collectible_event: activeCollectibleEvent.id,
+                        status: 'published',
+                };
 
                         const existing = await participantsHelper.fetchParticipationByProfileAndEvent(
                                 profile.id,
@@ -106,9 +110,9 @@ const CollectibleItem: React.FC<CollectibleItemProps> = ({
                                 { fields: ['id'] }
                         );
                         if (existing?.id) {
-                                await participantsHelper.updateItem(existing.id, payload);
+                                await participantsHelper.updateItem(existing.id, updatePayload);
                         } else {
-                                await participantsHelper.createItem(payload);
+                                await participantsHelper.createItem(createPayload);
                         }
                 } catch (error) {
                         console.error('Error saving collectible event participation:', error);


### PR DESCRIPTION
## Summary
- update collectible event save logic to only send data, points, email, and phone number when updating existing participations
- keep create payloads while avoiding forbidden fields during participant updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939df2e2d708330848e3e5dddec33f4)