### PR TITLE
Close logout confirmation modal on confirm

### DIFF
--- a/apps/frontend/app/hooks/useConfirmLogoutModal.tsx
+++ b/apps/frontend/app/hooks/useConfirmLogoutModal.tsx
@@ -17,8 +17,8 @@ const useConfirmLogoutModal = () => {
         const openConfirmLogoutModal = useCallback(
                 (asGuest: boolean = false) => {
                         const handleLogout = async () => {
-                                await logout(asGuest);
                                 close();
+                                await logout(asGuest);
                         };
 
                         show(


### PR DESCRIPTION
## Summary
- close the logout confirmation modal immediately when confirming logout to mirror other modal behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944a777a628833088519583cc3145ce)