### PR TITLE
Move collectible event drawer item

### DIFF
--- a/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -261,7 +261,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({ navigation
                                 iconLibName: MaterialCommunityIcons,
                                 activeKey: 'collectible-event/index',
                                 route: 'collectible-event/index',
-                                position: 7.2,
+                                position: 2.1,
                                 hasUnread: true,
                         });
                 }


### PR DESCRIPTION
## Summary
- move the collectible event drawer entry directly below the food offers item

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d475c44bc83308fb329d6d7b9c371)