### PR TITLE
Use scroll-view modal for Campus sorting

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -28,7 +28,6 @@ import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import DistanceModal from '@/components/DistanceModal';
 import * as Location from 'expo-location';
-import BuildingSortSheet from '@/components/BuildingSortSheet/BuildingSortSheet';
 import useToast from '@/hooks/useToast';
 import { useLanguage } from '@/hooks/useLanguage';
 import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
@@ -36,6 +35,7 @@ import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
+import useCampusSortingModal from '@/hooks/useCampusSortingModal';
 
 import IconButton from '@/components/UI/IconButton';
 import Button from '@/components/UI/Button';
@@ -69,12 +69,10 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 	const selectedCanteen = useSelectedCanteen();
 	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
 
-	const sortSheetRef = useRef<BottomSheet>(null);
 	const imageManagementSheetRef = useRef<BottomSheet>(null);
 	const [distanceModalVisible, setDistanceModalVisible] = useState(false);
+	const { openCampusSortingModal } = useCampusSortingModal();
 
-	const openSortSheet = useCallback(() => sortSheetRef.current?.expand(), []);
-	const closeSortSheet = useCallback(() => sortSheetRef.current?.close(), []);
 	const openImageManagementSheet = useCallback(() => imageManagementSheetRef.current?.expand(), []);
 	const closeImageManagementSheet = useCallback(() => imageManagementSheetRef.current?.close(), []);
 	const openDistanceSheet = useCallback(() => setDistanceModalVisible(true), []);
@@ -374,7 +372,7 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 							<Tooltip
 								placement="top"
 								trigger={triggerProps => (
-									<IconButton {...triggerProps} onPress={openSortSheet} style={{ padding: 10 }}>
+									<IconButton {...triggerProps} onPress={openCampusSortingModal} style={{ padding: 10 }}>
 										<MaterialIcons name="sort" size={24} color={theme.header.text} />
 									</IconButton>
 								)}
@@ -421,11 +419,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 						/>
 					</View>
 				</View>
-
-
-				<BaseBottomSheet ref={sortSheetRef} index={-1} backgroundStyle={{ ...styles.sheetBackground }} enablePanDownToClose handleComponent={null} onClose={closeSortSheet}>
-					<BuildingSortSheet closeSheet={closeSortSheet} freeRooms={false} />
-				</BaseBottomSheet>
 
 				<BaseBottomSheet
 					ref={imageManagementSheetRef}

--- a/apps/frontend/app/hooks/useCampusSortingModal.tsx
+++ b/apps/frontend/app/hooks/useCampusSortingModal.tsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { CampusSortOption } from 'repo-depkit-common';
+import { FontAwesome5, MaterialCommunityIcons } from '@expo/vector-icons';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import SettingsList from '@/components/SettingsList';
+import { RootState } from '@/redux/reducer';
+import { SET_CAMPUSES_SORTING } from '@/redux/Types/types';
+
+const CampusSortSheet: React.FC<{ closeSheet: () => void }> = ({ closeSheet }) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const dispatch = useDispatch();
+	const { campusesSortBy, primaryColor: projectColor, appSettings } = useSelector((state: RootState) => state.settings);
+	const [selectedOption, setSelectedOption] = useState<CampusSortOption | null>(null);
+	const campus_area_color = appSettings?.campus_area_color ? appSettings?.campus_area_color : projectColor;
+
+	const sortingOptions = [
+		{
+			id: CampusSortOption.INTELLIGENT,
+			label: TranslationKeys.sort_option_intelligent,
+			icon: <MaterialCommunityIcons name="brain" size={24} />,
+		},
+		{
+			id: CampusSortOption.DISTANCE,
+			label: TranslationKeys.sort_option_distance,
+			icon: <MaterialCommunityIcons name="map-marker-distance" size={24} />,
+		},
+		{
+			id: CampusSortOption.ALPHABETICAL,
+			label: TranslationKeys.sort_option_alphabetical,
+			icon: <FontAwesome5 name="sort-alpha-down" size={24} />,
+		},
+		{
+			id: CampusSortOption.NONE,
+			label: TranslationKeys.sort_option_none,
+			icon: <MaterialCommunityIcons name="sort-variant-remove" size={24} />,
+		},
+	];
+
+	const updateSort = (option: { id: CampusSortOption }) => {
+		setSelectedOption(option.id);
+		dispatch({ type: SET_CAMPUSES_SORTING, payload: option.id });
+		closeSheet();
+	};
+
+	useEffect(() => {
+		setSelectedOption(campusesSortBy as CampusSortOption);
+	}, [campusesSortBy]);
+
+	return (
+		<View style={{ width: '100%', gap: 12 }}>
+			<View style={{ width: '100%', paddingHorizontal: 10, marginTop: 12 }}>
+				{sortingOptions.map((option, index) => {
+					const isSelected = selectedOption === option.id;
+					const groupPosition =
+						sortingOptions.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === sortingOptions.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={option.id}
+							label={translate(option.label)}
+							leftIcon={option.icon}
+							iconBgColor={campus_area_color}
+							groupPosition={groupPosition}
+							showSeparator={index !== sortingOptions.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? campus_area_color : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => updateSort(option)}
+						/>
+					);
+				})}
+			</View>
+		</View>
+	);
+};
+
+export const useCampusSortingModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openCampusSortingModal = useCallback(() => {
+		showScrollViewModal({
+			title: translate(TranslationKeys.sort),
+			onClose: closeScrollViewModal,
+			children: <CampusSortSheet closeSheet={closeScrollViewModal} />,
+		});
+	}, [closeScrollViewModal, showScrollViewModal, translate]);
+
+	return { openCampusSortingModal };
+};
+
+export default useCampusSortingModal;


### PR DESCRIPTION
### Motivation
- Align Campus sorting UX with Housing/Foodoffers by switching from a bottom sheet to the scroll-view modal pattern.
- Keep sorting UI inline within a hook so the modal content is rendered the same way as the existing housing hook.
- Remove the dedicated Campus `BaseBottomSheet` usage to simplify screen logic and reuse the global modal system.
- Ensure the modal uses the same translation key `TranslationKeys.sort` and `useMyScrollViewModal` configuration as other lists.

### Description
- Added a new hook `useCampusSortingModal.tsx` under `apps/frontend/app/hooks/` that implements an inline `CampusSortSheet` and exposes `openCampusSortingModal`.
- `CampusSortSheet` renders the campus sorting options (INTELLIGENT, DISTANCE, ALPHABETICAL, NONE) using `SettingsList`, icons from `@expo/vector-icons`, and dispatches `SET_CAMPUSES_SORTING` when an option is selected.
- Replaced the sort action in the Campus screen (`apps/frontend/app/app/(app)/campus/index.tsx`) to call `openCampusSortingModal` and removed the `sortSheetRef` and the `BaseBottomSheet`-backed `BuildingSortSheet` for campus sorting.
- The modal is opened via `useMyScrollViewModal` and configured with `title: translate(TranslationKeys.sort)` and `onClose` pointing to the modal close handler.

### Testing
- No automated tests were executed for this change in this environment.
- Type checking or build was not run as part of this rollout.
- Manual runtime verification was not performed in this environment.
- CI/test status is unknown and should be validated in the project's pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cf41e44e0833095b528d63e326435)