### PR TITLE
Revert frontend modal/bottom-sheet components to f8c77f60677c

### DIFF
--- a/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
+++ b/apps/frontend/app/components/BaseBottomSheet/BaseBottomSheet.tsx
@@ -18,14 +18,12 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
         useSelector((state: RootState) => state.settings); // ensure theme subscription
         const snapPoints = useMemo(() => ['80%'], []);
 
-        const resolvedHeaderBackground = headerBackgroundColor || (backgroundStyle as any)?.backgroundColor || theme.sheet.sheetBg;
-        const effectiveBackgroundStyle = useMemo(
-                () => ({
-                        backgroundColor: resolvedHeaderBackground,
-                        ...(backgroundStyle ?? {}),
-                }),
-                [backgroundStyle, resolvedHeaderBackground]
-        );
+        //const effectiveBackgroundStyle = useMemo(() => ({ backgroundColor: theme.sheet.sheetBg, ...backgroundStyle }), [backgroundStyle, theme.sheet.sheetBg]);
+
+		const usedHeaderBg = headerBackgroundColor || theme.screen.background;
+
+		const effectiveBackgroundStyle = {backgroundColor: usedHeaderBg};
+        //const headerBg = headerBackgroundColor || (effectiveBackgroundStyle as any).backgroundColor || theme.sheet.sheetBg;
 
         const handleColor = theme.sheet.closeBg;
 
@@ -42,7 +40,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 
         return (
                 <BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} {...props}>
-			<View style={[styles.header, { backgroundColor: resolvedHeaderBackground }]}>
+			<View style={[styles.header]}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose}>

--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -3,16 +3,10 @@ import { StyleSheet, View } from 'react-native';
 import BaseBottomSheet from '@/components/BaseBottomSheet/BaseBottomSheet';
 import {useTheme} from "@/hooks/useTheme";
 
