### PR TITLE
Use scroll view modal for AI hint dialog

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -325,6 +325,18 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                                 return;
                         }
 
+                        if (sheet === 'aiGeneratedInfo') {
+                                showScrollViewModal(
+                                        {
+                                                title: translate(TranslationKeys.ai_generated_image),
+                                                onClose: closeScrollViewModal,
+                                                children: <AIGeneratedHintSheet closeSheet={closeScrollViewModal} />,
+                                        },
+                                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                                );
+                                return;
+                        }
+
                         setSelectedSheet(sheet);
                         setSheetProps(props);
                 },

--- a/apps/frontend/app/components/AIGeneratedHintSheet/AIGeneratedHintSheet.tsx
+++ b/apps/frontend/app/components/AIGeneratedHintSheet/AIGeneratedHintSheet.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { isWeb } from '@/constants/Constants';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -13,32 +11,11 @@ const AIGeneratedHintSheet: React.FC<AIGeneratedHintSheetProps> = () => {
         const { translate } = useLanguage();
 
         return (
-                <BottomSheetScrollView
-                        style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}
-                        contentContainerStyle={styles.contentContainer}
-                >
-                        <View
-                                style={{
-                                        ...styles.sheetHeader,
-                                        paddingRight: isWeb ? 10 : 0,
-                                        paddingTop: isWeb ? 10 : 0,
-                                }}
-                        >
-                                <View />
-                                <Text
-                                        style={{
-                                                ...styles.sheetHeading,
-                                                fontSize: isWeb ? 40 : 28,
-                                                color: theme.sheet.text,
-                                        }}
-                                >
-                                        {translate(TranslationKeys.ai_generated_image)}
-                                </Text>
-                        </View>
+                <View style={styles.contentContainer}>
                         <Text style={{ ...styles.sheetDescription, color: theme.sheet.text }}>
                                 {translate(TranslationKeys.ai_generated_image_hint)}
                         </Text>
-                </BottomSheetScrollView>
+                </View>
         );
 };
 

--- a/apps/frontend/app/components/AIGeneratedHintSheet/styles.ts
+++ b/apps/frontend/app/components/AIGeneratedHintSheet/styles.ts
@@ -1,34 +1,16 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-        sheetView: {
-                width: '100%',
-                height: '100%',
-                borderTopRightRadius: 28,
-                borderTopLeftRadius: 28,
-                padding: 10,
-                paddingBottom: 0,
-        },
         contentContainer: {
                 alignItems: 'center',
-                paddingBottom: 40,
-        },
-        sheetHeader: {
-                width: '100%',
-                flexDirection: 'row',
                 justifyContent: 'center',
-                alignItems: 'center',
-                borderTopRightRadius: 28,
-                borderTopLeftRadius: 28,
-        },
-        sheetHeading: {
-                fontFamily: 'Poppins_700Bold',
+                paddingHorizontal: 20,
+                paddingBottom: 40,
+                paddingTop: 10,
         },
         sheetDescription: {
-                width: '90%',
                 fontFamily: 'Poppins_400Regular',
                 fontSize: 16,
                 textAlign: 'center',
-                marginTop: 20,
         },
 });

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -16,6 +16,8 @@ import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import { SHEET_COMPONENTS } from '@/app/(app)/foodoffers';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
 
 interface FoodOffersScrollListProps {
 	canteenId: string;
@@ -30,23 +32,39 @@ interface DayData {
 const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, startDate }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
-	const { canteenFeedbackLabels, canteens } = useSelector((state: RootState) => state.canteenReducer);
-	const { sortBy, language } = useSelector((state: RootState) => state.settings);
-	const { ownFoodFeedbacks, foodCategories, foodOfferCategories } = useSelector((state: RootState) => state.food);
-	const { profile } = useSelector((state: RootState) => state.authReducer);
-	const selectedCanteen = canteens?.find(c => c.id === canteenId) as DatabaseTypes.Canteens | undefined;
-	const [days, setDays] = useState<DayData[]>([]);
-	const [loading, setLoading] = useState(false);
-	const [refreshing, setRefreshing] = useState(false);
-	const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
-	const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
-	const [selectedFoodId, setSelectedFoodId] = useState('');
-	const bottomSheetRef = useRef<BottomSheet>(null);
+        const { canteenFeedbackLabels, canteens } = useSelector((state: RootState) => state.canteenReducer);
+        const { sortBy, language } = useSelector((state: RootState) => state.settings);
+        const { ownFoodFeedbacks, foodCategories, foodOfferCategories } = useSelector((state: RootState) => state.food);
+        const { profile } = useSelector((state: RootState) => state.authReducer);
+        const selectedCanteen = canteens?.find(c => c.id === canteenId) as DatabaseTypes.Canteens | undefined;
+        const [days, setDays] = useState<DayData[]>([]);
+        const [loading, setLoading] = useState(false);
+        const [refreshing, setRefreshing] = useState(false);
+        const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
+        const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
+        const [selectedFoodId, setSelectedFoodId] = useState('');
+        const bottomSheetRef = useRef<BottomSheet>(null);
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 
-	const openSheet = useCallback((sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
-		setSelectedSheet(sheet);
-		setSheetProps(props);
-	}, []);
+        const openSheet = useCallback(
+                (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
+                        if (sheet === 'aiGeneratedInfo') {
+                                showScrollViewModal(
+                                        {
+                                                title: translate(TranslationKeys.ai_generated_image),
+                                                onClose: closeScrollViewModal,
+                                                children: <AIGeneratedHintSheet closeSheet={closeScrollViewModal} />,
+                                        },
+                                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                                );
+                                return;
+                        }
+
+                        setSelectedSheet(sheet);
+                        setSheetProps(props);
+                },
+                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+        );
 
 	const closeSheet = useCallback(() => {
 		bottomSheetRef.current?.snapToIndex(-1);


### PR DESCRIPTION
## Summary
- show the AI-generated info dialog through the shared scroll-view modal on food offer screens
- simplify the AI-generated hint sheet content for embedding in the reusable modal and adjust its styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d70e1cdc483309c223b4597e77e80)