### PR TITLE
Add collectible event timing details

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-event/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-event/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, SafeAreaView, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import { COLLECTABLE_AT_FIELDS, CollectibleAt, DatabaseTypes } from 'repo-depkit-common';
+import { COLLECTABLE_AT_FIELDS, CollectibleAt, DatabaseTypes, DateHelper } from 'repo-depkit-common';
 
 import useActiveCollectibleEvent from '@/hooks/useActiveCollectibleEvent';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -196,6 +196,19 @@ const CollectibleEventScreen = () => {
         const [isPermissionModalVisible, setIsPermissionModalVisible] = useState(false);
         const [participation, setParticipation] = useState<DatabaseTypes.CollectibleEventParticipants | null>(null);
         const [visibleHints, setVisibleHints] = useState<Record<string, boolean>>({});
+
+        const formatEventDate = useCallback((dateString?: string | null) => {
+                if (!dateString || !DateHelper.isValidDateString(dateString)) {
+                        return '-';
+                }
+
+                try {
+                        return DateHelper.formatOfferDateToReadable(new Date(dateString), true, true);
+                } catch (error) {
+                        console.error('Error formatting date:', error);
+                        return '-';
+                }
+        }, []);
 
         const toggleCollectibleHint = useCallback((key: string) => {
                 setVisibleHints(prev => ({ ...prev, [key]: !prev[key] }));
@@ -425,6 +438,8 @@ const CollectibleEventScreen = () => {
                 const title =
                     getTitleFromTranslation(activeCollectibleEvent.translations as any, language) || activeCollectibleEvent.alias || '';
                 const description = getDescriptionFromTranslation(activeCollectibleEvent.translations as any, language);
+                const startDateLabel = formatEventDate(activeCollectibleEvent.date_start);
+                const endDateLabel = formatEventDate(activeCollectibleEvent.date_end);
 
                 return (
                     <View style={styles.section}>
@@ -432,6 +447,25 @@ const CollectibleEventScreen = () => {
                             {description ? (
                                 <Text style={{ ...styles.description, color: theme.inactiveText }}>{description}</Text>
                             ) : null}
+
+                            <View style={{ marginTop: 16, gap: 0 }}>
+                                    <SettingsList
+                                        leftIcon={
+                                                <MaterialCommunityIcons name="calendar-start" size={22} color={theme.screen.icon} />
+                                        }
+                                        label={translate(TranslationKeys.collectible_event_start_date)}
+                                        value={startDateLabel}
+                                        groupPosition="top"
+                                    />
+                                    <SettingsList
+                                        leftIcon={
+                                                <MaterialCommunityIcons name="calendar-end" size={22} color={theme.screen.icon} />
+                                        }
+                                        label={translate(TranslationKeys.collectible_event_end_date)}
+                                        value={endDateLabel}
+                                        groupPosition="bottom"
+                                    />
+                            </View>
 
                             <View style={{ alignItems: 'center', marginTop: 16 }}>
                                     <CollectibleItem collectibleKey={sampleCollectibleKey} hideOnCollect={false} isPreview />

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -187,6 +187,8 @@ export enum TranslationKeys {
 	import = 'import',
         event = 'event',
         collectible_event = 'collectible_event',
+        collectible_event_start_date = 'collectible_event_start_date',
+        collectible_event_end_date = 'collectible_event_end_date',
         collectible_event_points = 'collectible_event_points',
         collectible_event_no_active = 'collectible_event_no_active',
         collectible_event_save_success = 'collectible_event_save_success',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1889,6 +1889,26 @@
     "tr": "Koleksiyon etkinliği",
     "zh": "收集活动"
   },
+  "collectible_event_start_date": {
+    "de": "Start des Events",
+    "en": "Event start",
+    "ar": "بداية الحدث",
+    "es": "Inicio del evento",
+    "fr": "Début de l'événement",
+    "ru": "Начало события",
+    "tr": "Etkinlik başlangıcı",
+    "zh": "活动开始"
+  },
+  "collectible_event_end_date": {
+    "de": "Ende des Events",
+    "en": "Event end",
+    "ar": "نهاية الحدث",
+    "es": "Fin del evento",
+    "fr": "Fin de l'événement",
+    "ru": "Окончание события",
+    "tr": "Etkinlik bitişi",
+    "zh": "活动结束"
+  },
   "collectible_event_points": {
     "de": "Aktuelle Punkte",
     "en": "Current points",


### PR DESCRIPTION
## Summary
- display localized event start and end in collectible event screen via SettingsList rows
- format event date values with locale-aware strings for clearer timing information
- add translation keys and localized strings for the new labels

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942855ae7b08330966f45be8ab2e1b0)