### PR TITLE
Remove header/background options from useMyScrollViewModal calls

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -205,14 +205,9 @@ const AccountBalanceScreen = () => {
                                         </View>
                                 ),
                         },
-                        {
-                                backgroundStyle: {
-                                        ...styles.sheetBackground,
-                                        backgroundColor: theme.sheet.sheetBg,
-                                },
-                        }
+                        {}
                 );
-        }, [isActive, showModal, theme.screen.text, theme.sheet.sheetBg, translate]);
+        }, [isActive, showModal, theme.screen.text, translate]);
 
         useEffect(() => {
                 closeInstructionRef.current = closeModal;

--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -38,9 +38,9 @@ const EventsScreen = () => {
 				onClose: () => setSelectedEvent(null),
 				children: <PopupEventSheet closeSheet={handleClose} eventData={event} />,
 			},
-			{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+			{}
 		);
-	}, [handleClose, showScrollViewModal, theme.sheet.sheetBg]);
+	}, [handleClose, showScrollViewModal]);
 
 	const resetSeenEvents = () => {
 		const resetEvents = popupEvents.map((e: any, idx: number) => ({

--- a/apps/frontend/app/app/(app)/experimentell/test-use-modal/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/test-use-modal/index.tsx
@@ -55,7 +55,7 @@ const TestUseModalScreen = () => {
                                         </View>
                                 ),
                         },
-                        { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
+                        {}
                 );
         };
 

--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -150,7 +150,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                                                 onClose: closeScrollViewModal,
                                                 children: <SortSheet closeSheet={closeScrollViewModal} />,
                                         },
-                                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                                        {}
                                 );
                                 return;
                         }
@@ -158,7 +158,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                         setSelectedSheet(sheet);
                         setSheetProps(props);
                 },
-                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+                [closeScrollViewModal, showScrollViewModal, translate]
         );
 
 	const openManagementSheet = (id: string) => {

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -383,9 +383,9 @@ const Settings = () => {
                                         </View>
                                 ),
                         },
-                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg } }
+                        {}
                 );
-        }, [collectibleSizeLabel, collectibleSizeOptions, handleSelectCollectibleSize, showScrollViewModal, theme.sheet.sheetBg, translate]);
+        }, [collectibleSizeLabel, collectibleSizeOptions, handleSelectCollectibleSize, showScrollViewModal, translate]);
 
         const openCollectibleSettingsModal = useCallback(() => {
                 showScrollViewModal(
@@ -434,9 +434,9 @@ const Settings = () => {
                                         </View>
                                 ),
                         },
-                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg } }
+                        {}
                 );
-        }, [collectibleRandomPosition, collectibleSizeLabel, handleResetCollectibles, openCollectibleSizeModal, primaryColor, showScrollViewModal, theme.screen.icon, theme.screen.iconBg, theme.screen.text, theme.sheet.sheetBg, translate, toggleCollectibleRandomPosition]);
+        }, [collectibleRandomPosition, collectibleSizeLabel, handleResetCollectibles, openCollectibleSizeModal, primaryColor, showScrollViewModal, theme.screen.icon, theme.screen.iconBg, theme.screen.text, translate, toggleCollectibleRandomPosition]);
 
         useEffect(() => {
                 collectibleSettingsModalRef.current = openCollectibleSettingsModal;

--- a/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
+++ b/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
@@ -86,7 +86,7 @@ const DropdownInput = ({ id, value, onChange, error, isDisabled, custom_type, op
                                         />
                                 ),
                         },
-                        { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
+                        {}
                 );
         }, [
                 isDisabled,
@@ -101,7 +101,6 @@ const DropdownInput = ({ id, value, onChange, error, isDisabled, custom_type, op
                 prefix,
                 suffix,
                 error,
-                theme.sheet?.sheetBg,
                 translate,
         ]);
 

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -225,10 +225,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                             title: translate(TranslationKeys.ai_generated_image),
                             children: <AIGeneratedHintSheet />,
                           },
-                          {
-                            backgroundStyle: { backgroundColor: theme.sheet.sheetBg },
-                            headerBackgroundColor: theme.sheet.sheetBg,
-                          }
+                          {}
                         )
                       }
                     >

--- a/apps/frontend/app/hooks/useConfirmLogoutModal.tsx
+++ b/apps/frontend/app/hooks/useConfirmLogoutModal.tsx
@@ -52,10 +52,10 @@ const useConfirmLogoutModal = () => {
                                                 </View>
                                         ),
                                 },
-                                { backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+                                {}
                         );
                 },
-                [buttonLabel, close, logout, modalDescription, show, theme.screen.text, theme.sheet.sheetBg, translate]
+                [buttonLabel, close, logout, modalDescription, show, theme.screen.text, translate]
         );
 
         return { openConfirmLogoutModal, closeConfirmLogoutModal: close };

--- a/apps/frontend/app/hooks/useLanguageModal.tsx
+++ b/apps/frontend/app/hooks/useLanguageModal.tsx
@@ -81,9 +81,9 @@ export const useLanguageModal = () => {
                                         </View>
                                 ),
                         },
