### PR TITLE
Revert modal sheet color change

### DIFF
--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,29 +1,29 @@
 import { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
-import { useTheme } from '@/hooks/useTheme';
 
 export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, debug } = useModal();
-        const { theme } = useTheme();
 
         const show = (modalProps: MyScrollViewModalConfig, options?: { backgroundStyle?: any; headerBackgroundColor?: string }) => {
                 const { children, backgroundColor, ...restProps } = modalProps;
 
-                const resolvedBackgroundColor =
-                        backgroundColor ?? options?.backgroundStyle?.backgroundColor ?? theme.sheet.sheetBg ?? theme.screen.background;
-                const backgroundStyle = { ...options?.backgroundStyle, backgroundColor: resolvedBackgroundColor };
-                const headerBackgroundColor = options?.headerBackgroundColor ?? resolvedBackgroundColor;
-                const mergedOptions = {
-                        ...options,
-                        backgroundStyle,
-                        headerBackgroundColor,
-                };
+                const backgroundStyle = backgroundColor
+                        ? { backgroundColor, ...options?.backgroundStyle }
+                        : options?.backgroundStyle;
+                const headerBackgroundColor = backgroundColor ?? options?.headerBackgroundColor;
+                const mergedOptions = options
+                        ? {
+                                  ...options,
+                                  backgroundStyle,
+                                  headerBackgroundColor,
+                          }
+                        : undefined;
 
                 showModal(
-                        <MyScrollViewModal closeSheet={close} backgroundColor={resolvedBackgroundColor} {...restProps}>
+                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>,
                         mergedOptions,

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -39,7 +39,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const resolvedBackgroundColor = backgroundColor ?? theme.sheet.sheetBg ?? theme.screen.background;
+  const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
 
   React.useEffect(() => () => onClose?.(), [onClose]);
 
@@ -96,3 +96,4 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 };
 
 export default MyScrollViewModal;
+

--- a/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
+++ b/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
@@ -3,11 +3,13 @@ import React, { useCallback } from 'react';
 import SortSheet from '@/components/SortSheet/SortSheet';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 
 export const useFoodofferSortingModal = () => {
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { translate } = useLanguage();
+        const { theme } = useTheme();
 
         const openFoodofferSortingModal = useCallback(() => {
                 showScrollViewModal(
@@ -15,9 +17,10 @@ export const useFoodofferSortingModal = () => {
                                 title: translate(TranslationKeys.sort),
                                 onClose: closeScrollViewModal,
                                 children: <SortSheet closeSheet={closeScrollViewModal} />,
-                        }
+                        },
+                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
                 );
-        }, [closeScrollViewModal, showScrollViewModal, translate]);
+        }, [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]);
 
         return { openFoodofferSortingModal };
 };


### PR DESCRIPTION
### Motivation
- The previous refactor introduced a new color resolution for modal sheets that produced incorrect background/header colors.
- Restore the prior color handling so modals use the expected theme colors already relied on across the app.

### Description
- Reverted changes in `useMyScrollViewModal.tsx` to restore the original conditional `backgroundStyle`/`headerBackgroundColor` merge and removed the `useTheme`-based resolution logic.
- Reverted `MyScrollViewModal.tsx` to prefer `theme.screen.background` for `resolvedBackgroundColor` instead of `theme.sheet.sheetBg`.
- Restored `useFoodofferSortingModal.tsx` to re-import `useTheme` and explicitly pass `theme.sheet.sheetBg` as the sort-modal background/header color.
- This undoes the earlier "Default modal sheet colors" refactor so modal appearance matches the previous behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c193c09ec8330aeadf00d00d1cb3d)