### PR TITLE
Add customizable left icon component to SettingsList

### DIFF
--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -55,8 +55,11 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLangu
                                                 <SettingsList
                                                         key={language.value}
                                                         label={language.label}
-                                                        iconBgColor="transparent"
-                                                        leftIcon={<MyImage source={language.flag} style={styles.flagIcon} />}
+                                                        leftIconComponent={
+                                                                <View style={styles.flagWrapper}>
+                                                                        <MyImage source={language.flag} style={styles.flagIcon} />
+                                                                </View>
+                                                        }
                                                         groupPosition={groupPosition}
                                                         showSeparator={index !== languages.length - 1}
                                                         rightIcon={

--- a/apps/frontend/app/components/LanguageSheet/styles.ts
+++ b/apps/frontend/app/components/LanguageSheet/styles.ts
@@ -26,4 +26,13 @@ export default StyleSheet.create({
                 width: 32,
                 height: 32,
         },
+        flagWrapper: {
+                width: 34,
+                height: 34,
+                marginRight: 10,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: 'red',
+                borderRadius: 4,
+        },
 });

--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -10,7 +10,7 @@ const padding = 0; // px used for additional padding and border radius
 const borderRadius = 10;
 const basePaddingVertical = 10;
 
-const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, value, rightElement, rightIcon, onPress, handleFunction, iconBackgroundColor, iconBgColor, showSeparator = true, groupPosition, noIconIndent = false }) => {
+const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, leftIconComponent, title, label, value, rightElement, rightIcon, onPress, handleFunction, iconBackgroundColor, iconBgColor, showSeparator = true, groupPosition, noIconIndent = false }) => {
         const { theme } = useTheme();
         const { primaryColor, selectedTheme } = useSelector((state: RootState) => state.settings);
 
@@ -19,7 +19,7 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, val
         const iconBg = iconBackgroundColor || iconBgColor || primaryColor;
         const iconColor = myContrastColor(iconBg, theme, selectedTheme === 'dark');
 
-        const hasIcon = !!leftIcon;
+        const hasIcon = !!leftIconComponent || !!leftIcon;
         const showIconWrapper = hasIcon && !noIconIndent;
         const shouldReserveIconSpace = !hasIcon && !noIconIndent;
 
@@ -54,7 +54,11 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, title, label, val
                 <>
                         <Container onPress={pressHandler} style={containerStyles}>
                                 {showIconWrapper ? (
-                                        <View style={iconWrapperStyles}>{React.isValidElement(leftIcon) ? React.cloneElement(leftIcon, { color: iconColor }) : leftIcon}</View>
+                                        leftIconComponent ? (
+                                                leftIconComponent
+                                        ) : (
+                                                <View style={iconWrapperStyles}>{React.isValidElement(leftIcon) ? React.cloneElement(leftIcon, { color: iconColor }) : leftIcon}</View>
+                                        )
                                 ) : null}
                                 {shouldReserveIconSpace ? <View style={styles.iconPlaceholder} /> : null}
                                 <View style={styles.textWrapper}>

--- a/apps/frontend/app/components/SettingsList/types.ts
+++ b/apps/frontend/app/components/SettingsList/types.ts
@@ -2,11 +2,15 @@ import {PropsWithChildren} from "react";
 
 type SettingsListPropsOwn = {
         leftIcon?: React.ReactNode;
-	/**
-	 * Title text for the row. "label" is kept for backwards
-	 * compatibility with the old `SettingList` component.
-	 */
-	title?: string;
+        /**
+         * Custom component rendered in place of the default left icon wrapper.
+         */
+        leftIconComponent?: React.ReactNode;
+        /**
+         * Title text for the row. "label" is kept for backwards
+         * compatibility with the old `SettingList` component.
+         */
+        title?: string;
 	label?: string;
 	value?: string;
 	/**


### PR DESCRIPTION
## Summary
- add a leftIconComponent prop to SettingsList to allow custom icon containers
- use the new prop in LanguageSheet to display the language flags inside a custom red wrapper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949d5c380b08330b8efdadafd3e4378)