### PR TITLE
Use scroll view modal for language selection

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -62,7 +62,6 @@ const Settings = () => {
 	};
 	const [selectedLanguage, setSelectedLanguage] = useState<string>('');
 	const drawerSheetRef = useRef<BottomSheet>(null);
-        const languageSheetRef = useRef<BottomSheet>(null);
         const amountColumnSheetRef = useRef<BottomSheet>(null);
         const firstDaySheetRef = useRef<BottomSheet>(null);
         const colorSchemeSheetRef = useRef<BottomSheet>(null);
@@ -70,7 +69,7 @@ const Settings = () => {
         const foodOffersTimeSheetRef = useRef<BottomSheet>(null);
         const collectibleSettingsModalRef = useRef<() => void>(() => {});
         const isOpeningNestedCollectibleModal = useRef(false);
-        const { show: showScrollViewModal } = useMyScrollViewModal();
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const [disabled, setDisabled] = useState(false);
         const { manualCheck } = useExpoUpdateChecker();
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useSelector((state: RootState) => state.authReducer);
@@ -146,17 +145,9 @@ const Settings = () => {
 		setSelectedLanguage(language);
 	}, [language]);
 
-	const openLanguageModal = () => {
-		languageSheetRef?.current?.expand();
-	};
-
-	const closeLanguageModal = () => {
-		languageSheetRef?.current?.close();
-	};
-
-	const openColorSchemeSheet = () => {
-		colorSchemeSheetRef?.current?.expand();
-	};
+        const openColorSchemeSheet = () => {
+                colorSchemeSheetRef?.current?.expand();
+        };
 
 	const closeColorSchemeSheet = () => {
 		colorSchemeSheetRef?.current?.close();
@@ -248,15 +239,33 @@ const Settings = () => {
 		manualCheck();
 	};
 
-	const changeLanguage = (language: { label?: string; flag?: string; value: any }) => {
-		setSelectedLanguage(language.value);
-		setLanguageMode(language.value);
-		closeLanguageModal();
-	};
+        const changeLanguage = (language: { label?: string; flag?: string; value: any }) => {
+                setSelectedLanguage(language.value);
+                setLanguageMode(language.value);
+                closeScrollViewModal();
+        };
 
-	const handleDrawerPosition = (position: string) => {
-		dispatch({
-			type: SET_DRAWER_POSITION,
+        const openLanguageModal = () => {
+                showScrollViewModal(
+                        {
+                                title: translate(TranslationKeys.language),
+                                children: (
+                                        <LanguageSheet
+                                                closeSheet={closeScrollViewModal}
+                                                selectedLanguage={selectedLanguage}
+                                                onSelect={value => {
+                                                        changeLanguage({ value } as any);
+                                                }}
+                                        />
+                                ),
+                        },
+                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                );
+        };
+
+        const handleDrawerPosition = (position: string) => {
+                dispatch({
+                        type: SET_DRAWER_POSITION,
 			payload: position,
 		});
 		closeDrawerSheet();
@@ -548,25 +557,6 @@ const Settings = () => {
 						onClose={closeCanteenSheet}
 					>
 						<CanteenSelectionSheet closeSheet={closeCanteenSheet} />
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={languageSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeLanguageModal}
-					>
-						<LanguageSheet
-							closeSheet={closeLanguageModal}
-							selectedLanguage={selectedLanguage}
-							onSelect={value => {
-								changeLanguage({ value } as any);
-							}}
-						/>
 					</BaseBottomSheet>
 					<BaseBottomSheet
 						ref={amountColumnSheetRef}

--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
@@ -20,57 +19,55 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLangu
 	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
-	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.language)}
-				</Text>
-			</View>
-			<View style={styles.optionsContainer}>
-				{languages.map((language, index) => (
-					<TouchableOpacity
-						key={index}
-						style={[
-							styles.languageRow,
-							{
-								paddingHorizontal: isWeb ? 20 : 10,
-								backgroundColor: selectedLanguage === language.value ? primaryColor : theme.screen.iconBg,
-							},
-						]}
-						onPress={() => {
-							onSelect(language.value);
-							closeSheet();
-						}}
-					>
-						<MyImage source={language.flag} style={styles.flagIcon} />
-						<Text
-							style={{
-								...styles.languageText,
-								color: selectedLanguage === language.value ? contrastColor : theme.screen.text,
-							}}
-						>
-							{language.label}
-						</Text>
-						<MaterialCommunityIcons name={selectedLanguage === language.value ? 'checkbox-marked' : 'checkbox-blank'} size={24} color={selectedLanguage === language.value ? contrastColor : theme.screen.icon} style={styles.radioButton} />
-					</TouchableOpacity>
-				))}
-			</View>
-		</BottomSheetScrollView>
-	);
+        return (
+                <View style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
+                        <View
+                                style={{
+                                        ...styles.sheetHeader,
+                                        paddingRight: isWeb ? 10 : 0,
+                                        paddingTop: isWeb ? 10 : 0,
+                                }}
+                        >
+                                <View />
+                                <Text
+                                        style={{
+                                                ...styles.sheetHeading,
+                                                fontSize: isWeb ? 40 : 28,
+                                                color: theme.sheet.text,
+                                        }}
+                                >
+                                        {translate(TranslationKeys.language)}
+                                </Text>
+                        </View>
+                        <View style={styles.optionsContainer}>
+                                {languages.map((language, index) => (
+                                        <TouchableOpacity
+                                                key={index}
+                                                style={{
+                                                        ...styles.languageRow,
+                                                        paddingHorizontal: isWeb ? 20 : 10,
+                                                        backgroundColor: selectedLanguage === language.value ? primaryColor : theme.screen.iconBg,
+                                                }}
+                                                onPress={() => {
+                                                        onSelect(language.value);
+                                                        closeSheet();
+                                                }}
+                                        >
+                                                <MyImage source={language.flag} style={styles.flagIcon} />
+                                                <Text
+                                                        style={{
+                                                                ...styles.languageText,
+                                                                color: selectedLanguage === language.value ? contrastColor : theme.screen.text,
+                                                        }}
+                                                >
+                                                        {language.label}
+                                                </Text>
+                                                <MaterialCommunityIcons name={selectedLanguage === language.value ? 'checkbox-marked' : 'checkbox-blank'} size={24} color={selectedLanguage === language.value ? contrastColor : theme.screen.icon} style={styles.radioButton} />
+                                        </TouchableOpacity>
+                                ))}
+                        </View>
+                </View>
+        );
 };
 
 export default LanguageSheet;


### PR DESCRIPTION
## Summary
- switch the settings language picker to use the shared scroll view modal hook
- update the language sheet layout to work within the global modal presentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bba21523c8330a7c5b191d44f98f8)