### PR TITLE
Update opening hours modal layout

### DIFF
--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -14,6 +14,7 @@ import { BusinessHour, HourSheetProps } from './types';
 import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import SettingsList from '@/components/SettingsList/SettingsList';
 
 const getSortedBusinessHoursGroups = (groups: { id: string; sort?: number | null }[]) => {
 	return [...groups].sort((a, b) => {
@@ -351,61 +352,68 @@ const HourSheet: React.FC<HourSheetProps> = ({ closeSheet }) => {
 
 	const formatTime = (time: string | null): string => time?.slice(0, 5) || 'N/A';
 
-	const renderHours = (
-		groupId: string,
-		hoursData: {
-			day: string[];
-			time_start: string | null;
-			time_end: string | null;
-		}[]
-	) => {
-		if (!hoursData.length) {
-			return <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.no_business_hours_available)}</Text>;
-		}
+        const renderHours = (
+                groupId: string,
+                hoursData: {
+                        day: string[];
+                        time_start: string | null;
+                        time_end: string | null;
+                }[]
+        ) => {
+                if (!hoursData.length) {
+                        return <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.no_business_hours_available)}</Text>;
+                }
 
-		const daysOfWeek = [
-			{ name: translate(TranslationKeys.Mon), key: 'monday' },
-			{ name: translate(TranslationKeys.Tue), key: 'tuesday' },
-			{ name: translate(TranslationKeys.Wed), key: 'wednesday' },
-			{ name: translate(TranslationKeys.Thu), key: 'thursday' },
-			{ name: translate(TranslationKeys.Fri), key: 'friday' },
-			{ name: translate(TranslationKeys.Sat), key: 'saturday' },
-			{ name: translate(TranslationKeys.Sun), key: 'sunday' },
-		];
+                const daysOfWeek = [
+                        { name: translate(TranslationKeys.Mon), key: 'monday' },
+                        { name: translate(TranslationKeys.Tue), key: 'tuesday' },
+                        { name: translate(TranslationKeys.Wed), key: 'wednesday' },
+                        { name: translate(TranslationKeys.Thu), key: 'thursday' },
+                        { name: translate(TranslationKeys.Fri), key: 'friday' },
+                        { name: translate(TranslationKeys.Sat), key: 'saturday' },
+                        { name: translate(TranslationKeys.Sun), key: 'sunday' },
+                ];
 
-		let renderedOuput: React.ReactNode[] = [];
-		hoursData.forEach(range => {
-			let firstDayKey = range.day[0];
-			let lastDayKey = range.day[range.day.length - 1];
-			let firstDay = daysOfWeek.find(d => d.key === firstDayKey);
-			let lastDay = daysOfWeek.find(d => d.key === lastDayKey);
-			let label = `${firstDay?.name}`;
-			if (firstDayKey !== lastDayKey) {
-				label += ` - ${lastDay?.name}`;
-			}
-			let hoursDataKey = groupId + range.day.join('-') + range.time_start + range.time_end;
+                return hoursData.map((range, index) => {
+                        let firstDayKey = range.day[0];
+                        let lastDayKey = range.day[range.day.length - 1];
+                        let firstDay = daysOfWeek.find(d => d.key === firstDayKey);
+                        let lastDay = daysOfWeek.find(d => d.key === lastDayKey);
+                        let label = `${firstDay?.name}`;
+                        if (firstDayKey !== lastDayKey) {
+                                label += ` - ${lastDay?.name}`;
+                        }
+                        let hoursDataKey = groupId + range.day.join('-') + range.time_start + range.time_end;
 
-			let timeText = translate(TranslationKeys.closed_hours);
-			if (range.time_start && range.time_end) {
-				timeText = `${formatTime(range.time_start)} - ${formatTime(range.time_end)}`;
-				if (range.time_start === range.time_end) {
-					timeText = `${formatTime(range.time_start)}`;
-				}
-			}
+                        let timeText = translate(TranslationKeys.closed_hours);
+                        if (range.time_start && range.time_end) {
+                                timeText = `${formatTime(range.time_start)} - ${formatTime(range.time_end)}`;
+                                if (range.time_start === range.time_end) {
+                                        timeText = `${formatTime(range.time_start)}`;
+                                }
+                        }
 
-			renderedOuput.push(
-				<View key={hoursDataKey} style={styles.row}>
-					<Text style={{ ...styles.body, color: theme.screen.text }}>{label}</Text>
-					<Text style={{ ...styles.body, color: theme.screen.text }}>{timeText}</Text>
-				</View>
-			);
-		});
+                        const isFirst = index === 0;
+                        const isLast = index === hoursData.length - 1;
+                        const isSingle = hoursData.length === 1;
+                        const groupPosition = isSingle ? 'single' : isFirst ? 'top' : isLast ? 'bottom' : 'middle';
 
-		return renderedOuput;
-	};
+                        return (
+                                <SettingsList
+                                        key={hoursDataKey}
+                                        leftIcon={<View />}
+                                        title={label}
+                                        value={timeText}
+                                        showSeparator={!isLast}
+                                        groupPosition={groupPosition}
+                                        iconBackgroundColor={theme.sheet.sheetBg}
+                                />
+                        );
+                });
+        };
 
-	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
+        return (
+                <BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: 'transparent' }} contentContainerStyle={styles.contentContainer}>
 			<View
 				style={{
 					...styles.sheetHeader,


### PR DESCRIPTION
## Summary
- remove the explicit background color from the opening hours modal content
- display grouped opening hour ranges inside SettingsList rows for consistent styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448c810ab08330a48d548b0c4feacd)