### PR TITLE
Refactor settings: move menu position, card columns and first day to scroll-view modal hooks

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -10,21 +10,18 @@ import SettingsList from '@/components/SettingsList';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import SettingsListNickname from '@/components/SettingsListNickname';
-import DrawerPositionSheet from '@/components/DrawerPositionSheet/DrawerPositionSheet';
 import { router, useFocusEffect } from 'expo-router';
 import { ConfigCustomerEnum, getCustomerEnumForConfig, type CustomerConfig, getVersionInternalForAppsettingsScreen } from '@/config';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { useLanguage } from '@/hooks/useLanguage';
 import useCustomerServerUrl from '@/hooks/useCustomerServerUrl';
-import { RESET_ALL_COLLECTIBLE_EVENT_DICTS, SET_AMOUNT_COLUMNS_FOR_CARDS, SET_COLLECTIBLE_ITEM_SIZE, SET_COLLECTIBLE_RANDOM_POSITION, SET_DEBUG_MODE, SET_DRAWER_POSITION, SET_FIRST_DAY_OF_THE_WEEK, SET_FOODOFFERS_NEXT_DAY_THRESHOLD, SET_NICKNAME_LOCAL, SET_SELECTED_CUSTOMER, SET_SIMULATE_EXPO_UPDATE_AVAILABLE, SET_USE_WEBP_FOR_ASSETS, UPDATE_DEVELOPER_MODE, UPDATE_MANAGEMENT, UPDATE_PROFILE } from '@/redux/Types/types';
+import { RESET_ALL_COLLECTIBLE_EVENT_DICTS, SET_COLLECTIBLE_ITEM_SIZE, SET_COLLECTIBLE_RANDOM_POSITION, SET_DEBUG_MODE, SET_FOODOFFERS_NEXT_DAY_THRESHOLD, SET_NICKNAME_LOCAL, SET_SELECTED_CUSTOMER, SET_SIMULATE_EXPO_UPDATE_AVAILABLE, SET_USE_WEBP_FOR_ASSETS, UPDATE_DEVELOPER_MODE, UPDATE_MANAGEMENT, UPDATE_PROFILE } from '@/redux/Types/types';
 import { performLogout } from '@/helper/logoutHelper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import CanteenSelectionSheet from '@/components/CanteenSelectionSheet/CanteenSelectionSheet';
-import AmountColumnSheet from '@/components/AmountColumnSheet/AmountColumnSheet';
-import FirstDaySheet from '@/components/FirstDaySheet/FirstDaySheet';
 import FoodOffersNextDayTimeSheet from '@/components/FoodOffersNextDayTimeSheet';
 import { excerpt, formatPrice, getImageUrl, showFormatedPrice } from '@/constants/HelperFunctions';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
@@ -47,6 +44,9 @@ import useCustomerConfig from '@/hooks/useCustomerConfig';
 import useCustomerConfigModal from '@/hooks/useCustomerConfigModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import useThemeSettingsModal from '@/hooks/useThemeSettingsModal';
+import useMenuPositionModal from '@/hooks/useMenuPositionModal';
+import useCardColumnsModal from '@/hooks/useCardColumnsModal';
+import useFirstDayOfWeekModal from '@/hooks/useFirstDayOfWeekModal';
 import { FoodSortOption } from 'repo-depkit-common';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
@@ -59,9 +59,6 @@ const Settings = () => {
         const canteenSheetRef = useRef<BottomSheet>(null);
         const [isActive, setIsActive] = useState(false);
         const { translate, language } = useLanguage();
-        const drawerSheetRef = useRef<BottomSheet>(null);
-        const amountColumnSheetRef = useRef<BottomSheet>(null);
-        const firstDaySheetRef = useRef<BottomSheet>(null);
         const foodOffersTimeSheetRef = useRef<BottomSheet>(null);
         const collectibleSettingsModalRef = useRef<() => void>(() => {});
         const isOpeningNestedCollectibleModal = useRef(false);
@@ -74,6 +71,9 @@ const Settings = () => {
         const { openLanguageModal } = useLanguageModal();
         const { openFoodofferSortingModal } = useFoodofferSortingModal();
         const { openThemeSettingsModal } = useThemeSettingsModal();
+        const { openMenuPositionModal } = useMenuPositionModal();
+        const { openCardColumnsModal } = useCardColumnsModal();
+        const { openFirstDayOfWeekModal } = useFirstDayOfWeekModal();
 
         const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, simulateExpoUpdateAvailable, collectibleItemSize, collectibleRandomPosition, selectedCustomer, sortBy } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
@@ -206,29 +206,6 @@ const Settings = () => {
                 });
         }, [handleTheme, openThemeSettingsModal, selectedTheme]);
 
