### PR TITLE
Refactor settings modals to hook-based scroll-view modals

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -10,7 +10,6 @@ import SettingsList from '@/components/SettingsList';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import SettingsListNickname from '@/components/SettingsListNickname';
-import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
 import { router, useFocusEffect } from 'expo-router';
 import { ConfigCustomerEnum, getCustomerEnumForConfig, type CustomerConfig, getVersionInternalForAppsettingsScreen } from '@/config';
 import { useDispatch, useSelector } from 'react-redux';
@@ -23,8 +22,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import CanteenSelectionSheet from '@/components/CanteenSelectionSheet/CanteenSelectionSheet';
-import AmountColumnSheet from '@/components/AmountColumnSheet/AmountColumnSheet';
-import FirstDaySheet from '@/components/FirstDaySheet/FirstDaySheet';
 import FoodOffersNextDayTimeSheet from '@/components/FoodOffersNextDayTimeSheet';
 import { excerpt, formatPrice, getImageUrl, showFormatedPrice } from '@/constants/HelperFunctions';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
@@ -48,6 +45,9 @@ import useCustomerConfigModal from '@/hooks/useCustomerConfigModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import useThemeSettingsModal from '@/hooks/useThemeSettingsModal';
 import { FoodSortOption } from 'repo-depkit-common';
+import useDrawerPositionModal from '@/hooks/useDrawerPositionModal';
+import useAmountColumnModal from '@/hooks/useAmountColumnModal';
+import useFirstDayModal from '@/hooks/useFirstDayModal';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
 
@@ -59,9 +59,6 @@ const Settings = () => {
         const canteenSheetRef = useRef<BottomSheet>(null);
         const [isActive, setIsActive] = useState(false);
         const { translate, language } = useLanguage();
-        const drawerSheetRef = useRef<BottomSheet>(null);
-        const amountColumnSheetRef = useRef<BottomSheet>(null);
-        const firstDaySheetRef = useRef<BottomSheet>(null);
         const foodOffersTimeSheetRef = useRef<BottomSheet>(null);
         const collectibleSettingsModalRef = useRef<() => void>(() => {});
         const isOpeningNestedCollectibleModal = useRef(false);
@@ -74,6 +71,9 @@ const Settings = () => {
         const { openLanguageModal } = useLanguageModal();
         const { openFoodofferSortingModal } = useFoodofferSortingModal();
         const { openThemeSettingsModal } = useThemeSettingsModal();
+        const { openDrawerPositionModal } = useDrawerPositionModal();
+        const { openAmountColumnModal } = useAmountColumnModal();
+        const { openFirstDayModal } = useFirstDayModal();
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, simulateExpoUpdateAvailable, collectibleItemSize, collectibleRandomPosition, selectedCustomer, sortBy } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
@@ -207,29 +207,6 @@ const Settings = () => {
                 });
         }, [handleTheme, openThemeSettingsModal, selectedTheme]);
 
-	const openDrawerSheet = () => {
-		drawerSheetRef?.current?.expand();
-	};
-
-	const closeDrawerSheet = () => {
-		drawerSheetRef?.current?.close();
-	};
-
-	const openAmountColumnModal = () => {
-		amountColumnSheetRef?.current?.expand();
-	};
-
-	const closeAmountColumnModal = () => {
-		amountColumnSheetRef?.current?.close();
-	};
-
-	const openFirstDayModal = () => {
-		firstDaySheetRef?.current?.expand();
-	};
-
-	const closeFirstDayModal = () => {
-		firstDaySheetRef?.current?.close();
-	};
         const openFoodOffersTimeSheet = () => {
                 foodOffersTimeSheetRef?.current?.expand();
         };
@@ -313,7 +290,6 @@ const Settings = () => {
 			type: SET_DRAWER_POSITION,
 			payload: position,
 		});
