### PR TITLE
Remove inner header and extra styling from ColorSchemeSheet

### DIFF
--- a/apps/frontend/app/components/ColorSchemeSheet/ColorSchemeSheet.tsx
+++ b/apps/frontend/app/components/ColorSchemeSheet/ColorSchemeSheet.tsx
@@ -1,44 +1,15 @@
 import React from 'react';
-import { Text, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import { useTheme } from '@/hooks/useTheme';
-import { useLanguage } from '@/hooks/useLanguage';
-import { useSelector } from 'react-redux';
+import { View } from 'react-native';
 import styles from './styles';
 import { ColorSchemeSheetProps } from './types';
 import ColorScheme from '@/components/ColorScheme/ColorScheme';
 import { themes } from '@/constants/SettingData';
-import { isWeb } from '@/constants/Constants';
-import { TranslationKeys } from '@/locales/keys';
-import { RootState } from '@/redux/reducer';
 import CollectibleSpot from "@/components/CollectibleItem/CollectibleSpot";
 import { CollectibleAt } from 'repo-depkit-common';
 
 const ColorSchemeSheet: React.FC<ColorSchemeSheetProps> = ({ closeSheet, selectedTheme, onSelect }) => {
-	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const { primaryColor } = useSelector((state: RootState) => state.settings);
-
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.color_scheme)}
-				</Text>
-			</View>
+		<View style={styles.sheetView}>
 			<View style={styles.optionsContainer}>
 				{themes.map(th => (
 					<ColorScheme
@@ -53,7 +24,7 @@ const ColorSchemeSheet: React.FC<ColorSchemeSheetProps> = ({ closeSheet, selecte
 				))}
 			</View>
 			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_theme} />
-		</BottomSheetScrollView>
+		</View>
 	);
 };
 

--- a/apps/frontend/app/components/ColorSchemeSheet/styles.ts
+++ b/apps/frontend/app/components/ColorSchemeSheet/styles.ts
@@ -3,29 +3,11 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
 	sheetView: {
 		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
-	contentContainer: {
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
+		padding: 0,
 	},
 	optionsContainer: {
 		width: '100%',
-		paddingHorizontal: 10,
-		marginTop: 20,
+		paddingHorizontal: 0,
+		marginTop: 0,
 	},
 });


### PR DESCRIPTION
### Motivation

- The theme settings modal was rendering an inner title, inner background, and extra padding that produced a nested card-like appearance.
- The goal is to remove the secondary title and inner styling so the modal uses the outer sheet styling consistently.
- Simplify the `ColorSchemeSheet` layout to be purely the options list and collectible spot.

### Description

- Removed the inner header/title and the `BottomSheetScrollView` wrapper in `apps/frontend/app/components/ColorSchemeSheet/ColorSchemeSheet.tsx` and replaced it with a single `View` using `styles.sheetView`.
- Dropped imports and references to theme/translation/selectors that were only used for the removed inner header.
- Updated `apps/frontend/app/components/ColorSchemeSheet/styles.ts` to remove `height`, border radii, padding, and to zero out `optionsContainer` padding/margin so no inner background or extra spacing remains.
- Kept the `ColorScheme` mapping and `CollectibleSpot` intact to preserve functionality.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba9596f9883309ac151be3d1efcbc)