### PR TITLE
fix: preserve fork changes during sync

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -60,8 +60,8 @@ jobs:
           echo "Upstream repository: rocket-meals/rocket-meals"
           echo "Target branch: master"
 
-          # Sync the fork with the upstream repository using --force to handle conflicts
-          if gh repo sync "$REPO_FULL_NAME" -b master --force; then
+          # Sync the fork with the upstream repository without overwriting local commits
+          if gh repo sync "$REPO_FULL_NAME" -b master; then
             echo "✅ Fork synchronization completed successfully!"
             echo "sync-success=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- stop forcing upstream syncs for forks to avoid overwriting local commits
- keep fork-specific changes like customer configuration intact during scheduled syncs

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bcbcf09a083308d5c9e0a703145e0)