### PR TITLE
Add radio list component for language sheet

### DIFF
--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { languages } from '@/constants/SettingData';
@@ -10,16 +8,12 @@ import { isWeb } from '@/constants/Constants';
 import styles from './styles';
 import { LanguageSheetProps } from './types';
 import { TranslationKeys } from '@/locales/keys';
-import { RootState } from '@/redux/reducer';
-import { myContrastColor } from '@/helper/ColorHelper';
 import MyImage from '@/components/MyImage';
-import SettingsList from '@/components/SettingsList/SettingsList';
+import SettingsListRadio from '@/components/SettingsListRadio';
 
 const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLanguage, onSelect }) => {
         const { theme } = useTheme();
         const { translate } = useLanguage();
-        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 
         return (
                 <BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
@@ -54,29 +48,17 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLangu
                                                                         : 'middle';
 
                                         return (
-                                                <SettingsList
+                                                <SettingsListRadio
                                                         key={language.value}
                                                         leftIcon={<MyImage source={language.flag} style={styles.flagIcon} />}
                                                         label={language.label}
-                                                        rightElement={
-                                                                <View
-                                                                        style={[
-                                                                                styles.selectionIndicator,
-                                                                                {
-                                                                                        backgroundColor: isSelected ? primaryColor : 'transparent',
-                                                                                        borderColor: isSelected ? primaryColor : theme.screen.icon,
-                                                                                },
-                                                                        ]}
-                                                                >
-                                                                        {isSelected ? <MaterialCommunityIcons name="check" size={18} color={contrastColor} /> : null}
-                                                                </View>
-                                                        }
-                                                        handleFunction={() => {
+                                                        selected={isSelected}
+                                                        onPress={() => {
                                                                 onSelect(language.value);
                                                                 closeSheet();
                                                         }}
                                                         showSeparator={index !== languages.length - 1}
-                                                        groupPosition={groupPosition as any}
+                                                        groupPosition={groupPosition}
                                                         iconBackgroundColor="transparent"
                                                 />
                                         );

--- a/apps/frontend/app/components/LanguageSheet/styles.ts
+++ b/apps/frontend/app/components/LanguageSheet/styles.ts
@@ -33,12 +33,4 @@ export default StyleSheet.create({
                 height: 20,
                 marginLeft: 4,
         },
-        selectionIndicator: {
-                width: 28,
-                height: 28,
-                borderRadius: 14,
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderWidth: 1.5,
-        },
 });

--- a/apps/frontend/app/components/ProjectRadioElement/ProjectRadioElement.tsx
+++ b/apps/frontend/app/components/ProjectRadioElement/ProjectRadioElement.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { useSelector } from 'react-redux';
+import { useTheme } from '@/hooks/useTheme';
+import { RootState } from '@/redux/reducer';
+
+type ProjectRadioElementProps = {
+        selected?: boolean;
+        onPress?: () => void;
+        size?: number;
+        style?: ViewStyle;
+};
+
+const ProjectRadioElement: React.FC<ProjectRadioElementProps> = ({ selected = false, onPress, size = 20, style }) => {
+        const { theme } = useTheme();
+        const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+        const Component: any = onPress ? TouchableOpacity : View;
+
+        return (
+                <Component
+                        {...(onPress ? { onPress, activeOpacity: 0.7 } : {})}
+                        style={[
+                                styles.base,
+                                {
+                                        width: size,
+                                        height: size,
+                                        borderRadius: size / 2,
+                                        borderColor: selected ? primaryColor : theme.screen.icon,
+                                },
+                                style,
+                        ]}
+                >
+                        {selected ? (
+                                <View
+                                        style={[
+                                                styles.inner,
+                                                {
+                                                        width: size / 2,
+                                                        height: size / 2,
+                                                        borderRadius: size / 4,
+                                                        backgroundColor: primaryColor,
+                                                },
+                                        ]}
+                                />
+                        ) : null}
+                </Component>
+        );
+};
+
+export default ProjectRadioElement;
+
+const styles = StyleSheet.create({
+        base: {
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderWidth: 2,
+        },
+        inner: {
+                alignItems: 'center',
+                justifyContent: 'center',
+        },
+});

--- a/apps/frontend/app/components/ProjectRadioElement/index.ts
+++ b/apps/frontend/app/components/ProjectRadioElement/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProjectRadioElement';

--- a/apps/frontend/app/components/SettingsListRadio/SettingsListRadio.tsx
+++ b/apps/frontend/app/components/SettingsListRadio/SettingsListRadio.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import SettingsList from '@/components/SettingsList';
+import ProjectRadioElement from '@/components/ProjectRadioElement';
+import { SettingsListRadioProps } from './types';
+
+const SettingsListRadio: React.FC<SettingsListRadioProps> = ({ selected = false, radioSize, ...settingsListProps }) => {
+        return (
+                <SettingsList
+                        {...settingsListProps}
+                        rightElement={<ProjectRadioElement selected={selected} size={radioSize} />}
+                />
+        );
+};
+
+export default SettingsListRadio;

--- a/apps/frontend/app/components/SettingsListRadio/index.ts
+++ b/apps/frontend/app/components/SettingsListRadio/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SettingsListRadio';
+export type { SettingsListRadioProps } from './types';

--- a/apps/frontend/app/components/SettingsListRadio/types.ts
+++ b/apps/frontend/app/components/SettingsListRadio/types.ts
@@ -1,0 +1,6 @@
+import { SettingsListProps } from '@/components/SettingsList/types';
+
+export type SettingsListRadioProps = Omit<SettingsListProps, 'rightElement' | 'rightIcon'> & {
+        selected?: boolean;
+        radioSize?: number;
+};


### PR DESCRIPTION
## Summary
- add a reusable ProjectRadioElement that renders radio indicators with the app primary color and optional touch handling
- introduce SettingsListRadio to embed the radio indicator in settings rows without forwarding press handlers to it
- switch the LanguageSheet to use the new settings radio items instead of a custom checkmark element

## Testing
- yarn lint *(fails: expo lint could not find a script named "eslint" in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a335634c8330923c0c88248f8978)