### PR TITLE
Fix popup event sheet close button to also close modal

### DIFF
--- a/apps/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
+++ b/apps/frontend/app/components/PopupEventSheet/PopupEventSheet.tsx
@@ -14,9 +14,11 @@ import { getTextFromTranslation, getTitleFromTranslation } from '@/helper/resour
 import RedirectButton from '../RedirectButton';
 import ProjectButton from '../ProjectButton';
 import { RootState } from '@/redux/reducer';
+import { useMyScrollViewModal } from '../GlobalModal/useMyScrollViewModal';
 
 const PopupEventSheet: React.FC<PopupEventSheetProps> = ({ closeSheet, dismissSheet, eventData }) => {
 	const { theme } = useTheme();
+	const { close: closeScrollViewModal } = useMyScrollViewModal();
 	const { primaryColor, language, appSettings, serverInfo, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
 	const title = eventData?.translations ? getTitleFromTranslation(eventData?.translations, language) : '';
@@ -210,7 +212,13 @@ const PopupEventSheet: React.FC<PopupEventSheetProps> = ({ closeSheet, dismissSh
 			return <View style={{ paddingBottom: 20 }}>{renderContent(hierarchicalContent)}</View>;
 		}
 
-		return null;
+			return null;
+	};
+
+	const handleClose = () => {
+		dismissSheet?.();
+		closeScrollViewModal();
+		closeSheet();
 	};
 
 	return (
@@ -223,7 +231,7 @@ const PopupEventSheet: React.FC<PopupEventSheetProps> = ({ closeSheet, dismissSh
 					alignItems: 'center',
 				}}
 			>
-				{closeSheet && <ProjectButton text="Schließen und nicht erneut anzeigen" onPress={dismissSheet || closeSheet} />}
+				{closeSheet && <ProjectButton text="Schließen und nicht erneut anzeigen" onPress={handleClose} />}
 			</View>
 			<View
 				style={{


### PR DESCRIPTION
## Summary
- ensure the popup event sheet close button dismisses the event using the modal close helper so the sheet closes reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694302cffbc083309dff640d406d95e9)