### PR TITLE
Fix ScrollView modal theming updates and add DebugView background swatch

### DIFF
--- a/apps/frontend/app/components/DebugView/index.tsx
+++ b/apps/frontend/app/components/DebugView/index.tsx
@@ -116,6 +116,18 @@ const DebugView: React.FC<DebugViewProps> = ({
                                         ))}
                                 </View>
                         ) : null}
+
+                        <View style={styles.themeBackgroundRow}>
+                                <Text style={[styles.themeBackgroundLabel, { color: theme.screen.text }]}>
+                                        {theme.screen.background}
+                                </Text>
+                                <View
+                                        style={[
+                                                styles.themeBackgroundSwatch,
+                                                { backgroundColor: theme.screen.background },
+                                        ]}
+                                />
+                        </View>
                 </View>
         );
 };

--- a/apps/frontend/app/components/DebugView/styles.ts
+++ b/apps/frontend/app/components/DebugView/styles.ts
@@ -50,6 +50,21 @@ const styles = StyleSheet.create({
                 fontFamily: 'monospace',
                 marginBottom: 4,
         },
+        themeBackgroundRow: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginTop: 12,
+        },
+        themeBackgroundLabel: {
+                fontSize: 13,
+        },
+        themeBackgroundSwatch: {
+                width: 32,
+                height: 32,
+                borderWidth: 1,
+                borderColor: '#FF0000',
+        },
 });
 
 export default styles;

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,30 +1,29 @@
 import { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
-import { useTheme } from '@/hooks/useTheme';
-import {View} from "react-native";
 import React from 'react';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
-        const { theme } = useTheme();
-
-        const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
+        const show = (
+                modalProps: MyScrollViewModalConfig,
+                options?: { backgroundStyle?: any; headerBackgroundColor?: string }
+        ) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
-
-                const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
-                const backgroundStyle = { backgroundColor: resolvedBackgroundColor, ...options?.backgroundStyle };
+                const backgroundStyle = backgroundColor
+                        ? { backgroundColor, ...options?.backgroundStyle }
+                        : options?.backgroundStyle;
 
                 const mergedOptions = {
                         ...options,
                         backgroundStyle,
-                        headerBackgroundColor: resolvedBackgroundColor,
+                        headerBackgroundColor: options?.headerBackgroundColor ?? backgroundColor,
                 };
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,


### PR DESCRIPTION
### Motivation
- The ScrollView modal previously captured the theme background when shown, which prevented immediate updates to the modal content/header colors when the app theme changed.
- The modal header/background should follow live theme changes immediately without needing to re-open the modal.
- Provide an easy visual debug aid to inspect the current `theme.screen.background` value at runtime.

### Description
- Updated `useMyScrollViewModal` so it no longer locks the modal background/header to the theme at hook call time and instead forwards the provided `backgroundColor` and merged `backgroundStyle` through to the global modal options (`useMyScrollViewModal.tsx`).
- Made `headerBackgroundColor` derive from `options?.headerBackgroundColor ?? backgroundColor` so header color follows the provided background when present.
- Updated `DebugView` to render the `theme.screen.background` value as text and a 32×32 swatch with a red border (`DebugView/index.tsx` and `DebugView/styles.ts`).
- Changes touch `useMyScrollViewModal.tsx`, `DebugView/index.tsx`, and `DebugView/styles.ts` and remove an unused `useTheme` import from the hook.

### Testing
- No automated tests were run for this change.
- (No CI/build verification included in this PR.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0e10a6fc8330bd27fdc14bdf7a6c)