### PR TITLE
Use scroll modal for nickname editing

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -53,15 +53,8 @@ const Settings = () => {
         const canteenSheetRef = useRef<BottomSheet>(null);
         const [isActive, setIsActive] = useState(false);
         const { translate, setLanguageMode, language } = useLanguage();
-        const [nickname, setNickname] = useState<string>('');
-        const nicknameSheetRef = useRef<BottomSheet>(null);
-	const openNicknameSheet = () => nicknameSheetRef?.current?.expand();
-	const closeNicknameSheet = () => {
-		Keyboard.dismiss();
-		nicknameSheetRef?.current?.close();
-	};
-	const [selectedLanguage, setSelectedLanguage] = useState<string>('');
-	const drawerSheetRef = useRef<BottomSheet>(null);
+        const [selectedLanguage, setSelectedLanguage] = useState<string>('');
+        const drawerSheetRef = useRef<BottomSheet>(null);
         const languageSheetRef = useRef<BottomSheet>(null);
         const amountColumnSheetRef = useRef<BottomSheet>(null);
         const firstDaySheetRef = useRef<BottomSheet>(null);
@@ -70,13 +63,16 @@ const Settings = () => {
         const foodOffersTimeSheetRef = useRef<BottomSheet>(null);
         const collectibleSettingsModalRef = useRef<() => void>(() => {});
         const isOpeningNestedCollectibleModal = useRef(false);
-        const { show: showScrollViewModal } = useMyScrollViewModal();
-        const [disabled, setDisabled] = useState(false);
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { manualCheck } = useExpoUpdateChecker();
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useSelector((state: RootState) => state.authReducer);
         const isRegisteredUser = UserHelper.isRegisteredUser(user);
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, collectibleItemSize, collectibleRandomPosition } = useSelector((state: RootState) => state.settings);
+        const currentNickname = useMemo(
+                () => (profile?.id ? profile?.nickname ?? '' : nickNameLocal ?? ''),
+                [nickNameLocal, profile?.id, profile?.nickname]
+        );
 	const selectedCanteen = useSelectedCanteen();
 	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
 	const profileHelper = useMemo(() => new ProfileHelper(), []);
@@ -101,26 +97,35 @@ const Settings = () => {
                 [collectibleItemSize, collectibleSizeOptions]
         );
 
-	const saveNickname = async () => {
-		if (isRegisteredUser) {
-			const result = (await profileHelper.updateProfile({
-				...profile,
-				nickname: nickname?.trim(),
-			})) as DatabaseTypes.Profiles;
-			if (result) {
-				dispatch({
-					type: UPDATE_PROFILE,
-					payload: result,
-				});
-			}
-		} else {
-			dispatch({
-				type: SET_NICKNAME_LOCAL,
-				payload: nickname?.trim(),
-			});
-		}
-		closeNicknameSheet();
-	};
+        const closeNicknameSheet = useCallback(() => {
+                Keyboard.dismiss();
+                closeScrollViewModal();
+        }, [closeScrollViewModal]);
+
+        const saveNickname = useCallback(
+                async (value: string) => {
+                        const nextNickname = value?.trim?.() ?? '';
+                        if (isRegisteredUser) {
+                                const result = (await profileHelper.updateProfile({
+                                        ...profile,
+                                        nickname: nextNickname,
+                                })) as DatabaseTypes.Profiles;
+                                if (result) {
+                                        dispatch({
+                                                type: UPDATE_PROFILE,
+                                                payload: result,
+                                        });
+                                }
+                        } else {
+                                dispatch({
+                                        type: SET_NICKNAME_LOCAL,
+                                        payload: nextNickname,
+                                });
+                        }
+                        closeNicknameSheet();
+                },
+                [closeNicknameSheet, dispatch, isRegisteredUser, profile, profileHelper]
+        );
 
 	useFocusEffect(
 		useCallback(() => {
@@ -146,9 +151,26 @@ const Settings = () => {
 		setSelectedLanguage(language);
 	}, [language]);
 
-	const openLanguageModal = () => {
-		languageSheetRef?.current?.expand();
-	};
+        const openNicknameSheet = useCallback(() => {
+                showScrollViewModal(
+                        {
+                                title: translate(TranslationKeys.nickname),
+                                onClose: closeNicknameSheet,
+                                children: (
+                                        <NicknameSheet
+                                                closeSheet={closeNicknameSheet}
+                                                initialValue={currentNickname}
+                                                onSave={saveNickname}
+                                        />
+                                ),
+                        },
+                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg } }
+                );
+        }, [closeNicknameSheet, currentNickname, saveNickname, showScrollViewModal, theme.sheet.sheetBg, translate]);
+
+        const openLanguageModal = () => {
+                languageSheetRef?.current?.expand();
+        };
 
 	const closeLanguageModal = () => {
 		languageSheetRef?.current?.close();
@@ -414,20 +436,14 @@ const Settings = () => {
 						<SettingsList
 							iconBgColor={primaryColor}
 							leftIcon={<MaterialCommunityIcons name="account" size={24} color={theme.screen.icon} />}
-							label={translate(TranslationKeys.nickname)}
-							value={profile?.id ? profile?.nickname : nickNameLocal}
-							rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
-							handleFunction={() => {
-								openNicknameSheet();
-								setNickname(profile?.id ? profile?.nickname : nickNameLocal);
-								if (profile?.nickname === nickname) {
-									setDisabled(true);
-								} else {
-									setDisabled(false);
-								}
-							}}
-							groupPosition="middle"
-						/>
+                                                        label={translate(TranslationKeys.nickname)}
+                                                        value={profile?.id ? profile?.nickname : nickNameLocal}
+                                                        rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
+                                                        handleFunction={() => {
+                                                                openNicknameSheet();
+                                                        }}
+                                                        groupPosition="middle"
+                                                />
 						{isRegisteredUser ? (
 							<>
 								<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.logout)} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={handleLogout} groupPosition="middle" />
@@ -610,35 +626,6 @@ const Settings = () => {
 									payload: day,
 								});
 							}}