-	const openDrawerSheet = () => {
-		drawerSheetRef?.current?.expand();
-	};
-
-	const closeDrawerSheet = () => {
-		drawerSheetRef?.current?.close();
-	};
-
-	const openAmountColumnModal = () => {
-		amountColumnSheetRef?.current?.expand();
-	};
-
-	const closeAmountColumnModal = () => {
-		amountColumnSheetRef?.current?.close();
-	};
-
-	const openFirstDayModal = () => {
-		firstDaySheetRef?.current?.expand();
-	};
-
-	const closeFirstDayModal = () => {
-		firstDaySheetRef?.current?.close();
-	};
         const openFoodOffersTimeSheet = () => {
                 foodOffersTimeSheetRef?.current?.expand();
         };
@@ -306,14 +283,6 @@ const Settings = () => {
         const handleCheckForUpdates = () => {
                 manualCheck();
         };
-
-	const handleDrawerPosition = (position: string) => {
-		dispatch({
-			type: SET_DRAWER_POSITION,
-			payload: position,
-		});
-		closeDrawerSheet();
-	};
 
 	const handleTheme = (theme: any) => {
 		setThemeMode(theme);
@@ -493,9 +462,9 @@ const Settings = () => {
 					{/* color Scheme */}
 					<View style={{ gap: 0 }}>
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="theme-light-dark" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.color_scheme)} value={selectedTheme === 'systematic' ? translate(TranslationKeys.color_scheme_system) : selectedTheme === 'dark' ? translate(TranslationKeys.color_scheme_dark) : translate(TranslationKeys.color_scheme_light)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openColorSchemeSheet()} groupPosition="top" />
-                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="menu" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.drawer_config_position)} value={drawerPosition === 'left' ? translate(TranslationKeys.drawer_config_position_left) : drawerPosition === 'right' ? translate(TranslationKeys.drawer_config_position_right) : translate(TranslationKeys.drawer_config_position_system)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openDrawerSheet()} groupPosition="middle" />
-                                                <SettingsList iconBgColor={primaryColor} leftIcon={<FontAwesome5 name="columns" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.amount_columns_for_cards)} value={amountColumnsForcard === 0 ? translate(TranslationKeys.automatic) : amountColumnsForcard} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openAmountColumnModal()} groupPosition="middle" />
-                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Feather name="calendar" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.first_day_of_week)} value={translate(firstDayOfTheWeek?.name)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openFirstDayModal()} groupPosition="bottom" />
+                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="menu" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.drawer_config_position)} value={drawerPosition === 'left' ? translate(TranslationKeys.drawer_config_position_left) : drawerPosition === 'right' ? translate(TranslationKeys.drawer_config_position_right) : translate(TranslationKeys.drawer_config_position_system)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openMenuPositionModal} groupPosition="middle" />
+                                                <SettingsList iconBgColor={primaryColor} leftIcon={<FontAwesome5 name="columns" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.amount_columns_for_cards)} value={amountColumnsForcard === 0 ? translate(TranslationKeys.automatic) : amountColumnsForcard} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openCardColumnsModal} groupPosition="middle" />
+                                                <SettingsList iconBgColor={primaryColor} leftIcon={<Feather name="calendar" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.first_day_of_week)} value={translate(firstDayOfTheWeek?.name)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFirstDayOfWeekModal} groupPosition="bottom" />
                                         </View>
 					<SettingsGroupTitle>{translate(TranslationKeys.group_app_management)}</SettingsGroupTitle>
 					<View style={{ gap: 0 }}>
