### PR TITLE
Use rating permission modal for food notifications and standardize copy

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -34,7 +34,6 @@ import { handleFoodRating } from '@/helper/feedback';
 import { RootState } from '@/redux/reducer';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import useRatingPermissionModal from '@/hooks/useRatingPermissionModal';
-import PermissionModal from '@/components/PermissionModal/PermissionModal';
 
 const selectFoodState = (state: RootState) => state.food;
 
@@ -70,7 +69,6 @@ export default function FoodDetailsScreen() {
 	const selectedCanteen = useSelectedCanteen();
 	const foodOfferCanteenId = selectedCanteen?.id as string | undefined;
 	const [foodDetails, setFoodDetails] = useState<any>(null);
-        const [isNotificationPermissionVisible, setIsNotificationPermissionVisible] = useState(false);
         const { openRatingPermissionModal } = useRatingPermissionModal();
 
 	const [activeTab, setActiveTab] = useState('feedbacks');
@@ -389,7 +387,7 @@ export default function FoodDetailsScreen() {
 
 	const updateNotification = async () => {
 		if (!user?.id) {
-			setIsNotificationPermissionVisible(true);
+			openRatingPermissionModal();
 			return;
 		}
 		if (isSmartPhone()) {
@@ -772,7 +770,6 @@ export default function FoodDetailsScreen() {
                                 </View>
                         </View>
                         <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_details} />
-                        <PermissionModal isVisible={isNotificationPermissionVisible} setIsVisible={setIsNotificationPermissionVisible} />
                 </View>
         </ScrollView>
 			{isActive && (

--- a/apps/frontend/app/hooks/useRatingPermissionModal.tsx
+++ b/apps/frontend/app/hooks/useRatingPermissionModal.tsx
@@ -23,12 +23,12 @@ const useRatingPermissionModal = () => {
 		};
 
 		show({
-			title: translate(TranslationKeys.rating_requires_account_title),
+			title: translate(TranslationKeys.access_limited),
 			onClose: close,
 			children: (
 				<View style={{ gap: 12 }}>
 					<Text style={{ color: theme.sheet.text }}>
-						{translate(TranslationKeys.rating_requires_account_description)}
+						{translate(TranslationKeys.limited_access_description)}
 					</Text>
 					<ProjectButton
 						text={`${translate(TranslationKeys.sign_in)} / ${translate(TranslationKeys.create_account)}`}


### PR DESCRIPTION
### Motivation
- Reuse the existing rating permission modal for the food-offer notification login prompt so the same UX is used for rating and notification flows.
- Make the permission modal copy generic and consistent with the app-wide access-limited text.

### Description
- Replaced the local `PermissionModal` usage in `apps/frontend/app/app/(app)/foodoffers/details/index.tsx` by calling `openRatingPermissionModal()` when unauthenticated in `updateNotification` and removed the unused `isNotificationPermissionVisible` state.
- Removed the `PermissionModal` import and its render from the food details screen.
- Updated `apps/frontend/app/hooks/useRatingPermissionModal.tsx` to show the generic access-limited title and description using `TranslationKeys.access_limited` and `TranslationKeys.limited_access_description`.
- Changes touch two files: `apps/frontend/app/app/(app)/foodoffers/details/index.tsx` and `apps/frontend/app/hooks/useRatingPermissionModal.tsx`.

### Testing
- No automated tests were run for this change.
- Basic local type/compile checks were not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dcf45d5548330b4772272471eee6a)