-		closeDrawerSheet();
 	};
 
 	const handleTheme = (theme: any) => {
@@ -494,9 +470,58 @@ const Settings = () => {
 					{/* color Scheme */}
 					<View style={{ gap: 0 }}>
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="theme-light-dark" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.color_scheme)} value={selectedTheme === 'systematic' ? translate(TranslationKeys.color_scheme_system) : selectedTheme === 'dark' ? translate(TranslationKeys.color_scheme_dark) : translate(TranslationKeys.color_scheme_light)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openColorSchemeSheet()} groupPosition="top" />
-                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="menu" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.drawer_config_position)} value={drawerPosition === 'left' ? translate(TranslationKeys.drawer_config_position_left) : drawerPosition === 'right' ? translate(TranslationKeys.drawer_config_position_right) : translate(TranslationKeys.drawer_config_position_system)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openDrawerSheet()} groupPosition="middle" />
-                                                <SettingsList iconBgColor={primaryColor} leftIcon={<FontAwesome5 name="columns" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.amount_columns_for_cards)} value={amountColumnsForcard === 0 ? translate(TranslationKeys.automatic) : amountColumnsForcard} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openAmountColumnModal()} groupPosition="middle" />
-                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Feather name="calendar" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.first_day_of_week)} value={translate(firstDayOfTheWeek?.name)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openFirstDayModal()} groupPosition="bottom" />
+                                                <SettingsList
+                                                        iconBgColor={primaryColor}
+                                                        leftIcon={<Entypo name="menu" size={24} color={theme.screen.icon} />}
+                                                        label={translate(TranslationKeys.drawer_config_position)}
+                                                        value={drawerPosition === 'left' ? translate(TranslationKeys.drawer_config_position_left) : drawerPosition === 'right' ? translate(TranslationKeys.drawer_config_position_right) : translate(TranslationKeys.drawer_config_position_system)}
+                                                        rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+                                                        handleFunction={() =>
+                                                                openDrawerPositionModal({
+                                                                        selectedPosition: drawerPosition,
+                                                                        onSelect: handleDrawerPosition,
+                                                                })
+                                                        }
+                                                        groupPosition="middle"
+                                                />
+                                                <SettingsList
+                                                        iconBgColor={primaryColor}
+                                                        leftIcon={<FontAwesome5 name="columns" size={24} color={theme.screen.icon} />}
+                                                        label={translate(TranslationKeys.amount_columns_for_cards)}
+                                                        value={amountColumnsForcard === 0 ? translate(TranslationKeys.automatic) : amountColumnsForcard}
+                                                        rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+                                                        handleFunction={() =>
+                                                                openAmountColumnModal({
+                                                                        selectedAmount: amountColumnsForcard,
+                                                                        onSelect: val => {
+                                                                                dispatch({
+                                                                                        type: SET_AMOUNT_COLUMNS_FOR_CARDS,
+                                                                                        payload: val,
+                                                                                });
+                                                                        },
+                                                                })
+                                                        }
+                                                        groupPosition="middle"
+                                                />
+                                                <SettingsList
+                                                        iconBgColor={primaryColor}
+                                                        leftIcon={<Feather name="calendar" size={24} color={theme.screen.icon} />}
+                                                        label={translate(TranslationKeys.first_day_of_week)}
+                                                        value={translate(firstDayOfTheWeek?.name)}
+                                                        rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+                                                        handleFunction={() =>
+                                                                openFirstDayModal({
+                                                                        selectedDay: firstDayOfTheWeek?.name ?? '',
+                                                                        onSelect: day => {
+                                                                                dispatch({
+                                                                                        type: SET_FIRST_DAY_OF_THE_WEEK,
+                                                                                        payload: day,
+                                                                                });
+                                                                        },
+                                                                })
+                                                        }
+                                                        groupPosition="bottom"
+                                                />
                                         </View>
 					<SettingsGroupTitle>{translate(TranslationKeys.group_app_management)}</SettingsGroupTitle>
 					<View style={{ gap: 0 }}>