@@ -616,69 +585,6 @@ const Settings = () => {
                                         >
                                                 <CanteenSelectionSheet closeSheet={closeCanteenSheet} />
                                         </BaseBottomSheet>
-					<BaseBottomSheet
-						ref={amountColumnSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeAmountColumnModal}
-					>
-						<AmountColumnSheet
-							closeSheet={closeAmountColumnModal}
-							selectedAmount={amountColumnsForcard}
-							onSelect={val => {
-								dispatch({
-									type: SET_AMOUNT_COLUMNS_FOR_CARDS,
-									payload: val,
-								});
-							}}
-						/>
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={firstDaySheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeFirstDayModal}
-					>
-						<FirstDaySheet
-							closeSheet={closeFirstDayModal}
-							selectedDay={firstDayOfTheWeek?.name}
-							onSelect={day => {
-								dispatch({
-									type: SET_FIRST_DAY_OF_THE_WEEK,
-									payload: day,
-								});
-							}}
-						/>
-					</BaseBottomSheet>
-					<BaseBottomSheet
-						ref={drawerSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						handleComponent={null}
-						onClose={closeDrawerSheet}
-					>
-						<DrawerPositionSheet
-							closeSheet={closeDrawerSheet}
-							selectedPosition={drawerPosition}
-							onSelect={position => {
-								handleDrawerPosition(position);
-							}}
-						/>
-					</BaseBottomSheet>
                                         <BaseBottomSheet
                                                 ref={foodOffersTimeSheetRef}
                                                 index={-1}

--- a/apps/frontend/app/hooks/useCardColumnsModal.tsx
+++ b/apps/frontend/app/hooks/useCardColumnsModal.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import SettingsList from '@/components/SettingsList';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import { AmountColumn } from '@/constants/SettingData';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+import { SET_AMOUNT_COLUMNS_FOR_CARDS } from '@/redux/Types/types';
+import { CollectibleAt } from 'repo-depkit-common';
+
+const CardColumnsSheet: React.FC<{ closeSheet: () => void }> = ({ closeSheet }) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const dispatch = useDispatch();
+	const { amountColumnsForcard, primaryColor } = useSelector((state: RootState) => state.settings);
+	const [selectedOption, setSelectedOption] = useState<number | null>(null);
+
+	const updateColumns = (value: number) => {
+		setSelectedOption(value);
+		dispatch({ type: SET_AMOUNT_COLUMNS_FOR_CARDS, payload: value });
+		closeSheet();
+	};
+
+	useEffect(() => {
+		setSelectedOption(amountColumnsForcard);
+	}, [amountColumnsForcard]);
+
+	return (
+		<View style={{ width: '100%', gap: 12 }}>
+			<View style={{ width: '100%', paddingHorizontal: 10, marginTop: 12 }}>
+				{AmountColumn.map((column, index) => {
+					const isSelected = selectedOption === column.id;
+					const groupPosition =
+						AmountColumn.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === AmountColumn.length - 1
+									? 'bottom'
+									: 'middle';
+					const label = column.id === 0 ? translate(TranslationKeys.automatic) : column.name;
+
+					return (
+						<SettingsList
+							key={column.id}
+							label={label}
+							noIconIndent
+							groupPosition={groupPosition}
+							showSeparator={index !== AmountColumn.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => updateColumns(column.id)}
+						/>
+					);
+				})}
+			</View>
+			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_amount_column} />
+		</View>
+	);
+};
+
+export const useCardColumnsModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openCardColumnsModal = useCallback(() => {
+		showScrollViewModal({
+			title: translate(TranslationKeys.amount_columns_for_cards),
+			onClose: closeScrollViewModal,
+			children: <CardColumnsSheet closeSheet={closeScrollViewModal} />,
+		});
+	}, [closeScrollViewModal, showScrollViewModal, translate]);
+
+	return { openCardColumnsModal };
+};
+
+export default useCardColumnsModal;

--- a/apps/frontend/app/hooks/useFirstDayOfWeekModal.tsx
+++ b/apps/frontend/app/hooks/useFirstDayOfWeekModal.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import SettingsList from '@/components/SettingsList';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import { days } from '@/constants/SettingData';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+import { SET_FIRST_DAY_OF_THE_WEEK } from '@/redux/Types/types';
+import { CollectibleAt } from 'repo-depkit-common';
+
+const FirstDayOfWeekSheet: React.FC<{ closeSheet: () => void }> = ({ closeSheet }) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const dispatch = useDispatch();
+	const { firstDayOfTheWeek, primaryColor } = useSelector((state: RootState) => state.settings);
+	const [selectedOption, setSelectedOption] = useState<string | null>(null);
+
+	const updateFirstDay = (day: { id: string; name: string }) => {
+		setSelectedOption(day.name);
+		dispatch({ type: SET_FIRST_DAY_OF_THE_WEEK, payload: day });
+		closeSheet();
+	};
+
+	useEffect(() => {
+		setSelectedOption(firstDayOfTheWeek?.name);
+	}, [firstDayOfTheWeek]);
+
+	return (
+		<View style={{ width: '100%', gap: 12 }}>
+			<View style={{ width: '100%', paddingHorizontal: 10, marginTop: 12 }}>
+				{days.map((day, index) => {
+					const isSelected = selectedOption === day.name;
+					const groupPosition =
+						days.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === days.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={day.id}
+							label={translate(day.name)}
+							noIconIndent
+							groupPosition={groupPosition}
+							showSeparator={index !== days.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => updateFirstDay({ id: day.id, name: day.name })}
+						/>
+					);
+				})}
+			</View>
+			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_first_day_of_week} />
+		</View>
+	);
+};
+
+export const useFirstDayOfWeekModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openFirstDayOfWeekModal = useCallback(() => {
+		showScrollViewModal({
+			title: translate(TranslationKeys.first_day_of_week),
+			onClose: closeScrollViewModal,
+			children: <FirstDayOfWeekSheet closeSheet={closeScrollViewModal} />,
+		});
+	}, [closeScrollViewModal, showScrollViewModal, translate]);
+
+	return { openFirstDayOfWeekModal };
+};
+
+export default useFirstDayOfWeekModal;

