### PR TITLE
Resolve modal background/header colors against active theme for live updates

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -18,13 +18,12 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
         useSelector((state: RootState) => state.settings); // ensure theme subscription
         const snapPoints = useMemo(() => ['80%'], []);
 
-        //const effectiveBackgroundStyle = useMemo(() => ({ backgroundColor: theme.sheet.sheetBg, ...backgroundStyle }), [backgroundStyle, theme.sheet.sheetBg]);
+        const effectiveBackgroundStyle = useMemo(
+                () => ({ backgroundColor: theme.screen.background, ...backgroundStyle }),
+                [backgroundStyle, theme.screen.background]
+        );
 
-		const usedHeaderBg = headerBackgroundColor || theme.screen.background;
-
-		const effectiveBackgroundStyle = {backgroundColor: usedHeaderBg};
-        //const headerBg = headerBackgroundColor || (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
-
+        const headerBackground = headerBackgroundColor ?? theme.screen.background;
         const handleColor = theme.sheet.closeBg;
 
 	const handleChange = useCallback(
@@ -38,9 +37,9 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 		[onClose, onChange]
 	);
 
-        return (
+		return (
                 <BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header]}>
+			<View style={[styles.header, { backgroundColor: headerBackground }]}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>

--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -1,11 +1,11 @@
 import React, { createContext, useContext, useState, ReactNode, useRef, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import BaseBottomSheet from '@/components/BaseBottomSheet/BaseBottomSheet';
-import {useTheme} from "@/hooks/useTheme";
+import { useTheme } from '@/hooks/useTheme';
 
-type ModalOptions = {
-        backgroundStyle?: any; // styling passed to the BottomSheet background
-        headerBackgroundColor?: string;
+export type ModalOptions = {
+        backgroundStyle?: any | ((theme: any) => any); // styling passed to the BottomSheet background
+        headerBackgroundColor?: string | ((theme: any) => string | undefined);
         overlayStyle?: any; // styling for the fullscreen overlay behind the sheet (e.g. rgba dim)
 };
 
@@ -26,14 +26,20 @@ const ModalContext = createContext<ModalContextType | null>(null);
 
 export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
         const [content, setContent] = useState<ReactNode | null>(null);
-        const [backgroundStyle, setBackgroundStyle] = useState<any>(null);
+        const [backgroundStyle, setBackgroundStyle] = useState<ModalOptions['backgroundStyle']>(null);
         // overlay shown over the app (should usually be semi-transparent) - separate from sheet background
-        const [overlayStyle, setOverlayStyle] = useState<any>(null);
-        const [headerBackgroundColor, setHeaderBackgroundColor] = useState<string | undefined>(undefined);
+        const [overlayStyle, setOverlayStyle] = useState<ModalOptions['overlayStyle']>(null);
+        const [headerBackgroundColor, setHeaderBackgroundColor] = useState<ModalOptions['headerBackgroundColor']>(undefined);
         const sheetRef = useRef<any>(null);
 
         const { theme } = useTheme();
-        let screenBackgroundColor = headerBackgroundColor || theme.screen.background;
+        const resolvedHeaderBackgroundColor =
+                typeof headerBackgroundColor === 'function' ? headerBackgroundColor(theme) : headerBackgroundColor;
+        const screenBackgroundColor = resolvedHeaderBackgroundColor || theme.screen.background;
+        const resolvedBackgroundStyle =
+                typeof backgroundStyle === 'function'
+                        ? backgroundStyle(theme)
+                        : backgroundStyle ?? { backgroundColor: theme.screen.background };
 
         const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({
@@ -58,12 +64,9 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 clearCloseTimeout();
 
                 setContent(c);
-                const resolvedBackgroundStyle = options?.backgroundStyle ?? null;
-                setBackgroundStyle(resolvedBackgroundStyle);
+                setBackgroundStyle(options?.backgroundStyle ?? null);
                 setOverlayStyle(options?.overlayStyle ?? { backgroundColor: 'rgba(0,0,0,0.5)' });
-                const resolvedHeaderBackgroundColor =
-                        options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
-                setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
+                setHeaderBackgroundColor(options?.headerBackgroundColor);
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
@@ -152,7 +155,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                                                  enablePanDownToClose
                                                  onClose={close}
                                                  headerBackgroundColor={screenBackgroundColor}
-                                                 backgroundStyle={backgroundStyle}
+                                                 backgroundStyle={resolvedBackgroundStyle}
                                          >
                                                  {content}
                                          </BaseBottomSheet>

--- a/apps/frontend/app/components/GlobalModal/useModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useModal.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useCallback } from 'react';
-import { useModalContext } from './ModalProvider';
+import { type ModalOptions, useModalContext } from './ModalProvider';
 
 export const useModal = () => {
         const { open, close, debug } = useModalContext();
 
         const show = useCallback(
-                (content: ReactNode, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
+                (content: ReactNode, options?: ModalOptions) => {
                         open(content, options);
                 },
                 [open]
@@ -17,4 +17,3 @@ export const useModal = () => {
 
         return { show, close: closeModal, debug };
 };
-

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,30 +1,48 @@
 import { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
+import { type ModalOptions } from './ModalProvider';
 import { useTheme } from '@/hooks/useTheme';
-import {View} from "react-native";
 import React from 'react';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
+
+const resolveThemedColor = (color: string | undefined, theme: any) => {
+        if (!color) return undefined;
+        if (color === theme.sheet.sheetBg) return (activeTheme: any) => activeTheme.sheet.sheetBg;
+        if (color === theme.screen.background) return (activeTheme: any) => activeTheme.screen.background;
+        return color;
+};
+
+const resolveThemedBackgroundStyle = (style: any, theme: any) => {
+        if (!style?.backgroundColor) return style;
+        if (style.backgroundColor === theme.sheet.sheetBg) {
+                return (activeTheme: any) => ({ ...style, backgroundColor: activeTheme.sheet.sheetBg });
+        }
+        if (style.backgroundColor === theme.screen.background) {
+                return (activeTheme: any) => ({ ...style, backgroundColor: activeTheme.screen.background });
+        }
+        return style;
+};
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
         const { theme } = useTheme();
 
-        const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
+        const show = (modalProps: MyScrollViewModalConfig, options?: ModalOptions) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
-                const backgroundStyle = { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle };
+                const themedBackgroundStyle = resolveThemedBackgroundStyle(options?.backgroundStyle, theme);
+                const themedHeaderBackgroundColor = resolveThemedColor(options?.headerBackgroundColor ?? backgroundColor, theme);
 
                 const mergedOptions = {
                         ...options,
-                        backgroundStyle,
-                        headerBackgroundColor: resolvedBackgroundColor,
+                        backgroundStyle: themedBackgroundStyle,
+                        headerBackgroundColor: themedHeaderBackgroundColor,
                 };
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,


### PR DESCRIPTION
### Motivation
- Theme changes did not update the modal background/header until the sheet was reopened, so modal visuals should react to theme changes immediately.
- Modal helpers passed concrete colors into the global modal which prevented live resolution against the current theme.

### Description
- Introduce `ModalOptions` (exported) and allow `backgroundStyle` and `headerBackgroundColor` to be either values or theme-resolving functions so options can be evaluated against the active theme at render time.
- Update `ModalProvider` to accept function-based options and resolve them using the active theme before rendering `BaseBottomSheet`, and pass the resolved `backgroundStyle` and `headerBackgroundColor` into the sheet.
- Update `BaseBottomSheet` to derive `effectiveBackgroundStyle` from `theme.screen.background` merged with provided `backgroundStyle` and to apply `headerBackgroundColor` to the sheet header so header colors update live.
- Update `useMyScrollViewModal` to translate common color shortcuts into theme-resolving options and to reuse the new `ModalOptions` shape, and update `useModal` to use the shared type.

### Testing
- No automated tests were executed for this change (not requested).
- Manual runtime verification is expected in the app to confirm modal colors update live when switching themes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bffb8362c8330bef6a8687d65844e)