### PR TITLE
Use value prop for collectible event points

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -446,11 +446,7 @@ const CollectibleEventScreen = () => {
                                         label={translate(TranslationKeys.collectible_event_points)}
                                         groupPosition="single"
                                         showSeparator={false}
-                                        rightElement={
-                                                <Text style={{ color: theme.screen.text }}>
-                                                        {collectedCount}/{maxCollectibleKeys || '∞'}
-                                                </Text>
-                                        }
+                                        value={`${collectedCount}/${maxCollectibleKeys || '∞'}`}
                                     />
                             </View>
 


### PR DESCRIPTION
## Summary
- use the SettingsList value prop to display collectible event point totals
- align the collectible event points row with other settings rows

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f98d69d4833087464368090cba38)