### PR TITLE
Move calendar collectible spot below calendar title

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -65,7 +65,6 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
                     marginTop: isWeb ? 40 : 20,
                 }}
             >
-                <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_select_date} />
                 <Calendar
                     key={currentMonth.toISOString()}
                     style={styles.calendar}
@@ -128,6 +127,7 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
                         textDayHeaderFontSize: 14,
                     }}
                 />
+                <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_select_date} />
             </View>
         </MyScrollViewModal>
     );


### PR DESCRIPTION
## Summary
- move the collectible spot display to below the calendar component so it no longer aligns with the calendar title

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a079257ac8330b97cd2b580256f0d)