-                        { backgroundStyle: { backgroundColor: theme.sheet.sheetBg } }
+                        {}
                 );
-        }, [LanguageOption, showScrollViewModal, theme.sheet.sheetBg, translate]);
+        }, [LanguageOption, showScrollViewModal, translate]);
 
         return { openLanguageModal };
 };

--- a/apps/frontend/app/hooks/usePopupEventModal.tsx
+++ b/apps/frontend/app/hooks/usePopupEventModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import PopupEventSheet from '@/components/PopupEventSheet/PopupEventSheet';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
-import { useTheme } from '@/hooks/useTheme';
 import { PopupEventHelper } from '@/helper/PopupEventHelper';
 import { useDispatch, useSelector } from 'react-redux';
 import { SET_POPUP_EVENTS } from '@/redux/Types/types';
@@ -10,7 +9,6 @@ import { RootState } from '@/redux/reducer';
 
 const usePopupEventModal = () => {
 	const dispatch = useDispatch();
-	const { theme } = useTheme();
 	const kioskMode = useKioskMode();
 	const { popupEvents } = useSelector((state: RootState) => state.food);
 	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
@@ -75,11 +73,11 @@ const usePopupEventModal = () => {
 					/>
 				),
 			},
-			{ backgroundStyle: { backgroundColor: theme.sheet.sheetBg }, headerBackgroundColor: theme.sheet.sheetBg }
+			{}
 		);
-		}, [closeEventSheet, closeEventSheetForSession, kioskMode, popupEvents, showScrollViewModal, theme.sheet.sheetBg]);
+	}, [closeEventSheet, closeEventSheetForSession, kioskMode, popupEvents, showScrollViewModal]);
 
-		return { openActiveModal, activePopupEvent: currentPopupEvent, popupEvents };
-	};
+	return { openActiveModal, activePopupEvent: currentPopupEvent, popupEvents };
+};
 
 export default usePopupEventModal;

--- a/apps/frontend/app/hooks/useRateAppModal.tsx
+++ b/apps/frontend/app/hooks/useRateAppModal.tsx
@@ -161,7 +161,7 @@ const useRateAppModal = (buttonColorOverride?: string) => {
                                         </View>
                                 ),
                         },
-                        { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
+                        {}
                 );
         }, [
                 appSettings?.app_stores_url_to_apple,
@@ -173,7 +173,6 @@ const useRateAppModal = (buttonColorOverride?: string) => {
                 show,
                 theme.drawerBg,
                 theme.screen.text,
-                theme.sheet?.sheetBg,
                 translate,
         ]);
 

--- a/apps/frontend/app/hooks/useUtilizationModal.tsx
+++ b/apps/frontend/app/hooks/useUtilizationModal.tsx
@@ -2,13 +2,11 @@ import React, {useCallback} from 'react';
 import ForecastSheet from '@/components/ForecastSheet/ForecastSheet';
 import {useMyScrollViewModal} from '@/components/GlobalModal/useMyScrollViewModal';
 import {useLanguage} from '@/hooks/useLanguage';
-import {useTheme} from '@/hooks/useTheme';
 import {TranslationKeys} from '@/locales/keys';
 import {DatabaseTypes} from 'repo-depkit-common';
 
 export const useUtilizationModal = () => {
         const {show: showScrollViewModal, close: closeScrollViewModal} = useMyScrollViewModal();
-        const {theme} = useTheme();
         const {translate} = useLanguage();
 
         const openUtilizationModal = useCallback(
@@ -24,9 +22,9 @@ export const useUtilizationModal = () => {
                                                 />
                                         ),
                                 },
-                                {backgroundStyle: {backgroundColor: theme.sheet.sheetBg}, headerBackgroundColor: theme.sheet.sheetBg}
+                                {}
                         ),
-                [closeScrollViewModal, showScrollViewModal, theme.sheet.sheetBg, translate]
+                [closeScrollViewModal, showScrollViewModal, translate]
         );
 
         return {openUtilizationModal};


### PR DESCRIPTION
### Motivation
- Calls to `useMyScrollViewModal` were passing explicit `backgroundStyle` and `headerBackgroundColor` option objects as the second parameter, causing duplicated styling and unnecessary coupling to `theme.sheet.sheetBg`.
- The goal is to stop providing these explicit header/background options and instead rely on the modal provider defaults.
- This also enables removing now-unused `theme` references from some hooks and callbacks.

### Description
- Replaced the options argument passed to `showScrollViewModal` with an empty object (`{}`) across screens, hooks and components such as `events`, `settings`, `foodoffers-scroll`, `account-balance`, `DropdownInput`, `FoodItem`, `useRateAppModal`, `useUtilizationModal`, `useLanguageModal`, `usePopupEventModal`, and `useConfirmLogoutModal`.
- Removed `theme.sheet.sheetBg` from effect dependency arrays and removed unused `useTheme` imports where they became unnecessary after the option removal.
- Adjusted callbacks and hook dependency lists to reflect the removed option properties and avoid stale dependencies on sheet background values.
- In total, 12 frontend files were modified to apply the above changes.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c64cbf7188330ae293c2ab17f8ec7)