### PR TITLE
Replace feedback field modals with scroll view modal

### DIFF
--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -1,24 +1,63 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, Dimensions, PixelRatio, Platform, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Dimensions, Keyboard, KeyboardTypeOptions, PixelRatio, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import FeedbackItem from '../../../components/FeedbackSupport/FeedbackSupport';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { deviceData, feedbackData } from '../../../constants/FeedbackSupportData';
-import ModalComponent from '../../../components/ModalSetting/ModalComponent';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useSelector } from 'react-redux';
 import * as DeviceInfo from 'expo-device';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { AppFeedback } from '@/redux/actions/AppFeedback/AppFeedback';
-import { FontAwesome5 } from '@expo/vector-icons';
+import { FontAwesome5, MaterialIcons, Octicons } from '@expo/vector-icons';
 import useToast from '@/hooks/useToast';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
+import SettingsList from '@/components/SettingsList';
+import SettingsListInput from '@/components/SettingsListInput';
+import { excerpt } from '@/constants/HelperFunctions';
+
+type FeedbackFieldSheetProps = {
+	initialValue: string;
+	placeholder: string;
+	saveLabel: string;
+	onSave: (value: string) => void;
+	multiline?: boolean;
+	keyboardType?: KeyboardTypeOptions;
+};
+
+const FeedbackFieldSheet: React.FC<FeedbackFieldSheetProps> = ({ initialValue, placeholder, saveLabel, onSave, multiline = false, keyboardType }) => {
+	const [value, setValue] = useState(initialValue ?? '');
+	const disableSave = useMemo(() => value === initialValue, [initialValue, value]);
+
+	useEffect(() => {
+		setValue(initialValue ?? '');
+	}, [initialValue]);
+
+	const handleSave = useCallback(() => onSave(value), [onSave, value]);
+
+	return (
+		<SettingsListInput
+			placeholder={placeholder}
+			value={value}
+			onChangeText={setValue}
+			onSave={handleSave}
+			saveLabel={saveLabel}
+			disableSave={disableSave}
+			multiline={multiline}
+			numberOfLines={multiline ? 4 : 1}
+			textAlignVertical={multiline ? 'top' : 'center'}
+			keyboardType={keyboardType}
+			inputStyle={multiline ? { height: 150 } : undefined}
+		/>
+	);
+};
 
 const FeedbackScreen = () => {
 	useSetPageTitle(TranslationKeys.feedback_and_support);
@@ -30,9 +69,6 @@ const FeedbackScreen = () => {
 	const { profile } = useSelector((state: RootState) => state.authReducer);
 	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
-	const [isModalVisible, setModalVisible] = useState(false);
-	const [selectedTitle, setSelectedTitle] = useState('');
-	const [selectedKey, setSelectedKey] = useState('');
 	const [loading, setLoading] = useState(false);
 	const [inputValues, setInputValues] = useState<{
 		[key: string]: string | boolean | number | any;
@@ -40,6 +76,7 @@ const FeedbackScreen = () => {
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [errorJson, setErrorJson] = useState<string | null>(null);
 	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
+	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 
 	useFocusEffect(
 		useCallback(() => {
@@ -115,12 +152,32 @@ const FeedbackScreen = () => {
 		setErrorJson(null);
 	};
 
-	const handleInputChange = (key: string, text: string) => {
-		setInputValues(prevState => ({
-			...prevState,
-			[key]: text,
-		}));
-	};
+	const closeFeedbackSheet = useCallback(() => {
+		Keyboard.dismiss();
+		closeScrollViewModal();
+	}, [closeScrollViewModal]);
+
+	const feedbackSettingsItems = useMemo(
+		() =>
+			feedbackData
+				.filter(item => item.key !== 'positive')
+				.map(item => ({
+					...item,
+					multiline: item.key === 'content',
+					keyboardType: item.key === 'contact_email' ? 'email-address' : undefined,
+				})),
+		[]
+	);
+
+	const getFeedbackIcon = useCallback(
+		(iconName: string) => {
+			if (iconName === 'feed') {
+				return <MaterialIcons name={iconName as any} size={24} color={theme.screen.icon} />;
+			}
+			return <MaterialCommunityIcons name={iconName as any} size={24} color={theme.screen.icon} />;
+		},
+		[theme.screen.icon]
+	);
 
 	useEffect(() => {
 		const onChange = ({ window }: { window: any }) => {
@@ -133,17 +190,41 @@ const FeedbackScreen = () => {
 		};
 	}, []);
 
-	const openModal = (key: string, title: string) => {
-		setSelectedTitle(title);
-		setSelectedKey(key);
-		setModalVisible(true);
-	};
-
-	const closeModal = () => {
-		setSelectedTitle('');
-		setSelectedKey('');
-		setModalVisible(false);
-	};
+	const openFeedbackSheet = useCallback(
+		({
+			key,
+			title,
+			multiline,
+			keyboardType,
+		}: {
+			key: string;
+			title: string;
+			multiline?: boolean;
+			keyboardType?: KeyboardTypeOptions;
+		}) => {
+			showScrollViewModal({
+				title: translate(title as any),
+				onClose: closeFeedbackSheet,
+				children: (
+					<FeedbackFieldSheet
+						placeholder={translate(title as any)}
+						initialValue={String(inputValues[key] ?? '')}
+						saveLabel={translate(TranslationKeys.save)}
+						onSave={value => {
+							setInputValues(prevState => ({
+								...prevState,
+								[key]: value,
+							}));
+							closeFeedbackSheet();
+						}}
+						multiline={multiline}
+						keyboardType={keyboardType}
+					/>
+				),
+			});
+		},
+		[closeFeedbackSheet, inputValues, showScrollViewModal, translate]
+	);
 
 	const handleCreateAppFeedback = async () => {
 		if (inputValues) {
@@ -243,25 +324,40 @@ const FeedbackScreen = () => {
 						>
 							{translate(TranslationKeys.your_request)}
 						</Text>
-						{feedbackData.map((item, index) => (
-							<FeedbackItem
-								key={index}
-								icon={item.icon}
-								title={item.title}
-								extraIcons={item.extraIcons}
-								theme={theme}
-								windowWidth={windowWidth}
-								value={inputValues[item.key] || ''}
-								inputValues={inputValues}
-								setInputValues={setInputValues}
-								onPress={() => {
-									if (item.title !== 'like_status') {
-										openModal(item.key, item.title);
-									} else {
-									}
+						{feedbackSettingsItems.map((item, index) => (
+							<SettingsList
+								key={item.key}
+								iconBgColor={primaryColor}
+								leftIcon={getFeedbackIcon(item.icon)}
+								label={translate(item.title as any)}
+								value={excerpt(String(inputValues[item.key] ?? ''), windowWidth > 850 ? 50 : 20)}
+								rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+								handleFunction={() => {
+									openFeedbackSheet({
+										key: item.key,
+										title: item.title,
+										multiline: item.multiline,
+										keyboardType: item.keyboardType,
+									});
 								}}
+								groupPosition={index === 0 ? 'top' : index === feedbackSettingsItems.length - 1 ? 'bottom' : 'middle'}
 							/>
 						))}
+						{feedbackData
+							.filter(item => item.key === 'positive')
+							.map(item => (
+								<FeedbackItem
+									key={item.key}
+									icon={item.icon}
+									title={item.title}
+									extraIcons={item.extraIcons}
+									theme={theme}
+									windowWidth={windowWidth}
+									value={inputValues[item.key] || ''}
+									inputValues={inputValues}
+									setInputValues={setInputValues}
+								/>
+							))}
 						{!profile?.id && (
 							<Text
 								style={{
@@ -400,37 +496,13 @@ const FeedbackScreen = () => {
 						)}
 						{deviceData.map((item, index) => (
 							<TouchableOpacity key={index}>
-								<FeedbackItem key={index} title={item.title} value={item?.key === 'device_brand' ? (inputValues[item.key] ? inputValues[item.key] : translate(TranslationKeys.unknown)) : inputValues[item.key] || ''} theme={theme} windowWidth={windowWidth} onPress={() => openModal(item.key, item.title)} />
+								<FeedbackItem key={index} title={item.title} value={item?.key === 'device_brand' ? (inputValues[item.key] ? inputValues[item.key] : translate(TranslationKeys.unknown)) : inputValues[item.key] || ''} theme={theme} windowWidth={windowWidth} />
 							</TouchableOpacity>
 						))}
 
 						{errorJson && <Text style={{ color: 'red', marginVertical: 10 }}>{errorJson}</Text>}
 						{errorMessage && <Text style={{ color: 'red', marginBottom: 10 }}>{errorMessage}</Text>}
 					</View>
-
-					<ModalComponent
-						isVisible={isModalVisible}
-						title={selectedTitle}
-						onClose={closeModal}
-						onSave={() => {
-							closeModal();
-						}}
-					>
-						<TextInput
-							style={{
-								...styles.input,
-								color: 'black',
-								backgroundColor: '#fff',
-								borderWidth: 1,
-								height: selectedTitle === 'feedback' ? 150 : 60,
-								textAlignVertical: 'top',
-							}}
-							value={inputValues[selectedKey] || ''}
-							onChangeText={text => handleInputChange(selectedKey, text)}
-							multiline={true}
-							numberOfLines={selectedTitle === 'feedback' ? 4 : 1}
-						/>
-					</ModalComponent>
 				</View>
 			</ScrollView>
 		</View>

--- a/apps/frontend/app/components/SettingsListInput/SettingsListInput.tsx
+++ b/apps/frontend/app/components/SettingsListInput/SettingsListInput.tsx
@@ -17,6 +17,10 @@ const SettingsListInput: React.FC<SettingsListInputProps> = ({
         disableSave = false,
         autoFocus = true,
         keyboardType,
+        multiline = false,
+        numberOfLines,
+        textAlignVertical,
+        inputStyle,
 }) => {
         const { theme } = useTheme();
         const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
@@ -34,6 +38,7 @@ const SettingsListInput: React.FC<SettingsListInputProps> = ({
                                         color: theme.sheet.text,
                                         backgroundColor: theme.sheet.inputBg,
                                         borderColor: theme.sheet.inputBorder,
+                                        ...(inputStyle ?? {}),
                                 }}
                                 autoFocus={autoFocus}
                                 placeholder={placeholder}
@@ -43,6 +48,9 @@ const SettingsListInput: React.FC<SettingsListInputProps> = ({
                                 value={value}
                                 onChangeText={onChangeText}
                                 keyboardType={keyboardType}
+                                multiline={multiline}
+                                numberOfLines={numberOfLines}
+                                textAlignVertical={textAlignVertical}
                         />
 
                         <View style={styles.buttonContainer}>

--- a/apps/frontend/app/components/SettingsListInput/types.ts
+++ b/apps/frontend/app/components/SettingsListInput/types.ts
@@ -9,4 +9,8 @@ export interface SettingsListInputProps {
         disableSave?: boolean;
         autoFocus?: boolean;
         keyboardType?: KeyboardTypeOptions;
+        multiline?: boolean;
+        numberOfLines?: number;
+        textAlignVertical?: 'auto' | 'top' | 'bottom' | 'center';
+        inputStyle?: object;
 }


### PR DESCRIPTION
### Motivation
- Replace the old modal editing flow for feedback fields with the shared `useMyScrollViewModal` hook to match the settings nickname behavior and unify UX.
- Render `title`, `content` and `email` as `SettingsList` rows so they reuse the existing settings list component and show summarized values inline.
- Allow multi-line editing for the `content` feedback field (ticket body) using a proper multiline input sheet.
- Remove duplicated/custom `ModalComponent` usage and centralize the sheet UI via `SettingsListInput` + scroll view modal.

### Description
- Extended `SettingsListInput` (`types.ts`, `SettingsListInput.tsx`) to support `multiline`, `numberOfLines`, `textAlignVertical`, and `inputStyle` props for multiline fields.
- Replaced the in-component modal in `apps/frontend/app/app/(app)/feedback-support/index.tsx` with `useMyScrollViewModal` and added a `FeedbackFieldSheet` wrapper that uses `SettingsListInput`.
- Converted the feedback fields (`title`, `content`, `contact_email`) to `SettingsList` entries that open the scroll view modal for editing, while keeping the `positive` (`like_status`) row using the existing `FeedbackItem` component.
- Removed the old `ModalComponent` + inline `TextInput` usage and updated imports/usages accordingly.

### Testing
- No automated tests were executed as part of this change in the current environment.
- No CI/build checks were run here (changes are focused on refactor and UI wiring).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e5bc1d0f48330b378190786c5c579)