### PR TITLE
Use rating permission modal for feedback actions

### DIFF
--- a/apps/frontend/app/components/FeedbackLabel/index.tsx
+++ b/apps/frontend/app/components/FeedbackLabel/index.tsx
@@ -11,22 +11,22 @@ import { FoodFeedbackLabelEntryHelper } from '@/redux/actions/FoodFeeedbackLabel
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 import { DELETE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL, UPDATE_OWN_FOOD_FEEDBACK_LABEL_ENTRIES_LOCAL } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
+import useRatingPermissionModal from '@/hooks/useRatingPermissionModal';
 
 const FeedbackLabel: React.FC<FeedbackLabelProps> = ({ label, icon, imageUrl, labelEntries, foodId, offerId }) => {
 	const { theme } = useTheme();
 	const dispatch = useDispatch();
 	const { translate } = useLanguage();
 	const { primaryColor, language, appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const [warning, setWarning] = useState(false);
 	const [showTooltip, setShowTooltip] = useState(false);
 	const { user, profile } = useSelector((state: RootState) => state.authReducer);
 	const selectedCanteen = useSelectedCanteen();
+	const { openRatingPermissionModal } = useRatingPermissionModal();
 	const foodFeedbackLabelEntryHelper = new FoodFeedbackLabelEntryHelper();
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
@@ -39,7 +39,7 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({ label, icon, imageUrl, la
 	// Function to handle updating the entry
 	const handleUpdateEntry = async (isLike: boolean | null) => {
 		if (!user?.id) {
-			setWarning(true);
+			openRatingPermissionModal();
 			return;
 		}
 		let likeStats = null;
@@ -146,7 +146,6 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({ label, icon, imageUrl, la
 					</TooltipContent>
 				</Tooltip>
 			</View>
-			<PermissionModal isVisible={warning} setIsVisible={setWarning} />
 		</View>
 	);
 };

--- a/apps/frontend/app/components/Feedbacks/index.tsx
+++ b/apps/frontend/app/components/Feedbacks/index.tsx
@@ -11,7 +11,6 @@ import { DatabaseTypes, DateHelper } from 'repo-depkit-common';
 import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks';
 import useToast from '@/hooks/useToast';
 import { DELETE_FOOD_FEEDBACK_LOCAL, UPDATE_FOOD_FEEDBACK_LOCAL } from '@/redux/Types/types';
-import PermissionModal from '../PermissionModal/PermissionModal';
 import { createSelector } from 'reselect';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/ColorHelper';
@@ -19,6 +18,7 @@ import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { TranslationKeys } from '@/locales/keys';
 import { FeedbacksProps } from './types';
 import { RootState } from '@/redux/reducer';
+import useRatingPermissionModal from '@/hooks/useRatingPermissionModal';
 
 const loadingState = {
 	submitLoading: false,
@@ -41,8 +41,8 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId }
 	const { appSettings, primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const [commentType, setCommentType] = useState('');
 	const [loading, setLoading] = useState(loadingState);
-	const [warning, setWarning] = useState(false);
 	const [comment, setComment] = useState('');
+	const { openRatingPermissionModal } = useRatingPermissionModal();
 	const foodFeedbackHelper = useMemo(() => new FoodFeedbackHelper(), []);
 	const { labels, labelEntries, previousFeedback } = useSelector((state: any) => selectFeedbackData(state, foodDetails?.id));
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
@@ -55,7 +55,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId }
 
 	const submitCommentFeedback = async (string: string | null) => {
 		if (!user?.id) {
-			setWarning(true);
+			openRatingPermissionModal();
 			return;
 		}
 
@@ -95,7 +95,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId }
 
 	const handleTextChange = (text: string) => {
 		if (!user?.id) {
-			setWarning(true);
+			openRatingPermissionModal();
 			return;
 		}
 
@@ -317,7 +317,6 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId }
 				</>
 			)}
 
-			<PermissionModal isVisible={warning} setIsVisible={setWarning} />
 		</View>
 	);
 };


### PR DESCRIPTION
### Motivation
- Replace ad-hoc anonymous guest warning popups with the centralized rating permission modal used elsewhere in the app to provide a consistent sign-in prompt when guests attempt feedback actions.
- Ensure anonymous users see the same sign-in/create-account flow when interacting with food feedback (ratings, comments, labels).

### Description
- Replaced local `warning` state and `PermissionModal` usage with `useRatingPermissionModal` and calls to `openRatingPermissionModal` for guest flows.
- Updated comment and text handlers in `apps/frontend/app/components/Feedbacks/index.tsx` to call `openRatingPermissionModal()` when `user?.id` is missing.
- Updated label like/dislike handler in `apps/frontend/app/components/FeedbackLabel/index.tsx` to call `openRatingPermissionModal()` when `user?.id` is missing.
- Modified imports and removed the now-unused `PermissionModal` state from the two updated components.

### Testing
- No automated tests were executed for this change.
- Changes were limited to UI event handlers and hook usage and should be verified via manual QA for the sign-in modal behavior when anonymous users interact with feedback features.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dca8ea36083308d1879f1d7a6d912)