--- a/apps/frontend/app/hooks/useMenuPositionModal.tsx
+++ b/apps/frontend/app/hooks/useMenuPositionModal.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import SettingsList from '@/components/SettingsList';
+import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import { drawers } from '@/constants/SettingData';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+import { SET_DRAWER_POSITION } from '@/redux/Types/types';
+import { CollectibleAt } from 'repo-depkit-common';
+
+const MenuPositionSheet: React.FC<{ closeSheet: () => void }> = ({ closeSheet }) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const dispatch = useDispatch();
+	const { drawerPosition, primaryColor } = useSelector((state: RootState) => state.settings);
+	const [selectedOption, setSelectedOption] = useState<string | null>(null);
+
+	const updatePosition = (position: string) => {
+		setSelectedOption(position);
+		dispatch({ type: SET_DRAWER_POSITION, payload: position });
+		closeSheet();
+	};
+
+	useEffect(() => {
+		setSelectedOption(drawerPosition);
+	}, [drawerPosition]);
+
+	return (
+		<View style={{ width: '100%', gap: 12 }}>
+			<View style={{ width: '100%', paddingHorizontal: 10, marginTop: 12 }}>
+				{drawers.map((drawer, index) => {
+					const isSelected = selectedOption === drawer.id;
+					const groupPosition =
+						drawers.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === drawers.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={drawer.id}
+							label={translate(drawer.name)}
+							leftIcon={<MaterialCommunityIcons name={drawer.icon} size={24} />}
+							iconBgColor={primaryColor}
+							groupPosition={groupPosition}
+							showSeparator={index !== drawers.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => updatePosition(drawer.id)}
+						/>
+					);
+				})}
+			</View>
+			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_settings_menuposition} />
+		</View>
+	);
+};
+
+export const useMenuPositionModal = () => {
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openMenuPositionModal = useCallback(() => {
+		showScrollViewModal({
+			title: translate(TranslationKeys.drawer_config_position),
+			onClose: closeScrollViewModal,
+			children: <MenuPositionSheet closeSheet={closeScrollViewModal} />,
+		});
+	}, [closeScrollViewModal, showScrollViewModal, translate]);
+
+	return { openMenuPositionModal };
+};
+
+export default useMenuPositionModal;


### PR DESCRIPTION
### Motivation
- Migrate three settings (menu position, card columns, first day of week) from `BaseBottomSheet` implementations to the existing Scroll-View modal pattern used by other settings.
- Render each dialog inline inside a hook to centralize open/close behavior and reuse `useMyScrollViewModal` configuration.
- Keep UI parity with the previous implementation (icons, labels, options and collectible spots) while wiring selection to the correct Redux actions.
- Remove BottomSheet refs / components for these three settings from the settings screen to simplify the component tree.

### Description
- Added three hooks with inline sheets: `apps/frontend/app/hooks/useMenuPositionModal.tsx`, `useCardColumnsModal.tsx`, and `useFirstDayOfWeekModal.tsx`, each rendering a local sheet using `SettingsList` and dispatching the correct Redux action (`SET_DRAWER_POSITION`, `SET_AMOUNT_COLUMNS_FOR_CARDS`, `SET_FIRST_DAY_OF_THE_WEEK`).
- Updated the settings screen `apps/frontend/app/app/(app)/settings/index.tsx` to import and call `openMenuPositionModal`, `openCardColumnsModal`, and `openFirstDayOfWeekModal` instead of using BottomSheet refs and separate sheet components.
- Removed the now-unused BottomSheet instances and open/close helpers for these three options, and preserved `CollectibleSpot` usage inside the new modal sheets.
- Kept translation keys, icons, and option values consistent with the existing `SettingData` constants and the previous sheet components.

### Testing
- No automated tests were executed against this change set.
- Code changes were compiled and committed locally as part of the change (no CI run included here).
- Manual runtime verification is expected to ensure the `useMyScrollViewModal` behavior (open/close, selection updates, scroll/touch) matches the existing pattern, but was not performed automatically.
- Linting/typecheck steps were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d011a78c083308213b7e3ee1fd7d4)