### PR TITLE
Inline HousingSortSheet into `useHousingSortingModal` and remove standalone files

### DIFF
--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -17,7 +17,6 @@ import { ApartmentsHelper } from '@/redux/actions/Apartments/Apartments';
 import ApartmentItem from '@/components/ApartmentItem/ApartmentItem';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
-import BuildingSortSheet from '@/components/BuildingSortSheet/BuildingSortSheet';
 import useToast from '@/hooks/useToast';
 import { useLanguage } from '@/hooks/useLanguage';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
@@ -31,6 +30,7 @@ import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { RootState } from '@/redux/reducer';
 import { FlashList } from '@shopify/flash-list';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import useHousingSortingModal from '@/hooks/useHousingSortingModal';
 
 const MIN_CARD_WIDTH = 280;
 
@@ -45,7 +45,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const [query, setQuery] = useState<string>('');
 	const [loading, setLoading] = useState(true);
 	const [isActive, setIsActive] = useState(false);
-	const sortSheetRef = useRef<BottomSheet>(null);
 	const imageManagementSheetRef = useRef<BottomSheet>(null);
 
 	const [distanceModalVisible, setDistanceModalVisible] = useState(false);
@@ -64,16 +63,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { apartments, apartmentsLocal, unSortedApartments } = useSelector((state: RootState) => state.apartment);
 
 	const housing_area_color = appSettings?.housing_area_color ? appSettings?.housing_area_color : projectColor;
+	const { openHousingSortingModal } = useHousingSortingModal();
 
 	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
-
-	const openSortSheet = () => {
-		sortSheetRef.current?.expand();
-	};
-
-	const closeSortSheet = () => {
-		sortSheetRef?.current?.close();
-	};
 
 	const openImageManagementSheet = () => {
 		imageManagementSheetRef?.current?.expand();
@@ -486,7 +478,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 							<Tooltip
 								placement="top"
 								trigger={triggerProps => (
-									<TouchableOpacity {...triggerProps} onPress={openSortSheet} style={{ padding: 10 }}>
+									<TouchableOpacity {...triggerProps} onPress={openHousingSortingModal} style={{ padding: 10 }}>
 										<MaterialIcons name="sort" size={24} color={theme.header.text} />
 									</TouchableOpacity>
 								)}
@@ -533,22 +525,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 						/>
 					</View>
 				</View>
-				{isActive && (
-					<BaseBottomSheet
-						ref={sortSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeSortSheet}
-					>
-						<BuildingSortSheet closeSheet={closeSortSheet} freeRooms={true} />
-					</BaseBottomSheet>
-				)}
-
 				{isActive && (
 					<BaseBottomSheet
 						ref={imageManagementSheetRef}

--- a/apps/frontend/app/hooks/useHousingSortingModal.tsx
+++ b/apps/frontend/app/hooks/useHousingSortingModal.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApartmentSortOption } from 'repo-depkit-common';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import SettingsList from '@/components/SettingsList';
+import { RootState } from '@/redux/reducer';
+import { SET_APARTMENTS_SORTING } from '@/redux/Types/types';
+
+const HousingSortSheet: React.FC<{ closeSheet: () => void }> = ({ closeSheet }) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const dispatch = useDispatch();
+	const { apartmentsSortBy, primaryColor: projectColor, appSettings } = useSelector((state: RootState) => state.settings);
+	const [selectedOption, setSelectedOption] = useState<ApartmentSortOption | null>(null);
+	const housing_area_color = appSettings?.housing_area_color ? appSettings?.housing_area_color : projectColor;
+
+	const sortingOptions = [
+		{
+			id: ApartmentSortOption.INTELLIGENT,
+			label: TranslationKeys.sort_option_intelligent,
+			icon: <MaterialCommunityIcons name="brain" size={24} />,
+		},
+		{
+			id: ApartmentSortOption.FREE_ROOMS,
+			label: TranslationKeys.free_rooms,
+			icon: <MaterialCommunityIcons name="door-open" size={24} />,
+		},
+		{
+			id: ApartmentSortOption.DISTANCE,
+			label: TranslationKeys.sort_option_distance,
+			icon: <MaterialCommunityIcons name="map-marker-distance" size={24} />,
+		},
+		{
+			id: ApartmentSortOption.ALPHABETICAL,
+			label: TranslationKeys.sort_option_alphabetical,
+			icon: <MaterialCommunityIcons name="sort-alphabetical-ascending" size={24} />,
+		},
+		{
+			id: ApartmentSortOption.NONE,
+			label: TranslationKeys.sort_option_none,
+			icon: <MaterialCommunityIcons name="sort-variant-remove" size={24} />,
+		},
+	];
+
+	const updateSort = (option: { id: ApartmentSortOption }) => {
+		setSelectedOption(option.id);
+		dispatch({ type: SET_APARTMENTS_SORTING, payload: option.id });
+		closeSheet();
+	};
+
+	useEffect(() => {
+		setSelectedOption(apartmentsSortBy as ApartmentSortOption);
+	}, [apartmentsSortBy]);
+
+	return (
+		<View style={{ width: '100%', gap: 12 }}>
+			<View style={{ width: '100%', paddingHorizontal: 10, marginTop: 12 }}>
+				{sortingOptions.map((option, index) => {
+					const isSelected = selectedOption === option.id;
+					const groupPosition =
+						sortingOptions.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === sortingOptions.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={option.id}
+							label={translate(option.label)}
+							leftIcon={option.icon}
+							iconBgColor={housing_area_color}
+							groupPosition={groupPosition}
+							showSeparator={index !== sortingOptions.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? housing_area_color : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => updateSort(option)}
+						/>
+					);
+				})}
+			</View>
+		</View>
+	);
+};
+
+export const useHousingSortingModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openHousingSortingModal = useCallback(() => {
+		showScrollViewModal({
+			title: translate(TranslationKeys.sort),
+			onClose: closeScrollViewModal,
+			children: <HousingSortSheet closeSheet={closeScrollViewModal} />,
+		});
+	}, [closeScrollViewModal, showScrollViewModal, translate]);
+
+	return { openHousingSortingModal };
+};
+
+export default useHousingSortingModal;


### PR DESCRIPTION
### Motivation
- Consolidate the housing sorting UI into the scroll-view modal hook instead of a separate component as requested by the reviewer.
- Reuse the existing `useMyScrollViewModal` API and keep sorting behavior consistent with the `ApartmentSortOption` enum.
- Reduce indirection and number of component files to simplify maintenance.

### Description
- Removed the standalone `HousingSortSheet` component files and inlined the sheet UI as a local `HousingSortSheet` component inside `useHousingSortingModal.tsx`.
- Added `SettingsList`, `MaterialCommunityIcons`, `ApartmentSortOption` usage and a mapping of sorting options with icons, labels, and selection state, and dispatch `SET_APARTMENTS_SORTING` on selection.
- Updated the Housing screen to call `openHousingSortingModal` from `useHousingSortingModal` and removed the previous `BaseBottomSheet`-based sort sheet and ref handling.
- Added necessary imports (`useTheme`, `useDispatch`, `useSelector`, `RootState`) and local state handling to sync selected sort option from Redux.

### Testing
- No automated tests were executed for this change.
- Manual compile/run was not recorded as an automated test.
- No test failures were reported by automated test suites because none were run.
- Further automated test coverage was not added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6ac2a93083309f10ffdbca587511)