### PR TITLE
Switch foodoffers sort to scroll view modal

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -42,6 +42,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 export const SHEET_COMPONENTS = {
         canteen: CanteenSelectionSheet,
@@ -79,11 +80,12 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const animationRef = useRef<LottieView>(null);
 	const [animationJson, setAmimationJson] = useState<any>(null);
 	const { profile, user } = useSelector((state: RootState) => state.authReducer);
-	const selectedCanteen = useSelectedCanteen();
-		const kioskMode = useKioskMode();
+        const selectedCanteen = useSelectedCanteen();
+                const kioskMode = useKioskMode();
         const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
-	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
-	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
+        const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
+        const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 
 	// Set Page Title
 	useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);
@@ -157,10 +159,25 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 	}, [popupEvents, kioskMode, sessionDismissed]);
 
-	const openSheet = useCallback((sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
-		setSelectedSheet(sheet);
-		setSheetProps(props);
-	}, []);
+        const openSheet = useCallback(
+                (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
+                        if (sheet === 'sort') {
+                                showScrollViewModal(
+                                        {
+                                                title: translate(TranslationKeys.sort),
+                                                onClose: closeScrollViewModal,
+                                                children: <SortSheet closeSheet={closeScrollViewModal} />,
+                                        },
+                                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                                );
+                                return;
+                        }
+
+                        setSelectedSheet(sheet);
+                        setSheetProps(props);
+                },
+                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+        );
 
 	const openManagementSheet = (id: string) => {
 		if (id) {

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -71,6 +71,7 @@ import useChatUnreadStatus from '@/hooks/useChatUnreadStatus';
 
 import IconButton from '@/components/UI/IconButton';
 import Button from '@/components/UI/Button';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 export const SHEET_COMPONENTS = {
 	canteen: CanteenSelectionSheet,
@@ -132,12 +133,13 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { profile, user } = useSelector((state: RootState) => state.authReducer);
 	const { appElements } = useSelector((state: RootState) => state.appElements);
 	const { selectedCanteenFoodOffers, canteenFeedbackLabels } = useSelector((state: RootState) => state.canteenReducer);
-	const selectedCanteen = useSelectedCanteen();
-	useFoodOffersDefaultDate();
-	const kioskMode = useKioskMode();
+        const selectedCanteen = useSelectedCanteen();
+        useFoodOffersDefaultDate();
+        const kioskMode = useKioskMode();
         const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
-	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
-	const { hasUnreadChats } = useChatUnreadStatus();
+        const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
+        const { hasUnreadChats } = useChatUnreadStatus();
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
 
 	const MIN_CARD_WIDTH = 280;
@@ -309,10 +311,25 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 	}, [popupEvents, kioskMode, sessionDismissed]);
 
-	const openSheet = useCallback((sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
-		setSelectedSheet(sheet);
-		setSheetProps(props);
-	}, []);
+        const openSheet = useCallback(
+                (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
+                        if (sheet === 'sort') {
+                                showScrollViewModal(
+                                        {
+                                                title: translate(TranslationKeys.sort),
+                                                onClose: closeScrollViewModal,
+                                                children: <SortSheet closeSheet={closeScrollViewModal} />,
+                                        },
+                                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                                );
+                                return;
+                        }
+
+                        setSelectedSheet(sheet);
+                        setSheetProps(props);
+                },
+                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+        );
 
 	const openManagementSheet = useCallback((id: string) => {
 		if (id) {

--- a/apps/frontend/app/components/SortSheet/SortSheet.tsx
+++ b/apps/frontend/app/components/SortSheet/SortSheet.tsx
@@ -1,9 +1,7 @@
 import { Text, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
-import { isWeb } from '@/constants/Constants';
 import { AntDesign, FontAwesome5, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 
 import { SortSheetProps } from './types';
@@ -19,8 +17,8 @@ import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
 
 const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
 
 	const dispatch = useDispatch();
 	const { canteenFoodOffers } = useSelector((state: RootState) => state.canteenReducer);
@@ -137,76 +135,58 @@ const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
 		setSelectedOption(sortBy as FoodSortOption);
 	}, []);
 
-	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-                                <View
-                                        style={{
-                                                ...styles.sheetHeader,
-                                                paddingRight: isWeb ? 10 : 0,
-                                                paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.screen.text,
-                                        }}
-                                >
-                                        {translate(TranslationKeys.sort)}
-                                </Text>
-                        </View>
-			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_sort} />
+        return (
+                <View style={{ width: '100%', gap: 12 }}>
+                        <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_sort} />
                         <View style={styles.sortingListContainer}>
                                 {sortingOptions.map((option, index) => (
-					<TouchableOpacity
-						key={option.id + index}
-						style={[
-							styles.actionItem,
-							selectedOption === option.id
-								? {
-										backgroundColor: foods_area_color,
-									}
-								: {
-										backgroundColor: theme.screen.iconBg,
-									},
-						]}
-						onPress={() => updateSort(option)}
-					>
-						<View style={styles.col}>
-							{React.cloneElement(
-								option.icon,
-								selectedOption === option.id
-									? {
-											color: contrastColor,
-										}
-									: { color: theme.screen.icon }
-							)}
-							<Text
-								style={[
-									styles.label,
-									selectedOption === option.id
-										? {
-												color: contrastColor,
-											}
-										: { color: theme.screen.text },
-								]}
-							>
-								{translate(option.label)}
-							</Text>
-						</View>
-						<Checkbox
-							style={styles.checkbox}
-							value={selectedOption === option.id}
-							// onValueChange={() => updateSort(option)} // Toggle option
-							color={selectedOption === option.id ? '#000000' : undefined}
-						/>
-					</TouchableOpacity>
-				))}
-			</View>
-		</BottomSheetScrollView>
-	);
+                                        <TouchableOpacity
+                                                key={option.id + index}
+                                                style={[
+                                                        styles.actionItem,
+                                                        selectedOption === option.id
+                                                                ? {
+                                                                                backgroundColor: foods_area_color,
+                                                                        }
+                                                                : {
+                                                                                backgroundColor: theme.screen.iconBg,
+                                                                        },
+                                                ]}
+                                                onPress={() => updateSort(option)}
+                                        >
+                                                <View style={styles.col}>
+                                                        {React.cloneElement(
+                                                                option.icon,
+                                                                selectedOption === option.id
+                                                                        ? {
+                                                                                        color: contrastColor,
+                                                                                }
+                                                                        : { color: theme.screen.icon }
+                                                        )}
+                                                        <Text
+                                                                style={[
+                                                                        styles.label,
+                                                                        selectedOption === option.id
+                                                                                ? {
+                                                                                                color: contrastColor,
+                                                                                        }
+                                                                                : { color: theme.screen.text },
+                                                                ]}
+                                                        >
+                                                                {translate(option.label)}
+                                                        </Text>
+                                                </View>
+                                                <Checkbox
+                                                        style={styles.checkbox}
+                                                        value={selectedOption === option.id}
+                                                        // onValueChange={() => updateSort(option)} // Toggle option
+                                                        color={selectedOption === option.id ? '#000000' : undefined}
+                                                />
+                                        </TouchableOpacity>
+                                ))}
+                        </View>
+                </View>
+        );
 };
 
 export default SortSheet;


### PR DESCRIPTION
## Summary
- use the shared scroll view modal hook for the foodoffers sort dialog on both list views
- simplify the sort sheet content to live inside the global modal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d4f41eb348330a75e6043c405e7a3)