### PR TITLE
Remove border radius from language sheet styles

### DIFF
--- a/apps/frontend/app/components/LanguageSheet/styles.ts
+++ b/apps/frontend/app/components/LanguageSheet/styles.ts
@@ -1,35 +1,29 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	sheetView: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
+        sheetView: {
+                width: '100%',
+                height: '100%',
+                padding: 0,
+        },
 	contentContainer: {
 		alignItems: 'center',
 	},
 	sheetHeader: {
 		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
-	},
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
+        },
+        sheetHeading: {
+                fontFamily: 'Poppins_700Bold',
+        },
         optionsContainer: {
                 width: '100%',
-                paddingHorizontal: 10,
-                marginTop: 20,
+                marginTop: 0,
         },
         flagIcon: {
-                width: 35.2,
-                height: 22,
+                width: 32,
+                height: 32,
         },
 });


### PR DESCRIPTION
## Summary
- remove the border radius from the language sheet container and header styles
- retain layout adjustments aligning the sheet with the settings screen

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483820bbfc83308f9c7e90966aa15b)