### PR TITLE
Fix theme selection indicator update in modal

### DIFF
--- a/apps/frontend/app/components/ColorSchemeSheet/ColorSchemeSheet.tsx
+++ b/apps/frontend/app/components/ColorSchemeSheet/ColorSchemeSheet.tsx
@@ -15,13 +15,14 @@ import { RootState } from '@/redux/reducer';
 const ColorSchemeSheet: React.FC<ColorSchemeSheetProps> = ({ closeSheet, selectedTheme, onSelect }) => {
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
-	const { primaryColor } = useSelector((state: RootState) => state.settings);
+	const { primaryColor, selectedTheme: selectedThemeFromStore } = useSelector((state: RootState) => state.settings);
+	const activeSelectedTheme = selectedThemeFromStore ?? selectedTheme;
 
 	return (
 		<View style={styles.sheetView}>
 			<View style={styles.optionsContainer}>
 				{themes.map((themeOption, index) => {
-					const isSelected = selectedTheme === themeOption.id;
+					const isSelected = activeSelectedTheme === themeOption.id;
 					const groupPosition =
 						themes.length === 1
 							? 'single'


### PR DESCRIPTION
### Motivation
- The color scheme modal did not reflect theme changes immediately because it relied only on the `selectedTheme` prop instead of the Redux store value.
- The radio icon and displayed selected value could remain stale after changing the theme elsewhere in the app.
- The intent is to ensure the modal shows the current selection immediately after a change.

### Description
- Read `selectedTheme` from the Redux store in `apps/frontend/app/components/ColorSchemeSheet/ColorSchemeSheet.tsx` as `selectedThemeFromStore` via `useSelector`.
- Compute `activeSelectedTheme = selectedThemeFromStore ?? selectedTheme` and use it to determine `isSelected` for each option so the radio icon follows the store state.
- Preserve existing behavior when the store value is absent by falling back to the `selectedTheme` prop.
- Only `ColorSchemeSheet.tsx` was modified.

### Testing
- No automated tests were executed as part of this change.
- Rely on project CI to run unit/integration tests after the PR is opened.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bc6a385548330870bfa062736bf9b)