### PR TITLE
Adjust customer configuration labeling

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -47,6 +47,7 @@ import { languages } from '@/constants/SettingData';
 import { myContrastColor } from '@/helper/ColorHelper';
 import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
 import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
+import useCustomerConfig from '@/hooks/useCustomerConfig';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
 
@@ -79,9 +80,10 @@ const Settings = () => {
                 () => (profile?.id ? profile?.nickname ?? '' : nickNameLocal ?? ''),
                 [nickNameLocal, profile?.id, profile?.nickname]
         );
-	const selectedCanteen = useSelectedCanteen();
-	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
-	const profileHelper = useMemo(() => new ProfileHelper(), []);
+        const selectedCanteen = useSelectedCanteen();
+        const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
+        const profileHelper = useMemo(() => new ProfileHelper(), []);
+        const customerConfig = useCustomerConfig();
 
         const languageCode = language;
 
@@ -90,6 +92,11 @@ const Settings = () => {
         const contrastColor = useMemo(
                 () => myContrastColor(primaryColor, theme, selectedTheme === 'dark'),
                 [primaryColor, selectedTheme, theme]
+        );
+
+        const selectedCustomerDisplayName = useMemo(
+                () => customerConfig.projectName || selectedCustomer || '',
+                [customerConfig.projectName, selectedCustomer]
         );
 
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
@@ -588,7 +595,7 @@ const Settings = () => {
 					>
 						<Text style={{ ...styles.devModeText, color: theme.screen.text }}>{translate(TranslationKeys.developerModeActive)}</Text>
 						<View style={{ gap: 0 }}>
-                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={selectedCustomer} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
+                                                        <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={selectedCustomerDisplayName} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
 							<SettingsList

--- a/apps/frontend/app/components/ServerOption/ServerOption.tsx
+++ b/apps/frontend/app/components/ServerOption/ServerOption.tsx
@@ -8,15 +8,16 @@ import type { RootState } from '@/redux/reducer';
 import type { CustomerConfig } from '@/config';
 
 interface ServerOptionProps {
-	server: CustomerConfig;
-	isSelected: boolean;
-	onPress: () => void;
+        server: CustomerConfig;
+        label: string;
+        isSelected: boolean;
+        onPress: () => void;
 }
 
-const ServerOption: React.FC<ServerOptionProps> = ({ server, isSelected, onPress }) => {
-	const { theme } = useTheme();
-	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+const ServerOption: React.FC<ServerOptionProps> = ({ server, label, isSelected, onPress }) => {
+        const { theme } = useTheme();
+        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 	return (
 		<TouchableOpacity
 			style={{
@@ -27,14 +28,14 @@ const ServerOption: React.FC<ServerOptionProps> = ({ server, isSelected, onPress
 			onPress={onPress}
 		>
 			<MaterialCommunityIcons name="server" size={24} color={isSelected ? contrastColor : theme.screen.icon} style={styles.icon} />
-			<Text
-				style={{
-					...styles.text,
-					color: isSelected ? contrastColor : theme.header.text,
-				}}
-			>
-				{server.projectName}
-			</Text>
+                        <Text
+                                style={{
+                                        ...styles.text,
+                                        color: isSelected ? contrastColor : theme.header.text,
+                                }}
+                        >
+                                {label}
+                        </Text>
 			<MaterialCommunityIcons name={isSelected ? 'checkbox-marked' : 'checkbox-blank'} size={24} color={isSelected ? contrastColor : theme.screen.icon} style={styles.radioButton} />
 		</TouchableOpacity>
 	);

--- a/apps/frontend/app/components/ServerSelectionSheet/ServerSelectionSheet.tsx
+++ b/apps/frontend/app/components/ServerSelectionSheet/ServerSelectionSheet.tsx
@@ -6,7 +6,7 @@ import {useLanguage} from '@/hooks/useLanguage';
 import {isWeb} from '@/constants/Constants';
 import styles from './styles';
 import ServerOption from '@/components/ServerOption/ServerOption';
-import {CustomerConfig, getCustomerConfigurations} from '@/config';
+import {CustomerConfig, getCustomerConfigurations, getCustomerEnumForConfig} from '@/config';
 import {TranslationKeys} from '@/locales/keys';
 
 export interface ServerSelectionSheetProps {
@@ -16,9 +16,11 @@ export interface ServerSelectionSheetProps {
 }
 
 const ServerSelectionSheet: React.FC<ServerSelectionSheetProps> = ({ closeSheet, selectedServer, onSelect }) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const servers: CustomerConfig[] = getCustomerConfigurations();
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const servers: CustomerConfig[] = getCustomerConfigurations();
+
+        const getDisplayName = (config: CustomerConfig) => config.projectName || getCustomerEnumForConfig(config) || '';
 
 	return (
 		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
@@ -37,19 +39,20 @@ const ServerSelectionSheet: React.FC<ServerSelectionSheetProps> = ({ closeSheet,
 						color: theme.sheet.text,
 					}}
 				>
-					{translate(TranslationKeys.backend_server)}
-				</Text>
-			</View>
-			<View style={styles.optionsContainer}>
-				{servers.map(srv => (
-					<ServerOption
-						key={srv.projectSlug}
-						server={srv}
-						isSelected={selectedServer === srv.server_url}
-						onPress={() => {
-							onSelect(srv);
-							closeSheet();
-						}}
+                                {translate(TranslationKeys.backend_server)}
+                        </Text>
+                </View>
+                <View style={styles.optionsContainer}>
+                        {servers.map(srv => (
+                                <ServerOption
+                                        key={srv.projectSlug}
+                                        server={srv}
+                                        label={getDisplayName(srv)}
+                                        isSelected={selectedServer === srv.server_url}
+                                        onPress={() => {
+                                                onSelect(srv);
+                                                closeSheet();
+                                        }}
 					/>
 				))}
 			</View>

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -250,14 +250,14 @@
     "zh": "时间格式无效（例如 HH:MM）"
   },
   "backend_server": {
-    "de": "Backend-Server",
-    "en": "Backend Server",
-    "ar": "خادم الخلفية",
-    "es": "Servidor Backend",
-    "fr": "Serveur Backend",
-    "ru": "Сервер Бэкэнда",
-    "tr": "Arka Uç Sunucusu",
-    "zh": "后端服务器"
+    "de": "Kunden Konfiguration",
+    "en": "Customer Configuration",
+    "ar": "Customer Configuration",
+    "es": "Customer Configuration",
+    "fr": "Customer Configuration",
+    "ru": "Customer Configuration",
+    "tr": "Customer Configuration",
+    "zh": "Customer Configuration"
   },
   "developer_homepage": {
     "de": "Entwickler-Homepage",


### PR DESCRIPTION
## Summary
- rename the backend server label and sheet title to the new customer configuration wording
- display the selected customer using the project name with an enum fallback
- show server options in the selection sheet using the same display-friendly name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69472e49d9708330a758c488d6248eed)