### PR TITLE
Reduce top spacing in food offer sort modal

### DIFF
--- a/apps/frontend/app/components/SortSheet/styles.ts
+++ b/apps/frontend/app/components/SortSheet/styles.ts
@@ -1,9 +1,9 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-        sortingListContainer: {
-                width: '100%',
-                paddingHorizontal: 10,
-                marginTop: 30,
-        },
+	sortingListContainer: {
+		width: '100%',
+		paddingHorizontal: 10,
+		marginTop: 12,
+	},
 });


### PR DESCRIPTION
### Motivation
- Tighten visual spacing in the food offer sorting modal by reducing the gap between the title/header and the list of sort options.
- Improve the compactness of the settings list so more options are visible without scrolling.

### Description
- Adjusted the style for the sorting list container in `apps/frontend/app/components/SortSheet/styles.ts`.
- Changed `marginTop` for `sortingListContainer` from `30` to `12` to reduce the vertical gap.

### Testing
- No unit or integration tests were executed as part of this change.
- A visual smoke check via Playwright was attempted but failed because the app was not reachable (`net::ERR_EMPTY_RESPONSE`).
- The style change is a small visual tweak and should be validated in the running app or during a QA pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af7013b808330b5236e21ab0064dc)