### PR TITLE
Replace nullish coalescing in useModalTextInput to fix Expo parse error

### DIFF
--- a/apps/frontend/app/hooks/useModalTextInput.ts
+++ b/apps/frontend/app/hooks/useModalTextInput.ts
@@ -94,11 +94,11 @@ const ModalTextInputContent: React.FC<ModalTextInputContentProps> = ({
 
         return (
                 <SettingsListInput
-                        placeholder={placeholder ?? ''}
+                        placeholder={placeholder != null ? placeholder : ''}
                         value={value}
                         onChangeText={setValue}
                         onSave={handleSave}
-                        saveLabel={saveLabel ?? ''}
+                        saveLabel={saveLabel != null ? saveLabel : ''}
                         disableSave={disableSave}
                         multiline={multiline}
                         numberOfLines={numberOfLines}
@@ -127,8 +127,12 @@ const useModalTextInput = () => {
                                 children: (
                                         <ModalTextInputContent
                                                 initialValue={config.initialValue}
-                                                placeholder={config.placeholder ?? config.title}
-                                                saveLabel={config.saveLabel ?? translate(TranslationKeys.save)}
+                                                placeholder={config.placeholder != null ? config.placeholder : config.title}
+                                                saveLabel={
+                                                        config.saveLabel != null
+                                                                ? config.saveLabel
+                                                                : translate(TranslationKeys.save)
+                                                }
                                                 onSave={config.onSave}
                                                 keyboardType={config.keyboardType}
                                                 multiline={config.multiline}


### PR DESCRIPTION
### Motivation
- The Expo parser produced a `SyntaxError` at `useModalTextInput.ts` when encountering nullish coalescing operators.  
- Ensure fallback values are applied without relying on `??` to remain compatible with the runtime/parser.  

### Description
- Replaced `placeholder={placeholder ?? ''}` with `placeholder={placeholder != null ? placeholder : ''}` in `useModalTextInput`.  
- Replaced `saveLabel={saveLabel ?? ''}` with `saveLabel={saveLabel != null ? saveLabel : ''}` in `useModalTextInput`.  
- Replaced `config.placeholder ?? config.title` and `config.saveLabel ?? translate(TranslationKeys.save)` with explicit null checks and conditional fallbacks.  

### Testing
- No automated tests were run for this change.  
- A commit was created and the file `apps/frontend/app/hooks/useModalTextInput.ts` was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed67308308330aac2bbed7ef2befa)