### PR TITLE
Add native labels for English and German languages

### DIFF
--- a/apps/frontend/app/constants/SettingData.ts
+++ b/apps/frontend/app/constants/SettingData.ts
@@ -24,11 +24,11 @@ export const themes = [
 
 // Languages
 export const languages = [
-	{
-		label: 'English',
-		flag: flagUs,
-		value: 'en',
-	},
+        {
+                label: 'English (English)',
+                flag: flagUs,
+                value: 'en',
+        },
 	{
 		label: 'Turkish (Türkçe)',
 		flag: flagTr,
@@ -43,12 +43,12 @@ export const languages = [
 		label: 'French (Français)',
 		flag: flagFr,
 		value: 'fr',
-	},
-	{
-		label: 'German',
-		flag: flagDe,
-		value: 'de',
-	},
+        },
+        {
+                label: 'German (Deutsch)',
+                flag: flagDe,
+                value: 'de',
+        },
 	{
 		label: 'Chinese (中文)',
 		flag: flagCn,


### PR DESCRIPTION
## Summary
- update language sheet data so English and German entries follow native naming pattern

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694837a27d3483308a0dcb2662e67c98)