### PR TITLE
Add foodoffer sorting modal hook

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -68,9 +68,9 @@ import useChatUnreadStatus from '@/hooks/useChatUnreadStatus';
 
 import IconButton from '@/components/UI/IconButton';
 import Button from '@/components/UI/Button';
-import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
+import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 
 export const SHEET_COMPONENTS = {
         canteen: CanteenSelectionSheet,
@@ -134,10 +134,10 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const [prefetchedFoodOffers, setPrefetchedFoodOffers] = useState<Record<string, DatabaseTypes.Foodoffers[]>>({});
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
         const { hasUnreadChats } = useChatUnreadStatus();
-        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { openUtilizationModal } = useUtilizationModal();
         const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
         const { openActiveModal, activePopupEvent } = usePopupEventModal();
+        const { openFoodofferSortingModal } = useFoodofferSortingModal();
 
 	const MIN_CARD_WIDTH = 280;
 	const numColumns = useMemo(() => {
@@ -297,25 +297,15 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}, [])
 	);
 
-        const openSheet = useCallback(
-                (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
-                        if (sheet === 'sort') {
-                                showScrollViewModal(
-                                        {
-                                                title: translate(TranslationKeys.sort),
-                                                onClose: closeScrollViewModal,
-                                                children: <SortSheet closeSheet={closeScrollViewModal} />,
-                                        },
-                                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
-                                );
-                                return;
-                        }
+        const openSheet = useCallback((sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
+                if (sheet === 'sort') {
+                        openFoodofferSortingModal();
+                        return;
+                }
 
-                        setSelectedSheet(sheet);
-                        setSheetProps(props);
-                },
-                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
-        );
+                setSelectedSheet(sheet);
+                setSheetProps(props);
+        }, [openFoodofferSortingModal]);
 
         const openManagementSheet = useCallback((id: string) => {
                 if (id) {

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -46,6 +46,8 @@ import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
 import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 import useCustomerConfig from '@/hooks/useCustomerConfig';
 import useCustomerConfigModal from '@/hooks/useCustomerConfigModal';
+import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
+import { FoodSortOption } from 'repo-depkit-common';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
 
@@ -71,8 +73,9 @@ const Settings = () => {
         const isRegisteredUser = UserHelper.isRegisteredUser(user);
         const { buttonLabel: logoutButtonLabel } = useLogoutButtonTranslation();
         const { openLanguageModal } = useLanguageModal();
+        const { openFoodofferSortingModal } = useFoodofferSortingModal();
 
-        const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, collectibleItemSize, collectibleRandomPosition, selectedCustomer } = useSelector((state: RootState) => state.settings);
+        const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, collectibleItemSize, collectibleRandomPosition, selectedCustomer, sortBy } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
                 () => (profile?.id ? profile?.nickname ?? '' : nickNameLocal ?? ''),
                 [nickNameLocal, profile?.id, profile?.nickname]
@@ -108,6 +111,27 @@ const Settings = () => {
         const collectibleSizeLabel = useMemo(
                 () => collectibleSizeOptions.find(option => option.value === collectibleItemSize)?.label || '',
                 [collectibleItemSize, collectibleSizeOptions]
+        );
+
+        const sortingOptionLabels: Partial<Record<FoodSortOption, string>> = useMemo(
+                () => ({
+                        [FoodSortOption.INTELLIGENT]: 'sort_option_intelligent',
+                        [FoodSortOption.FAVORITE]: 'sort_option_favorite',
+                        [FoodSortOption.EATING]: 'eating_habits',
+                        [FoodSortOption.FOOD_CATEGORY]: 'sort_option_food_category',
+                        [FoodSortOption.FOODOFFER_CATEGORY]: 'sort_option_foodoffer_category',
+                        [FoodSortOption.RATING]: 'sort_option_public_rating',
+                        [FoodSortOption.PRICE_ASCENDING]: 'sort_option_price_ascending',
+                        [FoodSortOption.PRICE_DESCENDING]: 'sort_option_price_descending',
+                        [FoodSortOption.ALPHABETICAL]: 'sort_option_alphabetical',
+                        [FoodSortOption.NONE]: 'sort_option_none',
+                }),
+                []
+        );
+
+        const sortingLabel = useMemo(
+                () => translate(sortingOptionLabels[sortBy as FoodSortOption] ?? 'sort_option_none'),
+                [sortBy, sortingOptionLabels, translate]
         );
 
         const closeNicknameSheet = useCallback(() => {
@@ -454,11 +478,12 @@ const Settings = () => {
 					{/* Canteen */}
 					<View style={{ gap: 0 }}>
 						<SettingsList iconBgColor={foods_area_color} leftIcon={<MaterialIcons name="restaurant-menu" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.canteen)} value={excerpt(String(selectedCanteen?.alias), 30)} rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />} handleFunction={openCanteenSheet} groupPosition="top" />
-						<SettingsList iconBgColor={foods_area_color} leftIcon={<MaterialIcons name="euro" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.price_group)} value={profile?.price_group && priceGroups[profile.price_group as PriceGroupKey] ? priceGroups[profile.price_group as PriceGroupKey].label : ''} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/price-group')} groupPosition="middle" />
-						<SettingsList iconBgColor={foods_area_color} leftIcon={<Ionicons name="card" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.accountbalance)} value={profile?.credit_balance ? showFormatedPrice(formatPrice(profile?.credit_balance)) : '€'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/account-balance')} groupPosition="middle" />
-						<SettingsList iconBgColor={foods_area_color} leftIcon={<Ionicons name="bag-add-sharp" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.eating_habits)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/eating-habits')} groupPosition="middle" />
-						<SettingsList iconBgColor={primaryColor} leftIcon={<Ionicons name="notifications" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.notification)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/notification')} groupPosition="bottom" />
-					</View>
+                                                <SettingsList iconBgColor={foods_area_color} leftIcon={<MaterialIcons name="euro" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.price_group)} value={profile?.price_group && priceGroups[profile.price_group as PriceGroupKey] ? priceGroups[profile.price_group as PriceGroupKey].label : ''} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/price-group')} groupPosition="middle" />
+                                                <SettingsList iconBgColor={foods_area_color} leftIcon={<Ionicons name="card" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.accountbalance)} value={profile?.credit_balance ? showFormatedPrice(formatPrice(profile?.credit_balance)) : '€'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/account-balance')} groupPosition="middle" />
+                                                <SettingsList iconBgColor={foods_area_color} leftIcon={<Ionicons name="bag-add-sharp" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.eating_habits)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/eating-habits')} groupPosition="middle" />
+                                                <SettingsList iconBgColor={foods_area_color} leftIcon={<MaterialIcons name="sort" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.sort)} value={sortingLabel} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodofferSortingModal} groupPosition="middle" />
+                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Ionicons name="notifications" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.notification)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.navigate('/notification')} groupPosition="bottom" />
+                                        </View>
 					<SettingsGroupTitle>{translate(TranslationKeys.group_app_settings)}</SettingsGroupTitle>
 					{/* color Scheme */}
 					<View style={{ gap: 0 }}>

--- a/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
+++ b/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback } from 'react';
+
+import SortSheet from '@/components/SortSheet/SortSheet';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+
+export const useFoodofferSortingModal = () => {
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+        const { translate } = useLanguage();
+        const { theme } = useTheme();
+
+        const openFoodofferSortingModal = useCallback(() => {
+                showScrollViewModal(
+                        {
+                                title: translate(TranslationKeys.sort),
+                                onClose: closeScrollViewModal,
+                                children: <SortSheet closeSheet={closeScrollViewModal} />,
+                        },
+                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                );
+        }, [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]);
+
+        return { openFoodofferSortingModal };
+};
+
+export default useFoodofferSortingModal;


### PR DESCRIPTION
## Summary
- extract the food offer sorting modal into a reusable `useFoodofferSortingModal` hook
- update the foodoffers screen to use the new hook for opening the sorting modal
- add a settings list entry that opens the food offer sorting modal and shows the current selection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a59984e808330b3267efe2d2e9383)