### PR TITLE
Use scroll view modal for popup events

### DIFF
--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { SafeAreaView, ScrollView } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import SettingsList from '@/components/SettingsList';
 import { MaterialIcons, Octicons } from '@expo/vector-icons';
-import BaseBottomSheet from '@/components/BaseBottomSheet';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';
-import type BottomSheet from '@gorhom/bottom-sheet';
 import { useDispatch, useSelector } from 'react-redux';
 import { SET_POPUP_EVENTS } from '@/redux/Types/types';
 import { useFocusEffect } from 'expo-router';
@@ -16,6 +14,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import useKioskMode from '@/hooks/useKioskMode';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 const EventsScreen = () => {
 	useSetPageTitle(TranslationKeys.events);
@@ -26,18 +25,22 @@ const EventsScreen = () => {
 	const { popupEvents } = useSelector((state: RootState) => state.food);
 	const { primaryColor } = useSelector((state: RootState) => state.settings);
 	const [selectedEvent, setSelectedEvent] = useState<any | null>(null);
-	const bottomSheetRef = useRef<BottomSheet>(null);
-	const [isActive, setIsActive] = useState(false);
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const handleClose = useCallback(() => {
+		setSelectedEvent(null);
+		closeScrollViewModal();
+	}, [closeScrollViewModal]);
 
 	const openSheet = useCallback((event: any) => {
 		setSelectedEvent(event);
-		bottomSheetRef.current?.expand();
-	}, []);
-
-	const closeSheet = useCallback(() => {
-		bottomSheetRef.current?.close();
-		setSelectedEvent(null);
-	}, []);
+		showScrollViewModal(
+			{
+				onClose: () => setSelectedEvent(null),
+				children: <PopupEventSheet closeSheet={handleClose} eventData={event} />,
+			},
+			{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+		);
+	}, [handleClose, showScrollViewModal, theme.sheet.sheetBg]);
 
 	const resetSeenEvents = () => {
 		const resetEvents = popupEvents.map((e: any, idx: number) => ({
@@ -49,10 +52,7 @@ const EventsScreen = () => {
 	};
 
 	useFocusEffect(
-		useCallback(() => {
-			setIsActive(true);
-			return () => setIsActive(false);
-		}, [])
+		useCallback(() => () => setSelectedEvent(null), [])
 	);
 
 	return (
@@ -61,21 +61,6 @@ const EventsScreen = () => {
 				<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="refresh" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.reset_seen_popup_events)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={resetSeenEvents} groupPosition={'single'} />
 				{!kioskMode && popupEvents.map((event: any) => <SettingsList iconBgColor={primaryColor} key={event.id} leftIcon={<MaterialIcons name="event" size={24} color={theme.screen.icon} />} label={event.translations ? getTitleFromTranslation(event.translations, language) : event.alias} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openSheet(event)} groupPosition={'single'} />)}
 			</ScrollView>
-			{isActive && !kioskMode && (
-				<BaseBottomSheet
-					ref={bottomSheetRef}
-					index={-1}
-					backgroundStyle={{
-						...styles.sheetBackground,
-						backgroundColor: theme.sheet.sheetBg,
-					}}
-					enablePanDownToClose
-					handleComponent={null}
-					onClose={closeSheet}
-				>
-					<PopupEventSheet closeSheet={closeSheet} eventData={selectedEvent || {}} />
-				</BaseBottomSheet>
-			)}
 		</SafeAreaView>
 	);
 };

--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -62,7 +62,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const router = useRouter();
 	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
 	const bottomSheetRef = useRef<BottomSheet>(null);
-	const eventSheetRef = useRef<BottomSheet>(null);
 	const businessHoursHelper = new BusinessHoursHelper();
 	const [loading, setLoading] = useState(false);
 	const [isActive, setIsActive] = useState(false);
@@ -86,6 +85,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
         const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+        const popupEventShownIdRef = useRef<string | null>(null);
 
 	// Set Page Title
 	useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);
@@ -151,9 +151,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		const nextEvent = popupEvents?.find((e: any) => !e.isOpen && !PopupEventHelper.isDismissed(e.id));
 		if (nextEvent) {
 			setCurrentPopupEvent(nextEvent);
-			setTimeout(() => {
-				openEventSheet();
-			}, 300);
 		} else {
 			setCurrentPopupEvent(null);
 		}
@@ -190,27 +187,45 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 	};
 
-	const openEventSheet = () => {
-		if (kioskMode) return;
-		eventSheetRef?.current?.expand();
-	};
-
-	const closeEventSheet = () => {
-		eventSheetRef?.current?.close();
+	const closeEventSheet = useCallback(() => {
+		closeScrollViewModal();
 		setTimeout(() => {
 			if (!currentPopupEvent) return;
 			const updatedEvents = popupEvents.map((e: any) => (e.id === currentPopupEvent.id ? { ...e, isOpen: true } : e));
 			dispatch({ type: SET_POPUP_EVENTS, payload: updatedEvents });
+			popupEventShownIdRef.current = null;
 			setCurrentPopupEvent(null);
-		}, 500);
-	};
+		}, 200);
+	}, [closeScrollViewModal, currentPopupEvent, dispatch, popupEvents]);
 
