### PR TITLE
Adjust PopupEventSheet background styling

### DIFF
--- a/apps/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
+++ b/apps/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
@@ -214,7 +214,7 @@ const PopupEventSheet: React.FC<PopupEventSheetProps> = ({ closeSheet, dismissSh
 	};
 
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
+		<BottomSheetScrollView style={styles.sheetView} contentContainerStyle={styles.contentContainer}>
 			<View
 				style={{
 					...styles.sheetHeaderClose,

--- a/apps/frontend/app/components/PopupEventSheet/styles.ts
+++ b/apps/frontend/app/components/PopupEventSheet/styles.ts
@@ -4,8 +4,6 @@ export default StyleSheet.create({
 	sheetView: {
 		width: '100%',
 		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
 		padding: 10,
 		paddingBottom: 0,
 	},
@@ -15,8 +13,6 @@ export default StyleSheet.create({
 	sheetHeaderClose: {
 		width: '100%',
 		flexDirection: 'column',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
 	},
 	sheetHeaderText: {
 		width: '100%',


### PR DESCRIPTION
## Summary
- remove explicit background color from popup event sheet to use modal default
- eliminate top border radii on sheet containers for flush modal appearance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fb4a807483308b096055e265074b)