### PR TITLE
Use scroll view modal for update checks

### DIFF
--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -1,7 +1,6 @@
-import React, { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, AppState, AppStateStatus, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import * as Updates from 'expo-updates';
-import ModalSheet from '../BaseBottomModal';
 import usePlatformHelper from '@/helper/platformHelper';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -10,6 +9,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { isInExpoGo } from '@/helper/DeviceRuntimeHelper';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 interface ExpoUpdateCheckerProps {
 	children?: ReactNode;
@@ -22,39 +22,65 @@ interface UpdateCheckerContextType {
 const UpdateCheckerContext = createContext<UpdateCheckerContextType | null>(null);
 
 const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
-	const appState = useRef<AppStateStatus>(AppState.currentState);
-	const { isSmartPhone } = usePlatformHelper();
-	const { translate } = useLanguage();
-	const { theme } = useTheme();
-	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+        const appState = useRef<AppStateStatus>(AppState.currentState);
+        const { isSmartPhone } = usePlatformHelper();
+        const { translate } = useLanguage();
+        const { theme } = useTheme();
+        const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+        const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 
-	const [modalVisible, setModalVisible] = useState(false);
-	const [updating, setUpdating] = useState(false);
-	const [updateAvailable, setUpdateAvailable] = useState(false);
-	const [titleKey, setTitleKey] = useState<TranslationKeys>(TranslationKeys.update_available);
-	const [messageKey, setMessageKey] = useState<TranslationKeys>(TranslationKeys.update_available_message);
+        const backgroundColor = theme.sheet?.sheetBg ?? theme.screen.background;
 
-	const checkForUpdates = async (showUpToDate = false) => {
-		if (!isSmartPhone()) return;
-		if (isInExpoGo()) return;
-		try {
-			const update = await Updates.checkForUpdateAsync();
-			if (update.isAvailable) {
-				setUpdateAvailable(true);
-				setTitleKey(TranslationKeys.update_available);
-				setMessageKey(TranslationKeys.update_available_message);
-				setModalVisible(true);
-			} else if (showUpToDate) {
-				setUpdateAvailable(false);
-				setTitleKey(TranslationKeys.updates);
-				setMessageKey(TranslationKeys.no_updates_available);
-				setModalVisible(true);
-			}
-		} catch (e) {
-			console.error('Error while checking updates', e);
-		}
-	};
+        const openUpdateModal = useCallback(
+                ({ titleKey, messageKey, isUpdateAvailable }: { titleKey: TranslationKeys; messageKey: TranslationKeys; isUpdateAvailable: boolean }) => {
+                        showScrollViewModal(
+                                {
+                                        title: translate(titleKey),
+                                        onClose: closeScrollViewModal,
+                                        children: (
+                                                <UpdateModalContent
+                                                        updateAvailable={isUpdateAvailable}
+                                                        messageKey={messageKey}
+                                                        translate={translate}
+                                                        theme={theme}
+                                                        primaryColor={primaryColor}
+                                                        contrastColor={contrastColor}
+                                                        closeModal={closeScrollViewModal}
+                                                />
+                                        ),
+                                },
+                                {
+                                        backgroundStyle: { backgroundColor },
+                                        headerBackgroundColor: backgroundColor,
+                                }
+                        );
+                },
+                [backgroundColor, closeScrollViewModal, contrastColor, primaryColor, showScrollViewModal, theme, translate]
+        );
+
+        const checkForUpdates = async (showUpToDate = false) => {
+                if (!isSmartPhone()) return;
+                if (isInExpoGo()) return;
+                try {
+                        const update = await Updates.checkForUpdateAsync();
+                        if (update.isAvailable) {
+                                openUpdateModal({
+                                        titleKey: TranslationKeys.update_available,
+                                        messageKey: TranslationKeys.update_available_message,
+                                        isUpdateAvailable: true,
+                                });
+                        } else if (showUpToDate) {
+                                openUpdateModal({
+                                        titleKey: TranslationKeys.updates,
+                                        messageKey: TranslationKeys.no_updates_available,
+                                        isUpdateAvailable: false,
+                                });
+                        }
+                } catch (e) {
+                        console.error('Error while checking updates', e);
+                }
+        };
 
 	useEffect(() => {
 		if (!isSmartPhone()) return;
@@ -64,43 +90,75 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 			}
 			appState.current = nextState;
 		});
-		return () => {
-			subscription.remove();
-		};
-	}, []);
+                return () => {
+                        subscription.remove();
+                };
+        }, []);
 
