### PR TITLE
Remove nested sheet from utilization modal

### DIFF
--- a/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -1,10 +1,7 @@
-import {ActivityIndicator, Text, TouchableOpacity, View} from 'react-native';
-import {AntDesign} from '@expo/vector-icons';
+import {ActivityIndicator, Text, View} from 'react-native';
 import React, {useEffect, useState} from 'react';
 import {useTheme} from '@/hooks/useTheme';
-import {BottomSheetScrollView, BottomSheetView} from '@gorhom/bottom-sheet';
 import styles from './styles';
-import {isWeb} from '@/constants/Constants';
 import {ForecastSheetProps} from './types';
 import {format, parseISO} from 'date-fns';
 import {UtilizationEntryHelper} from '@/redux/actions/UtilizationEntries/UtilizationEntries';
@@ -23,7 +20,7 @@ type ForecastEntry = {
 
 const showDebugInformation = false;
 
-const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate, canteen }) => {
+const ForecastSheet: React.FC<ForecastSheetProps> = ({ forDate, canteen }) => {
         const { theme } = useTheme();
         const { translate } = useLanguage();
         const utilizationEntryHelper = new UtilizationEntryHelper();
@@ -139,59 +136,19 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate, cant
                 }
         }, [canteen, forDate]);
 
-        const title = translate(TranslationKeys.forecast);
         let debugInformationInTitle = '';
         if(showDebugInformation) {
             debugInformationInTitle = `all_time_high ${currentUtilizationGroup?.all_time_high ?? 'N/A'}, threshold_until_max ${currentUtilizationGroup?.threshold_until_max ?? 'N/A'}`;
         }
 
         return (
-                <BottomSheetView style={{ ...styles.container, backgroundColor: theme.sheet.sheetBg }}>
-			<View
-				style={{
-					...styles.header,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View style={styles.placeholder} />
-				<View style={[styles.handle, { backgroundColor: theme.sheet.closeBg }]} />
-				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={closeSheet}>
-					<AntDesign name="close" size={24} color={theme.sheet.closeIcon} />
-				</TouchableOpacity>
-			</View>
-			<View style={styles.titleContainer}>
-                <View>
-                    <Text
-                        style={{
-                            ...styles.sheetHeading,
-                            fontSize: isWeb ? 40 : 28,
-                            color: theme.sheet.text,
-                        }}
-                    >
-                        {title}
-                    </Text>
-                </View>
-                {showDebugInformation && (
-                    <View>
-                        <Text
-                            style={{
-                                color: theme.sheet.text,
-                            }}
-                        >
-                            {debugInformationInTitle}
-                        </Text>
-                    </View>
-                )}
-			</View>
-                        <BottomSheetScrollView
-                                style={styles.forecastContainer}
-                                contentContainerStyle={{
-                                        paddingHorizontal: 10,
-                                        paddingBottom: 40,
-                                        paddingTop: 20,
-                                }}
-                        >
+                <View style={styles.container}>
+                        {showDebugInformation && (
+                                <Text style={[styles.debugInformation, { color: theme.sheet.text }]}>
+                                        {debugInformationInTitle}
+                                </Text>
+                        )}
+                        <View style={styles.forecastContainer}>
                                 {loading ? (
                                         <View style={styles.loadingContainer}>
                                                 <ActivityIndicator size={40} color={theme.screen.icon} />
@@ -232,8 +189,8 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({ closeSheet, forDate, cant
                                                 {translate(TranslationKeys.no_data_found)}
                                         </Text>
                                 )}
-                        </BottomSheetScrollView>
-                </BottomSheetView>
+                        </View>
+                </View>
         );
 };
 

--- a/apps/frontend/app/components/ForecastSheet/styles.ts
+++ b/apps/frontend/app/components/ForecastSheet/styles.ts
@@ -1,56 +1,18 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	container: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-		alignItems: 'center',
-	},
-	header: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-	},
-	titleContainer: {
-		width: '100%',
-		flexDirection: 'column',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	closeButton: {
-		width: 45,
-		height: 45,
-		borderRadius: 50,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	handle: {
-		width: '30%',
-		height: 6,
-		borderRadius: 3,
-		marginHorizontal: 10,
-		alignSelf: 'center',
-	},
-	placeholder: {
-		width: 45,
-		height: 45,
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
-	},
+        container: {
+                width: '100%',
+                gap: 16,
+        },
+        debugInformation: {
+                fontFamily: 'Poppins_400Regular',
+                fontSize: 14,
+        },
         forecastContainer: {
                 width: '100%',
                 minHeight: 400,
+                gap: 8,
         },
         loadingContainer: {
                 width: '100%',

--- a/apps/frontend/app/components/ForecastSheet/types.ts
+++ b/apps/frontend/app/components/ForecastSheet/types.ts
@@ -1,7 +1,6 @@
 import {DatabaseTypes} from 'repo-depkit-common';
 
 export interface ForecastSheetProps {
-        closeSheet: () => void;
         forDate: string;
         canteen: DatabaseTypes.Canteens | null;
 }

--- a/apps/frontend/app/hooks/useUtilizationModal.tsx
+++ b/apps/frontend/app/hooks/useUtilizationModal.tsx
@@ -19,7 +19,6 @@ export const useUtilizationModal = () => {
                                         onClose: closeScrollViewModal,
                                         children: (
                                                 <ForecastSheet
-                                                        closeSheet={closeScrollViewModal}
                                                         forDate={forDate}
                                                         canteen={canteen}
                                                 />


### PR DESCRIPTION
## Summary
- render the utilization forecast content directly in the shared scroll view modal instead of nesting another sheet
- simplify the forecast sheet layout and styles to match the single-modal structure

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694512fc28d0833097bb5c8709789e13)