### PR TITLE
Improve logout modal handling

### DIFF
--- a/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -24,6 +24,7 @@ import useActiveCollectibleEvent from '@/hooks/useActiveCollectibleEvent';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
 import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
+import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 
 export const iconLibraries: Record<string, any> = {
 	Ionicons,
@@ -66,6 +67,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({ navigation
         const { hasUnreadChats } = useChatUnreadStatus();
         const { hasActiveCollectibleEvent } = useActiveCollectibleEvent();
         const { openConfirmLogoutModal } = useConfirmLogoutModal();
+        const { buttonLabel: logoutButtonLabel } = useLogoutButtonTranslation();
 
 	const balance_area_color = appSettings?.balance_area_color ? appSettings?.balance_area_color : projectColor;
 	const course_timetable_area_color = appSettings?.course_timetable_area_color ? appSettings?.course_timetable_area_color : projectColor;
@@ -388,7 +390,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({ navigation
                                                         onPress={() => openConfirmLogoutModal(!user?.id)}
                                                 >
                                                         <MaterialCommunityIcons name="logout" size={28} color={theme.inactiveIcon} />
-                                                        <Text style={getMenuLabelStyle('faq-living/index')}>{translate(TranslationKeys.logout)}</Text>
+                                                        <Text style={getMenuLabelStyle('faq-living/index')}>{logoutButtonLabel}</Text>
                                                 </TouchableOpacity>
                                                 <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_drawer} />
                                         </View>

--- a/apps/frontend/app/hooks/useLogout.ts
+++ b/apps/frontend/app/hooks/useLogout.ts
@@ -3,16 +3,19 @@ import { useDispatch } from 'react-redux';
 import { useRouter } from 'expo-router';
 
 import { performLogout } from '@/helper/logoutHelper';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 const useLogout = () => {
         const dispatch = useDispatch();
         const router = useRouter();
+        const { close } = useMyScrollViewModal();
 
         return useCallback(
                 async (asGuest: boolean = false) => {
+                        close();
                         await performLogout(dispatch, router, asGuest);
                 },
-                [dispatch, router]
+                [close, dispatch, router]
         );
 };
 


### PR DESCRIPTION
## Summary
- align the drawer logout button label with the shared logout translation hook
- close the shared scroll-view modal when performing logout so the confirm dialog dismisses reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ae037efc8330b9b6ccd9ca27834c)