### PR TITLE
Add fullscreen toggle and background support to collectible event monitor

### DIFF
--- a/apps/frontend/app/app/(monitor)/_layout.tsx
+++ b/apps/frontend/app/app/(monitor)/_layout.tsx
@@ -134,6 +134,12 @@ export default function MonitorLayout() {
 				}}
 			/>
 			<Stack.Screen
+				name="collectible-event-monitor/index"
+				options={{
+					headerShown: false,
+				}}
+			/>
+			<Stack.Screen
 				name="labels/index"
 				options={{
 					title: 'Labels',

--- a/apps/frontend/app/app/(monitor)/collectible-event-monitor/index.tsx
+++ b/apps/frontend/app/app/(monitor)/collectible-event-monitor/index.tsx
@@ -1,36 +1,100 @@
 import React, { useMemo } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ImageBackground, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { TranslationKeys } from '@/locales/keys';
 import useActiveCollectibleEvent from '@/hooks/useActiveCollectibleEvent';
 import { useLanguage } from '@/hooks/useLanguage';
+import CustomStackHeader from '@/components/CustomStackHeader/CustomStackHeader';
+import { getHighResImageUrl } from '@/constants/HelperFunctions';
 
 const CollectibleEventMonitor = () => {
-        useSetPageTitle(TranslationKeys.collectible_event_monitor);
-        const { theme } = useTheme();
-        const { translate } = useLanguage();
-        const { activeCollectibleEvent } = useActiveCollectibleEvent();
+	useSetPageTitle(TranslationKeys.collectible_event_monitor);
+	const { theme } = useTheme();
+	const router = useRouter();
+	const { fullscreen } = useLocalSearchParams();
+	const { translate } = useLanguage();
+	const { activeCollectibleEvent } = useActiveCollectibleEvent();
+	const isFullscreen = Array.isArray(fullscreen) ? fullscreen.includes('true') : fullscreen === 'true';
 
-        const jsonString = useMemo(
-                () => JSON.stringify(activeCollectibleEvent ?? null, null, 2),
-                [activeCollectibleEvent]
-        );
+	const jsonString = useMemo(
+		() => JSON.stringify(activeCollectibleEvent ?? null, null, 2),
+		[activeCollectibleEvent]
+	);
 
-        return (
-                <ScrollView
-                        style={{ ...styles.container, backgroundColor: theme.screen.background }}
-                        contentContainerStyle={{ ...styles.contentContainer, backgroundColor: theme.screen.background }}
-                >
-                        <Text style={{ ...styles.heading, color: theme.screen.text }}>
-                                {translate(TranslationKeys.collectible_event_monitor)}
-                        </Text>
-                        <View style={{ ...styles.card, backgroundColor: theme.screen.iconBg }}>
-                                <Text style={{ ...styles.code, color: theme.screen.text }}>{jsonString}</Text>
-                        </View>
-                </ScrollView>
-        );
+	const backgroundImageUrl = useMemo(() => {
+		if (activeCollectibleEvent?.monitor_background_image_remote_url) {
+			return activeCollectibleEvent.monitor_background_image_remote_url;
+		}
+
+		if (activeCollectibleEvent?.monitor_background_image) {
+			return getHighResImageUrl(activeCollectibleEvent.monitor_background_image, 1920);
+		}
+
+		return null;
+	}, [activeCollectibleEvent]);
+
+	const toggleFullscreen = () => {
+		if (isFullscreen) {
+			router.replace('/collectible-event-monitor');
+			return;
+		}
+
+		router.replace({
+			pathname: '/collectible-event-monitor',
+			params: { fullscreen: 'true' },
+		});
+	};
+
+	const fullscreenButton = (
+		<TouchableOpacity
+			onPress={toggleFullscreen}
+			style={[styles.actionButton, { backgroundColor: theme.screen.iconBg, borderColor: theme.screen.icon }]}
+		>
+			<MaterialCommunityIcons
+				name={isFullscreen ? 'fullscreen-exit' : 'fullscreen'}
+				size={20}
+				color={theme.screen.text}
+			/>
+		</TouchableOpacity>
+	);
+
+	return (
+		<SafeAreaView style={[styles.safeArea, { backgroundColor: theme.screen.background }]}>
+			<ImageBackground
+				source={backgroundImageUrl ? { uri: backgroundImageUrl } : undefined}
+				style={styles.background}
+				imageStyle={styles.backgroundImage}
+			>
+				<View
+					style={[
+						styles.overlay,
+						{ backgroundColor: backgroundImageUrl ? 'rgba(0,0,0,0.45)' : theme.screen.background },
+					]}
+				>
+					{isFullscreen ? (
+						<View style={styles.floatingButton}>{fullscreenButton}</View>
+					) : (
+						<View style={styles.headerContainer}>
+							<CustomStackHeader label={translate(TranslationKeys.collectible_event_monitor)} rightElement={fullscreenButton} />
+						</View>
+					)}
+
+					<ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+						<Text style={{ ...styles.heading, color: theme.screen.text }}>
+							{translate(TranslationKeys.collectible_event_monitor)}
+						</Text>
+						<View style={{ ...styles.card, backgroundColor: theme.screen.iconBg }}>
+							<Text style={{ ...styles.code, color: theme.screen.text }}>{jsonString}</Text>
+						</View>
+					</ScrollView>
+				</View>
+			</ImageBackground>
+		</SafeAreaView>
+	);
 };
 
 export default CollectibleEventMonitor;

--- a/apps/frontend/app/app/(monitor)/collectible-event-monitor/styles.ts
+++ b/apps/frontend/app/app/(monitor)/collectible-event-monitor/styles.ts
@@ -1,26 +1,54 @@
 import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
-        container: {
-                flex: 1,
-        },
-        contentContainer: {
-                flexGrow: 1,
-                padding: 20,
-                gap: 20,
-        },
-        heading: {
-                fontSize: 24,
-                fontWeight: '700',
-        },
-        card: {
-                padding: 16,
-                borderRadius: 12,
-        },
-        code: {
-                fontFamily: 'monospace',
-                fontSize: 14,
-        },
+	safeArea: {
+		flex: 1,
+	},
+	background: {
+		flex: 1,
+	},
+	backgroundImage: {
+		opacity: 0.35,
+	},
+	overlay: {
+		flex: 1,
+		paddingHorizontal: 16,
+		paddingVertical: 12,
+	},
+	headerContainer: {
+		marginBottom: 10,
+	},
+	container: {
+		flex: 1,
+	},
+	contentContainer: {
+		flexGrow: 1,
+		paddingVertical: 12,
+		gap: 16,
+	},
+	heading: {
+		fontSize: 24,
+		fontWeight: '700',
+	},
+	card: {
+		padding: 16,
+		borderRadius: 12,
+	},
+	code: {
+		fontFamily: 'monospace',
+		fontSize: 14,
+	},
+	actionButton: {
+		padding: 10,
+		borderRadius: 50,
+		borderWidth: 1,
+	},
+	floatingButton: {
+		position: 'absolute',
+		right: 16,
+		top: 12,
+		zIndex: 1,
+	},
 });
 
 export default styles;


### PR DESCRIPTION
## Summary
- hide the navigation header for the collectible event monitor screen and manage its own header
- add a custom header with a fullscreen toggle that sets the `fullscreen=true` param and a floating control when fullscreen
- support monitor background images (asset or remote URL) and refresh the layout styling for the monitor display

## Testing
- yarn lint *(fails: package.json has no "eslint" script in this workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427548fc908330974978f65cc0c0e4)