### PR TITLE
Fix calendar modal height

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/styles.ts
+++ b/apps/frontend/app/components/CalendarSheet/styles.ts
@@ -32,11 +32,10 @@ export default StyleSheet.create({
 		justifyContent: 'center',
 		borderRadius: 12,
 	},
-	calendar: {
-		width: '100%',
-		height: '100%',
-		borderRadius: 12,
-	},
+        calendar: {
+                width: '100%',
+                borderRadius: 12,
+        },
 	customHeader: {
 		flexDirection: 'row',
 		justifyContent: 'space-between',


### PR DESCRIPTION
## Summary
- remove forced full height on calendar to prevent oversized modal content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a68a96700833095f01281c05aa616)