### PR TITLE
Add `usePermissionModal` hook and wire FoodItem quick-rating to it

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import { Linking, Text, TouchableOpacity, View, Image } from 'react-native';
 import MyImage from '@/components/MyImage';
 import styles from './styles';
@@ -11,7 +11,6 @@ import { getTextFromTranslation } from '@/helper/resourceHelper';
 import { DatabaseTypes, RatingHelper } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import { SET_MARKING_DETAILS, SET_SELECTED_FOOD_MARKINGS } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
 import { router } from 'expo-router';
 import { createSelector } from 'reselect';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -24,6 +23,7 @@ import CardWithText from '../CardWithText/CardWithText';
 import useFoodCard from '@/hooks/useFoodCard';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import AIGeneratedHintSheet from '../AIGeneratedHintSheet';
+import usePermissionModal from '@/hooks/usePermissionModal';
 
 
 const selectFoodState = (state: RootState) => state.food;
@@ -40,7 +40,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
     const { translate } = useLanguage();
     const { show: showScrollViewModal } = useMyScrollViewModal();
 
-    const [warning, setWarning] = useState(false);
+    const { openPermissionModal, permissionModal, setPermissionModalVisible } = usePermissionModal();
 
     const { food } = item;
     const foodItem = food as DatabaseTypes.Foods;
@@ -123,11 +123,11 @@ const FoodItem: React.FC<FoodItemProps> = memo(
             canteenId: canteen?.id,
             previousFeedback,
             dispatch,
-            setWarning,
+            setWarning: setPermissionModalVisible,
           });
         } catch (err) {
           if ((err as any).status === 403) {
-            setWarning(true);
+            openPermissionModal();
           } else {
             console.error('Failed to update rating:', err);
             toast('Could not update rating', 'error');
@@ -291,7 +291,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
           </TooltipContent>
         </Tooltip>
 
-        <PermissionModal isVisible={warning} setIsVisible={setWarning} />
+        {permissionModal}
       </>
     );
   },

--- a/apps/frontend/app/hooks/usePermissionModal.tsx
+++ b/apps/frontend/app/hooks/usePermissionModal.tsx
@@ -1,0 +1,30 @@
+import React, { useCallback, useMemo, useState } from 'react';
+
+import PermissionModal from '@/components/PermissionModal/PermissionModal';
+
+export const usePermissionModal = () => {
+	const [isPermissionModalVisible, setPermissionModalVisible] = useState(false);
+
+	const openPermissionModal = useCallback(() => {
+		setPermissionModalVisible(true);
+	}, []);
+
+	const closePermissionModal = useCallback(() => {
+		setPermissionModalVisible(false);
+	}, []);
+
+	const permissionModal = useMemo(
+		() => <PermissionModal isVisible={isPermissionModalVisible} setIsVisible={setPermissionModalVisible} />,
+		[isPermissionModalVisible]
+	);
+
+	return {
+		closePermissionModal,
+		isPermissionModalVisible,
+		openPermissionModal,
+		permissionModal,
+		setPermissionModalVisible,
+	};
+};
+
+export default usePermissionModal;


### PR DESCRIPTION
### Motivation
- Centralize and reuse the permission modal state/rendering instead of local state in multiple components.  
- Allow quick-rating flows to open a shared permission modal on 403 responses like the existing foodoffers pattern.  
- Keep UI behavior consistent with other scroll-view modals by managing visibility via a hook.  

### Description
- Added a new hook `usePermissionModal` in `apps/frontend/app/hooks/usePermissionModal.tsx` to manage `PermissionModal` visibility and provide `openPermissionModal`/`setPermissionModalVisible`.  
- Replaced the local `warning` state in `apps/frontend/app/components/FoodItem/FoodItem.tsx` with the new hook and render the modal via the hook's `permissionModal`.  
- Wired the quick-rating path to call `openPermissionModal()` on 403 responses and pass `setPermissionModalVisible` into `handleFoodRating` as the `setWarning` callback.  

### Testing
- No automated tests were run for this change.  
- Changes were committed locally and build/run verification was not requested or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d1c20723c83308dd509d09cb13bd7)