### PR TITLE
Use SettingsList in foodoffer sorting modal

### DIFF
--- a/apps/frontend/app/components/SortSheet/SortSheet.tsx
+++ b/apps/frontend/app/components/SortSheet/SortSheet.tsx
@@ -1,189 +1,188 @@
-import { Text, TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { AntDesign, FontAwesome5, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 
 import { SortSheetProps } from './types';
-import Checkbox from 'expo-checkbox';
-import { FoodSortOption, intelligentSort, sortByEatingHabits, sortByFoodCategory, sortByFoodName, sortByFoodOfferCategory, sortByOwnFavorite, sortByPrice, sortByPublicFavorite } from 'repo-depkit-common';
+import {
+        CollectibleAt,
+        FoodSortOption,
+        intelligentSort,
+        sortByEatingHabits,
+        sortByFoodCategory,
+        sortByFoodName,
+        sortByFoodOfferCategory,
+        sortByOwnFavorite,
+        sortByPrice,
+        sortByPublicFavorite,
+} from 'repo-depkit-common';
 import { SET_SELECTED_CANTEEN_FOOD_OFFERS, SET_SORTING } from '@/redux/Types/types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
-import { myContrastColor } from '@/helper/ColorHelper';
-import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
-import { CollectibleAt } from 'repo-depkit-common';
+import SettingsList from '@/components/SettingsList';
 
 const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
         const { theme } = useTheme();
         const { translate } = useLanguage();
 
-	const dispatch = useDispatch();
-	const { canteenFoodOffers } = useSelector((state: RootState) => state.canteenReducer);
-	const { primaryColor, language: languageCode, sortBy, appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const { ownFoodFeedbacks, foodCategories, foodOfferCategories } = useSelector((state: RootState) => state.food);
-	const { profile } = useSelector((state: RootState) => state.authReducer);
-	const [selectedOption, setSelectedOption] = useState<FoodSortOption | null>(null);
-	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
-	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
+        const dispatch = useDispatch();
+        const { canteenFoodOffers } = useSelector((state: RootState) => state.canteenReducer);
+        const { primaryColor, language: languageCode, sortBy, appSettings } = useSelector((state: RootState) => state.settings);
+        const { ownFoodFeedbacks, foodCategories, foodOfferCategories } = useSelector((state: RootState) => state.food);
+        const { profile } = useSelector((state: RootState) => state.authReducer);
+        const [selectedOption, setSelectedOption] = useState<FoodSortOption | null>(null);
+        const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 
-	const sortingOptions = [
-		{
-			id: FoodSortOption.INTELLIGENT,
-			label: 'sort_option_intelligent',
-			icon: <MaterialCommunityIcons name="brain" size={24} />,
-		},
-		{
-			id: FoodSortOption.FAVORITE,
-			label: 'sort_option_favorite',
-			icon: <AntDesign name="heart" size={24} />,
-		},
-		{
-			id: FoodSortOption.EATING,
-			label: 'eating_habits',
-			icon: <Ionicons name="bag-add" size={24} />,
-		},
-		{
-			id: FoodSortOption.FOOD_CATEGORY,
-			label: 'sort_option_food_category',
-			icon: <MaterialCommunityIcons name="food" size={24} />,
-		},
-		{
-			id: FoodSortOption.FOODOFFER_CATEGORY,
-			label: 'sort_option_foodoffer_category',
-			icon: <MaterialCommunityIcons name="food-variant" size={24} />,
-		},
-		{
-			id: FoodSortOption.RATING,
-			label: 'sort_option_public_rating',
-			icon: <AntDesign name="star" size={24} />,
-		},
-		{
-			id: FoodSortOption.PRICE_ASCENDING,
-			label: 'sort_option_price_ascending',
-			icon: <FontAwesome5 name="sort-numeric-up" size={24} />,
-		},
-		{
-			id: FoodSortOption.PRICE_DESCENDING,
-			label: 'sort_option_price_descending',
-			icon: <FontAwesome5 name="sort-numeric-down" size={24} />,
-		},
-		{
-			id: FoodSortOption.ALPHABETICAL,
-			label: 'sort_option_alphabetical',
-			icon: <FontAwesome5 name="sort-alpha-down" size={24} />,
-		},
-		{
-			id: FoodSortOption.NONE,
-			label: 'sort_option_none',
-			icon: <MaterialCommunityIcons name="sort-variant-remove" size={24} />,
-		},
-	];
+        const sortingOptions = [
+                {
+                        id: FoodSortOption.INTELLIGENT,
+                        label: 'sort_option_intelligent',
+                        icon: <MaterialCommunityIcons name="brain" size={24} />,
+                },
+                {
+                        id: FoodSortOption.FAVORITE,
+                        label: 'sort_option_favorite',
+                        icon: <AntDesign name="heart" size={24} />,
+                },
+                {
+                        id: FoodSortOption.EATING,
+                        label: 'eating_habits',
+                        icon: <Ionicons name="bag-add" size={24} />,
+                },
+                {
+                        id: FoodSortOption.FOOD_CATEGORY,
+                        label: 'sort_option_food_category',
+                        icon: <MaterialCommunityIcons name="food" size={24} />,
+                },
+                {
+                        id: FoodSortOption.FOODOFFER_CATEGORY,
+                        label: 'sort_option_foodoffer_category',
+                        icon: <MaterialCommunityIcons name="food-variant" size={24} />,
+                },
+                {
+                        id: FoodSortOption.RATING,
+                        label: 'sort_option_public_rating',
+                        icon: <AntDesign name="star" size={24} />,
+                },
+                {
+                        id: FoodSortOption.PRICE_ASCENDING,
+                        label: 'sort_option_price_ascending',
+                        icon: <FontAwesome5 name="sort-numeric-up" size={24} />,
+                },
+                {
+                        id: FoodSortOption.PRICE_DESCENDING,
+                        label: 'sort_option_price_descending',
+                        icon: <FontAwesome5 name="sort-numeric-down" size={24} />,
+                },
+                {
+                        id: FoodSortOption.ALPHABETICAL,
+                        label: 'sort_option_alphabetical',
+                        icon: <FontAwesome5 name="sort-alpha-down" size={24} />,
+                },
+                {
+                        id: FoodSortOption.NONE,
+                        label: 'sort_option_none',
+                        icon: <MaterialCommunityIcons name="sort-variant-remove" size={24} />,
+                },
+        ];
 
-	const updateSort = (option: { id: FoodSortOption }) => {
-		setSelectedOption(option.id);
-		dispatch({ type: SET_SORTING, payload: option.id });
+        const updateSort = (option: { id: FoodSortOption }) => {
+                setSelectedOption(option.id);
+                dispatch({ type: SET_SORTING, payload: option.id });
 
-		// Copy food offers to avoid mutation
-		let copiedFoodOffers = [...canteenFoodOffers];
+                // Copy food offers to avoid mutation
+                let copiedFoodOffers = [...canteenFoodOffers];
 
-		// Sorting logic based on option id
-		switch (option.id) {
-			case FoodSortOption.ALPHABETICAL:
-				copiedFoodOffers = sortByFoodName(copiedFoodOffers, languageCode);
-				break;
-			case FoodSortOption.FAVORITE:
-				copiedFoodOffers = sortByOwnFavorite(copiedFoodOffers, ownFoodFeedbacks);
-				break;
-			case FoodSortOption.EATING:
-				copiedFoodOffers = sortByEatingHabits(copiedFoodOffers, profile.markings);
-				break;
-			case FoodSortOption.FOOD_CATEGORY:
-				copiedFoodOffers = sortByFoodCategory(copiedFoodOffers, foodCategories, languageCode);
-				break;
-			case FoodSortOption.FOODOFFER_CATEGORY:
-				copiedFoodOffers = sortByFoodOfferCategory(copiedFoodOffers, foodOfferCategories);
-				break;
-			case FoodSortOption.RATING:
-				copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
-				break;
-			case FoodSortOption.PRICE_ASCENDING:
-				copiedFoodOffers = sortByPrice(copiedFoodOffers, profile?.price_group, false);
-				break;
-			case FoodSortOption.PRICE_DESCENDING:
-				copiedFoodOffers = sortByPrice(copiedFoodOffers, profile?.price_group, true);
-				break;
-			case FoodSortOption.INTELLIGENT:
-				copiedFoodOffers = intelligentSort(copiedFoodOffers, ownFoodFeedbacks, profile.markings, languageCode, foodCategories, foodOfferCategories);
-				break;
-			default:
-				console.warn('Unknown sorting option:', option.id);
-				break;
-		}
+                // Sorting logic based on option id
+                switch (option.id) {
+                        case FoodSortOption.ALPHABETICAL:
+                                copiedFoodOffers = sortByFoodName(copiedFoodOffers, languageCode);
+                                break;
+                        case FoodSortOption.FAVORITE:
+                                copiedFoodOffers = sortByOwnFavorite(copiedFoodOffers, ownFoodFeedbacks);
+                                break;
+                        case FoodSortOption.EATING:
+                                copiedFoodOffers = sortByEatingHabits(copiedFoodOffers, profile.markings);
+                                break;
+                        case FoodSortOption.FOOD_CATEGORY:
+                                copiedFoodOffers = sortByFoodCategory(copiedFoodOffers, foodCategories, languageCode);
+                                break;
+                        case FoodSortOption.FOODOFFER_CATEGORY:
+                                copiedFoodOffers = sortByFoodOfferCategory(copiedFoodOffers, foodOfferCategories);
+                                break;
+                        case FoodSortOption.RATING:
+                                copiedFoodOffers = sortByPublicFavorite(copiedFoodOffers);
+                                break;
+                        case FoodSortOption.PRICE_ASCENDING:
+                                copiedFoodOffers = sortByPrice(copiedFoodOffers, profile?.price_group, false);
+                                break;
+                        case FoodSortOption.PRICE_DESCENDING:
+                                copiedFoodOffers = sortByPrice(copiedFoodOffers, profile?.price_group, true);
+                                break;
+                        case FoodSortOption.INTELLIGENT:
+                                copiedFoodOffers = intelligentSort(
+                                        copiedFoodOffers,
+                                        ownFoodFeedbacks,
+                                        profile.markings,
+                                        languageCode,
+                                        foodCategories,
+                                        foodOfferCategories
+                                );
+                                break;
+                        default:
+                                console.warn('Unknown sorting option:', option.id);
+                                break;
+                }
 
-		// Dispatch updated food offers and close the sheet
-		dispatch({
-			type: SET_SELECTED_CANTEEN_FOOD_OFFERS,
-			payload: copiedFoodOffers,
-		});
-		closeSheet();
-	};
+                // Dispatch updated food offers and close the sheet
+                dispatch({
+                        type: SET_SELECTED_CANTEEN_FOOD_OFFERS,
+                        payload: copiedFoodOffers,
+                });
+                closeSheet();
+        };
 
-	useEffect(() => {
-		setSelectedOption(sortBy as FoodSortOption);
-	}, []);
+        useEffect(() => {
+                setSelectedOption(sortBy as FoodSortOption);
+        }, []);
 
         return (
                 <View style={{ width: '100%', gap: 12 }}>
                         <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_sort} />
                         <View style={styles.sortingListContainer}>
-                                {sortingOptions.map((option, index) => (
-                                        <TouchableOpacity
-                                                key={option.id + index}
-                                                style={[
-                                                        styles.actionItem,
-                                                        selectedOption === option.id
-                                                                ? {
-                                                                                backgroundColor: foods_area_color,
-                                                                        }
-                                                                : {
-                                                                                backgroundColor: theme.screen.iconBg,
-                                                                        },
-                                                ]}
-                                                onPress={() => updateSort(option)}
-                                        >
-                                                <View style={styles.col}>
-                                                        {React.cloneElement(
-                                                                option.icon,
-                                                                selectedOption === option.id
-                                                                        ? {
-                                                                                        color: contrastColor,
-                                                                                }
-                                                                        : { color: theme.screen.icon }
-                                                        )}
-                                                        <Text
-                                                                style={[
-                                                                        styles.label,
-                                                                        selectedOption === option.id
-                                                                                ? {
-                                                                                                color: contrastColor,
-                                                                                        }
-                                                                                : { color: theme.screen.text },
-                                                                ]}
-                                                        >
-                                                                {translate(option.label)}
-                                                        </Text>
-                                                </View>
-                                                <Checkbox
-                                                        style={styles.checkbox}
-                                                        value={selectedOption === option.id}
-                                                        // onValueChange={() => updateSort(option)} // Toggle option
-                                                        color={selectedOption === option.id ? '#000000' : undefined}
+                                {sortingOptions.map((option, index) => {
+                                        const isSelected = selectedOption === option.id;
+                                        const groupPosition =
+                                                sortingOptions.length === 1
+                                                        ? 'single'
+                                                        : index === 0
+                                                                ? 'top'
+                                                                : index === sortingOptions.length - 1
+                                                                        ? 'bottom'
+                                                                        : 'middle';
+
+                                        return (
+                                                <SettingsList
+                                                        key={option.id}
+                                                        label={translate(option.label)}
+                                                        leftIcon={option.icon}
+                                                        iconBgColor={foods_area_color}
+                                                        groupPosition={groupPosition}
+                                                        showSeparator={index !== sortingOptions.length - 1}
+                                                        rightIcon={
+                                                                <MaterialCommunityIcons
+                                                                        name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+                                                                        size={24}
+                                                                        color={isSelected ? foods_area_color : theme.screen.icon}
+                                                                />
+                                                        }
+                                                        handleFunction={() => updateSort(option)}
                                                 />
-                                        </TouchableOpacity>
-                                ))}
+                                        );
+                                })}
                         </View>
                 </View>
         );

--- a/apps/frontend/app/components/SortSheet/styles.ts
+++ b/apps/frontend/app/components/SortSheet/styles.ts
@@ -1,68 +1,10 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-	sheetView: {
-		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
-	contentContainer: {
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	sheetcloseButton: {
-		width: 45,
-		height: 45,
-		borderRadius: 50,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
-	},
-	sortingListContainer: {
-		width: '100%',
-		paddingHorizontal: 10,
-		gap: 20,
-		marginTop: 30,
-	},
-	actionItem: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		alignItems: 'center',
-		padding: 10,
-		paddingHorizontal: 20,
-		borderRadius: 10,
-	},
-	col: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		gap: 10,
-	},
-	label: {
-		fontSize: 18,
-		fontFamily: 'Poppins_400Regular',
-	},
-	checkbox: {
-		width: 20,
-		height: 20,
-		borderRadius: 50,
-	},
-	canteenName: {
-		fontSize: 18,
-		fontFamily: 'Poppins_700Bold',
-		textAlign: 'center',
-		marginTop: 10,
-	},
+        sortingListContainer: {
+                width: '100%',
+                paddingHorizontal: 10,
+                gap: 20,
+                marginTop: 30,
+        },
 });


### PR DESCRIPTION
## Summary
- replace the food offer sorting modal items with the shared SettingsList component used on the settings screen
- adjust the selection indicator to use radio-style icons and clean up unused styles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5b8af8208330aa3787541e40def9)