### PR TITLE
Revert modal header background color changes

### DIFF
--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -14,7 +14,7 @@ export const useMyScrollViewModal = () => {
 
                 const mergedOptions = {
                         ...options,
-                        backgroundStyle: { backgroundColor: theme.sheet.sheetBg, ...options?.backgroundStyle },
+                        backgroundStyle: { backgroundColor: theme.screen.background, ...options?.backgroundStyle },
                 };
 
                 showModal(

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -43,7 +43,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
     <>
       {title && (
         <View
-          style={{ backgroundColor: theme.sheet.sheetBg, paddingHorizontal: 20, paddingTop: 8, paddingBottom: 8 }}
+          style={{ backgroundColor: theme.screen.background, paddingHorizontal: 20, paddingTop: 8, paddingBottom: 8 }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.sheet.text }}>{title}</Text>
         </View>
@@ -57,7 +57,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const contentStyle = { paddingBottom: 24 + insets.bottom + 80, paddingHorizontal: 20 };
   const scrollInsets = { bottom: insets.bottom + 80 };
 
-  const containerStyle = { backgroundColor: theme.sheet.sheetBg };
+  const containerStyle = { backgroundColor: theme.screen.background };
 
   if (useFlatList && renderItem && keyExtractor) {
     return (


### PR DESCRIPTION
## Summary
- revert the modal background color changes introduced in #961
- restore modal and scroll view styling to the previous theme values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4f78a9948330932170bb960be291)