### PR TITLE
Streamline Expo update modal actions

### DIFF
--- a/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
+++ b/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
@@ -85,27 +85,36 @@ const useAppForegroundUpdateCheckModal = () => {
         );
 
         const handleDownloadUpdate = useCallback(async () => {
-                showStatusModal({
-                        title: 'Update wird geladen',
-                        message: 'Update wird heruntergeladen ...',
-                        loading: true,
-                }, { force: true });
+                showStatusModal(
+                        {
+                                title: 'Update wird geladen',
+                                message: 'Update wird heruntergeladen ...',
+                                loading: true,
+                        },
+                        { force: true }
+                );
 
                 try {
                         await Updates.fetchUpdateAsync();
-                        showStatusModal({
-                                title: 'Update geladen',
-                                message: 'Das Update wurde geladen. Bitte App neu starten.',
-                                primaryAction: { label: 'App neu starten', onPress: () => void Updates.reloadAsync() },
-                                allowClose: true,
-                        }, { force: true });
+                        showStatusModal(
+                                {
+                                        title: 'Update bereit',
+                                        message: 'App wird neu gestartet ...',
+                                        loading: true,
+                                },
+                                { force: true }
+                        );
+                        await Updates.reloadAsync();
                 } catch (error) {
                         console.error('Error while fetching Expo updates', error);
-                        showStatusModal({
-                                title: 'Update-Download fehlgeschlagen',
-                                message: 'Das Update konnte nicht heruntergeladen werden.',
-                                allowClose: true,
-                        }, { force: true });
+                        showStatusModal(
+                                {
+                                        title: 'Update-Download fehlgeschlagen',
+                                        message: 'Das Update konnte nicht heruntergeladen werden.',
+                                        allowClose: true,
+                                },
+                                { force: true }
+                        );
                 }
         }, [showStatusModal]);
 
@@ -114,12 +123,14 @@ const useAppForegroundUpdateCheckModal = () => {
 
                 if (simulateExpoUpdateAvailable) {
                         dispatch({ type: SET_SIMULATE_EXPO_UPDATE_AVAILABLE, payload: false });
-                        showStatusModal({
-                                title: 'Update gefunden',
-                                message: 'Ein neues Update ist verfügbar.',
-                                primaryAction: { label: 'Update downloaden', onPress: handleDownloadUpdate },
-                                allowClose: true,
-                        }, { force: true });
+                        showStatusModal(
+                                {
+                                        title: 'Update gefunden',
+                                        message: 'Ein neues Update ist verfügbar.',
+                                        primaryAction: { label: 'Herunterladen und aktualisieren', onPress: handleDownloadUpdate },
+                                },
+                                { force: true }
+                        );
                         return true;
                 }
 
@@ -145,12 +156,14 @@ const useAppForegroundUpdateCheckModal = () => {
                 try {
                         const update = await Updates.checkForUpdateAsync();
                         if (update.isAvailable) {
-                                showStatusModal({
-                                        title: 'Update gefunden',
-                                        message: 'Ein neues Update ist verfügbar.',
-                                        primaryAction: { label: 'Update downloaden', onPress: handleDownloadUpdate },
-                                        allowClose: true,
-                                }, { force: true });
+                                showStatusModal(
+                                        {
+                                                title: 'Update gefunden',
+                                                message: 'Ein neues Update ist verfügbar.',
+                                                primaryAction: { label: 'Herunterladen und aktualisieren', onPress: handleDownloadUpdate },
+                                        },
+                                        { force: true }
+                                );
                         } else {
                                 showStatusModal({
                                         title: 'Kein Update gefunden',


### PR DESCRIPTION
### Motivation
- Ensure the app restarts immediately after an OTA update is downloaded to provide a seamless update experience.
- Simplify the update modal workflow by removing redundant cancel actions.
- Make the primary update action label clearer for users by using an explicit German label.

### Description
- Updated `apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx` to connect `Updates.fetchUpdateAsync()` directly to `Updates.reloadAsync()` inside `handleDownloadUpdate` and show a loading state while restarting.
- Changed the update-available modal primary action label to `Herunterladen und aktualisieren` and removed the extra `allowClose` cancel button for that modal.
- Adjusted modal status messages to reflect the new flow (e.g., `Update bereit` / `App wird neu gestartet ...`).

### Testing
- No automated tests were run for this change.
- Manual runtime verification was not performed in this environment due to mobile/Expo constraints.
- Type checks or linting were not executed as part of this change.
- The modified file was compiled/committed locally but no CI run was observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b033b2b5883309f84a139cbf7d1c8)