### PR TITLE
Fix FAQ software link redirect

### DIFF
--- a/apps/frontend/app/app/(app)/support-FAQ/index.tsx
+++ b/apps/frontend/app/app/(app)/support-FAQ/index.tsx
@@ -137,7 +137,7 @@ const SupportFaq = () => {
                                                         value="Rocket Meals"
 							rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
 							handleFunction={() => {
-								openInBrowser('https://rocket-meals.de/homepage/');
+								openInBrowser('https://rocket-meals.de');
 							}}
                                                         groupPosition="bottom"
                                                 />


### PR DESCRIPTION
### Motivation
- The FAQ "Software Name" entry should open the root Rocket Meals homepage without any extra path as requested.
- The current link pointed to `https://rocket-meals.de/homepage/` which includes an unwanted path segment.

### Description
- Update made in `apps/frontend/app/app/(app)/support-FAQ/index.tsx` to change the software link URL.
- The `SettingsList` `handleFunction` for `TranslationKeys.software_name` now calls `openInBrowser('https://rocket-meals.de')` instead of the previous `/homepage/` URL.
- No other UI or navigation logic was modified and the existing `openInBrowser` helper is reused.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea6a0e38c8330a85bc4c9b88a53b4)