### PR TITLE
Fix modal close guard in GlobalModal provider

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -35,7 +35,6 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const { theme } = useTheme();
         let screenBackgroundColor = headerBackgroundColor || theme.screen.background;
 
-        const [isVisible, setIsVisible] = useState(false);
         const [debug, setDebug] = useState<ModalContextType['debug']>({
                 lastAction: null,
                 contentSet: false,
@@ -64,7 +63,6 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 const resolvedHeaderBackgroundColor =
                         options?.headerBackgroundColor ?? resolvedBackgroundStyle?.backgroundColor ?? undefined;
                 setHeaderBackgroundColor(resolvedHeaderBackgroundColor);
-                setIsVisible(true);
                 setDebug(prev => ({
                         ...prev,
                         lastAction: 'open',
@@ -76,7 +74,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         };
 
         const close = () => {
-                if (!isVisible) return;
+                if (!content) return;
 
                 sheetRef.current?.close?.();
                 setBackgroundStyle(null);
@@ -85,7 +83,6 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
                 clearCloseTimeout();
                 closeTimeoutRef.current = setTimeout(() => {
                         setContent(null);
-                        setIsVisible(false);
                         clearCloseTimeout();
                 }, 200);
                 setDebug(prev => ({


### PR DESCRIPTION
### Motivation
- The global modal sometimes failed to close when `close` was called due to a stale `isVisible` guard.
- The visibility was tracked separately from `content`, causing mismatches between actual modal presence and the guard condition. 
- Closing should be allowed when modal `content` exists and the sheet ref can be instructed to close.

### Description
- Removed the unused `isVisible` state from `apps/frontend/app/components/GlobalModal/ModalProvider.tsx`.
- Changed the close guard from `if (!isVisible) return;` to `if (!content) return;` so closure is based on actual modal content.
- Removed the `setIsVisible(true)` and `setIsVisible(false)` updates during `open` and the close timeout.
- Kept the existing behavior to call `sheetRef.current?.close?.()` and to clear modal `content` after the timeout.

### Testing
- No automated tests were executed as part of this change.
- Recommend running the app and exercising modal open/close flows to verify the fix and adding a unit or integration test for the modal provider in a follow-up change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db6d69fd08330981a3cd647a7e32a)