### PR TITLE
Add foreground update check modal wrapper

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -71,7 +71,7 @@ import Button from '@/components/UI/Button';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
-import useAppForegroundScrollViewModal from '@/hooks/useAppForegroundScrollViewModal';
+import useAppForegroundUpdateCheckModal from '@/hooks/useAppForegroundUpdateCheckModal';
 
 export const SHEET_COMPONENTS = {
         canteen: CanteenSelectionSheet,
@@ -139,7 +139,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
         const { openActiveModal, activePopupEvent } = usePopupEventModal();
         const { openFoodofferSortingModal } = useFoodofferSortingModal();
-        useAppForegroundScrollViewModal();
+        useAppForegroundUpdateCheckModal();
 
 	const MIN_CARD_WIDTH = 280;
 	const numColumns = useMemo(() => {

--- a/apps/frontend/app/hooks/useAppForegroundScrollViewModal.tsx
+++ b/apps/frontend/app/hooks/useAppForegroundScrollViewModal.tsx
@@ -4,7 +4,11 @@ import { AppState, AppStateStatus, Text, View } from 'react-native';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useTheme } from '@/hooks/useTheme';
 
-const useAppForegroundScrollViewModal = () => {
+interface UseAppForegroundScrollViewModalOptions {
+        autoRegister?: boolean;
+}
+
+const useAppForegroundScrollViewModal = ({ autoRegister = true }: UseAppForegroundScrollViewModalOptions = {}) => {
         const appState = useRef<AppStateStatus>(AppState.currentState);
         const { show } = useMyScrollViewModal();
         const { theme } = useTheme();
@@ -22,6 +26,8 @@ const useAppForegroundScrollViewModal = () => {
         }, [show, theme.screen.text]);
 
         useEffect(() => {
+                if (!autoRegister) return;
+
                 const subscription = AppState.addEventListener('change', nextState => {
                         if (appState.current.match(/inactive|background/) && nextState === 'active') {
                                 handleAppForeground();
@@ -32,7 +38,9 @@ const useAppForegroundScrollViewModal = () => {
                 return () => {
                         subscription.remove();
                 };
-        }, [handleAppForeground]);
+        }, [autoRegister, handleAppForeground]);
+
+        return handleAppForeground;
 };
 
 export default useAppForegroundScrollViewModal;

--- a/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
+++ b/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { AppState, AppStateStatus, Text, View } from 'react-native';
+import * as Updates from 'expo-updates';
+import { useSelector } from 'react-redux';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import useAppForegroundScrollViewModal from '@/hooks/useAppForegroundScrollViewModal';
+import usePlatformHelper from '@/helper/platformHelper';
+import { RootState } from '@/redux/reducer';
+import { isInExpoGo } from '@/helper/DeviceRuntimeHelper';
+import { useTheme } from '@/hooks/useTheme';
+
+const useAppForegroundUpdateCheckModal = () => {
+        const appState = useRef<AppStateStatus>(AppState.currentState);
+        const { appSettings } = useSelector((state: RootState) => state.settings);
+        const { isSmartPhone } = usePlatformHelper();
+        const handleAppForegroundModal = useAppForegroundScrollViewModal({ autoRegister: false });
+        const { show } = useMyScrollViewModal();
+        const { theme } = useTheme();
+
+        const checkForUpdate = useCallback(async () => {
+                const expoUpdateCheckEnabled =
+                        appSettings?.experimental_expo_update_check ||
+                        appSettings?.experimentell_expo_update_check;
+
+                if (!expoUpdateCheckEnabled) return false;
+                if (!isSmartPhone()) return false;
+                if (isInExpoGo()) return false;
+
+                try {
+                        const update = await Updates.checkForUpdateAsync();
+                        return update.isAvailable;
+                } catch (error) {
+                        console.error('Error while checking Expo updates', error);
+                        return false;
+                }
+        }, [appSettings?.experimental_expo_update_check, appSettings?.experimentell_expo_update_check, isSmartPhone]);
+
+        const showUpdateNotice = useCallback(() => {
+                show({
+                        children: (
+                                <View style={{ padding: 24 }}>
+                                        <Text style={{ color: theme.screen.text, textAlign: 'center', marginBottom: 8 }}>
+                                                Die App hat ein Update.
+                                        </Text>
+                                        <Text style={{ color: theme.screen.text, textAlign: 'center', fontWeight: '600' }}>
+                                                Bitte App Neustarten.
+                                        </Text>
+                                </View>
+                        ),
+                });
+        }, [show, theme.screen.text]);
+
+        const handleAppForeground = useCallback(async () => {
+                const updateAvailable = await checkForUpdate();
+                if (updateAvailable) {
+                        showUpdateNotice();
+                }
+
+                handleAppForegroundModal();
+        }, [checkForUpdate, handleAppForegroundModal, showUpdateNotice]);
+
+        useEffect(() => {
+                const subscription = AppState.addEventListener('change', nextState => {
+                        if (appState.current.match(/inactive|background/) && nextState === 'active') {
+                                void handleAppForeground();
+                        }
+                        appState.current = nextState;
+                });
+
+                return () => {
+                        subscription.remove();
+                };
+        }, [handleAppForeground]);
+};
+
+export default useAppForegroundUpdateCheckModal;


### PR DESCRIPTION
## Summary
- add a foreground update-check hook that wraps the existing scroll view modal logic
- refactor the app foreground modal hook to allow manual triggering
- show a restart notice when an experimental Expo update check reports an available update

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ada016da08330b96d86305e94f42f)