### PR TITLE
Remove spacing between sort settings rows

### DIFF
--- a/apps/frontend/app/components/SortSheet/styles.ts
+++ b/apps/frontend/app/components/SortSheet/styles.ts
@@ -4,7 +4,6 @@ export default StyleSheet.create({
         sortingListContainer: {
                 width: '100%',
                 paddingHorizontal: 10,
-                gap: 20,
                 marginTop: 30,
         },
 });


### PR DESCRIPTION
## Summary
- remove extra gap between sort sheet settings rows in the foodoffers modal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a91f3c1608330aaceb295e9b7b75c)