### PR TITLE
Add no icon indent option for SettingsList

### DIFF
--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -402,12 +402,11 @@ const HourSheet: React.FC<HourSheetProps> = ({ closeSheet }) => {
                         return (
                                 <SettingsList
                                         key={hoursDataKey}
-                                        leftIcon={<View />}
                                         title={label}
                                         value={timeText}
                                         showSeparator={!isLast}
                                         groupPosition={groupPosition}
-                                        iconBackgroundColor={theme.sheet.sheetBg}
+                                        noIconIndent
                                 />
                         );
                 });

--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -10,16 +10,20 @@ const padding = 0; // px used for additional padding and border radius
 const borderRadius = 10;
 const basePaddingVertical = 10;
 
-const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, value, rightElement, rightIcon, onPress, handleFunction, iconBackgroundColor, iconBgColor, showSeparator = true, groupPosition }) => {
-	const { theme } = useTheme();
-	const { primaryColor, selectedTheme } = useSelector((state: RootState) => state.settings);
+const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, value, rightElement, rightIcon, onPress, handleFunction, iconBackgroundColor, iconBgColor, showSeparator = true, groupPosition, noIconIndent = false }) => {
+        const { theme } = useTheme();
+        const { primaryColor, selectedTheme } = useSelector((state: RootState) => state.settings);
 
-	const pressHandler = onPress || handleFunction;
-	const Container: any = pressHandler ? TouchableOpacity : View;
-	const iconBg = iconBackgroundColor || iconBgColor || primaryColor;
-	const iconColor = myContrastColor(iconBg, theme, selectedTheme === 'dark');
+        const pressHandler = onPress || handleFunction;
+        const Container: any = pressHandler ? TouchableOpacity : View;
+        const iconBg = iconBackgroundColor || iconBgColor || primaryColor;
+        const iconColor = myContrastColor(iconBg, theme, selectedTheme === 'dark');
 
-	const containerStyles: ViewStyle[] = [styles.container, { backgroundColor: theme.screen.iconBg } as ViewStyle];
+        const hasIcon = !!leftIcon;
+        const showIconWrapper = hasIcon && !noIconIndent;
+        const shouldReserveIconSpace = !hasIcon && !noIconIndent;
+
+        const containerStyles: ViewStyle[] = [styles.container, { backgroundColor: theme.screen.iconBg } as ViewStyle];
 
 	if (groupPosition === 'top') {
 		containerStyles.push({
@@ -41,15 +45,18 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, val
 		});
 	}
 
-	return (
-		<>
-			<Container onPress={pressHandler} style={containerStyles}>
-				<View style={[styles.iconWrapper, { backgroundColor: iconBg }]}>{React.isValidElement(leftIcon) ? React.cloneElement(leftIcon, { color: iconColor }) : leftIcon}</View>
-				<View style={styles.textWrapper}>
-					<View style={styles.titleContainer}>
-						<Text style={[styles.title, { color: theme.screen.text } as TextStyle]} numberOfLines={0}>
-							{title || label}
-						</Text>
+        return (
+                <>
+                        <Container onPress={pressHandler} style={containerStyles}>
+                                {showIconWrapper ? (
+                                        <View style={[styles.iconWrapper, { backgroundColor: iconBg }]}>{React.isValidElement(leftIcon) ? React.cloneElement(leftIcon, { color: iconColor }) : leftIcon}</View>
+                                ) : null}
+                                {shouldReserveIconSpace ? <View style={styles.iconPlaceholder} /> : null}
+                                <View style={styles.textWrapper}>
+                                        <View style={styles.titleContainer}>
+                                                <Text style={[styles.title, { color: theme.screen.text } as TextStyle]} numberOfLines={0}>
+                                                        {title || label}
+                                                </Text>
 					</View>
 					{value ? (
 						<View style={styles.valueContainer}>
@@ -58,12 +65,12 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, val
 							</Text>
 						</View>
 					) : null}
-				</View>
-				{rightElement || rightIcon ? <View style={styles.rightWrapper}>{rightElement || rightIcon}</View> : null}
-			</Container>
-			{showSeparator && <View style={[styles.separator, { backgroundColor: theme.screen.background, marginLeft: 54 }]} />}
-		</>
-	);
+                                </View>
+                                {rightElement || rightIcon ? <View style={styles.rightWrapper}>{rightElement || rightIcon}</View> : null}
+                        </Container>
+                        {showSeparator && <View style={[styles.separator, { backgroundColor: theme.screen.background, marginLeft: noIconIndent ? 0 : 54 }]} />}
+                </>
+        );
 };
 
 export default SettingsList;
@@ -76,17 +83,22 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 16,
 		paddingVertical: basePaddingVertical,
 	},
-	iconWrapper: {
-		width: 34,
-		height: 34,
-		borderRadius: 8,
-		alignItems: 'center',
-		justifyContent: 'center',
-		marginRight: 10,
-	},
-	textWrapper: {
-		flexDirection: 'row',
-		flexWrap: 'wrap',
+        iconWrapper: {
+                width: 34,
+                height: 34,
+                borderRadius: 8,
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginRight: 10,
+        },
+        iconPlaceholder: {
+                width: 34,
+                height: 34,
+                marginRight: 10,
+        },
+        textWrapper: {
+                flexDirection: 'row',
+                flexWrap: 'wrap',
 		alignItems: 'center', // statt flex-start, damit beide Container mittig sind
 		columnGap: 3,
 		flex: 1,

--- a/apps/frontend/app/components/SettingsList/types.ts
+++ b/apps/frontend/app/components/SettingsList/types.ts
@@ -1,7 +1,7 @@
 import {PropsWithChildren} from "react";
 
 type SettingsListPropsOwn = {
-	leftIcon: React.ReactNode;
+        leftIcon?: React.ReactNode;
 	/**
 	 * Title text for the row. "label" is kept for backwards
 	 * compatibility with the old `SettingList` component.
@@ -26,8 +26,13 @@ type SettingsListPropsOwn = {
 	 * kept for backwards compatibility with the old `SettingList`
 	 * component.
 	 */
-	iconBackgroundColor?: string;
-	iconBgColor?: string;
+        iconBackgroundColor?: string;
+        iconBgColor?: string;
+        /**
+         * Disable indentation that is normally reserved for the icon column.
+         * Useful when no icon should be displayed.
+         */
+        noIconIndent?: boolean;
 	/**
 	 * Optional separator below the item.
 	 */


### PR DESCRIPTION
## Summary
- add a `noIconIndent` prop to SettingsList to control icon spacing when no icon is shown
- adjust separator alignment and spacing logic when no icon indentation is disabled
- use the new prop for opening hours entries so text aligns without a placeholder icon

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69449320c58083309137ba5cab548ffc)