### PR TITLE
Align foodoffer sort modal header styling with theme modal

### DIFF
--- a/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
+++ b/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
@@ -3,24 +3,20 @@ import React, { useCallback } from 'react';
 import SortSheet from '@/components/SortSheet/SortSheet';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useLanguage } from '@/hooks/useLanguage';
-import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 
 export const useFoodofferSortingModal = () => {
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { translate } = useLanguage();
-        const { theme } = useTheme();
-
         const openFoodofferSortingModal = useCallback(() => {
                 showScrollViewModal(
                         {
                                 title: translate(TranslationKeys.sort),
                                 onClose: closeScrollViewModal,
                                 children: <SortSheet closeSheet={closeScrollViewModal} />,
-                        },
-                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                        }
                 );
-        }, [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]);
+        }, [closeScrollViewModal, showScrollViewModal, translate]);
 
         return { openFoodofferSortingModal };
 };


### PR DESCRIPTION
### Motivation
- The foodoffer sorting modal used a custom header/background override and an unused theme dependency which caused inconsistent header colors compared to other modals.
- The goal is to have the foodoffer sorting modal follow the default modal header styling provided by the global modal system.

### Description
- Removed the `useTheme` import and its usage from `useFoodofferSortingModal.tsx`.
- Stopped passing explicit `backgroundStyle` and `headerBackgroundColor` options to `showScrollViewModal` so the modal uses the `ModalProvider` defaults.
- Updated the hook's dependency array to remove `theme.sheet.sheetBg`.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to a single hook file (`useFoodofferSortingModal.tsx`) and only removes styling overrides and an unused import.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1c972ebc8330859c73a06e3279fa)