### PR TITLE
Allow MyScrollViewModal background to react to theme changes

### DIFF
--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,26 +1,25 @@
 import { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
-import { useTheme } from '@/hooks/useTheme';
-import {View} from "react-native";
-import React from 'react';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
-        const { theme } = useTheme();
 
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
+                const resolvedBackgroundColor = backgroundColor ?? undefined;
+                const backgroundStyle = resolvedBackgroundColor
+                        ? { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle }
+                        : options?.backgroundStyle;
 
-                const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
-                const backgroundStyle = { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle };
+                const headerBackgroundColor = options?.headerBackgroundColor ?? resolvedBackgroundColor;
 
                 const mergedOptions = {
                         ...options,
-                        backgroundStyle,
-                        headerBackgroundColor: resolvedBackgroundColor,
+                        ...(backgroundStyle ? { backgroundStyle } : {}),
+                        ...(headerBackgroundColor ? { headerBackgroundColor } : {}),
                 };
 
                 showModal(

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -96,4 +96,3 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 };
 
 export default MyScrollViewModal;
-


### PR DESCRIPTION
### Motivation
- The modal background was being locked to a resolved color which prevented it from updating when the app theme changed.
- The global modal provider should only receive explicit background overrides and otherwise let the sheet resolve the theme at render time.
- Reduce unnecessary props being passed to the provider to avoid stale color resolution.
- Clean up unused imports in the modal hook.

### Description
- Update `apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx` to stop defaulting `backgroundColor` to the current theme and instead use `undefined` when not provided so the sheet can resolve theme colors later.
- Only include `backgroundStyle` and `headerBackgroundColor` in the `mergedOptions` object when they are explicitly set by the caller.
- Keep passing an explicit `backgroundColor` into `MyScrollViewModal` only when provided by the caller so explicit overrides still work.
- Remove unused imports (`useTheme`, `View`, `React`) from `useMyScrollViewModal`.

### Testing
- No automated tests were run.
- Local static checks and compilation were not executed as part of this change.
- Manual verification was intended to ensure the modal background now responds to theme changes (not recorded as an automated test).
- No test failures reported (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bd21fc7c88330977a0995d89906a4)