### PR TITLE
Update modal theme colors live

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -3,12 +3,16 @@ import { StyleSheet, View } from 'react-native';
 import BaseBottomSheet from '@/components/BaseBottomSheet/BaseBottomSheet';
 import {useTheme} from "@/hooks/useTheme";
 
-type ModalOptions = {
+export type ThemeBackgroundSource = 'screen' | 'sheet';
+
+export type ModalOptions = {
         backgroundStyle?: any; // styling passed to the BottomSheet background
         headerBackgroundColor?: string;
         overlayStyle?: any; // styling for the fullscreen overlay behind the sheet (e.g. rgba dim)
         useThemeBackground?: boolean;
         useThemeHeaderBackground?: boolean;
+        themeBackgroundSource?: ThemeBackgroundSource;
+        themeHeaderBackgroundSource?: ThemeBackgroundSource;
 };
 
 type ModalContextType = {
@@ -34,6 +38,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const [headerBackgroundColor, setHeaderBackgroundColor] = useState<string | undefined>(undefined);
         const [useThemeBackground, setUseThemeBackground] = useState(false);
         const [useThemeHeaderBackground, setUseThemeHeaderBackground] = useState(false);
+        const [themeBackgroundSource, setThemeBackgroundSource] = useState<ThemeBackgroundSource | null>(null);
+        const [themeHeaderBackgroundSource, setThemeHeaderBackgroundSource] = useState<ThemeBackgroundSource | null>(null);
         const sheetRef = useRef<any>(null);
 
         const { theme } = useTheme();
@@ -70,6 +76,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
                 setUseThemeBackground(Boolean(options?.useThemeBackground));
                 setUseThemeHeaderBackground(Boolean(options?.useThemeHeaderBackground));
+                setThemeBackgroundSource(options?.themeBackgroundSource ?? null);
+                setThemeHeaderBackgroundSource(options?.themeHeaderBackgroundSource ?? null);
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
@@ -90,6 +98,8 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 setHeaderBackgroundColor(undefined);
                 setUseThemeBackground(false);
                 setUseThemeHeaderBackground(false);
+                setThemeBackgroundSource(null);
+                setThemeHeaderBackgroundSource(null);
                 clearCloseTimeout();
                 closeTimeoutRef.current = setTimeout(() => {
                         setContent(null);
@@ -147,16 +157,27 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
         useEffect(() => {
                 if (!isVisible) return;
-                if (useThemeBackground) {
+                const resolveThemeBackground = (source: ThemeBackgroundSource | null) =>
+                        source === 'sheet' ? theme.sheet.sheetBg : theme.screen.background;
+
+                if (useThemeBackground || themeBackgroundSource) {
                         setBackgroundStyle((prev: any) => ({
                                 ...(prev ?? {}),
-                                backgroundColor: theme.screen.background,
+                                backgroundColor: resolveThemeBackground(themeBackgroundSource),
                         }));
                 }
-                if (useThemeHeaderBackground) {
-                        setHeaderBackgroundColor(theme.screen.background);
+                if (useThemeHeaderBackground || themeHeaderBackgroundSource) {
+                        setHeaderBackgroundColor(resolveThemeBackground(themeHeaderBackgroundSource));
                 }
-        }, [isVisible, theme.screen.background, useThemeBackground, useThemeHeaderBackground]);
+        }, [
+                isVisible,
+                theme.screen.background,
+                theme.sheet.sheetBg,
+                useThemeBackground,
+                useThemeHeaderBackground,
+                themeBackgroundSource,
+                themeHeaderBackgroundSource,
+        ]);
 
         return (
                 <ModalContext.Provider value={{ open, close, debug }}>

--- a/apps/frontend/app/components/GlobalModal/useModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useModal.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useCallback } from 'react';
-import { useModalContext } from './ModalProvider';
+import { ModalOptions, useModalContext } from './ModalProvider';
 
 export const useModal = () => {
         const { open, close, debug } = useModalContext();
 
         const show = useCallback(
-                (content: ReactNode, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
+                (content: ReactNode, options?: ModalOptions) => {
                         open(content, options);
                 },
                 [open]
@@ -17,4 +17,3 @@ export const useModal = () => {
 
         return { show, close: closeModal, debug };
 };
-

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -4,6 +4,7 @@ import { useModal } from './useModal';
 import { useTheme } from '@/hooks/useTheme';
 import {View} from "react-native";
 import React from 'react';
+import { ThemeBackgroundSource } from './ModalProvider';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
 
@@ -14,9 +15,24 @@ export const useMyScrollViewModal = () => {
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                const themeDrivenBackground = backgroundColor == null && options?.backgroundStyle?.backgroundColor == null;
-                const resolvedBackgroundColor =
-                        options?.backgroundStyle?.backgroundColor ?? backgroundColor ?? theme.screen.background;
+                let themeBackgroundSource: ThemeBackgroundSource | undefined;
+                if (backgroundColor == null && options?.backgroundStyle?.backgroundColor == null) {
+                        themeBackgroundSource = 'screen';
+                } else if (options?.backgroundStyle?.backgroundColor === theme.sheet.sheetBg || backgroundColor === theme.sheet.sheetBg) {
+                        themeBackgroundSource = 'sheet';
+                } else if (
+                        options?.backgroundStyle?.backgroundColor === theme.screen.background ||
+                        backgroundColor === theme.screen.background
+                ) {
+                        themeBackgroundSource = 'screen';
+                }
+
+                const themeDrivenBackground = Boolean(themeBackgroundSource);
+                const resolvedBackgroundColor = themeDrivenBackground
+                        ? themeBackgroundSource === 'sheet'
+                                ? theme.sheet.sheetBg
+                                : theme.screen.background
+                        : options?.backgroundStyle?.backgroundColor ?? backgroundColor ?? theme.screen.background;
                 const backgroundStyle = { ...options?.backgroundStyle, backgroundColor: resolvedBackgroundColor };
                 const modalBackgroundColor = themeDrivenBackground ? undefined : resolvedBackgroundColor;
 
@@ -26,10 +42,17 @@ export const useMyScrollViewModal = () => {
                         headerBackgroundColor: resolvedBackgroundColor,
                         useThemeBackground: themeDrivenBackground,
                         useThemeHeaderBackground: themeDrivenBackground,
+                        themeBackgroundSource,
+                        themeHeaderBackgroundSource: themeBackgroundSource,
                 };
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={modalBackgroundColor} {...restProps}>
+                        <MyScrollViewModal
+                                closeSheet={close}
+                                backgroundColor={modalBackgroundColor}
+                                backgroundColorSource={themeBackgroundSource}
+                                {...restProps}
+                        >
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -8,6 +8,7 @@ export interface MyScrollViewModalProps {
   title?: string;
   closeSheet?: () => void;
   backgroundColor?: string;
+  backgroundColorSource?: 'screen' | 'sheet';
   children?: ReactNode;
   // For FlatList mode
   useFlatList?: boolean;
@@ -27,6 +28,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   children,
   useFlatList = false,
   backgroundColor,
+  backgroundColorSource,
   data = [],
   renderItem,
   keyExtractor,
@@ -39,7 +41,12 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
+  const resolvedBackgroundColor =
+    backgroundColorSource === 'sheet'
+      ? theme.sheet.sheetBg
+      : backgroundColorSource === 'screen'
+        ? theme.screen.background
+        : backgroundColor ?? theme.screen.background;
 
   React.useEffect(() => () => onClose?.(), [onClose]);
 
@@ -96,4 +103,3 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 };
 
 export default MyScrollViewModal;
-


### PR DESCRIPTION
### Motivation
- Modals used the global provider and did not update their content/header background immediately when the app `theme` changed, requiring reopen to reflect new colors.
- Make modal background/header colors react live to theme changes so the UI updates immediately.
- Provide an explicit way to choose whether a modal should follow the `screen` or `sheet` theme color source.

### Description
- Add `ThemeBackgroundSource` and extend `ModalOptions` in `ModalProvider` to carry `themeBackgroundSource` and `themeHeaderBackgroundSource` flags.
- Track `themeBackgroundSource` / `themeHeaderBackgroundSource` in `ModalProvider` and resolve background/header colors from `theme.screen` or `theme.sheet` in the `useEffect` that updates visible modal styles.
- Change `useModal` to accept the typed `ModalOptions`, and update `useMyScrollViewModal` to detect theme-driven backgrounds and propagate the chosen source to the provider via merged options.
- Extend `MyScrollViewModal` with a `backgroundColorSource` prop and resolve the actual background color from the corresponding theme source so header/content update live.

### Testing
- No automated tests were executed for this change.
- (No test runs reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0717e5d48330ba283fbf2c4ba0d7)