### PR TITLE
Replace chevrons with pencil edit icons in feedback & device SettingsList rows

### DIFF
--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -338,7 +338,7 @@ const FeedbackScreen = () => {
 								leftIcon={getFeedbackIcon(item.icon)}
 								label={translate(item.title as any)}
 								value={excerpt(String(inputValues[item.key] ?? ''), windowWidth > 850 ? 50 : 20)}
-								rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+								rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
 								handleFunction={() => {
 									openFeedbackSheet({
 										key: item.key,
@@ -507,6 +507,7 @@ const FeedbackScreen = () => {
 								iconBgColor={primaryColor}
 								label={translate(item.title as any)}
 								value={excerpt(String(item.key === 'device_brand' ? (inputValues[item.key] ? inputValues[item.key] : translate(TranslationKeys.unknown)) : inputValues[item.key] || ''), windowWidth > 850 ? 50 : 20)}
+								rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
 								handleFunction={() => {
 									openFeedbackSheet({
 										key: item.key,


### PR DESCRIPTION
### Motivation
- Make editable feedback fields and device info entries visually indicate they are editable by showing a pencil edit icon on the right.
- Align the UI for feedback/settings entries so users see an edit affordance instead of a navigation chevron.

### Description
- Updated `apps/frontend/app/app/(app)/feedback-support/index.tsx` to use `MaterialCommunityIcons` pencil icon for `SettingsList` `rightIcon` in `feedbackSettingsItems` rows.
- Also added the pencil `rightIcon` for `deviceSettingsItems` rows in the same file so device info rows show the edit icon.
- No behavior or handler changes were made to `SettingsList` usages; only the right-side icon was replaced.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e6fd984cc8330b823b426f2ac45e2)