### PR TITLE
Fix modal header theming

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -18,12 +18,11 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
         useSelector((state: RootState) => state.settings); // ensure theme subscription
         const snapPoints = useMemo(() => ['80%'], []);
 
-        //const effectiveBackgroundStyle = useMemo(() => ({ backgroundColor: theme.sheet.sheetBg, ...backgroundStyle }), [backgroundStyle, theme.sheet.sheetBg]);
-
-		const usedHeaderBg = headerBackgroundColor || theme.screen.background;
-
-		const effectiveBackgroundStyle = {backgroundColor: usedHeaderBg};
-        //const headerBg = headerBackgroundColor || (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
+        const resolvedBackgroundColor = headerBackgroundColor ?? (backgroundStyle as any)?.backgroundColor ?? theme.screen.background;
+        const effectiveBackgroundStyle = useMemo(
+                () => ({ ...(backgroundStyle ?? {}), backgroundColor: resolvedBackgroundColor }),
+                [backgroundStyle, resolvedBackgroundColor],
+        );
 
         const handleColor = theme.sheet.closeBg;
 
@@ -40,7 +39,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 
         return (
                 <BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header]}>
+			<View style={[styles.header, { backgroundColor: resolvedBackgroundColor }]}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>


### PR DESCRIPTION
### Motivation
- The bottom sheet header did not follow the resolved modal background color when themes or custom background styles changed.
- The header needed to mirror the same background resolution logic used for the sheet to keep UI consistent.

### Description
- Updated `apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx` to compute `resolvedBackgroundColor` as `headerBackgroundColor ?? (backgroundStyle as any)?.backgroundColor ?? theme.screen.background`.
- Built `effectiveBackgroundStyle` with `useMemo` to merge provided `backgroundStyle` while enforcing the resolved background color via `backgroundColor: resolvedBackgroundColor`.
- Applied the `resolvedBackgroundColor` to the header container View so the header tracks theme and modal background changes.

### Testing
- No automated tests were run for this change.
- (Only the single file `BaseBottomSheet.tsx` was modified.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdcbd3ae083309feeaf1468ff2461)