### PR TITLE
Avoid redundant collectible payload updates

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -219,21 +219,35 @@ const CollectibleEventScreen = () => {
                                 parsedData = rawData as Record<string, boolean>;
                         }
 
+                        const existingData = collectibleDict || {};
                         const mergedData: Record<string, boolean> = { ...parsedData };
 
-                        Object.entries(collectibleDict || {}).forEach(([key, value]) => {
+                        Object.entries(existingData).forEach(([key, value]) => {
                                 if (value) {
                                         mergedData[key] = true;
                                 }
                         });
 
-                        dispatch({
-                                type: SET_COLLECTIBLE_EVENT_DICT_BULK,
-                                payload: { eventId: activeCollectibleEvent.id, data: mergedData },
-                        });
+                        const hasChanges = (() => {
+                                const allKeys = new Set([...Object.keys(existingData), ...Object.keys(mergedData)]);
+                                for (const key of allKeys) {
+                                        if (Boolean(existingData[key]) !== Boolean(mergedData[key])) {
+                                                return true;
+                                        }
+                                }
 
-                        if (Object.keys(parsedData || {}).length) {
-                                appendDebugLog('Applied collectible data from server');
+                                return false;
+                        })();
+
+                        if (hasChanges) {
+                                dispatch({
+                                        type: SET_COLLECTIBLE_EVENT_DICT_BULK,
+                                        payload: { eventId: activeCollectibleEvent.id, data: mergedData },
+                                });
+
+                                if (Object.keys(parsedData || {}).length) {
+                                        appendDebugLog('Applied collectible data from server');
+                                }
                         }
                 },
                 [activeCollectibleEvent?.id, appendDebugLog, collectibleDict, dispatch]


### PR DESCRIPTION
## Summary
- remove ref-based tracking for collectible event participations
- compare incoming collectible payloads with current state before dispatching updates to avoid needless writes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e9f0d5a88330900a40f731623a12)