-	const closeEventSheetForSession = () => {
-		eventSheetRef?.current?.close();
-		PopupEventHelper.dismiss(currentPopupEvent?.id);
-		setSessionDismissed(PopupEventHelper.getAll());
+	const closeEventSheetForSession = useCallback(() => {
+		closeScrollViewModal();
+		if (currentPopupEvent?.id) {
+			PopupEventHelper.dismiss(currentPopupEvent.id);
+			setSessionDismissed(PopupEventHelper.getAll());
+		}
+		popupEventShownIdRef.current = null;
 		setCurrentPopupEvent(null);
-	};
+	}, [closeScrollViewModal, currentPopupEvent]);
+
+	useEffect(() => {
+		if (!currentPopupEvent) {
+			popupEventShownIdRef.current = null;
+			return;
+		}
+
+		const eventId = String(currentPopupEvent.id ?? '');
+		if (popupEventShownIdRef.current === eventId) return;
+		popupEventShownIdRef.current = eventId;
+
+		showScrollViewModal(
+			{
+				onClose: closeEventSheetForSession,
+				children: <PopupEventSheet closeSheet={closeEventSheet} eventData={currentPopupEvent} />,
+			},
+			{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+		);
+	}, [closeEventSheet, closeEventSheetForSession, currentPopupEvent, showScrollViewModal, theme.sheet.sheetBg]);
 
 	useEffect(() => {
 		if (isActive && selectedSheet) {
@@ -722,21 +737,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 						</BaseBottomSheet>
 					))}
 
-				{isActive && currentPopupEvent && (
-					<BaseBottomSheet
-						ref={eventSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose={false}
-						handleComponent={null}
-						onClose={closeEventSheetForSession}
-					>
-						<PopupEventSheet closeSheet={closeEventSheet} eventData={currentPopupEvent} />
-					</BaseBottomSheet>
-				)}
 			</SafeAreaView>
 		</>
 	);

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -97,7 +97,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const router = useRouter();
 	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
 	const bottomSheetRef = useRef<BottomSheet>(null);
-	const eventSheetRef = useRef<BottomSheet>(null);
 	const businessHoursHelper = new BusinessHoursHelper();
 	const canteenFeedbackLabelHelper = new CanteenFeedbackLabelHelper();
 	const [loading, setLoading] = useState(false);
@@ -140,6 +139,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
         const { hasUnreadChats } = useChatUnreadStatus();
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const popupEventShownIdRef = useRef<string | null>(null);
 	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
 
 	const MIN_CARD_WIDTH = 280;
@@ -305,7 +305,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		const nextEvent = popupEvents?.find((e: any) => !e.isOpen && !PopupEventHelper.isDismissed(e.id));
 		if (nextEvent) {
 			setCurrentPopupEvent(nextEvent);
-			setTimeout(() => openEventSheet(), 300);
 		} else {
 			setCurrentPopupEvent(null);
 		}
@@ -354,27 +353,45 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 	}, []);
 
-	const openEventSheet = () => {
-		if (kioskMode) return;
-		eventSheetRef?.current?.expand();
-	};
-
-	const closeEventSheet = () => {
-		eventSheetRef?.current?.close();
+	const closeEventSheet = useCallback(() => {
+		closeScrollViewModal();
 		setTimeout(() => {
 			if (!currentPopupEvent) return;
 			const updatedEvents = popupEvents.map((e: any) => (e.id === currentPopupEvent.id ? { ...e, isOpen: true } : e));
 			dispatch({ type: SET_POPUP_EVENTS, payload: updatedEvents });
+			popupEventShownIdRef.current = null;
 			setCurrentPopupEvent(null);
-		}, 500);
-	};
+		}, 200);
+	}, [closeScrollViewModal, currentPopupEvent, dispatch, popupEvents]);
 
-	const closeEventSheetForSession = () => {
-		eventSheetRef?.current?.close();
-		PopupEventHelper.dismiss(currentPopupEvent?.id);
-		setSessionDismissed(PopupEventHelper.getAll());
+	const closeEventSheetForSession = useCallback(() => {
+		closeScrollViewModal();
+		if (currentPopupEvent?.id) {
+			PopupEventHelper.dismiss(currentPopupEvent.id);
+			setSessionDismissed(PopupEventHelper.getAll());
+		}
+		popupEventShownIdRef.current = null;
 		setCurrentPopupEvent(null);
-	};
+	}, [closeScrollViewModal, currentPopupEvent]);
+
+	useEffect(() => {
+		if (!currentPopupEvent) {
+			popupEventShownIdRef.current = null;
+			return;
+		}
+
+		const eventId = String(currentPopupEvent.id ?? '');
+		if (popupEventShownIdRef.current === eventId) return;
+		popupEventShownIdRef.current = eventId;
+
+		showScrollViewModal(
+			{
+				onClose: closeEventSheetForSession,
+				children: <PopupEventSheet closeSheet={closeEventSheet} eventData={currentPopupEvent} />,
+			},
+			{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+		);
+	}, [closeEventSheet, closeEventSheetForSession, currentPopupEvent, showScrollViewModal, theme.sheet.sheetBg]);
 
 	useEffect(() => {
 		if (isActive && selectedSheet) {


### PR DESCRIPTION
## Summary
- open popup events in the food offers screens through the shared scroll view modal hook and manage dismiss/seen tracking there
- switch the events overview to use the same scroll modal approach for viewing popup event content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bd838e248330b663c970f04e1baf)