### PR TITLE
Enhance collectible events list display

### DIFF
--- a/apps/frontend/app/app/(app)/collectible-events/index.tsx
+++ b/apps/frontend/app/app/(app)/collectible-events/index.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import { SafeAreaView, ScrollView, Text } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
+import { COLLECTABLE_AT_FIELDS, DateHelper } from 'repo-depkit-common';
+import type { DatabaseTypes } from 'repo-depkit-common';
 
 import SettingsList from '@/components/SettingsList';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
@@ -19,9 +21,22 @@ const getGroupPosition = (index: number, length: number) => {
         return 'middle';
 };
 
-const formatDateRange = (event: any) => {
-        const startDate = event?.date_start;
-        const endDate = event?.date_end;
+const formatDate = (dateString?: string | null) => {
+        if (!dateString || !DateHelper.isValidDateString(dateString)) {
+                return undefined;
+        }
+
+        try {
+                return DateHelper.formatOfferDateToReadable(new Date(dateString), true);
+        } catch (error) {
+                console.error('Error formatting date:', error);
+                return undefined;
+        }
+};
+
+const formatDateRange = (event: DatabaseTypes.CollectibleEvents) => {
+        const startDate = formatDate(event?.date_start);
+        const endDate = formatDate(event?.date_end);
 
         if (startDate && endDate) {
                 return `${startDate} - ${endDate}`;
@@ -30,21 +45,55 @@ const formatDateRange = (event: any) => {
         return startDate || endDate || undefined;
 };
 
+const formatEventValue = (collected: number, total: number, dateRange?: string) => {
+        const progress = `${collected}/${total}`;
+
+        if (dateRange) {
+                return `${progress}\n${dateRange}`;
+        }
+
+        return progress;
+};
+
 const CollectibleEventsScreen = () => {
         useSetPageTitle(TranslationKeys.collectible_events);
         const { theme } = useTheme();
         const { translate, language } = useLanguage();
         const { primaryColor } = useSelector((state: RootState) => state.settings);
-        const { collectibleEvents } = useSelector((state: RootState) => state.collectibleEvents);
+        const { collectibleEvents, collectibleEventsDict = {} } = useSelector(
+                (state: RootState) => state.collectibleEvents
+        );
 
-        const events = useMemo(() => collectibleEvents || [], [collectibleEvents]);
-        const hasEvents = events.length > 0;
+        const events = useMemo<DatabaseTypes.CollectibleEvents[]>(
+                () => collectibleEvents || [],
+                [collectibleEvents]
+        );
+        const eventsWithProgress = useMemo(
+                () =>
+                        events.map(event => {
+                                const totalCollectibles = COLLECTABLE_AT_FIELDS.filter(
+                                        key => (event as any)?.[key]
+                                ).length;
+                                const collectedCount = Object.values(
+                                        collectibleEventsDict?.[event?.id] || {}
+                                ).filter(Boolean).length;
+
+                                return {
+                                        event,
+                                        collectedCount,
+                                        totalCollectibles,
+                                        dateRange: formatDateRange(event),
+                                };
+                        }),
+                [collectibleEventsDict, events]
+        );
+        const hasEvents = eventsWithProgress.length > 0;
 
         return (
                 <SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.background }}>
                         <ScrollView contentContainerStyle={styles.container}>
                                 {hasEvents ? (
-                                        events.map((event: any, index: number) => (
+                                        eventsWithProgress.map(({ event, collectedCount, totalCollectibles, dateRange }, index) => (
                                                 <SettingsList
                                                         key={event.id || index}
                                                         iconBgColor={primaryColor}
@@ -60,8 +109,8 @@ const CollectibleEventsScreen = () => {
                                                                         ? getTitleFromTranslation(event.translations as any, language)
                                                                         : event?.alias || translate(TranslationKeys.collectible_event)
                                                         }
-                                                        value={formatDateRange(event)}
-                                                        groupPosition={getGroupPosition(index, events.length) as any}
+                                                        value={formatEventValue(collectedCount, totalCollectibles, dateRange)}
+                                                        groupPosition={getGroupPosition(index, eventsWithProgress.length) as any}
                                                 />
                                         ))
                                 ) : (


### PR DESCRIPTION
## Summary
- show collectible progress counts and formatted date ranges in the collectible events list
- format event dates with the shared DateHelper and render them beneath the progress indicator

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944a229add08330acab1a2d245956f6)