### PR TITLE
Use emoji flags in language selection

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -202,7 +202,11 @@ const Settings = () => {
                         <SettingsList
                                 key={`${languageOption.value}-${index}`}
                                 label={languageOption.label}
-                                leftIcon={<View style={[languageStyles.flagIcon, { backgroundColor: 'red' }]} />}
+                                leftIcon={
+                                        <View style={languageStyles.flagWrapper}>
+                                                <Text style={languageStyles.flagText}>{languageOption.emoji}</Text>
+                                        </View>
+                                }
                                 iconBgColor="transparent"
                                 showSeparator={index !== languages.length - 1}
                                 groupPosition={groupPosition}

--- a/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
+++ b/apps/frontend/app/components/LanguageSheet/LanguageSheet.tsx
@@ -12,7 +12,6 @@ import SettingsList from '@/components/SettingsList';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
-import MyImage from '@/components/MyImage';
 
 const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLanguage, onSelect }) => {
         const { theme } = useTheme();
@@ -57,7 +56,7 @@ const LanguageSheet: React.FC<LanguageSheetProps> = ({ closeSheet, selectedLangu
                                                         label={language.label}
                                                         leftIconComponent={
                                                                 <View style={styles.flagWrapper}>
-                                                                        <MyImage source={language.flag} style={styles.flagIcon} />
+                                                                        <Text style={styles.flagText}>{language.emoji}</Text>
                                                                 </View>
                                                         }
                                                         groupPosition={groupPosition}

--- a/apps/frontend/app/components/LanguageSheet/styles.ts
+++ b/apps/frontend/app/components/LanguageSheet/styles.ts
@@ -22,17 +22,15 @@ export default StyleSheet.create({
                 width: '100%',
                 marginTop: 0,
         },
-        flagIcon: {
-                width: 32,
-                height: 32,
-        },
         flagWrapper: {
-                width: 34,
-                height: 34,
+                minWidth: 34,
+                minHeight: 34,
                 marginRight: 10,
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: 'red',
-                borderRadius: 4,
+                borderRadius: 6,
+        },
+        flagText: {
+                fontSize: 22,
         },
 });

--- a/apps/frontend/app/components/Login/Header.tsx
+++ b/apps/frontend/app/components/Login/Header.tsx
@@ -87,7 +87,7 @@ const LoginHeader = () => {
 		closeLanguageModal();
 	};
 
-	const changeLanguage = (language: { label?: string; flag?: any; value: any }) => {
+        const changeLanguage = (language: { label?: string; emoji?: string; value: any }) => {
 		setSelectedLanguage(language.value);
 		setLanguageMode(language.value);
 		closeLanguageModal();
@@ -140,10 +140,10 @@ const LoginHeader = () => {
 								changeLanguage(language);
 							}}
 						>
-							<MyImage source={language.flag} style={styles.flagIcon} />
-							<Text
-								style={{
-									...styles.languageText,
+                                                        <Text style={styles.languageEmoji}>{language.emoji}</Text>
+                                                        <Text
+                                                                style={{
+                                                                        ...styles.languageText,
 									color: selectedLanguage === language.value ? theme.activeText : theme.screen.text,
 								}}
 							>

--- a/apps/frontend/app/components/Login/styles.ts
+++ b/apps/frontend/app/components/Login/styles.ts
@@ -282,20 +282,19 @@ export const styles = StyleSheet.create({
 		marginTop: 10,
 		paddingHorizontal: 10,
 	},
-	languageRow: {
-		marginTop: 10,
-		width: '100%',
-		height: 50,
-		flexDirection: 'row',
-		alignItems: 'center',
-		justifyContent: 'space-between',
-		borderRadius: 12,
-	},
-	flagIcon: {
-		width: 35.2,
-		height: 22,
-		marginRight: 10,
-	},
+        languageRow: {
+                marginTop: 10,
+                width: '100%',
+                height: 50,
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                borderRadius: 12,
+        },
+        languageEmoji: {
+                fontSize: 24,
+                marginRight: 10,
+        },
 
 	languageText: {
 		flex: 1,

--- a/apps/frontend/app/constants/SettingData.ts
+++ b/apps/frontend/app/constants/SettingData.ts
@@ -1,23 +1,6 @@
-//import flagUs from '@/assets/images/flags/us.svg';
-//import flagTr from '@/assets/images/flags/tr.svg';
-//import flagEs from '@/assets/images/flags/es.svg';
-//import flagFr from '@/assets/images/flags/fr.svg';
-//import flagDe from '@/assets/images/flags/de.svg';
-//import flagCn from '@/assets/images/flags/cn.svg';
-//import flagSa from '@/assets/images/flags/sa.svg';
-//import flagRu from '@/assets/images/flags/ru.svg';
-const flagUs = require('@/assets/images/flags/us.png');
-const flagTr = require('@/assets/images/flags/tr.png');
-const flagEs = require('@/assets/images/flags/es.png');
-const flagFr = require('@/assets/images/flags/fr.png');
-const flagDe = require('@/assets/images/flags/de.png');
-const flagCn = require('@/assets/images/flags/cn.png');
-const flagSa = require('@/assets/images/flags/sa.png');
-const flagRu = require('@/assets/images/flags/ru.png');
-
 // Themes
 export const themes = [
-	{ id: 'light', name: 'color_scheme_light', icon: 'white-balance-sunny' },
+        { id: 'light', name: 'color_scheme_light', icon: 'white-balance-sunny' },
 	{ id: 'dark', name: 'color_scheme_dark', icon: 'moon-waning-crescent' },
 	{ id: 'systematic', name: 'color_scheme_system', icon: 'theme-light-dark' },
 ];
@@ -26,44 +9,44 @@ export const themes = [
 export const languages = [
         {
                 label: 'English (English)',
-                flag: flagUs,
+                emoji: '🇬🇧',
                 value: 'en',
         },
-	{
-		label: 'Turkish (Türkçe)',
-		flag: flagTr,
-		value: 'tr',
-	},
-	{
-		label: 'Spanish (Español)',
-		flag: flagEs,
-		value: 'es',
-	},
-	{
-		label: 'French (Français)',
-		flag: flagFr,
-		value: 'fr',
+        {
+                label: 'Turkish (Türkçe)',
+                emoji: '🇹🇷',
+                value: 'tr',
+        },
+        {
+                label: 'Spanish (Español)',
+                emoji: '🇪🇸',
+                value: 'es',
+        },
+        {
+                label: 'French (Français)',
+                emoji: '🇫🇷',
+                value: 'fr',
         },
         {
                 label: 'German (Deutsch)',
-                flag: flagDe,
+                emoji: '🇩🇪',
                 value: 'de',
         },
-	{
-		label: 'Chinese (中文)',
-		flag: flagCn,
-		value: 'zh',
-	},
-	{
-		label: 'Arabic (العربية)',
-		flag: flagSa,
-		value: 'ar',
-	},
-	{
-		label: 'Russian (Русский)',
-		flag: flagRu,
-		value: 'ru',
-	},
+        {
+                label: 'Chinese (中文)',
+                emoji: '🇨🇳',
+                value: 'zh',
+        },
+        {
+                label: 'Arabic (العربية)',
+                emoji: '🇸🇦',
+                value: 'ar',
+        },
+        {
+                label: 'Russian (Русский)',
+                emoji: '🇷🇺',
+                value: 'ru',
+        },
 ];
 
 // Drawers


### PR DESCRIPTION
## Summary
- replace language flag images with emoji icons across language selection sheets
- update language option data and styling to align with emoji display

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a3e44218c8330b98af9f95bbe538d)