### PR TITLE
Add logout translation hook and generic logout modal text

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -19,7 +19,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { useLanguage } from '@/hooks/useLanguage';
 import { RESET_ALL_COLLECTIBLE_EVENT_DICTS, SET_AMOUNT_COLUMNS_FOR_CARDS, SET_COLLECTIBLE_ITEM_SIZE, SET_COLLECTIBLE_RANDOM_POSITION, SET_DEBUG_MODE, SET_DRAWER_POSITION, SET_FIRST_DAY_OF_THE_WEEK, SET_FOODOFFERS_NEXT_DAY_THRESHOLD, SET_NICKNAME_LOCAL, SET_USE_WEBP_FOR_ASSETS, UPDATE_DEVELOPER_MODE, UPDATE_MANAGEMENT, UPDATE_PROFILE } from '@/redux/Types/types';
-import { performLogout } from '@/helper/logoutHelper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
@@ -45,6 +44,7 @@ import languageStyles from '@/components/LanguageSheet/styles';
 import { languages } from '@/constants/SettingData';
 import { myContrastColor } from '@/helper/ColorHelper';
 import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
+import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
 
@@ -70,6 +70,7 @@ const Settings = () => {
         const { manualCheck } = useExpoUpdateChecker();
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useSelector((state: RootState) => state.authReducer);
         const isRegisteredUser = UserHelper.isRegisteredUser(user);
+        const { buttonLabel: logoutButtonLabel } = useLogoutButtonTranslation();
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, collectibleItemSize, collectibleRandomPosition } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
@@ -348,9 +349,9 @@ const Settings = () => {
 
         const handleLogout = useCallback(() => openConfirmLogoutModal(), [openConfirmLogoutModal]);
 
-	const handleLogin = () => {
-		performLogout(dispatch, router, true);
-	};
+        const handleLogin = useCallback(() => openConfirmLogoutModal(true), [openConfirmLogoutModal]);
+
+        const logoutButtonHandler = useMemo(() => (isRegisteredUser ? handleLogout : handleLogin), [handleLogin, handleLogout, isRegisteredUser]);
 
 	const openCanteenSheet = () => {
 		canteenSheetRef?.current?.expand();
@@ -500,14 +501,10 @@ const Settings = () => {
                                                         }}
                                                         groupPosition="middle"
                                                 />
-						{isRegisteredUser ? (
-							<>
-								<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.logout)} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={handleLogout} groupPosition="middle" />
-								<SettingsList iconBgColor={primaryColor} leftIcon={<AntDesign name="user-delete" size={22} color={theme.screen.icon} />} label={`${translate(TranslationKeys.account_delete)}`} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={handleDeleteAccount} groupPosition="middle" />
-							</>
-						) : (
-							<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.sign_in)} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={handleLogin} groupPosition="middle" />
-						)}
+                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={logoutButtonLabel} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={logoutButtonHandler} groupPosition="middle" />
+                                                {isRegisteredUser ? (
+                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<AntDesign name="user-delete" size={22} color={theme.screen.icon} />} label={`${translate(TranslationKeys.account_delete)}`} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={handleDeleteAccount} groupPosition="middle" />
+                                                ) : null}
 						<SettingsList iconBgColor={primaryColor} leftIcon={<Ionicons name="language" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.language)} value={languageName} rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />} handleFunction={() => openLanguageModal()} groupPosition="bottom" />
 					</View>
 					<SettingsGroupTitle>{translate(TranslationKeys.group_canteen_usage)}</SettingsGroupTitle>