@@ -617,69 +642,6 @@ const Settings = () => {
                                         >
                                                 <CanteenSelectionSheet closeSheet={closeCanteenSheet} />
                                         </BaseBottomSheet>
-					<BaseBottomSheet
-						ref={amountColumnSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeAmountColumnModal}
-					>
-						<AmountColumnSheet
-							closeSheet={closeAmountColumnModal}
-							selectedAmount={amountColumnsForcard}
-							onSelect={val => {
-								dispatch({
-									type: SET_AMOUNT_COLUMNS_FOR_CARDS,
-									payload: val,
-								});
-							}}
-						/>
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={firstDaySheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeFirstDayModal}
-					>
-						<FirstDaySheet
-							closeSheet={closeFirstDayModal}
-							selectedDay={firstDayOfTheWeek?.name}
-							onSelect={day => {
-								dispatch({
-									type: SET_FIRST_DAY_OF_THE_WEEK,
-									payload: day,
-								});
-							}}
-						/>
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={drawerSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeDrawerSheet}
-					>
-						<DrawerPositionSheet
-							closeSheet={closeDrawerSheet}
-							selectedPosition={drawerPosition}
-							onSelect={position => {
-								handleDrawerPosition(position);
-							}}
-						/>
-					</BaseBottomSheet>
                                         <BaseBottomSheet
                                                 ref={foodOffersTimeSheetRef}
                                                 index={-1}

--- a/apps/frontend/app/components/AmountColumnSheet/AmountColumnSheet.tsx
+++ b/apps/frontend/app/components/AmountColumnSheet/AmountColumnSheet.tsx
@@ -1,56 +1,61 @@
 import React from 'react';
-import { Text, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
-import AmountColumns from '@/components/AmountColumn/AmountColumns';
 import { AmountColumn } from '@/constants/SettingData';
-import { isWeb } from '@/constants/Constants';
 import styles from './styles';
 import { AmountColumnSheetProps } from './types';
 import { TranslationKeys } from '@/locales/keys';
-import CollectibleSpot from "@/components/CollectibleItem/CollectibleSpot";
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
+import SettingsList from '@/components/SettingsList';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
 
 const AmountColumnSheet: React.FC<AmountColumnSheetProps> = ({ closeSheet, selectedAmount, onSelect }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
+	const { primaryColor } = useSelector((state: RootState) => state.settings);
 
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.amount_columns_for_cards)}
-				</Text>
-			</View>
+		<View style={styles.sheetView}>
 			<View style={styles.optionsContainer}>
-				{AmountColumn.map(column => (
-					<AmountColumns
-						key={column.id}
-						position={column}
-						isSelected={selectedAmount === column.id}
-						onPress={() => {
-							onSelect(column.id);
-							closeSheet();
-						}}
-					/>
-				))}
+				{AmountColumn.map((column, index) => {
+					const isSelected = selectedAmount === column.id;
+					const groupPosition =
+						AmountColumn.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === AmountColumn.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={column.id}
+							label={column.id === 0 ? translate(TranslationKeys.automatic) : column.name}
+							groupPosition={groupPosition}
+							showSeparator={index !== AmountColumn.length - 1}
+							noIconIndent
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => {
+								onSelect(column.id);
+								closeSheet();
+							}}
+						/>
+					);
+				})}
 			</View>
 			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_amount_column} />
-		</BottomSheetScrollView>
+		</View>
 	);
 };
 

--- a/apps/frontend/app/components/AmountColumnSheet/styles.ts
+++ b/apps/frontend/app/components/AmountColumnSheet/styles.ts
@@ -3,29 +3,11 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
 	sheetView: {
 		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
-	contentContainer: {
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
+		padding: 0,
 	},
 	optionsContainer: {
 		width: '100%',
-		paddingHorizontal: 10,
-		marginTop: 20,
+		paddingHorizontal: 0,
+		marginTop: 0,
 	},
 });

--- a/apps/frontend/app/components/DrawerPositionSheet/DrawerPositionSheet.tsx
+++ b/apps/frontend/app/components/DrawerPositionSheet/DrawerPositionSheet.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { Text, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useSelector } from 'react-redux';
 import styles from './styles';
 import { DrawerPositionSheetProps } from './types';
-import DrawerPosition from '@/components/Drawer/DrawerPosition';
 import { drawers } from '@/constants/SettingData';
-import { isWeb } from '@/constants/Constants';
-import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
-import CollectibleSpot from "@/components/CollectibleItem/CollectibleSpot";
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
+import SettingsList from '@/components/SettingsList';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 const DrawerPositionSheet: React.FC<DrawerPositionSheetProps> = ({ closeSheet, selectedPosition, onSelect }) => {
 	const { theme } = useTheme();
@@ -20,40 +18,44 @@ const DrawerPositionSheet: React.FC<DrawerPositionSheetProps> = ({ closeSheet, s
 	const { primaryColor } = useSelector((state: RootState) => state.settings);
 
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.drawer_config_position)}
-				</Text>
-			</View>
+		<View style={styles.sheetView}>
 			<View style={styles.optionsContainer}>
-				{drawers.map(drawer => (
-					<DrawerPosition
-						key={drawer.id}
-						position={drawer}
-						isSelected={selectedPosition === drawer.id}
-						onPress={() => {
-							onSelect(drawer.id);
-							closeSheet();
-						}}
-					/>
-				))}
+				{drawers.map((drawer, index) => {
+					const isSelected = selectedPosition === drawer.id;
+					const groupPosition =
+						drawers.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === drawers.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={drawer.id}
+							label={translate(drawer.name)}
+							leftIcon={<MaterialCommunityIcons name={drawer.icon as any} size={24} />}
+							iconBgColor={primaryColor}
+							groupPosition={groupPosition}
+							showSeparator={index !== drawers.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => {
+								onSelect(drawer.id);
+								closeSheet();
+							}}
+						/>
+					);
+				})}
 			</View>
 			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_menuposition} />
