### PR TITLE
Refactor PermissionModal to use shared `useLogout` hook and memoize handlers

### DIFF
--- a/apps/frontend/app/components/PermissionModal/PermissionModal.tsx
+++ b/apps/frontend/app/components/PermissionModal/PermissionModal.tsx
@@ -1,36 +1,34 @@
 import { Dimensions, Text, TouchableOpacity } from 'react-native';
-import React from 'react';
+import React, { useCallback } from 'react';
 import BaseModal from '@/components/BaseModal';
 import { styles } from './styles';
 import { PermissionModalProps } from './types';
-import { useRouter } from 'expo-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { RootState } from '@/redux/reducer';
-import { performLogout } from '@/helper/logoutHelper';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import useLogout from '@/hooks/useLogout';
 
 const PermissionModal: React.FC<PermissionModalProps> = ({ isVisible, setIsVisible }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
-	const router = useRouter();
-	const dispatch = useDispatch();
 	const { close: closeScrollViewModal } = useMyScrollViewModal();
+	const logout = useLogout();
 
-	const handleClose = () => {
+	const handleClose = useCallback(() => {
 		closeScrollViewModal();
 		setIsVisible(false);
-	};
+	}, [closeScrollViewModal, setIsVisible]);
 
-	const handleLogout = () => {
+	const handleLogout = useCallback(async () => {
 		handleClose();
-		performLogout(dispatch, router);
-	};
+		await logout();
+	}, [handleClose, logout]);
 
 	return (
 		<BaseModal isVisible={isVisible} title={translate(TranslationKeys.access_limited)} onClose={handleClose}>


### PR DESCRIPTION
### Motivation
- Ensure the permission modal closes reliably before performing logout/navigation to avoid race conditions with routing.
- Reuse the centralized logout logic to keep logout behavior consistent across different logout UI flows.
- Reduce unnecessary re-renders and keep handlers stable by memoizing callback functions.

### Description
- Replaced direct `performLogout`/`useDispatch`/`useRouter` usage with the shared `useLogout` hook and removed unused imports.
- Wrapped `handleClose` and `handleLogout` in `useCallback` to memoize handlers and match the confirm-logout modal behavior.
- Made `handleLogout` `async`, calling `handleClose()` first and then `await logout()` to ensure the modal dismisses before logout/navigation.
- Adjusted imports to include `useCallback` and `useLogout` and removed `performLogout`, `useRouter`, and `useDispatch` references.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694daaf1675883308a98df41864dc1cf)