### PR TITLE
Reuse settings language modal on login page

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -41,8 +41,7 @@ import DebugView from '@/components/DebugView';
 import DropdownInput from '@/components/DropdownInput/DropdownInput';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import useToast from '@/hooks/useToast';
-import languageStyles from '@/components/LanguageSheet/styles';
-import { languages } from '@/constants/SettingData';
+import { useLanguageModal } from '@/hooks/useLanguageModal';
 import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
 import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 import useCustomerConfig from '@/hooks/useCustomerConfig';
@@ -57,7 +56,7 @@ const Settings = () => {
         const toast = useToast();
         const canteenSheetRef = useRef<BottomSheet>(null);
         const [isActive, setIsActive] = useState(false);
-        const { translate, setLanguageMode, language } = useLanguage();
+        const { translate, language } = useLanguage();
         const drawerSheetRef = useRef<BottomSheet>(null);
         const amountColumnSheetRef = useRef<BottomSheet>(null);
         const firstDaySheetRef = useRef<BottomSheet>(null);
@@ -71,6 +70,7 @@ const Settings = () => {
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useSelector((state: RootState) => state.authReducer);
         const isRegisteredUser = UserHelper.isRegisteredUser(user);
         const { buttonLabel: logoutButtonLabel } = useLogoutButtonTranslation();
+        const { openLanguageModal } = useLanguageModal();
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, collectibleItemSize, collectibleRandomPosition, selectedCustomer } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
@@ -160,14 +160,6 @@ const Settings = () => {
 		};
 	}, []);
 