-		</BottomSheetScrollView>
+		</View>
 	);
 };
 

--- a/apps/frontend/app/components/DrawerPositionSheet/styles.ts
+++ b/apps/frontend/app/components/DrawerPositionSheet/styles.ts
@@ -3,29 +3,11 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
 	sheetView: {
 		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
-	contentContainer: {
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
+		padding: 0,
 	},
 	optionsContainer: {
 		width: '100%',
-		paddingHorizontal: 10,
-		marginTop: 20,
+		paddingHorizontal: 0,
+		marginTop: 0,
 	},
 });

--- a/apps/frontend/app/components/FirstDaySheet/FirstDaySheet.tsx
+++ b/apps/frontend/app/components/FirstDaySheet/FirstDaySheet.tsx
@@ -1,56 +1,61 @@
 import React from 'react';
-import { Text, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { days } from '@/constants/SettingData';
-import FirstDayOfWeek from '@/components/FirstDay/FirstDayOfWeek';
-import { isWeb } from '@/constants/Constants';
 import styles from './styles';
 import { FirstDaySheetProps } from './types';
 import { TranslationKeys } from '@/locales/keys';
 import CollectibleSpot from '../CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
+import SettingsList from '@/components/SettingsList';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
 
 const FirstDaySheet: React.FC<FirstDaySheetProps> = ({ closeSheet, selectedDay, onSelect }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
+	const { primaryColor } = useSelector((state: RootState) => state.settings);
 
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View
-				style={{
-					...styles.sheetHeader,
-					paddingRight: isWeb ? 10 : 0,
-					paddingTop: isWeb ? 10 : 0,
-				}}
-			>
-				<View />
-				<Text
-					style={{
-						...styles.sheetHeading,
-						fontSize: isWeb ? 40 : 28,
-						color: theme.sheet.text,
-					}}
-				>
-					{translate(TranslationKeys.first_day_of_week)}
-				</Text>
-			</View>
+		<View style={styles.sheetView}>
 			<View style={styles.optionsContainer}>
-				{days.map(firstDay => (
-					<FirstDayOfWeek
-						key={firstDay.id}
-						position={firstDay}
-						isSelected={selectedDay === firstDay.name}
-						onPress={() => {
-							onSelect({ id: firstDay.id, name: firstDay.name });
-							closeSheet();
-						}}
-					/>
-				))}
+				{days.map((firstDay, index) => {
+					const isSelected = selectedDay === firstDay.name;
+					const groupPosition =
+						days.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === days.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={firstDay.id}
+							label={translate(firstDay.name)}
+							groupPosition={groupPosition}
+							showSeparator={index !== days.length - 1}
+							noIconIndent
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => {
+								onSelect({ id: firstDay.id, name: firstDay.name });
+								closeSheet();
+							}}
+						/>
+					);
+				})}
 			</View>
 			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_first_day_of_week} />
-		</BottomSheetScrollView>
+		</View>
 	);
 };
 

--- a/apps/frontend/app/components/FirstDaySheet/styles.ts
+++ b/apps/frontend/app/components/FirstDaySheet/styles.ts
@@ -3,29 +3,11 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
 	sheetView: {
 		width: '100%',
-		height: '100%',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-		padding: 10,
-		paddingBottom: 0,
-	},
-	contentContainer: {
-		alignItems: 'center',
-	},
-	sheetHeader: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderTopRightRadius: 28,
-		borderTopLeftRadius: 28,
-	},
-	sheetHeading: {
-		fontFamily: 'Poppins_700Bold',
+		padding: 0,
 	},
 	optionsContainer: {
 		width: '100%',
-		paddingHorizontal: 10,
-		marginTop: 20,
+		paddingHorizontal: 0,
+		marginTop: 0,
 	},
 });