-						/>
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={nicknameSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={() => {
-							Keyboard.dismiss();
-							closeNicknameSheet();
-						}}
-					>
-						<NicknameSheet
-							closeSheet={closeNicknameSheet}
-							value={nickname}
-							onChange={text => {
-								setNickname(text);
-								if (text === profile?.nickname) {
-									setDisabled(true);
-								} else {
-									setDisabled(false);
-								}
-							}}
-							onSave={saveNickname}
-							disableSave={disabled}
 						/>
 					</BaseBottomSheet>
 					<BaseBottomSheet

--- a/apps/frontend/app/components/NicknameSheet/NicknameSheet.tsx
+++ b/apps/frontend/app/components/NicknameSheet/NicknameSheet.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { KeyboardAvoidingView, Platform, Text, TextInput, TouchableOpacity, View, Keyboard } from 'react-native';
-import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useSelector } from 'react-redux';
@@ -10,48 +9,45 @@ import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 
-const NicknameSheet: React.FC<NicknameSheetProps> = ({ closeSheet, value, onChange, onSave, disableSave }) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+const NicknameSheet: React.FC<NicknameSheetProps> = ({ closeSheet, initialValue, onSave }) => {
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
-	const Content = (
-		<View
-			style={{
-				...styles.sheetView,
+        const [value, setValue] = useState(initialValue ?? '');
+
+        useEffect(() => {
+                setValue(initialValue ?? '');
+        }, [initialValue]);
+
+        const trimmedValue = useMemo(() => value?.trim?.() ?? '', [value]);
+
+        const disableSave = useMemo(() => trimmedValue === (initialValue?.trim?.() ?? ''), [initialValue, trimmedValue]);
+
+        const Content = (
+                <View
+                        style={{
+                                ...styles.sheetView,
 				backgroundColor: theme.sheet.sheetBg,
 			}}
 		>
-			{/* Header */}
-			<View style={styles.sheetHeader}>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.nickname)}
-				</Text>
-			</View>
-
-			<TextInput
-				style={{
-					...styles.sheetInput,
+                        <TextInput
+                                style={{
+                                        ...styles.sheetInput,
 					color: theme.sheet.text,
 					backgroundColor: theme.sheet.inputBg,
 					borderColor: theme.sheet.inputBorder,
 				}}
-				placeholder={translate(TranslationKeys.nickname)}
-				placeholderTextColor={theme.sheet.placeholder}
-				cursorColor={theme.sheet.text}
-				selectionColor={primaryColor}
-				value={value}
-				onChangeText={onChange}
-			/>
+                                placeholder={translate(TranslationKeys.nickname)}
+                                placeholderTextColor={theme.sheet.placeholder}
+                                cursorColor={theme.sheet.text}
+                                selectionColor={primaryColor}
+                                value={value}
+                                onChangeText={setValue}
+                        />
 
-			<View style={styles.buttonContainer}>
+                        <View style={styles.buttonContainer}>
 				<TouchableOpacity
 					onPress={() => {
 						Keyboard.dismiss();
@@ -65,33 +61,37 @@ const NicknameSheet: React.FC<NicknameSheetProps> = ({ closeSheet, value, onChan
 					<Text style={[styles.buttonText, { color: theme.screen.text }]}>{translate(TranslationKeys.cancel)}</Text>
 				</TouchableOpacity>
 
-				<TouchableOpacity
-					onPress={() => {
-						Keyboard.dismiss();
-						onSave();
-					}}
+                                <TouchableOpacity
+                                        onPress={() => {
+                                                Keyboard.dismiss();
+                                                onSave(trimmedValue);
+                                        }}
 					disabled={disableSave}
-					style={{
-						...styles.saveButton,
-						backgroundColor: primaryColor,
-						opacity: disableSave ? 0.5 : 1,
-					}}
-				>
-					<Text style={[styles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.save)}</Text>
-				</TouchableOpacity>
-			</View>
-		</View>
-	);
+                                        style={{
+                                                ...styles.saveButton,
+                                                backgroundColor: primaryColor,
+                                                opacity: disableSave ? 0.5 : 1,
+                                        }}
+                                >
+                                        <Text style={[styles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.save)}</Text>
+                                </TouchableOpacity>
+                        </View>
+                </View>
+        );
 
-	if (Platform.OS === 'web') {
-		return <BottomSheetView>{Content}</BottomSheetView>;
-	}
+        if (Platform.OS === 'web') {
+                return Content;
+        }
 
-	return (
-		<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : undefined} keyboardVerticalOffset={Platform.OS === 'ios' ? 20 : 0}>
-			<BottomSheetView>{Content}</BottomSheetView>
-		</KeyboardAvoidingView>
-	);
+        return (
+                <KeyboardAvoidingView
+                        behavior={Platform.OS === 'ios' ? 'position' : undefined}
+                        keyboardVerticalOffset={Platform.OS === 'ios' ? 20 : 0}
+                        style={styles.keyboardAvoidingView}
+                >
+                        <View style={styles.keyboardAvoidingContent}>{Content}</View>
+                </KeyboardAvoidingView>
+        );
 };
 
 export default NicknameSheet;

--- a/apps/frontend/app/components/NicknameSheet/styles.ts
+++ b/apps/frontend/app/components/NicknameSheet/styles.ts
@@ -1,15 +1,12 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	sheetView: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 20,
-		alignItems: 'center',
-	},
+        sheetView: {
+                width: '100%',
+                padding: 10,
+                paddingBottom: 20,
+                alignItems: 'center',
+        },
 	keyboardAvoidingView: {
 		flex: 1,
 		width: '100%',

--- a/apps/frontend/app/components/NicknameSheet/types.ts
+++ b/apps/frontend/app/components/NicknameSheet/types.ts
@@ -1,7 +1,5 @@
 export interface NicknameSheetProps {
-	closeSheet: () => void;
-	value: string;
-	onChange: (val: string) => void;
-	onSave: () => void;
-	disableSave?: boolean;
+        closeSheet: () => void;
+        initialValue: string;
+        onSave: (value: string) => void;
 }


### PR DESCRIPTION
## Summary
- switch nickname editing in settings to use the shared scroll-view modal
- refactor NicknameSheet to manage its own value state and invoke saves with the new value
- adjust nickname sheet styling for modal content usage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c25b6066883308967a169f97e032b)