### PR TITLE
Fix SettingsList icons when no indentation

### DIFF
--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -23,6 +23,12 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, leftIconComponent
         const showIconWrapper = hasIcon && !noIconIndent;
         const shouldReserveIconSpace = !hasIcon && !noIconIndent;
 
+        const renderedLeftIcon = React.isValidElement(leftIcon)
+                ? noIconIndent
+                        ? leftIcon
+                        : React.cloneElement(leftIcon, { color: iconColor })
+                : leftIcon;
+
         const containerStyles: ViewStyle[] = [styles.container, { backgroundColor: theme.screen.iconBg } as ViewStyle];
         const iconWrapperStyles: ViewStyle[] = [styles.iconWrapper, { backgroundColor: iconBg }];
 
@@ -57,8 +63,10 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, leftIconComponent
                                         leftIconComponent ? (
                                                 leftIconComponent
                                         ) : (
-                                                <View style={iconWrapperStyles}>{React.isValidElement(leftIcon) ? React.cloneElement(leftIcon, { color: iconColor }) : leftIcon}</View>
+                                                <View style={iconWrapperStyles}>{renderedLeftIcon}</View>
                                         )
+                                ) : hasIcon ? (
+                                        leftIconComponent ? leftIconComponent : renderedLeftIcon
                                 ) : null}
                                 {shouldReserveIconSpace ? <View style={styles.iconPlaceholder} /> : null}
                                 <View style={styles.textWrapper}>


### PR DESCRIPTION
## Summary
- render SettingsList icons even when indentation is disabled
- keep custom icon colors when no icon indentation is requested

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dcb83d18833090184d2d37496b1c)