### PR TITLE
Remove background styling from marking modal content

### DIFF
--- a/apps/frontend/app/components/MenuSheet/MenuSheet.tsx
+++ b/apps/frontend/app/components/MenuSheet/MenuSheet.tsx
@@ -16,8 +16,8 @@ const MenuSheet: React.FC<MenuSheetProps> = ({ closeSheet }) => {
 	const { markingDetails } = useSelector((state: RootState) => state.food);
 	const { language } = useSelector((state: RootState) => state.settings);
 	const description = getDescriptionFromTranslation(markingDetails?.translations, language);
-	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
+        return (
+                <BottomSheetScrollView style={styles.sheetView} contentContainerStyle={styles.contentContainer}>
 			<View
 				style={{
 					...styles.sheetHeader,

--- a/apps/frontend/app/components/MenuSheet/styles.ts
+++ b/apps/frontend/app/components/MenuSheet/styles.ts
@@ -1,25 +1,21 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	sheetView: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
+        sheetView: {
+                width: '100%',
+                height: '100%',
+                padding: 10,
+                paddingBottom: 0,
+        },
 	contentContainer: {
 		alignItems: 'center',
 	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
+        sheetHeader: {
+                width: '100%',
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
+        },
 	sheetcloseButton: {
 		width: 45,
 		height: 45,


### PR DESCRIPTION
## Summary
- remove the sheet content background color from the marking modal
- drop the rounded corners on the modal content container while keeping existing layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69451b67610883308ac0b5f39ff5fbc1)