### PR TITLE
Restore default modal header background

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -61,8 +61,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 const resolvedBackgroundStyle = options?.backgroundStyle ?? null;
                 setBackgroundStyle(resolvedBackgroundStyle);
                 setOverlayStyle(options?.overlayStyle ?? { backgroundColor: 'rgba(0,0,0,0.5)' });
-                const resolvedHeaderBackgroundColor =
-                        options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
+                const resolvedHeaderBackgroundColor = options?.headerBackgroundColor ?? undefined;
                 setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
                 setIsVisible(true);
                 setDebug(prev => ({

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -14,7 +14,7 @@ export const useMyScrollViewModal = () => {
                         ? { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle }
                         : options?.backgroundStyle;
 
-                const headerBackgroundColor = options?.headerBackgroundColor ?? resolvedBackgroundColor;
+                const headerBackgroundColor = options?.headerBackgroundColor;
 
                 const mergedOptions = {
                         ...options,


### PR DESCRIPTION
### Motivation
- A prior change allowed modal content `backgroundColor` to flow into the bottom-sheet header, which changed the modal header color unexpectedly.
- The intent is to restore the previous visual behavior where the header uses the theme default unless explicitly overridden.
- Only the modal header behavior should be reverted, while keeping the ability to explicitly set a header color.

### Description
- Stop deriving the header background from the content background by changing `resolvedHeaderBackgroundColor` to only accept `options?.headerBackgroundColor` in `ModalProvider.tsx`.
- Prevent `useMyScrollViewModal` from defaulting `headerBackgroundColor` to the modal content `backgroundColor`, so header overrides are opt-in in `useMyScrollViewModal.tsx`.
- Keep passing `backgroundColor={resolvedBackgroundColor}` into `MyScrollViewModal` so the modal content background remains configurable.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf816b7a883309451c8f266c775cc)