### PR TITLE
Replace language flags with red placeholders

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -202,6 +202,8 @@ const Settings = () => {
                         <SettingsList
                                 key={`${languageOption.value}-${index}`}
                                 label={languageOption.label}
+                                leftIcon={<View style={[languageStyles.flagIcon, { backgroundColor: 'red' }]} />}
+                                iconBgColor="transparent"
                                 showSeparator={index !== languages.length - 1}
                                 groupPosition={groupPosition}
                                 noIconIndent
@@ -224,7 +226,11 @@ const Settings = () => {
                                 children: (
                                         <View style={languageStyles.optionsContainer}>
                                                 {languages.map((languageOption, index) => (
-                                                        <LanguageOption languageOption={languageOption} index={index} />
+                                                        <LanguageOption
+                                                                key={`${languageOption.value}-${index}`}
+                                                                languageOption={languageOption}
+                                                                index={index}
+                                                        />
                                                 ))}
                                         </View>
                                 ),


### PR DESCRIPTION
## Summary
- replace language modal flag icons with a temporary red square placeholder view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483bf42d2c83309b38d5c4eeba80f5)