-	const applyUpdate = async () => {
-		try {
-			setUpdating(true);
-			await Updates.fetchUpdateAsync();
-			await Updates.reloadAsync();
-		} catch (e) {
-			console.error('Error while applying updates', e);
-		}
-	};
+        return (
+                <UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>
+                        {children}
+                </UpdateCheckerContext.Provider>
+        );
+};
 
-	return (
-		<UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>
-			{children}
-			{modalVisible && (
-				<ModalSheet visible={modalVisible} onClose={() => setModalVisible(false)} title={translate(titleKey)}>
-					<View style={{ padding: 20 }}>
-						<Text style={{ color: theme.screen.text, textAlign: 'center' }}>{translate(messageKey)}</Text>
-					</View>
-					<View style={modalStyles.buttonContainer}>
-						<TouchableOpacity onPress={() => setModalVisible(false)} style={[modalStyles.cancelButton, { borderColor: primaryColor }]}>
-							<Text style={[modalStyles.buttonText, { color: theme.screen.text }]}>{translate(updateAvailable ? TranslationKeys.cancel : TranslationKeys.okay)}</Text>
-						</TouchableOpacity>
-						{updateAvailable && (
-							<TouchableOpacity onPress={applyUpdate} style={[modalStyles.saveButton, { backgroundColor: primaryColor }]}>
-								{updating ? <ActivityIndicator color={contrastColor} /> : <Text style={[modalStyles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.to_update)}</Text>}
-							</TouchableOpacity>
-						)}
-					</View>
-				</ModalSheet>
-			)}
-		</UpdateCheckerContext.Provider>
-	);
+type UpdateModalContentProps = {
+        updateAvailable: boolean;
+        messageKey: TranslationKeys;
+        translate: ReturnType<typeof useLanguage>['translate'];
+        theme: ReturnType<typeof useTheme>['theme'];
+        primaryColor: string;
+        contrastColor: string;
+        closeModal: () => void;
+};
+
+const UpdateModalContent: React.FC<UpdateModalContentProps> = ({
+        updateAvailable,
+        messageKey,
+        translate,
+        theme,
+        primaryColor,
+        contrastColor,
+        closeModal,
+}) => {
+        const [updating, setUpdating] = useState(false);
+
+        const applyUpdate = useCallback(async () => {
+                try {
+                        setUpdating(true);
+                        await Updates.fetchUpdateAsync();
+                        await Updates.reloadAsync();
+                } catch (e) {
+                        console.error('Error while applying updates', e);
+                        setUpdating(false);
+                }
+        }, []);
+
+        return (
+                <>
+                        <View style={{ padding: 20 }}>
+                                <Text style={{ color: theme.screen.text, textAlign: 'center' }}>{translate(messageKey)}</Text>
+                        </View>
+                        <View style={modalStyles.buttonContainer}>
+                                <TouchableOpacity onPress={closeModal} style={[modalStyles.cancelButton, { borderColor: primaryColor }]}>
+                                        <Text style={[modalStyles.buttonText, { color: theme.screen.text }]}>
+                                                {translate(updateAvailable ? TranslationKeys.cancel : TranslationKeys.okay)}
+                                        </Text>
+                                </TouchableOpacity>
+                                {updateAvailable && (
+                                        <TouchableOpacity onPress={applyUpdate} style={[modalStyles.saveButton, { backgroundColor: primaryColor }]}>
+                                                {updating ? (
+                                                        <ActivityIndicator color={contrastColor} />
+                                                ) : (
+                                                        <Text style={[modalStyles.buttonText, { color: contrastColor }]}>
+                                                                {translate(TranslationKeys.to_update)}
+                                                        </Text>
+                                                )}
+                                        </TouchableOpacity>
+                                )}
+                        </View>
+                </>
+        );
 };
 
 export const useExpoUpdateChecker = () => {


### PR DESCRIPTION
## Summary
- replace the ExpoUpdateChecker modal with the shared scroll view modal hook
- render update prompt content within the reusable modal content component
- align update prompt styling with the global sheet background colors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac538dbac8330bd799e437941da1d)