--- a/apps/frontend/app/hooks/useConfirmLogoutModal.tsx
+++ b/apps/frontend/app/hooks/useConfirmLogoutModal.tsx
@@ -7,12 +7,14 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import useLogout from './useLogout';
+import useLogoutButtonTranslation from './useLogoutButtonTranslation';
 
 const useConfirmLogoutModal = () => {
         const { show, close } = useMyScrollViewModal();
         const logout = useLogout();
         const { translate } = useLanguage();
         const { theme } = useTheme();
+        const { buttonLabel, modalDescription } = useLogoutButtonTranslation();
 
         const openConfirmLogoutModal = useCallback(
                 (asGuest: boolean = false) => {
@@ -32,10 +34,10 @@ const useConfirmLogoutModal = () => {
                                                                         color: theme.screen.text,
                                                                 }}
                                                         >
-                                                                {translate(TranslationKeys.logout)}
+                                                                {buttonLabel}
                                                         </Text>
                                                         <Text style={{ color: theme.screen.text }}>
-                                                                {translate(TranslationKeys.are_you_sure_to_logout)}
+                                                                {modalDescription}
                                                         </Text>
                                                         <ProjectButton
                                                                 text={translate(TranslationKeys.confirm)}
@@ -53,7 +55,7 @@ const useConfirmLogoutModal = () => {
                                 { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
                         );
                 },
-                [close, logout, show, theme.screen.text, theme.sheet.sheetBg, translate]
+                [buttonLabel, close, logout, modalDescription, show, theme.screen.text, theme.sheet.sheetBg, translate]
         );
 
         return { openConfirmLogoutModal, closeConfirmLogoutModal: close };

--- a/apps/frontend/app/hooks/useLogoutButtonTranslation.ts
+++ b/apps/frontend/app/hooks/useLogoutButtonTranslation.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { UserHelper } from '@/helper/UserHelper';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+
+const useLogoutButtonTranslation = () => {
+        const { translate } = useLanguage();
+        const { user } = useSelector((state: RootState) => state.authReducer);
+        const isRegisteredUser = UserHelper.isRegisteredUser(user);
+
+        const buttonLabel = useMemo(
+                () => translate(isRegisteredUser ? TranslationKeys.logout : TranslationKeys.sign_in),
+                [isRegisteredUser, translate]
+        );
+
+        const modalDescription = useMemo(
+                () => translate(TranslationKeys.logout_flow_modal_description),
+                [translate]
+        );
+
+        return { buttonLabel, modalDescription, isRegisteredUser };
+};
+
+export default useLogoutButtonTranslation;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -279,6 +279,7 @@ export enum TranslationKeys {
         if_you_want_to_login_with_this_account_please_press = 'if_you_want_to_login_with_this_account_please_press',
         logout = 'logout',
         are_you_sure_to_logout = 'are_you_sure_to_logout',
+        logout_flow_modal_description = 'logout_flow_modal_description',
         register = 'register',
         sign_in = 'sign_in',
         accountbalance = 'accountbalance',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2803,6 +2803,16 @@
     "tr": "Gerçekten çıkış yapmak istiyor musun?",
     "zh": "您确定要注销吗？"
   },
+  "logout_flow_modal_description": {
+    "de": "Du wirst zum Anmeldebildschirm geleitet. Wenn du ein Konto hast, wirst du abgemeldet.",
+    "en": "You will be taken to the login screen. If you have an account, you will be logged out.",
+    "ar": "سيتم نقلك إلى شاشة تسجيل الدخول. إذا كان لديك حساب، سيتم تسجيل خروجك.",
+    "es": "Se te llevará a la pantalla de inicio de sesión. Si tienes una cuenta, se cerrará tu sesión.",
+    "fr": "Vous serez redirigé vers l'écran de connexion. Si vous avez un compte, vous serez déconnecté.",
+    "ru": "Вы будете перенаправлены на экран входа. Если у вас есть аккаунт, вы будете разлогинены.",
+    "tr": "Giriş ekranına yönlendirileceksiniz. Bir hesabınız varsa oturumunuz kapatılacak.",
+    "zh": "您将被带到登录界面。如果您有账户，将会退出登录。"
+  },
   "register": {
     "de": "Registrieren",
     "en": "Register",


### PR DESCRIPTION
## Summary
- add a `useLogoutButtonTranslation` hook to centralize logout/sign-in labels and modal copy
- apply the hook to the settings logout button and confirmation modal for anonymous and registered users
- add translations for the generic logout/login modal description

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944a7e37028833080e1ddaed38b63fb)