### PR TITLE
Use scroll view modal for settings canteen selection

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -50,7 +50,6 @@ const Settings = () => {
         const { theme, setThemeMode } = useTheme();
         const dispatch = useDispatch();
         const toast = useToast();
-        const canteenSheetRef = useRef<BottomSheet>(null);
         const [isActive, setIsActive] = useState(false);
         const { translate, setLanguageMode, language } = useLanguage();
         const [nickname, setNickname] = useState<string>('');
@@ -70,7 +69,7 @@ const Settings = () => {
         const foodOffersTimeSheetRef = useRef<BottomSheet>(null);
         const collectibleSettingsModalRef = useRef<() => void>(() => {});
         const isOpeningNestedCollectibleModal = useRef(false);
-        const { show: showScrollViewModal } = useMyScrollViewModal();
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const [disabled, setDisabled] = useState(false);
         const { manualCheck } = useExpoUpdateChecker();
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useSelector((state: RootState) => state.authReducer);
@@ -274,13 +273,24 @@ const Settings = () => {
 		performLogout(dispatch, router, true);
 	};
 
-	const openCanteenSheet = () => {
-		canteenSheetRef?.current?.expand();
-	};
+        const openCanteenSheet = () => {
+                showScrollViewModal(
+                        {
+                                title: translate(TranslationKeys.canteen),
+                                children: (
+                                        <CanteenSelectionSheet
+                                                closeSheet={closeScrollViewModal}
+                                                useBottomSheetScrollView={false}
+                                        />
+                                ),
+                        },
+                        {
+                                backgroundStyle: { backgroundColor: theme.sheet.sheetBg },
+                                headerBackgroundColor: theme.sheet.sheetBg,
+                        }
+                );
+        };
 
-	const closeCanteenSheet = () => {
-		canteenSheetRef?.current?.close();
-	};
 
 	const handleDeleteAccount = async () => {
 		router.navigate('/(user)/delete-user');
@@ -536,22 +546,9 @@ const Settings = () => {
                         </ScrollView>
 			{isActive && (
 				<>
-					<BaseBottomSheet
-						ref={canteenSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeCanteenSheet}
-					>
-						<CanteenSelectionSheet closeSheet={closeCanteenSheet} />
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={languageSheetRef}
-						index={-1}
+                                        <BaseBottomSheet
+                                                ref={languageSheetRef}
+                                                index={-1}
 						backgroundStyle={{
 							...styles.sheetBackground,
 							backgroundColor: theme.sheet.sheetBg,

--- a/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
+++ b/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
@@ -17,7 +17,7 @@ import { RootState } from '@/redux/reducer';
 import CanteenSelection from '../CanteenSelection/CanteenSelection';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
-const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeSheet }) => {
+const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeSheet, useBottomSheetScrollView = true }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const dispatch = useDispatch();
@@ -103,21 +103,15 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeShee
 		return () => subscription?.remove();
 	}, []);
 
-	return (
-		<BottomSheetScrollView
-			style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
-			contentContainerStyle={{
-				...styles.contentContainer,
-				paddingHorizontal: isWeb ? (screenWidth < 500 ? 5 : 20) : 5,
-			}}
-		>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			></View>
+        const selectionContent = (
+                <>
+                        <View
+                                style={{
+                                        ...styles.sheetHeader,
+                                        paddingRight: isWeb ? 10 : 0,
+                                        paddingTop: isWeb ? 10 : 0,
+                                }}
+                        ></View>
                         <Text
                                 style={{
                                         ...styles.sheetHeading,
@@ -129,6 +123,32 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeShee
                         </Text>
                         <CanteenSelection onSelectCanteen={handleSelectCanteen} />
                         <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_canteen_selection} />
+                </>
+        );
+
+        if (!useBottomSheetScrollView) {
+                return (
+                        <View
+                                style={{
+                                        ...styles.sheetView,
+                                        backgroundColor: theme.sheet.sheetBg,
+                                        paddingHorizontal: isWeb ? (screenWidth < 500 ? 5 : 20) : 5,
+                                }}
+                        >
+                                {selectionContent}
+                        </View>
+                );
+        }
+
+        return (
+                <BottomSheetScrollView
+                        style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
+                        contentContainerStyle={{
+                                ...styles.contentContainer,
+                                paddingHorizontal: isWeb ? (screenWidth < 500 ? 5 : 20) : 5,
+                        }}
+                >
+                        {selectionContent}
                 </BottomSheetScrollView>
         );
 };

--- a/apps/frontend/app/components/CanteenSelectionSheet/types.ts
+++ b/apps/frontend/app/components/CanteenSelectionSheet/types.ts
@@ -1,7 +1,8 @@
 import { DatabaseTypes } from 'repo-depkit-common';
 
 export interface CanteenSelectionSheetProps {
-	closeSheet: () => void;
+        closeSheet: () => void;
+        useBottomSheetScrollView?: boolean;
 }
 
 export interface CanteenProps extends DatabaseTypes.Canteens {


### PR DESCRIPTION
## Summary
- use the shared scroll view modal for canteen selection in settings
- allow CanteenSelectionSheet to render without its own bottom sheet scroll container
- pass updated configuration through to the settings canteen chooser

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bba3ba9508330954238ff4a15fafd)