### PR TITLE
Use SettingsList items in language sheet

### DIFF
--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
@@ -13,64 +13,77 @@ import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import MyImage from '@/components/MyImage';
+import SettingsList from '@/components/SettingsList/SettingsList';
 
 const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLanguage, onSelect }) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+        const { theme } = useTheme();
+        const { translate } = useLanguage();
+        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
-	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.language)}
-				</Text>
-			</View>
-			<View style={styles.optionsContainer}>
-				{languages.map((language, index) => (
-					<TouchableOpacity
-						key={index}
-						style={[
-							styles.languageRow,
-							{
-								paddingHorizontal: isWeb ? 20 : 10,
-								backgroundColor: selectedLanguage === language.value ? primaryColor : theme.screen.iconBg,
-							},
-						]}
-						onPress={() => {
-							onSelect(language.value);
-							closeSheet();
-						}}
-					>
-						<MyImage source={language.flag} style={styles.flagIcon} />
-						<Text
-							style={{
-								...styles.languageText,
-								color: selectedLanguage === language.value ? contrastColor : theme.screen.text,
-							}}
-						>
-							{language.label}
-						</Text>
-						<MaterialCommunityIcons name={selectedLanguage === language.value ? 'checkbox-marked' : 'checkbox-blank'} size={24} color={selectedLanguage === language.value ? contrastColor : theme.screen.icon} style={styles.radioButton} />
-					</TouchableOpacity>
-				))}
-			</View>
-		</BottomSheetScrollView>
-	);
+        return (
+                <BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
+                        <View
+                                style={{
+                                        ...styles.sheetHeader,
+                                        paddingRight: isWeb ? 10 : 0,
+                                        paddingTop: isWeb ? 10 : 0,
+                                }}
+                        >
+                                <View />
+                                <Text
+                                        style={{
+                                                ...styles.sheetHeading,
+                                                fontSize: isWeb ? 40 : 28,
+                                                color: theme.sheet.text,
+                                        }}
+                                >
+                                        {translate(TranslationKeys.language)}
+                                </Text>
+                        </View>
+                        <View style={styles.optionsContainer}>
+                                {languages.map((language, index) => {
+                                        const isSelected = selectedLanguage === language.value;
+                                        const groupPosition =
+                                                languages.length === 1
+                                                        ? 'single'
+                                                        : index === 0
+                                                                ? 'top'
+                                                                : index === languages.length - 1
+                                                                        ? 'bottom'
+                                                                        : 'middle';
+
+                                        return (
+                                                <SettingsList
+                                                        key={language.value}
+                                                        leftIcon={<MyImage source={language.flag} style={styles.flagIcon} />}
+                                                        label={language.label}
+                                                        rightElement={
+                                                                <View
+                                                                        style={[
+                                                                                styles.selectionIndicator,
+                                                                                {
+                                                                                        backgroundColor: isSelected ? primaryColor : 'transparent',
+                                                                                        borderColor: isSelected ? primaryColor : theme.screen.icon,
+                                                                                },
+                                                                        ]}
+                                                                >
+                                                                        {isSelected ? <MaterialCommunityIcons name="check" size={18} color={contrastColor} /> : null}
+                                                                </View>
+                                                        }
+                                                        handleFunction={() => {
+                                                                onSelect(language.value);
+                                                                closeSheet();
+                                                        }}
+                                                        showSeparator={index !== languages.length - 1}
+                                                        groupPosition={groupPosition as any}
+                                                        iconBackgroundColor="transparent"
+                                                />
+                                        );
+                                })}
+                        </View>
+                </BottomSheetScrollView>
+        );
 };
 
 export default LanguageSheet;

--- a/apps/frontend/app/components/LanguageSheet/styles.ts
+++ b/apps/frontend/app/components/LanguageSheet/styles.ts
@@ -23,31 +23,22 @@ export default StyleSheet.create({
 	sheetHeading: {
 		fontFamily: 'Poppins_700Bold',
 	},
-	optionsContainer: {
-		width: '100%',
-		paddingHorizontal: 10,
-		marginTop: 20,
-	},
-	languageRow: {
-		marginTop: 10,
-		width: '100%',
-		height: 50,
-		flexDirection: 'row',
-		alignItems: 'center',
-		justifyContent: 'space-between',
-		borderRadius: 12,
-	},
-	flagIcon: {
-		width: 35.2,
-		height: 22,
-		marginRight: 10,
-	},
-	languageText: {
-		flex: 1,
-		fontSize: 18,
-		fontFamily: 'Poppins_400Regular',
-	},
-	radioButton: {
-		marginLeft: 10,
-	},
+        optionsContainer: {
+                width: '100%',
+                paddingHorizontal: 10,
+                marginTop: 20,
+        },
+        flagIcon: {
+                width: 32,
+                height: 20,
+                marginLeft: 4,
+        },
+        selectionIndicator: {
+                width: 28,
+                height: 28,
+                borderRadius: 14,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderWidth: 1.5,
+        },
 });


### PR DESCRIPTION
## Summary
- replace the language selection checklist with SettingsList items that use right-side indicators
- add selection indicator styling to match the new SettingsList layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a0d178808330b1671864c47770c1)