### PR TITLE
Refactor utilization modal into shared hook

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -22,7 +22,6 @@ import HourSheet from '@/components/HoursSheet/HoursSheet';
 import CalendarSheet from '@/components/CalendarSheet/CalendarSheet';
 import { excerpt } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
-import ForecastSheet from '@/components/ForecastSheet/ForecastSheet';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -42,13 +41,13 @@ import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
+import useUtilizationModal from '@/hooks/useUtilizationModal';
 
 export const SHEET_COMPONENTS = {
         canteen: CanteenSelectionSheet,
         sort: SortSheet,
         hours: HourSheet,
         calendar: CalendarSheet,
-        forecast: ForecastSheet,
         imageManagement: ImageManagementSheet,
         aiGeneratedInfo: AIGeneratedHintSheet,
         eatingHabits: EatingHabitsSheet,
@@ -77,12 +76,13 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const [animationJson, setAmimationJson] = useState<any>(null);
 	const { profile, user } = useSelector((state: RootState) => state.authReducer);
         const selectedCanteen = useSelectedCanteen();
-                const kioskMode = useKioskMode();
+        const kioskMode = useKioskMode();
         const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
         const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
-	const { openActiveModal, activePopupEvent } = usePopupEventModal();
+        const { openUtilizationModal } = useUtilizationModal();
+        const { openActiveModal, activePopupEvent } = usePopupEventModal();
 
 	// Set Page Title
 	useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);
