### PR TITLE
Add flag icons to language sheet list

### DIFF
--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -12,6 +12,7 @@ import SettingsList from '@/components/SettingsList';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
+import MyImage from '@/components/MyImage';
 
 const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLanguage, onSelect }) => {
         const { theme } = useTheme();
@@ -54,7 +55,8 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLangu
                                                 <SettingsList
                                                         key={language.value}
                                                         label={language.label}
-                                                        noIconIndent
+                                                        iconBgColor="transparent"
+                                                        leftIcon={<MyImage source={language.flag} style={styles.flagIcon} />}
                                                         groupPosition={groupPosition}
                                                         showSeparator={index !== languages.length - 1}
                                                         rightIcon={

--- a/apps/frontend/app/components/LanguageSheet/styles.ts
+++ b/apps/frontend/app/components/LanguageSheet/styles.ts
@@ -28,4 +28,8 @@ export default StyleSheet.create({
                 paddingHorizontal: 10,
                 marginTop: 20,
         },
+        flagIcon: {
+                width: 35.2,
+                height: 22,
+        },
 });


### PR DESCRIPTION
## Summary
- display language flags as left icons in the language sheet list using the shared MyImage component
- add styling to size the flag icons consistently while keeping a transparent icon background

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947b5da28288330b8118b35c2641440)