### PR TITLE
BaseBottomSheet: separate header background and clarify header radius comment

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -18,11 +18,12 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
         useSelector((state: RootState) => state.settings); // ensure theme subscription
         const snapPoints = useMemo(() => ['80%'], []);
 
-        const resolvedBackgroundColor = headerBackgroundColor ?? (backgroundStyle as any)?.backgroundColor ?? theme.screen.background;
+        const resolvedBackgroundColor = (backgroundStyle as any)?.backgroundColor ?? theme.screen.background;
         const effectiveBackgroundStyle = useMemo(
                 () => ({ ...(backgroundStyle ?? {}), backgroundColor: resolvedBackgroundColor }),
                 [backgroundStyle, resolvedBackgroundColor],
         );
+        const headerBackground = headerBackgroundColor ?? theme.screen.background;
 
         const handleColor = theme.sheet.closeBg;
 
@@ -39,7 +40,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 
         return (
                 <BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header, { backgroundColor: resolvedBackgroundColor }]}>
+			<View style={[styles.header, { backgroundColor: headerBackground }]}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>

--- a/apps/frontend/app/components/BaseBottomSheet/styles.ts
+++ b/apps/frontend/app/components/BaseBottomSheet/styles.ts
@@ -6,8 +6,10 @@ export default StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'space-between',
 		alignItems: 'center',
-//		borderTopRightRadius: 28,
-//		borderTopLeftRadius: 28,
+		// Rounded header corners are controlled elsewhere; this style is not responsible for them.
+		// Keep these commented to avoid implying they affect the header radius.
+		// borderTopRightRadius: 28,
+		// borderTopLeftRadius: 28,
 		padding: 10,
 	},
 	closeButton: {


### PR DESCRIPTION
### Motivation
- Prevent the sheet header from inheriting the sheet body background so the header can be themed independently.
- Make it explicit that the commented corner radius lines do not control the header rounding to avoid future confusion.
- Preserve the existing ability for callers to style the sheet body via `backgroundStyle` while isolating header theming.

### Description
- In `BaseBottomSheet.tsx` adjusted how `resolvedBackgroundColor` is computed and introduced `headerBackground` so the header uses `headerBackgroundColor ?? theme.screen.background`.
- Applied `headerBackground` to the header `View` instead of using the sheet `resolvedBackgroundColor` so header styling is separated from the body.
- Kept `effectiveBackgroundStyle` behavior so `backgroundStyle` still controls the sheet body background.
- In `styles.ts` updated the header comment to state that the commented `borderTopRightRadius`/`borderTopLeftRadius` lines do not control header rounding and left them commented.

### Testing
- No automated tests were run for this change.
- No test failures were reported because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be7fb1758833093211ab6a8458ab1)