### PR TITLE
Fix scroll view modal close handling

### DIFF
--- a/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
+++ b/apps/frontend/app/components/GlobalModal/ModalProvider.tsx
@@ -26,6 +26,7 @@ const ModalContext = createContext<ModalContextType | null>(null);
 
 export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
         const [content, setContent] = useState<ReactNode | null>(null);
+        const contentRef = useRef<ReactNode | null>(null);
         const [backgroundStyle, setBackgroundStyle] = useState<any>(null);
         // overlay shown over the app (should usually be semi-transparent) - separate from sheet background
         const [overlayStyle, setOverlayStyle] = useState<any>(null);
@@ -56,6 +57,7 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const open = (c: ReactNode, options?: ModalOptions) => {
                 clearCloseTimeout();
 
+                contentRef.current = c;
                 setContent(c);
                 const resolvedBackgroundStyle = options?.backgroundStyle ?? null;
                 setBackgroundStyle(resolvedBackgroundStyle);
@@ -74,8 +76,9 @@ export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         };
 
         const close = () => {
-                if (!content) return;
+                if (!contentRef.current) return;
 
+                contentRef.current = null;
                 sheetRef.current?.close?.();
                 setBackgroundStyle(null);
                 setOverlayStyle(null);


### PR DESCRIPTION
### Motivation
- The ScrollView-style bottom sheet modals could not always be closed when the close callback was invoked from inside the rendered modal content due to a stale content reference. 
- The goal is to make `close` robust when called from modal children (e.g. the experimental Events modal) so the sheet reliably dismisses.

### Description
- Track the currently open modal content in a ref by adding `contentRef` to `ModalProvider` and set it in `open` using `contentRef.current = c`.
- Guard `close` against stale state by checking `contentRef.current` and clearing it (`contentRef.current = null`) before triggering the sheet close and content teardown. 
- Change affects `apps/frontend/app/components/GlobalModal/ModalProvider.tsx` and leaves existing expand/teardown logic intact.

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps were not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbb613a4083308037c57dd10a6f5a)