### PR TITLE
Enable autofocus for nickname modal input

### DIFF
--- a/apps/frontend/app/components/NicknameSheet/NicknameSheet.tsx
+++ b/apps/frontend/app/components/NicknameSheet/NicknameSheet.tsx
@@ -34,10 +34,11 @@ const NicknameSheet: React.FC<NicknameSheetProps> = ({ initialValue, onSave }) =
                         <TextInput
                                 style={{
                                         ...styles.sheetInput,
-					color: theme.sheet.text,
-					backgroundColor: theme.sheet.inputBg,
-					borderColor: theme.sheet.inputBorder,
-				}}
+                                        color: theme.sheet.text,
+                                        backgroundColor: theme.sheet.inputBg,
+                                        borderColor: theme.sheet.inputBorder,
+                                }}
+                                autoFocus
                                 placeholder={translate(TranslationKeys.nickname)}
                                 placeholderTextColor={theme.sheet.placeholder}
                                 cursorColor={theme.sheet.text}


### PR DESCRIPTION
## Summary
- add autofocus to the nickname sheet input so the modal focuses the text field when opened

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d0bf7a878833089a994a61882c53a)