### PR TITLE
Update global modal to react to theme changes immediately

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -7,6 +7,8 @@ type ModalOptions = {
         backgroundStyle?: any; // styling passed to the BottomSheet background
         headerBackgroundColor?: string;
         overlayStyle?: any; // styling for the fullscreen overlay behind the sheet (e.g. rgba dim)
+        useThemeBackground?: boolean;
+        useThemeHeaderBackground?: boolean;
 };
 
 type ModalContextType = {
@@ -30,6 +32,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         // overlay shown over the app (should usually be semi-transparent) - separate from sheet background
         const [overlayStyle, setOverlayStyle] = useState<any>(null);
         const [headerBackgroundColor, setHeaderBackgroundColor] = useState<string | undefined>(undefined);
+        const [useThemeBackground, setUseThemeBackground] = useState(false);
+        const [useThemeHeaderBackground, setUseThemeHeaderBackground] = useState(false);
         const sheetRef = useRef<any>(null);
 
         const { theme } = useTheme();
@@ -64,6 +68,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 const resolvedHeaderBackgroundColor =
                         options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
                 setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
+                setUseThemeBackground(Boolean(options?.useThemeBackground));
+                setUseThemeHeaderBackground(Boolean(options?.useThemeHeaderBackground));
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
@@ -82,6 +88,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 setBackgroundStyle(null);
                 setOverlayStyle(null);
                 setHeaderBackgroundColor(undefined);
+                setUseThemeBackground(false);
+                setUseThemeHeaderBackground(false);
                 clearCloseTimeout();
                 closeTimeoutRef.current = setTimeout(() => {
                         setContent(null);
@@ -136,6 +144,19 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 const cancel = ensureExpand();
                 return () => cancel();
         }, [content]);
+
+        useEffect(() => {
+                if (!isVisible) return;
+                if (useThemeBackground) {
+                        setBackgroundStyle((prev: any) => ({
+                                ...(prev ?? {}),
+                                backgroundColor: theme.screen.background,
+                        }));
+                }
+                if (useThemeHeaderBackground) {
+                        setHeaderBackgroundColor(theme.screen.background);
+                }
+        }, [isVisible, theme.screen.background, useThemeBackground, useThemeHeaderBackground]);
 
         return (
                 <ModalContext.Provider value={{ open, close, debug }}>

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -14,17 +14,22 @@ export const useMyScrollViewModal = () => {
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
-                const backgroundStyle = { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle };
+                const themeDrivenBackground = backgroundColor == null && options?.backgroundStyle?.backgroundColor == null;
+                const resolvedBackgroundColor =
+                        options?.backgroundStyle?.backgroundColor ?? backgroundColor ?? theme.screen.background;
+                const backgroundStyle = { ...options?.backgroundStyle, backgroundColor: resolvedBackgroundColor };
+                const modalBackgroundColor = themeDrivenBackground ? undefined : resolvedBackgroundColor;
 
                 const mergedOptions = {
                         ...options,
                         backgroundStyle,
                         headerBackgroundColor: resolvedBackgroundColor,
+                        useThemeBackground: themeDrivenBackground,
+                        useThemeHeaderBackground: themeDrivenBackground,
                 };
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={modalBackgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,


### PR DESCRIPTION
### Motivation
- Theme changes should update modal background and header colors immediately without requiring the modal to be closed and reopened. 
- The current `useMyScrollViewModal` flow could freeze a modal's background color when no explicit color was provided. 

### Description
- Added `useThemeBackground` and `useThemeHeaderBackground` options to `ModalOptions` and tracked them in `ModalProvider`. 
- `ModalProvider` now updates `backgroundStyle` and `headerBackgroundColor` in a `useEffect` when the theme changes and the modal is visible. 
- `useMyScrollViewModal` detects when the modal should be theme-driven, avoids passing a fixed `backgroundColor` into `MyScrollViewModal`, and forwards the new flags to the provider. 
- Adjusted merging of `backgroundStyle` and resolution of `resolvedBackgroundColor` so the modal follows live theme values by default. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c046e08b083308c524a959ed4c2ca)