### PR TITLE
Ensure MyScrollViewModal header uses screen background

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -8,10 +8,11 @@ import type { RootState } from '@/redux/reducer';
 import styles from './styles';
 
 export interface BaseBottomSheetProps extends Omit<BottomSheetProps, 'backdropComponent'> {
-	onClose?: () => void;
+        onClose?: () => void;
+        headerBackgroundColor?: string;
 }
 
-const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose, children, backgroundStyle, onChange, ...props }, ref) => {
+const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose, children, backgroundStyle, onChange, headerBackgroundColor, ...props }, ref) => {
         const renderBackdrop = useCallback((backdropProps: BottomSheetBackdropProps) => <BottomSheetBackdrop {...backdropProps} appearsOnIndex={0} disappearsOnIndex={-1} onPress={onClose} />, [onClose]);
         const { theme } = useTheme();
         useSelector((state: RootState) => state.settings); // ensure theme subscription
@@ -19,7 +20,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 
         const effectiveBackgroundStyle = useMemo(() => ({ backgroundColor: theme.sheet.sheetBg, ...backgroundStyle }), [backgroundStyle, theme.sheet.sheetBg]);
 
-        const headerBg = (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
+        const headerBg = headerBackgroundColor || (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
         const handleColor = theme.sheet.closeBg;
 
 	const handleChange = useCallback(

--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -2,8 +2,13 @@ import React, { createContext, useContext, useState, ReactNode, useRef, useEffec
 import { StyleSheet, View } from 'react-native';
 import BaseBottomSheet from '@/components/BaseBottomSheet/BaseBottomSheet';
 
+type ModalOptions = {
+        backgroundStyle?: any;
+        headerBackgroundColor?: string;
+};
+
 type ModalContextType = {
-        open: (content: ReactNode, options?: { backgroundStyle?: any }) => void;
+        open: (content: ReactNode, options?: ModalOptions) => void;
         close: () => void;
         debug: {
                 lastAction: 'open' | 'close' | null;
@@ -20,6 +25,7 @@ const ModalContext = createContext<ModalContextType | null>(null);
 export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
         const [content, setContent] = useState<ReactNode | null>(null);
         const [backgroundStyle, setBackgroundStyle] = useState<any>(null);
+        const [headerBackgroundColor, setHeaderBackgroundColor] = useState<string | undefined>(undefined);
         const sheetRef = useRef<any>(null);
         const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({
@@ -40,11 +46,12 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 }
         };
 
-        const open = (c: ReactNode, options?: { backgroundStyle?: any }) => {
+        const open = (c: ReactNode, options?: ModalOptions) => {
                 clearCloseTimeout();
 
                 setContent(c);
                 setBackgroundStyle(options?.backgroundStyle ?? null);
+                setHeaderBackgroundColor(options?.headerBackgroundColor ?? undefined);
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
@@ -61,6 +68,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
                 sheetRef.current?.close?.();
                 setBackgroundStyle(null);
+                setHeaderBackgroundColor(undefined);
                 clearCloseTimeout();
                 closeTimeoutRef.current = setTimeout(() => {
                         setContent(null);
@@ -113,11 +121,13 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                                         ref={sheetRef}
                                         index={isVisible ? 0 : -1}
                                         backgroundStyle={backgroundStyle}
+                                        headerBackgroundColor={headerBackgroundColor}
                                         enablePanDownToClose
                                         onClose={() => {
                                                 clearCloseTimeout();
                                                 setContent(null);
                                                 setBackgroundStyle(null);
+                                                setHeaderBackgroundColor(undefined);
                                                 setIsVisible(false);
                                                 setDebug(prev => ({
                                                         ...prev,

--- a/apps/frontend/app/components/GlobalModal/useModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useModal.tsx
@@ -5,7 +5,7 @@ export const useModal = () => {
         const { open, close, debug } = useModalContext();
 
         const show = useCallback(
-                (content: ReactNode, options?: { backgroundStyle?: any }) => {
+                (content: ReactNode, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                         open(content, options);
                 },
                 [open]

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -9,12 +9,13 @@ export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
         const { theme } = useTheme();
 
-        const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any }) => {
+        const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, ...restProps } = modalProps;
 
                 const mergedOptions = {
                         ...options,
                         backgroundStyle: { backgroundColor: theme.screen.background, ...options?.backgroundStyle },
+                        headerBackgroundColor: options?.headerBackgroundColor ?? theme.screen.background,
                 };
 
                 showModal(


### PR DESCRIPTION
## Summary
- add an optional header background color override to the base bottom sheet
- propagate modal options to carry the header background to the provider
- default MyScrollViewModal to use the screen background for the header area

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b566011888330854d0ace773c9c05)