### PR TITLE
Add foreground modal hook for foodoffers

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -71,6 +71,7 @@ import Button from '@/components/UI/Button';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
+import useAppForegroundScrollViewModal from '@/hooks/useAppForegroundScrollViewModal';
 
 export const SHEET_COMPONENTS = {
         canteen: CanteenSelectionSheet,
@@ -99,11 +100,11 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const canteenFeedbackLabelHelper = new CanteenFeedbackLabelHelper();
 	const [loading, setLoading] = useState(false);
 	const [isActive, setIsActive] = useState(false);
-	const [refreshing, setRefreshing] = useState(false);
-	const [beforeElement, setBeforeElement] = useState<any>(null);
-	const [afterElement, setAfterElement] = useState<any>(null);
-	const [selectedFoodId, setSelectedFoodId] = useState('');
-	const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
+        const [refreshing, setRefreshing] = useState(false);
+        const [beforeElement, setBeforeElement] = useState<any>(null);
+        const [afterElement, setAfterElement] = useState<any>(null);
+        const [selectedFoodId, setSelectedFoodId] = useState('');
+        const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
 	const [feedbackLabelsLoading, setFeedbackLabelsLoading] = useState(true);
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const [listWidth, setListWidth] = useState<number | null>(null);
@@ -138,6 +139,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
         const { openActiveModal, activePopupEvent } = usePopupEventModal();
         const { openFoodofferSortingModal } = useFoodofferSortingModal();
+        useAppForegroundScrollViewModal();
 
 	const MIN_CARD_WIDTH = 280;
 	const numColumns = useMemo(() => {

--- a/apps/frontend/app/hooks/useAppForegroundScrollViewModal.tsx
+++ b/apps/frontend/app/hooks/useAppForegroundScrollViewModal.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { AppState, AppStateStatus, Text, View } from 'react-native';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useTheme } from '@/hooks/useTheme';
+
+const useAppForegroundScrollViewModal = () => {
+        const appState = useRef<AppStateStatus>(AppState.currentState);
+        const { show } = useMyScrollViewModal();
+        const { theme } = useTheme();
+
+        const handleAppForeground = useCallback(() => {
+                show({
+                        children: (
+                                <View style={{ padding: 24 }}>
+                                        <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
+                                                App in den Vordergrund
+                                        </Text>
+                                </View>
+                        ),
+                });
+        }, [show, theme.screen.text]);
+
+        useEffect(() => {
+                const subscription = AppState.addEventListener('change', nextState => {
+                        if (appState.current.match(/inactive|background/) && nextState === 'active') {
+                                handleAppForeground();
+                        }
+                        appState.current = nextState;
+                });
+
+                return () => {
+                        subscription.remove();
+                };
+        }, [handleAppForeground]);
+};
+
+export default useAppForegroundScrollViewModal;


### PR DESCRIPTION
## Summary
- add a reusable hook that shows a scroll view modal when the app returns to the foreground
- call the new hook on the food offers screen so users see the foreground notice

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad5f89b808330996c52aea4829e85)