-export type ThemeBackgroundSource = 'screen' | 'sheet';
-
-export type ModalOptions = {
+type ModalOptions = {
         backgroundStyle?: any; // styling passed to the BottomSheet background
         headerBackgroundColor?: string;
         overlayStyle?: any; // styling for the fullscreen overlay behind the sheet (e.g. rgba dim)
-        useThemeBackground?: boolean;
-        useThemeHeaderBackground?: boolean;
-        themeBackgroundSource?: ThemeBackgroundSource;
-        themeHeaderBackgroundSource?: ThemeBackgroundSource;
 };
 
 type ModalContextType = {
@@ -36,14 +30,10 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         // overlay shown over the app (should usually be semi-transparent) - separate from sheet background
         const [overlayStyle, setOverlayStyle] = useState<any>(null);
         const [headerBackgroundColor, setHeaderBackgroundColor] = useState<string | undefined>(undefined);
-        const [useThemeBackground, setUseThemeBackground] = useState(false);
-        const [useThemeHeaderBackground, setUseThemeHeaderBackground] = useState(false);
-        const [themeBackgroundSource, setThemeBackgroundSource] = useState<ThemeBackgroundSource | null>(null);
-        const [themeHeaderBackgroundSource, setThemeHeaderBackgroundSource] = useState<ThemeBackgroundSource | null>(null);
         const sheetRef = useRef<any>(null);
 
         const { theme } = useTheme();
-        let screenBackgroundColor = headerBackgroundColor || theme.sheet.sheetBg;
+        let screenBackgroundColor = headerBackgroundColor || theme.screen.background;
 
         const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({
@@ -74,10 +64,6 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 const resolvedHeaderBackgroundColor =
                         options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
                 setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
-                setUseThemeBackground(Boolean(options?.useThemeBackground));
-                setUseThemeHeaderBackground(Boolean(options?.useThemeHeaderBackground));
-                setThemeBackgroundSource(options?.themeBackgroundSource ?? null);
-                setThemeHeaderBackgroundSource(options?.themeHeaderBackgroundSource ?? null);
                 setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
@@ -96,10 +82,6 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 setBackgroundStyle(null);
                 setOverlayStyle(null);
                 setHeaderBackgroundColor(undefined);
-                setUseThemeBackground(false);
-                setUseThemeHeaderBackground(false);
-                setThemeBackgroundSource(null);
-                setThemeHeaderBackgroundSource(null);
                 clearCloseTimeout();
                 closeTimeoutRef.current = setTimeout(() => {
                         setContent(null);
@@ -154,30 +136,6 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 const cancel = ensureExpand();
                 return () => cancel();
         }, [content]);
-
-        useEffect(() => {
-                if (!isVisible) return;
-                const resolveThemeBackground = (source: ThemeBackgroundSource | null) =>
-                        source === 'sheet' ? theme.sheet.sheetBg : theme.screen.background;
-
-                if (useThemeBackground || themeBackgroundSource) {
-                        setBackgroundStyle((prev: any) => ({
-                                ...(prev ?? {}),
-                                backgroundColor: resolveThemeBackground(themeBackgroundSource),
-                        }));
-                }
-                if (useThemeHeaderBackground || themeHeaderBackgroundSource) {
-                        setHeaderBackgroundColor(resolveThemeBackground(themeHeaderBackgroundSource));
-                }
-        }, [
-                isVisible,
-                theme.screen.background,
-                theme.sheet.sheetBg,
-                useThemeBackground,
-                useThemeHeaderBackground,
-                themeBackgroundSource,
-                themeHeaderBackgroundSource,
-        ]);
 
         return (
                 <ModalContext.Provider value={{ open, close, debug }}>

--- a/apps/frontend/app/components/GlobalModal/useModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useModal.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useCallback } from 'react';
-import { ModalOptions, useModalContext } from './ModalProvider';
+import { useModalContext } from './ModalProvider';
 
 export const useModal = () => {
         const { open, close, debug } = useModalContext();
 
         const show = useCallback(
-                (content: ReactNode, options?: ModalOptions) => {
+                (content: ReactNode, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                         open(content, options);
                 },
                 [open]
@@ -17,3 +17,4 @@ export const useModal = () => {
 
         return { show, close: closeModal, debug };
 };
+

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -4,7 +4,6 @@ import { useModal } from './useModal';
 import { useTheme } from '@/hooks/useTheme';
 import {View} from "react-native";
 import React from 'react';
-import { ThemeBackgroundSource } from './ModalProvider';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
 
@@ -15,44 +14,17 @@ export const useMyScrollViewModal = () => {
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                let themeBackgroundSource: ThemeBackgroundSource | undefined;
-                if (backgroundColor == null && options?.backgroundStyle?.backgroundColor == null) {
-                        themeBackgroundSource = 'sheet';
-                } else if (options?.backgroundStyle?.backgroundColor === theme.sheet.sheetBg || backgroundColor === theme.sheet.sheetBg) {
-                        themeBackgroundSource = 'sheet';
-                } else if (
-                        options?.backgroundStyle?.backgroundColor === theme.screen.background ||
-                        backgroundColor === theme.screen.background
-                ) {
-                        themeBackgroundSource = 'screen';
-                }
-
-                const themeDrivenBackground = Boolean(themeBackgroundSource);
-                const resolvedBackgroundColor = themeDrivenBackground
-                        ? themeBackgroundSource === 'sheet'
-                                ? theme.sheet.sheetBg
-                                : theme.screen.background
-                        : options?.backgroundStyle?.backgroundColor ?? backgroundColor ?? theme.screen.background;
-                const backgroundStyle = { ...options?.backgroundStyle, backgroundColor: resolvedBackgroundColor };
-                const modalBackgroundColor = themeDrivenBackground ? undefined : resolvedBackgroundColor;
+                const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
+                const backgroundStyle = { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle };
 
                 const mergedOptions = {
                         ...options,
                         backgroundStyle,
                         headerBackgroundColor: resolvedBackgroundColor,
-                        useThemeBackground: themeDrivenBackground,
-                        useThemeHeaderBackground: themeDrivenBackground,
-                        themeBackgroundSource,
-                        themeHeaderBackgroundSource: themeBackgroundSource,
                 };
 
                 showModal(
-                        <MyScrollViewModal
-                                closeSheet={close}
-                                backgroundColor={modalBackgroundColor}
-                                backgroundColorSource={themeBackgroundSource}
-                                {...restProps}
-                        >
+                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -8,7 +8,6 @@ export interface MyScrollViewModalProps {
   title?: string;
   closeSheet?: () => void;
   backgroundColor?: string;
-  backgroundColorSource?: 'screen' | 'sheet';
   children?: ReactNode;
   // For FlatList mode
   useFlatList?: boolean;
@@ -28,7 +27,6 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   children,
   useFlatList = false,
   backgroundColor,
-  backgroundColorSource,
   data = [],
   renderItem,
   keyExtractor,
@@ -41,12 +39,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const resolvedBackgroundColor =
-    backgroundColorSource === 'sheet'
-      ? theme.sheet.sheetBg
-      : backgroundColorSource === 'screen'
-        ? theme.screen.background
-        : backgroundColor ?? theme.sheet.sheetBg;
+  const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
 
   React.useEffect(() => () => onClose?.(), [onClose]);
 
@@ -103,3 +96,4 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 };
 
 export default MyScrollViewModal;
+


### PR DESCRIPTION
### Motivation

- Restore frontend modal and bottom sheet components to the state from commit `f8c77f60677c`.
- Remove complex theme-source flags and dynamic background-source logic that were added previously.
- Re-establish consistent default backgrounds by using `theme.screen.background` for sheet/header backgrounds.

### Description

- Simplified `BaseBottomSheet` by replacing the computed `effectiveBackgroundStyle` with a straightforward background resolved from `headerBackgroundColor` or `theme.screen.background` and adjusted the header view accordingly.
- Removed theme-option state and related effect logic from `ModalProvider`, and switched header background resolution to `theme.screen.background` while keeping `open`/`close` behavior and debug tracking.
- Simplified `useModal` types and `useMyScrollViewModal` to no longer compute a `backgroundColorSource` and to pass a resolved background color via options.
- Updated `MyScrollViewModal` to use the resolved `backgroundColor` (defaulting to `theme.screen.background`) and removed the `backgroundColorSource` handling.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0bf742408330a0f3b37aa7954873)