-        const changeLanguage = useCallback(
-                (language: { label?: string; value: any }) => {
-                        setLanguageMode(language.value);
-                        closeScrollViewModal();
-                },
-                [closeScrollViewModal, setLanguageMode]
-        );
-
         const openNicknameSheet = useCallback(() => {
                 showScrollViewModal(
                         {
@@ -184,68 +176,9 @@ const Settings = () => {
                 );
         }, [closeNicknameSheet, currentNickname, saveNickname, showScrollViewModal, translate]);
 
-        const LanguageOption = ({ languageOption, index }: { languageOption: (typeof languages)[number]; index: number }) => {
-                const { language: currentLanguage } = useLanguage();
-                const { theme: currentTheme } = useTheme();
-
-                const isSelected = currentLanguage === languageOption.value;
-                const groupPosition =
-                        languages.length === 1
-                                ? 'single'
-                                : index === 0
-                                        ? 'top'
-                                        : index === languages.length - 1
-                                                ? 'bottom'
-                                                : 'middle';
-
-                return (
-                        <SettingsList
-                                key={`${languageOption.value}-${index}`}
-                                label={languageOption.label}
-                                leftIcon={
-                                        <View style={languageStyles.flagWrapper}>
-                                                <Text style={languageStyles.flagText}>{languageOption.emoji}</Text>
-                                        </View>
-                                }
-                                iconBgColor="transparent"
-                                showSeparator={index !== languages.length - 1}
-                                groupPosition={groupPosition}
-                                noIconIndent
-                                rightIcon={
-                                        <MaterialCommunityIcons
-                                                name={isSelected ? 'circle' : 'circle-outline'}
-                                                size={24}
-                                                color={isSelected ? primaryColor : currentTheme.screen.icon}
-                                        />
-                                }
-                                handleFunction={() => changeLanguage(languageOption)}
-                        />
-                );
+        const openColorSchemeSheet = () => {
+                colorSchemeSheetRef?.current?.expand();
         };
-
-        const openLanguageModal = useCallback(() => {
-                showScrollViewModal(
-                        {
-                                title: translate(TranslationKeys.language),
-                                children: (
-                                        <View style={languageStyles.optionsContainer}>
-                                                {languages.map((languageOption, index) => (
-                                                        <LanguageOption
-                                                                key={`${languageOption.value}-${index}`}
-                                                                languageOption={languageOption}
-                                                                index={index}
-                                                        />
-                                                ))}
-                                        </View>
-                                ),
-                        },
-                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg } }
-                );
-        }, [changeLanguage, primaryColor, showScrollViewModal, theme.sheet.sheetBg, translate]);
-
-	const openColorSchemeSheet = () => {
-		colorSchemeSheetRef?.current?.expand();
-	};
 
 	const closeColorSchemeSheet = () => {
 		colorSchemeSheetRef?.current?.close();

--- a/apps/frontend/app/components/Login/Header.tsx
+++ b/apps/frontend/app/components/Login/Header.tsx
@@ -1,5 +1,5 @@
 import { Platform, Text, TouchableOpacity, View } from 'react-native';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { styles } from './styles';
 import { isWeb } from '@/constants/Constants';
@@ -7,23 +7,21 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { useLocales } from 'expo-localization';
 import { useDispatch, useSelector } from 'react-redux';
 import { SET_DRAWER_POSITION } from '@/redux/Types/types';
-import ModalComponent from '../ModalSetting/ModalComponent';
 import { languages } from '../../constants/SettingData';
 import MyImage from '@/components/MyImage';
-import { Entypo, MaterialCommunityIcons } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons';
 import { getImageUrl } from '@/constants/HelperFunctions';
-import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import { useLanguageModal } from '@/hooks/useLanguageModal';
 
 const LoginHeader = () => {
-	const { translate, setLanguageMode, language } = useLanguage();
-	const locales = useLocales();
-	const dispatch = useDispatch();
-	const { theme } = useTheme();
-	const [isLanguageModalVisible, setIsLanguageModalVisible] = useState(false);
-	const [selectedLanguage, setSelectedLanguage] = useState<string>('');
-	const { primaryColor, serverInfo } = useSelector((state: RootState) => state.settings);
-	const deviceLocale: any = useDeviceLocaleCodesWithoutRegionCode();
+        const { setLanguageMode, language } = useLanguage();
+        const locales = useLocales();
+        const dispatch = useDispatch();
+        const { theme } = useTheme();
+        const { serverInfo } = useSelector((state: RootState) => state.settings);
+        const deviceLocale: any = useDeviceLocaleCodesWithoutRegionCode();
+        const { openLanguageModal } = useLanguageModal();
 
 	function useDeviceLocaleCodesWithoutRegionCode(): string[] {
 		let localeCodes: string[] = [];
@@ -71,27 +69,7 @@ const LoginHeader = () => {
 		}
 	}, []);
 
-	const openLanguageModal = () => {
-		setIsLanguageModalVisible(true);
-	};
-
-	const closeLanguageModal = () => {
-		setIsLanguageModalVisible(false);
-	};
-
-	useEffect(() => {
-		setSelectedLanguage(language);
-	}, [language]);
-
-	const saveLanguage = () => {
-		closeLanguageModal();
-	};
-
-        const changeLanguage = (language: { label?: string; emoji?: string; value: any }) => {
-		setSelectedLanguage(language.value);
-		setLanguageMode(language.value);
-		closeLanguageModal();
-	};
+        const selectedLanguage = language;
 	return (
 		<View style={styles.header}>
 			<MyImage
@@ -105,9 +83,9 @@ const LoginHeader = () => {
 					borderRadius: 6,
 				}}
 			/>
-			<TouchableOpacity
-				onPress={openLanguageModal}
-				style={{
+                        <TouchableOpacity
+                                onPress={openLanguageModal}
+                                style={{
 					...styles.picker,
 					height: isWeb ? 41 : 'auto',
 					backgroundColor: theme.login.pickerBg,
@@ -120,44 +98,12 @@ const LoginHeader = () => {
 						color: theme.screen.text,
 					}}
 				>
-					{languages.find(lang => lang.value === selectedLanguage)?.label || 'selected language'}
-				</Text>
-				<Entypo name="chevron-small-down" size={25} color={theme.screen.icon} />
-			</TouchableOpacity>
-
-			<ModalComponent isVisible={isLanguageModalVisible} onClose={closeLanguageModal} title={translate(TranslationKeys.language)} onSave={saveLanguage} showButtons={false}>
-				<View style={styles.languageContainer}>
-					{languages.map((language, index) => (
-						<TouchableOpacity
-							key={index}
-							style={{
-								...styles.languageRow,
-								paddingHorizontal: isWeb ? 20 : 10,
-
-								backgroundColor: selectedLanguage === language.value ? primaryColor : theme.screen.iconBg,
-							}}
-							onPress={() => {
-								changeLanguage(language);
-							}}
-						>
-                                                        <Text style={styles.languageEmoji}>{language.emoji}</Text>
-                                                        <Text
-                                                                style={{
-                                                                        ...styles.languageText,
-									color: selectedLanguage === language.value ? theme.activeText : theme.screen.text,
-								}}
-							>
-								{language.label}
-							</Text>
-
-							{/* Radio Button */}
-							<MaterialCommunityIcons name={selectedLanguage === language.value ? 'checkbox-marked' : 'checkbox-blank'} size={24} color="#ffffff" style={styles.radioButton} />
-						</TouchableOpacity>
-					))}
-				</View>
-			</ModalComponent>
-		</View>
-	);
+                                        {languages.find(lang => lang.value === selectedLanguage)?.label || 'selected language'}
+                                </Text>
+                                <Entypo name="chevron-small-down" size={25} color={theme.screen.icon} />
+                        </TouchableOpacity>
+                </View>
+        );
 };
 
 export default LoginHeader;

--- a/apps/frontend/app/hooks/useLanguageModal.tsx
+++ b/apps/frontend/app/hooks/useLanguageModal.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from 'react';
+import { Text, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import SettingsList from '@/components/SettingsList';
+import languageStyles from '@/components/LanguageSheet/styles';
+import { languages } from '@/constants/SettingData';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+
+export const useLanguageModal = () => {
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+        const { translate, setLanguageMode, language } = useLanguage();
+        const { theme } = useTheme();
+        const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+        const changeLanguage = useCallback(
+                (languageOption: (typeof languages)[number]) => {
+                        setLanguageMode(languageOption.value);
+                        closeScrollViewModal();
+                },
+                [closeScrollViewModal, setLanguageMode]
+        );
+
+        const LanguageOption = useCallback(
+                ({ languageOption, index }: { languageOption: (typeof languages)[number]; index: number }) => {
+                        const isSelected = language === languageOption.value;
+                        const groupPosition =
+                                languages.length === 1
+                                        ? 'single'
+                                        : index === 0
+                                                ? 'top'
+                                                : index === languages.length - 1
+                                                        ? 'bottom'
+                                                        : 'middle';
+
+                        return (
+                                <SettingsList
+                                        key={`${languageOption.value}-${index}`}
+                                        label={languageOption.label}
+                                        leftIcon={
+                                                <View style={languageStyles.flagWrapper}>
+                                                        <Text style={languageStyles.flagText}>{languageOption.emoji}</Text>
+                                                </View>
+                                        }
+                                        iconBgColor="transparent"
+                                        showSeparator={index !== languages.length - 1}
+                                        groupPosition={groupPosition}
+                                        noIconIndent
+                                        rightIcon={
+                                                <MaterialCommunityIcons
+                                                        name={isSelected ? 'circle' : 'circle-outline'}
+                                                        size={24}
+                                                        color={isSelected ? primaryColor : theme.screen.icon}
+                                                />
+                                        }
+                                        handleFunction={() => changeLanguage(languageOption)}
+                                />
+                        );
+                },
+                [changeLanguage, language, primaryColor, theme.screen.icon]
+        );
+
+        const openLanguageModal = useCallback(() => {
+                showScrollViewModal(
+                        {
+                                title: translate(TranslationKeys.language),
+                                children: (
+                                        <View style={languageStyles.optionsContainer}>
+                                                {languages.map((languageOption, index) => (
+                                                        <LanguageOption
+                                                                key={`${languageOption.value}-${index}`}
+                                                                languageOption={languageOption}
+                                                                index={index}
+                                                        />
+                                                ))}
+                                        </View>
+                                ),
+                        },
+                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg } }
+                );
+        }, [LanguageOption, showScrollViewModal, theme.sheet.sheetBg, translate]);
+
+        return { openLanguageModal };
+};


### PR DESCRIPTION
## Summary
- extract the settings language picker into a reusable `useLanguageModal` hook
- switch the settings screen to use the shared hook
- update the login header to open the shared language modal instead of its own dialog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a48216dec8330b35016fe3c8c09e8)