### PR TITLE
Remove unused popup event bottom sheet

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -944,11 +944,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 							)}
 						</BaseBottomSheet>
 					))}
-				{isActive && currentPopupEvent && (
-					<BaseBottomSheet ref={eventSheetRef} index={-1} backgroundStyle={{ ...styles.sheetBackground, backgroundColor: theme.sheet.sheetBg }} enablePanDownToClose={false} handleComponent={null} onClose={closeEventSheetForSession}>
-						<PopupEventSheet closeSheet={closeEventSheet} eventData={currentPopupEvent} />
-					</BaseBottomSheet>
-				)}
 			</SafeAreaView>
 		</>
 	);


### PR DESCRIPTION
## Summary
- remove the unused popup event bottom sheet in favor of the scroll view modal handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ccdaaadc83309f5b59123dd2a793)