### PR TITLE
Show update modal only when update is available

### DIFF
--- a/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
+++ b/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
@@ -49,26 +49,12 @@ const useAppForegroundUpdateCheckModal = () => {
                 });
         }, [show, theme.screen.text]);
 
-        const showNoUpdateNotice = useCallback(() => {
-                show({
-                        children: (
-                                <View style={{ padding: 24 }}>
-                                        <Text style={{ color: theme.screen.text, textAlign: 'center' }}>
-                                                Kein Update verfügbar.
-                                        </Text>
-                                </View>
-                        ),
-                });
-        }, [show, theme.screen.text]);
-
         const handleAppForeground = useCallback(async () => {
                 const updateAvailable = await checkForUpdate();
                 if (updateAvailable) {
                         showUpdateNotice();
-                } else {
-                        showNoUpdateNotice();
                 }
-        }, [checkForUpdate, showNoUpdateNotice, showUpdateNotice]);
+        }, [checkForUpdate, showUpdateNotice]);
 
         useEffect(() => {
                 const subscription = AppState.addEventListener('change', nextState => {


### PR DESCRIPTION
## Summary
- prevent displaying an update modal when no update is available
- simplify foreground update check hook to only notify when updates exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae69759e48330ae9ff4b30bdc2d6c)