### PR TITLE
Align modal header color with modal background

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -53,9 +53,12 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 clearCloseTimeout();
 
                 setContent(c);
-                setBackgroundStyle(options?.backgroundStyle ?? null);
+                const resolvedBackgroundStyle = options?.backgroundStyle ?? null;
+                setBackgroundStyle(resolvedBackgroundStyle);
                 setOverlayStyle(options?.overlayStyle ?? { backgroundColor: 'rgba(0,0,0,0.5)' });
-                setHeaderBackgroundColor(options?.headerBackgroundColor ?? undefined);
+                const resolvedHeaderBackgroundColor =
+                        options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
+                setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,


### PR DESCRIPTION
## Summary
- default modal header color now follows the modal background style for consistency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dcc18849c8330b2555eb8902cff40)