### PR TITLE
Revert modal background theme-change merge

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -18,12 +18,13 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
         useSelector((state: RootState) => state.settings); // ensure theme subscription
         const snapPoints = useMemo(() => ['80%'], []);
 
-        const effectiveBackgroundStyle = useMemo(
-                () => ({ backgroundColor: theme.screen.background, ...backgroundStyle }),
-                [backgroundStyle, theme.screen.background]
-        );
+        //const effectiveBackgroundStyle = useMemo(() => ({ backgroundColor: theme.sheet.sheetBg, ...backgroundStyle }), [backgroundStyle, theme.sheet.sheetBg]);
 
-        const headerBackground = headerBackgroundColor ?? theme.screen.background;
+		const usedHeaderBg = headerBackgroundColor || theme.screen.background;
+
+		const effectiveBackgroundStyle = {backgroundColor: usedHeaderBg};
+        //const headerBg = headerBackgroundColor || (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
+
         const handleColor = theme.sheet.closeBg;
 
 	const handleChange = useCallback(
@@ -37,9 +38,9 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 		[onClose, onChange]
 	);
 
-		return (
+        return (
                 <BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header, { backgroundColor: headerBackground }]}>
+			<View style={[styles.header]}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>

--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -1,11 +1,11 @@
 import React, { createContext, useContext, useState, ReactNode, useRef, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import BaseBottomSheet from '@/components/BaseBottomSheet/BaseBottomSheet';
-import { useTheme } from '@/hooks/useTheme';
+import {useTheme} from "@/hooks/useTheme";
 
-export type ModalOptions = {
-        backgroundStyle?: any | ((theme: any) => any); // styling passed to the BottomSheet background
-        headerBackgroundColor?: string | ((theme: any) => string | undefined);
+type ModalOptions = {
+        backgroundStyle?: any; // styling passed to the BottomSheet background
+        headerBackgroundColor?: string;
         overlayStyle?: any; // styling for the fullscreen overlay behind the sheet (e.g. rgba dim)
 };
 
@@ -26,20 +26,14 @@ const ModalContext = createContext<ModalContextType | null>(null);
 
 export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
         const [content, setContent] = useState<ReactNode | null>(null);
-        const [backgroundStyle, setBackgroundStyle] = useState<ModalOptions['backgroundStyle']>(null);
+        const [backgroundStyle, setBackgroundStyle] = useState<any>(null);
         // overlay shown over the app (should usually be semi-transparent) - separate from sheet background
-        const [overlayStyle, setOverlayStyle] = useState<ModalOptions['overlayStyle']>(null);
-        const [headerBackgroundColor, setHeaderBackgroundColor] = useState<ModalOptions['headerBackgroundColor']>(undefined);
+        const [overlayStyle, setOverlayStyle] = useState<any>(null);
+        const [headerBackgroundColor, setHeaderBackgroundColor] = useState<string | undefined>(undefined);
         const sheetRef = useRef<any>(null);
 
         const { theme } = useTheme();
-        const resolvedHeaderBackgroundColor =
-                typeof headerBackgroundColor === 'function' ? headerBackgroundColor(theme) : headerBackgroundColor;
-        const screenBackgroundColor = resolvedHeaderBackgroundColor || theme.screen.background;
-        const resolvedBackgroundStyle =
-                typeof backgroundStyle === 'function'
-                        ? backgroundStyle(theme)
-                        : backgroundStyle ?? { backgroundColor: theme.screen.background };
+        let screenBackgroundColor = headerBackgroundColor || theme.screen.background;
 
         const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({
@@ -64,9 +58,12 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 clearCloseTimeout();
 
                 setContent(c);
-                setBackgroundStyle(options?.backgroundStyle ?? null);
+                const resolvedBackgroundStyle = options?.backgroundStyle ?? null;
+                setBackgroundStyle(resolvedBackgroundStyle);
                 setOverlayStyle(options?.overlayStyle ?? { backgroundColor: 'rgba(0,0,0,0.5)' });
-                setHeaderBackgroundColor(options?.headerBackgroundColor);
+                const resolvedHeaderBackgroundColor =
+                        options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
+                setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
@@ -155,7 +152,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                                                  enablePanDownToClose
                                                  onClose={close}
                                                  headerBackgroundColor={screenBackgroundColor}
-                                                 backgroundStyle={resolvedBackgroundStyle}
+                                                 backgroundStyle={backgroundStyle}
                                          >
                                                  {content}
                                          </BaseBottomSheet>

--- a/apps/frontend/app/components/GlobalModal/useModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useModal.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useCallback } from 'react';
-import { type ModalOptions, useModalContext } from './ModalProvider';
+import { useModalContext } from './ModalProvider';
 
 export const useModal = () => {
         const { open, close, debug } = useModalContext();
 
         const show = useCallback(
-                (content: ReactNode, options?: ModalOptions) => {
+                (content: ReactNode, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                         open(content, options);
                 },
                 [open]
@@ -17,3 +17,4 @@ export const useModal = () => {
 
         return { show, close: closeModal, debug };
 };
+

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,48 +1,30 @@
 import { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
-import { type ModalOptions } from './ModalProvider';
 import { useTheme } from '@/hooks/useTheme';
+import {View} from "react-native";
 import React from 'react';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
-
-const resolveThemedColor = (color: string | undefined, theme: any) => {
-        if (!color) return undefined;
-        if (color === theme.sheet.sheetBg) return (activeTheme: any) => activeTheme.sheet.sheetBg;
-        if (color === theme.screen.background) return (activeTheme: any) => activeTheme.screen.background;
-        return color;
-};
-
-const resolveThemedBackgroundStyle = (style: any, theme: any) => {
-        if (!style?.backgroundColor) return style;
-        if (style.backgroundColor === theme.sheet.sheetBg) {
-                return (activeTheme: any) => ({ ...style, backgroundColor: activeTheme.sheet.sheetBg });
-        }
-        if (style.backgroundColor === theme.screen.background) {
-                return (activeTheme: any) => ({ ...style, backgroundColor: activeTheme.screen.background });
-        }
-        return style;
-};
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
         const { theme } = useTheme();
 
-        const show = (modalProps: MyScrollViewModalConfig, options?: ModalOptions) => {
+        const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                const themedBackgroundStyle = resolveThemedBackgroundStyle(options?.backgroundStyle, theme);
-                const themedHeaderBackgroundColor = resolveThemedColor(options?.headerBackgroundColor ?? backgroundColor, theme);
+                const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
+                const backgroundStyle = { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle };
 
                 const mergedOptions = {
                         ...options,
-                        backgroundStyle: themedBackgroundStyle,
-                        headerBackgroundColor: themedHeaderBackgroundColor,
+                        backgroundStyle,
+                        headerBackgroundColor: resolvedBackgroundColor,
                 };
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,


### PR DESCRIPTION
### Motivation
- Undo the recent merge that changed how modal and bottom-sheet backgrounds react to theme changes to restore previous visual behavior.
- Remove complex runtime theme-resolving logic that caused type inconsistencies and unexpected background/header colors.
- Simplify how header and sheet background colors are provided to the `BottomSheet` and global modal plumbing.

### Description
- Reverted `BaseBottomSheet.tsx` to use a single computed `effectiveBackgroundStyle` and removed the prior dynamic header background logic, while keeping the close/handle colors from `theme.sheet`.
- Simplified `ModalProvider.tsx` types and state, changed how `backgroundStyle` and `headerBackgroundColor` are resolved and passed into `BaseBottomSheet`, and removed the theme-function resolution layers.
- Updated `useModal.tsx` to drop the exported `ModalOptions` type dependency and to accept a simpler options shape for `show`, and adjusted `useMyScrollViewModal.tsx` to compute and pass a resolved `backgroundColor`/`backgroundStyle` instead of complex resolver helpers.
- Minor formatting and type adjustments across the modal-related components to align with the reverted behavior.

### Testing
- The revert was applied locally using `git revert` and produced a successful revert of the merge changes.
- No automated tests were executed as part of this change.
- No unit or integration test failures were reported because tests were not run.
- Manual build/run was not requested or performed by the automated rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c03e0e9888330a6495143ba076743)