### PR TITLE
Fix modal sheet background color defaults

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -18,12 +18,14 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
         useSelector((state: RootState) => state.settings); // ensure theme subscription
         const snapPoints = useMemo(() => ['80%'], []);
 
-        //const effectiveBackgroundStyle = useMemo(() => ({ backgroundColor: theme.sheet.sheetBg, ...backgroundStyle }), [backgroundStyle, theme.sheet.sheetBg]);
-
-		const usedHeaderBg = headerBackgroundColor || theme.screen.background;
-
-		const effectiveBackgroundStyle = {backgroundColor: usedHeaderBg};
-        //const headerBg = headerBackgroundColor || (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
+        const resolvedHeaderBackground = headerBackgroundColor || (backgroundStyle as any)?.backgroundColor || theme.sheet.sheetBg;
+        const effectiveBackgroundStyle = useMemo(
+                () => ({
+                        backgroundColor: resolvedHeaderBackground,
+                        ...(backgroundStyle ?? {}),
+                }),
+                [backgroundStyle, resolvedHeaderBackground]
+        );
 
         const handleColor = theme.sheet.closeBg;
 
@@ -40,7 +42,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 
         return (
                 <BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header]}>
+			<View style={[styles.header, { backgroundColor: resolvedHeaderBackground }]}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>

--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -43,7 +43,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const sheetRef = useRef<any>(null);
 
         const { theme } = useTheme();
-        let screenBackgroundColor = headerBackgroundColor || theme.screen.background;
+        let screenBackgroundColor = headerBackgroundColor || theme.sheet.sheetBg;
 
         const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -17,7 +17,7 @@ export const useMyScrollViewModal = () => {
 
                 let themeBackgroundSource: ThemeBackgroundSource | undefined;
                 if (backgroundColor == null && options?.backgroundStyle?.backgroundColor == null) {
-                        themeBackgroundSource = 'screen';
+                        themeBackgroundSource = 'sheet';
                 } else if (options?.backgroundStyle?.backgroundColor === theme.sheet.sheetBg || backgroundColor === theme.sheet.sheetBg) {
                         themeBackgroundSource = 'sheet';
                 } else if (

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -46,7 +46,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
       ? theme.sheet.sheetBg
       : backgroundColorSource === 'screen'
         ? theme.screen.background
-        : backgroundColor ?? theme.screen.background;
+        : backgroundColor ?? theme.sheet.sheetBg;
 
   React.useEffect(() => () => onClose?.(), [onClose]);
 


### PR DESCRIPTION
### Motivation
- Fix incorrect default background color used by modal components which previously fell back to `theme.screen.background` instead of the sheet color.
- Ensure scroll-view modals and bottom-sheet headers use the sheet background when no explicit `backgroundColor` is provided.
- Make theme-driven background resolution consistent across `useMyScrollViewModal`, `MyScrollViewModal`, `ModalProvider` and `BaseBottomSheet`.

### Description
- Default the theme background source to `'sheet'` in `apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx` when no background is provided.
- Change the fallback for resolved background in `apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx` to `theme.sheet.sheetBg`.
- Use `theme.sheet.sheetBg` as the header background default in `apps/frontend/app/components/GlobalModal/ModalProvider.tsx`.
- Compute a memoized `effectiveBackgroundStyle` and apply a `resolvedHeaderBackground` to the header view in `apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx` so header and sheet backgrounds stay in sync.

### Testing
- Ran `yarn frontend` to start the dev server and Metro, but the run failed with an `ENOSPC` file watcher limit error (Metro could not start fully).
- The package resolution and link steps completed with warnings during `yarn frontend` but no further automated tests or unit tests were executed.
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c09bc901c83309c76f9eb00f35607)