### PR TITLE
Default modal sheet colors from theme

### DIFF
--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,29 +1,29 @@
 import { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
+import { useTheme } from '@/hooks/useTheme';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
+        const { theme } = useTheme();
 
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                const backgroundStyle = backgroundColor
-                        ? { backgroundColor, ...options?.backgroundStyle }
-                        : options?.backgroundStyle;
-                const headerBackgroundColor = backgroundColor ?? options?.headerBackgroundColor;
-                const mergedOptions = options
-                        ? {
-                                  ...options,
-                                  backgroundStyle,
-                                  headerBackgroundColor,
-                          }
-                        : undefined;
+                const resolvedBackgroundColor =
+                        backgroundColor ?? options?.backgroundStyle?.backgroundColor ?? theme.sheet.sheetBg ?? theme.screen.background;
+                const backgroundStyle = { ...options?.backgroundStyle, backgroundColor: resolvedBackgroundColor };
+                const headerBackgroundColor = options?.headerBackgroundColor ?? resolvedBackgroundColor;
+                const mergedOptions = {
+                        ...options,
+                        backgroundStyle,
+                        headerBackgroundColor,
+                };
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -39,7 +39,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
+  const resolvedBackgroundColor = backgroundColor ?? theme.sheet.sheetBg ?? theme.screen.background;
 
   React.useEffect(() => () => onClose?.(), [onClose]);
 
@@ -96,4 +96,3 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 };
 
 export default MyScrollViewModal;
-

--- a/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
+++ b/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
@@ -3,13 +3,11 @@ import React, { useCallback } from 'react';
 import SortSheet from '@/components/SortSheet/SortSheet';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useLanguage } from '@/hooks/useLanguage';
-import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 
 export const useFoodofferSortingModal = () => {
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { translate } = useLanguage();
-        const { theme } = useTheme();
 
         const openFoodofferSortingModal = useCallback(() => {
                 showScrollViewModal(
@@ -17,10 +15,9 @@ export const useFoodofferSortingModal = () => {
                                 title: translate(TranslationKeys.sort),
                                 onClose: closeScrollViewModal,
                                 children: <SortSheet closeSheet={closeScrollViewModal} />,
-                        },
-                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                        }
                 );
-        }, [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]);
+        }, [closeScrollViewModal, showScrollViewModal, translate]);
 
         return { openFoodofferSortingModal };
 };


### PR DESCRIPTION
### Motivation
- Make modal header and background colors automatic so callers don't have to forward the theme every time.
- Align `MyScrollViewModal` fallback to use the sheet background color rather than only the screen background.
- Let shared modal helpers (e.g. the foodoffer sorting modal) rely on centralized defaults instead of passing explicit colors.

### Description
- Updated `useMyScrollViewModal` to compute `resolvedBackgroundColor` from `backgroundColor`, `options?.backgroundStyle?.backgroundColor`, `theme.sheet.sheetBg`, and `theme.screen.background` and to pass merged `backgroundStyle` and `headerBackgroundColor` into the modal provider.
- Changed `MyScrollViewModal` to fallback to `theme.sheet.sheetBg` before `theme.screen.background` for its `resolvedBackgroundColor`.
- Simplified `useFoodofferSortingModal` by removing explicit `theme` usage and the manual `backgroundStyle`/`headerBackgroundColor` options so it uses the new defaults.
- Small import/prop adjustments to propagate the resolved color into `MyScrollViewModal` usage via `useMyScrollViewModal`.

### Testing
- No automated tests were executed for this change.
- All modified files were compiled/committed locally as part of the change (manual validation only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1696b174833091f56878c0eb1121)