### PR TITLE
Align modal header background with modal background

### DIFF
--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -12,10 +12,12 @@ export const useMyScrollViewModal = () => {
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, ...restProps } = modalProps;
 
+                const backgroundStyle = { backgroundColor: theme.screen.background, ...options?.backgroundStyle };
                 const mergedOptions = {
                         ...options,
-                        backgroundStyle: { backgroundColor: theme.screen.background, ...options?.backgroundStyle },
-                        headerBackgroundColor: options?.headerBackgroundColor ?? theme.screen.background,
+                        backgroundStyle,
+                        headerBackgroundColor:
+                                options?.headerBackgroundColor ?? backgroundStyle?.backgroundColor ?? theme.screen.background,
                 };
 
                 showModal(


### PR DESCRIPTION
## Summary
- ensure global scroll modal headers default to the same background as the modal content by deriving the header color from the modal background style

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d73aef2d08330b1be56b8e6c21b36)