@@ -608,7 +608,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 										trigger={triggerProps => (
 											<TouchableOpacity
 												{...triggerProps}
-												onPress={() => openSheet('forecast', { forDate: selectedDate })}
+                                                                                                onPress={() => openUtilizationModal(selectedDate, selectedCanteen)}
 												style={{
 													padding: isWeb ? (screenWidth < 500 ? 2 : 5) : 2,
 												}}
@@ -666,19 +666,19 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 						<BaseBottomSheet
 							key={selectedSheet}
 							ref={bottomSheetRef}
-							backgroundStyle={{
-								...styles.sheetBackground,
-								backgroundColor: theme.sheet.sheetBg,
-							}}
-							enablePanDownToClose={selectedSheet === 'forecast' ? false : true}
-							enableContentPanningGesture={selectedSheet === 'forecast' ? false : true}
-							enableHandlePanningGesture={selectedSheet === 'forecast' ? false : true}
-							enableDynamicSizing={selectedSheet === 'forecast' ? false : true}
-							onChange={index => {
-								if (index === -1) {
-									closeSheet();
-								}
-							}}
+                                                        backgroundStyle={{
+                                                                ...styles.sheetBackground,
+                                                                backgroundColor: theme.sheet.sheetBg,
+                                                        }}
+                                                        enablePanDownToClose
+                                                        enableContentPanningGesture
+                                                        enableHandlePanningGesture
+                                                        enableDynamicSizing
+                                                        onChange={index => {
+                                                                if (index === -1) {
+                                                                        closeSheet();
+                                                                }
+                                                        }}
 							onClose={closeSheet}
 							handleComponent={null}
 						>

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -41,7 +41,6 @@ import HourSheet from '@/components/HoursSheet/HoursSheet';
 import CalendarSheet from '@/components/CalendarSheet/CalendarSheet';
 import {excerpt} from '@/constants/HelperFunctions';
 import {useLanguage} from '@/hooks/useLanguage';
-import ForecastSheet from '@/components/ForecastSheet/ForecastSheet';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet';
 import {CanteenFeedbackLabelHelper} from '@/redux/actions/CanteenFeedbacksLabel/CanteenFeedbacksLabel';
@@ -70,17 +69,17 @@ import useChatUnreadStatus from '@/hooks/useChatUnreadStatus';
 import IconButton from '@/components/UI/IconButton';
 import Button from '@/components/UI/Button';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import useUtilizationModal from '@/hooks/useUtilizationModal';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
 
 export const SHEET_COMPONENTS = {
-	canteen: CanteenSelectionSheet,
-	sort: SortSheet,
-	hours: HourSheet,
-	calendar: CalendarSheet,
-	forecast: ForecastSheet,
-	imageManagement: ImageManagementSheet,
-	aiGeneratedInfo: AIGeneratedHintSheet,
-	eatingHabits: EatingHabitsSheet,
+        canteen: CanteenSelectionSheet,
+        sort: SortSheet,
+        hours: HourSheet,
+        calendar: CalendarSheet,
+        imageManagement: ImageManagementSheet,
+        aiGeneratedInfo: AIGeneratedHintSheet,
+        eatingHabits: EatingHabitsSheet,
 };
 
 interface DayItem {
@@ -136,8 +135,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
         const { hasUnreadChats } = useChatUnreadStatus();
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
-	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
-	const { openActiveModal, activePopupEvent } = usePopupEventModal();
+        const { openUtilizationModal } = useUtilizationModal();
+        const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
+        const { openActiveModal, activePopupEvent } = usePopupEventModal();
 
 	const MIN_CARD_WIDTH = 280;
 	const numColumns = useMemo(() => {
@@ -329,9 +329,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
         );
 
-	const openManagementSheet = useCallback((id: string) => {
-		if (id) {
-			openSheet('imageManagement', {
+        const openManagementSheet = useCallback((id: string) => {
+                if (id) {
+                        openSheet('imageManagement', {
 				selectedFoodId: id,
 				fileName: 'foods',
 				closeSheet: closeSheet,
@@ -802,11 +802,15 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 								{appSettings?.utilization_display_enabled && (
 									<Tooltip
 										placement="top"
-										trigger={triggerProps => (
-											<IconButton {...triggerProps} onPress={() => openSheet('forecast', { forDate: selectedDate })} style={{ padding: isWeb ? (screenWidth < 500 ? 2 : 5) : 2 }}>
-												<FontAwesome6 name="people-group" size={24} color={theme.header.text} />
-											</IconButton>
-										)}
+                                                                                trigger={triggerProps => (
+                                                                                        <IconButton
+                                                                                                {...triggerProps}
+                                                                                                onPress={() => openUtilizationModal(selectedDate, selectedCanteen)}
+                                                                                                style={{ padding: isWeb ? (screenWidth < 500 ? 2 : 5) : 2 }}
+                                                                                        >
+                                                                                                <FontAwesome6 name="people-group" size={24} color={theme.header.text} />
+                                                                                        </IconButton>
+                                                                                )}
 									>
 										<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
 											<TooltipText fontSize="$sm" color={theme.tooltip.text}>
@@ -873,17 +877,17 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 						<MarkingBottomSheet ref={bottomSheetRef} onClose={closeSheet} />
 					) : (
 						<BaseBottomSheet
-							key={selectedSheet || 'sheet'}
-							ref={bottomSheetRef}
-							backgroundStyle={{ ...styles.sheetBackground, backgroundColor: theme.sheet.sheetBg }}
-							enablePanDownToClose={selectedSheet === 'forecast' ? false : true}
-							enableContentPanningGesture={selectedSheet === 'forecast' ? false : true}
-							enableHandlePanningGesture={selectedSheet === 'forecast' ? false : true}
-							enableDynamicSizing={selectedSheet === 'forecast' ? false : true}
-							onChange={index => {
-								if (index === -1) closeSheet();
-							}}
-							onClose={closeSheet}
+                                                        key={selectedSheet || 'sheet'}
+                                                        ref={bottomSheetRef}
+                                                        backgroundStyle={{ ...styles.sheetBackground, backgroundColor: theme.sheet.sheetBg }}
+                                                        enablePanDownToClose
+                                                        enableContentPanningGesture
+                                                        enableHandlePanningGesture
+                                                        enableDynamicSizing
+                                                        onChange={index => {
+                                                                if (index === -1) closeSheet();
+                                                        }}
+                                                        onClose={closeSheet}
 							handleComponent={null}
 						>
 							{SheetComponent && (

--- a/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -8,7 +8,6 @@ import {isWeb} from '@/constants/Constants';
 import {ForecastSheetProps} from './types';
 import {format, parseISO} from 'date-fns';
 import {UtilizationEntryHelper} from '@/redux/actions/UtilizationEntries/UtilizationEntries';
-import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import {useLanguage} from '@/hooks/useLanguage';
 import {TranslationKeys} from '@/locales/keys';
 import {DatabaseTypes} from 'repo-depkit-common';
@@ -24,12 +23,11 @@ type ForecastEntry = {
 
 const showDebugInformation = false;
 
-const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate }) => {
+const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate, canteen }) => {
         const { theme } = useTheme();
         const { translate } = useLanguage();
         const utilizationEntryHelper = new UtilizationEntryHelper();
         const [loading, setLoading] = useState(false);
-        const selectedCanteen = useSelectedCanteen();
         const [forecastEntries, setForecastEntries] = useState<ForecastEntry[]>([]);
         const [currentUtilizationGroup, setCurrentUtilizationGroup] = useState<DatabaseTypes.UtilizationsGroups | null>(null);
 
@@ -102,7 +100,7 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate }) =>
                 try {
                         setLoading(true);
 
-                        const utlizationGroupId = selectedCanteen?.utilization_group as string | undefined;
+                        const utlizationGroupId = canteen?.utilization_group as string | undefined;
 
                         if (!utlizationGroupId) {
                                 setForecastEntries([]);
@@ -132,10 +130,14 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate }) =>
         };
 
         useEffect(() => {
-                if (selectedCanteen) {
+                if (canteen) {
                         getUtilization(forDate);
+                } else {
+                        setForecastEntries([]);
+                        setCurrentUtilizationGroup(null);
+                        setLoading(false);
                 }
-        }, [selectedCanteen, forDate]);
+        }, [canteen, forDate]);
 
         const title = translate(TranslationKeys.forecast);
         let debugInformationInTitle = '';

--- a/apps/frontend/app/components/ForecastSheet/types.ts
+++ b/apps/frontend/app/components/ForecastSheet/types.ts
@@ -1,4 +1,7 @@
+import {DatabaseTypes} from 'repo-depkit-common';
+
 export interface ForecastSheetProps {
-	closeSheet: () => void;
-	forDate: string;
+        closeSheet: () => void;
+        forDate: string;
+        canteen: DatabaseTypes.Canteens | null;
 }

--- a/apps/frontend/app/hooks/useUtilizationModal.tsx
+++ b/apps/frontend/app/hooks/useUtilizationModal.tsx
@@ -1,0 +1,36 @@
+import React, {useCallback} from 'react';
+import ForecastSheet from '@/components/ForecastSheet/ForecastSheet';
+import {useMyScrollViewModal} from '@/components/GlobalModal/useMyScrollViewModal';
+import {useLanguage} from '@/hooks/useLanguage';
+import {useTheme} from '@/hooks/useTheme';
+import {TranslationKeys} from '@/locales/keys';
+import {DatabaseTypes} from 'repo-depkit-common';
+
+export const useUtilizationModal = () => {
+        const {show: showScrollViewModal, close: closeScrollViewModal} = useMyScrollViewModal();
+        const {theme} = useTheme();
+        const {translate} = useLanguage();
+
+        const openUtilizationModal = useCallback(
+                (forDate: string, canteen: DatabaseTypes.Canteens | null) =>
+                        showScrollViewModal(
+                                {
+                                        title: translate(TranslationKeys.forecast),
+                                        onClose: closeScrollViewModal,
+                                        children: (
+                                                <ForecastSheet
+                                                        closeSheet={closeScrollViewModal}
+                                                        forDate={forDate}
+                                                        canteen={canteen}
+                                                />
+                                        ),
+                                },
+                                {backgroundStyle: {backgroundColor: theme.sheet.sheetBg}, headerBackgroundColor: theme.sheet.sheetBg}
+                        ),
+                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+        );
+
+        return {openUtilizationModal};
+};
+
+export default useUtilizationModal;


### PR DESCRIPTION
## Summary
- extract utilization modal opening into a reusable hook shared by food offer screens
- pass selected date and canteen into ForecastSheet via the shared modal helper and clear data when no canteen is available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450b308c5c8330ba37830228f0d17e)