### PR TITLE
Treat undefined form boolean values as false

### DIFF
--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -91,14 +91,15 @@ const normalizeExpectedValue = (value: unknown): string => {
 };
 
 const normalizeCurrentValue = (value: unknown, customType?: string): string => {
-	if (value === null || value === undefined) return '';
+        if (customType === 'value_boolean') {
+                if (value === null || value === undefined) return 'false';
+                if (value === 1 || value === true) return 'true';
+                if (value === 0 || value === false) return 'false';
 
-	if (customType === 'value_boolean') {
-		if (value === 1 || value === true) return 'true';
-		if (value === 0 || value === false) return 'false';
+                return 'null';
+        }
 
-		return 'null';
-	}
+        if (value === null || value === undefined) return '';
 
 	if (typeof value === 'string') return value.trim().toLowerCase();
 	if (typeof value === 'number') return String(value);


### PR DESCRIPTION
## Summary
- handle undefined boolean form values as false when normalizing current values
- ensure conditional form fields evaluate visibility dependencies consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1e60f68083308ee26ce11135f7a3)