### PR TITLE
Align scroll modal header and content background

### DIFF
--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -20,8 +20,10 @@ export const useMyScrollViewModal = () => {
                                 options?.headerBackgroundColor ?? backgroundStyle?.backgroundColor ?? theme.screen.background,
                 };
 
+                const backgroundColor = mergedOptions.backgroundStyle?.backgroundColor ?? theme.screen.background;
+
                 showModal(
-                        <MyScrollViewModal closeSheet={close} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 export interface MyScrollViewModalProps {
   title?: string;
   closeSheet?: () => void;
+  backgroundColor?: string;
   children?: ReactNode;
   // For FlatList mode
   useFlatList?: boolean;
@@ -25,6 +26,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   title,
   children,
   useFlatList = false,
+  backgroundColor,
   data = [],
   renderItem,
   keyExtractor,
@@ -37,13 +39,15 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
+  const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
+
   React.useEffect(() => () => onClose?.(), [onClose]);
 
   const headerComponent = (
     <>
       {title && (
         <View
-          style={{ backgroundColor: theme.screen.background, paddingHorizontal: 20, paddingTop: 8, paddingBottom: 8 }}
+          style={{ backgroundColor: resolvedBackgroundColor, paddingHorizontal: 20, paddingTop: 8, paddingBottom: 8 }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.sheet.text }}>{title}</Text>
         </View>
@@ -57,7 +61,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const contentStyle = { paddingBottom: 24 + insets.bottom, paddingHorizontal: 20 };
   const scrollInsets = { bottom: insets.bottom };
 
-  const containerStyle = { backgroundColor: theme.screen.background };
+  const containerStyle = { backgroundColor: resolvedBackgroundColor };
 
   if (useFlatList && renderItem && keyExtractor) {
     return (


### PR DESCRIPTION
## Summary
- allow MyScrollViewModal to accept a background color for consistent styling
- pass the resolved modal background color from useMyScrollViewModal to align header and content

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd566249483309e262f61325532ed)