### PR TITLE
Close rating modal before login action and remove skip option

### DIFF
--- a/apps/frontend/app/hooks/useRatingPermissionModal.tsx
+++ b/apps/frontend/app/hooks/useRatingPermissionModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { useRouter } from 'expo-router';
 
@@ -19,7 +19,6 @@ const useRatingPermissionModal = () => {
 
 	const openRatingPermissionModal = useCallback(() => {
 		const handleLogin = () => {
-			close();
 			void performLogout(dispatch, router);
 		};
 
@@ -33,14 +32,12 @@ const useRatingPermissionModal = () => {
 					</Text>
 					<ProjectButton
 						text={`${translate(TranslationKeys.sign_in)} / ${translate(TranslationKeys.create_account)}`}
-						onPress={handleLogin}
+						onPress={() => {
+							close();
+							handleLogin();
+						}}
 						style={{ marginVertical: 0 }}
 					/>
-					<TouchableOpacity onPress={close} style={{ alignSelf: 'center', paddingVertical: 6 }}>
-						<Text style={{ color: theme.sheet.text }}>
-							{translate(TranslationKeys.continue_without_rating)}
-						</Text>
-					</TouchableOpacity>
 				</View>
 			),
 		});


### PR DESCRIPTION
### Motivation
- Ensure the rating modal is closed before starting the logout/login flow to avoid UI/navigation issues.
- Prevent users from bypassing account requirement when attempting to rate by removing the "continue without rating" option.

### Description
- Call `close()` before triggering the login/logout flow by wrapping the `onPress` handler to call `close()` and then `handleLogin()`.
- Keep `handleLogin()` focused on invoking `performLogout(dispatch, router)` without closing the modal itself.
- Remove the `TouchableOpacity` skip action UI and the now-unused `TouchableOpacity` import from `react-native` in `apps/frontend/app/hooks/useRatingPermissionModal.tsx`.

### Testing
- No automated tests were executed for this change.
- No CI or unit test runs were performed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d8bdaa0d8833088271ea3374e33c5)