--- a/apps/frontend/app/hooks/useAmountColumnModal.tsx
+++ b/apps/frontend/app/hooks/useAmountColumnModal.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback } from 'react';
+
+import AmountColumnSheet from '@/components/AmountColumnSheet/AmountColumnSheet';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+
+type AmountColumnModalOptions = {
+	selectedAmount: number;
+	onSelect: (amount: number) => void;
+};
+
+export const useAmountColumnModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+	const { theme } = useTheme();
+
+	const openAmountColumnModal = useCallback(
+		({ selectedAmount, onSelect }: AmountColumnModalOptions) => {
+			showScrollViewModal(
+				{
+					title: translate(TranslationKeys.amount_columns_for_cards),
+					onClose: closeScrollViewModal,
+					children: (
+						<AmountColumnSheet
+							closeSheet={closeScrollViewModal}
+							selectedAmount={selectedAmount}
+							onSelect={onSelect}
+						/>
+					),
+				},
+				{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+			);
+		},
+		[closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+	);
+
+	return { openAmountColumnModal };
+};
+
+export default useAmountColumnModal;

--- a/apps/frontend/app/hooks/useDrawerPositionModal.tsx
+++ b/apps/frontend/app/hooks/useDrawerPositionModal.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback } from 'react';
+
+import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+
+type DrawerPositionModalOptions = {
+	selectedPosition: string;
+	onSelect: (position: string) => void;
+};
+
+export const useDrawerPositionModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+	const { theme } = useTheme();
+
+	const openDrawerPositionModal = useCallback(
+		({ selectedPosition, onSelect }: DrawerPositionModalOptions) => {
+			showScrollViewModal(
+				{
+					title: translate(TranslationKeys.drawer_config_position),
+					onClose: closeScrollViewModal,
+					children: (
+						<DrawerPositionSheet
+							closeSheet={closeScrollViewModal}
+							selectedPosition={selectedPosition}
+							onSelect={onSelect}
+						/>
+					),
+				},
+				{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+			);
+		},
+		[closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+	);
+
+	return { openDrawerPositionModal };
+};
+
+export default useDrawerPositionModal;

--- a/apps/frontend/app/hooks/useFirstDayModal.tsx
+++ b/apps/frontend/app/hooks/useFirstDayModal.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback } from 'react';
+
+import FirstDaySheet from '@/components/FirstDaySheet/FirstDaySheet';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+
+type FirstDayModalOptions = {
+	selectedDay: string;
+	onSelect: (day: { id: string; name: string }) => void;
+};
+
+export const useFirstDayModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+	const { theme } = useTheme();
+
+	const openFirstDayModal = useCallback(
+		({ selectedDay, onSelect }: FirstDayModalOptions) => {
+			showScrollViewModal(
+				{
+					title: translate(TranslationKeys.first_day_of_week),
+					onClose: closeScrollViewModal,
+					children: (
+						<FirstDaySheet
+							closeSheet={closeScrollViewModal}
+							selectedDay={selectedDay}
+							onSelect={onSelect}
+						/>
+					),
+				},
+				{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+			);
+		},
+		[closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+	);
+
+	return { openFirstDayModal };
+};
+
+export default useFirstDayModal;


### PR DESCRIPTION
### Motivation
- Replace several BottomSheet-based settings modals with reusable hook-based scroll-view modals for a consistent UX like the `foodoffers` theme.
- Render modal options using the existing `SettingsList` rows so options have no gaps and consistent separators.
- Remove sheet background and corner radius from the wrapping view to match the look-and-feel in `foodoffers`.

### Description
- Added three hooks `useDrawerPositionModal`, `useAmountColumnModal`, and `useFirstDayModal` that open scroll-view modals using `useMyScrollViewModal` and the corresponding Sheet components.
- Reworked `DrawerPositionSheet`, `AmountColumnSheet`, and `FirstDaySheet` to render their options as `SettingsList` rows (with `groupPosition`, separators and radio icons) and removed `BottomSheetScrollView` / explicit sheet header markup.
- Simplified sheet styles to remove background, padding and border radius so the wrapping view has no background or rounded corners.
- Updated `settings/index.tsx` to use the new hooks (`openDrawerPositionModal`, `openAmountColumnModal`, `openFirstDayModal`) and removed the explicit `BaseBottomSheet` instances/refs for those three modals, wiring selection handlers to dispatch actions as before.

### Testing
- Committed changes locally and verified files were updated and staged successfully in a local commit.
- No automated tests (unit, lint or CI) were executed as part of this change set.
- Manual UI runtime verification was not performed in this environment due to lack of a device/emulator run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdd81d3a08330bcc48c86b6a957d5)