### PR TITLE
Add `useThemeSettingsModal` hook and move ColorSchemeSheet into global modal

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -10,7 +10,6 @@ import SettingsList from '@/components/SettingsList';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import SettingsListNickname from '@/components/SettingsListNickname';
-import ColorSchemeSheet from '@/components/ColorSchemeSheet/ColorSchemeSheet';
 import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
 import { router, useFocusEffect } from 'expo-router';
 import { ConfigCustomerEnum, getCustomerEnumForConfig, type CustomerConfig, getVersionInternalForAppsettingsScreen } from '@/config';
@@ -47,6 +46,7 @@ import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 import useCustomerConfig from '@/hooks/useCustomerConfig';
 import useCustomerConfigModal from '@/hooks/useCustomerConfigModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
+import useThemeSettingsModal from '@/hooks/useThemeSettingsModal';
 import { FoodSortOption } from 'repo-depkit-common';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
@@ -62,7 +62,6 @@ const Settings = () => {
         const drawerSheetRef = useRef<BottomSheet>(null);
         const amountColumnSheetRef = useRef<BottomSheet>(null);
         const firstDaySheetRef = useRef<BottomSheet>(null);
-        const colorSchemeSheetRef = useRef<BottomSheet>(null);
         const foodOffersTimeSheetRef = useRef<BottomSheet>(null);
         const collectibleSettingsModalRef = useRef<() => void>(() => {});
         const isOpeningNestedCollectibleModal = useRef(false);
@@ -74,6 +73,7 @@ const Settings = () => {
         const { buttonLabel: logoutButtonLabel } = useLogoutButtonTranslation();
         const { openLanguageModal } = useLanguageModal();
         const { openFoodofferSortingModal } = useFoodofferSortingModal();
+        const { openThemeSettingsModal } = useThemeSettingsModal();
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, simulateExpoUpdateAvailable, collectibleItemSize, collectibleRandomPosition, selectedCustomer, sortBy } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
@@ -200,13 +200,12 @@ const Settings = () => {
                 );
         }, [closeNicknameSheet, currentNickname, saveNickname, showScrollViewModal, translate]);
 
-        const openColorSchemeSheet = () => {
-                colorSchemeSheetRef?.current?.expand();
-        };
-
-	const closeColorSchemeSheet = () => {
-		colorSchemeSheetRef?.current?.close();
-	};
+        const openColorSchemeSheet = useCallback(() => {
+                openThemeSettingsModal({
+                        selectedTheme,
+                        onSelect: handleTheme,
+                });
+        }, [handleTheme, openThemeSettingsModal, selectedTheme]);
 
 	const openDrawerSheet = () => {
 		drawerSheetRef?.current?.expand();
@@ -659,25 +658,6 @@ const Settings = () => {
 									type: SET_FIRST_DAY_OF_THE_WEEK,
 									payload: day,
 								});
-							}}
-						/>
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={colorSchemeSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeColorSchemeSheet}
-					>
-						<ColorSchemeSheet
-							closeSheet={closeColorSchemeSheet}
-							selectedTheme={selectedTheme}
-							onSelect={theme => {
-								handleTheme(theme);
 							}}
 						/>
 					</BaseBottomSheet>

--- a/apps/frontend/app/hooks/useThemeSettingsModal.tsx
+++ b/apps/frontend/app/hooks/useThemeSettingsModal.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback } from 'react';
+
+import ColorSchemeSheet from '@/components/ColorSchemeSheet/ColorSchemeSheet';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+
+type ThemeSettingsModalOptions = {
+        selectedTheme: string;
+        onSelect: (theme: string) => void;
+};
+
+export const useThemeSettingsModal = () => {
+        const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+        const { translate } = useLanguage();
+        const { theme } = useTheme();
+
+        const openThemeSettingsModal = useCallback(
+                ({ selectedTheme, onSelect }: ThemeSettingsModalOptions) => {
+                        showScrollViewModal(
+                                {
+                                        title: translate(TranslationKeys.color_scheme),
+                                        onClose: closeScrollViewModal,
+                                        children: (
+                                                <ColorSchemeSheet
+                                                        closeSheet={closeScrollViewModal}
+                                                        selectedTheme={selectedTheme}
+                                                        onSelect={onSelect}
+                                                />
+                                        ),
+                                },
+                                { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                        );
+                },
+                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+        );
+
+        return { openThemeSettingsModal };
+};
+
+export default useThemeSettingsModal;


### PR DESCRIPTION
### Motivation
- Replace the pre-mounted `BaseBottomSheet` color scheme sheet with a reusable hook that opens the theme settings through the global scroll modal.
- Mirror the pattern used for other settings modals (e.g. food offer sorting) to avoid maintaining a separate bottom-sheet instance in the settings screen.
- Simplify `Settings` by removing sheet refs and delegating sheet presentation to the new hook.

### Description
- Added `apps/frontend/app/hooks/useThemeSettingsModal.tsx` which exports `useThemeSettingsModal` and an `openThemeSettingsModal` function that shows `ColorSchemeSheet` via `useMyScrollViewModal`.
- Updated `apps/frontend/app/app/(app)/settings/index.tsx` to import `useThemeSettingsModal`, remove `colorSchemeSheetRef` and the mounted `BaseBottomSheet` for the color scheme, and replace `openColorSchemeSheet` with a call to `openThemeSettingsModal` passing `selectedTheme` and `handleTheme`.
- Kept the existing `ColorSchemeSheet` component and wiring of the selected theme callback (`handleTheme`) unchanged.

### Testing
- No automated tests were run for this change.
- No automated build or typecheck was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b07a0aefc833083280df1fe7a6611)