### PR TITLE
Revert "Merge pull request #1088 from rocket-meals/codex/fix-syntax-error-in-usemodaltextinput"

### DIFF
--- a/apps/frontend/app/hooks/useModalTextInput.ts
+++ b/apps/frontend/app/hooks/useModalTextInput.ts
@@ -94,11 +94,11 @@ const ModalTextInputContent: React.FC<ModalTextInputContentProps> = ({
 
         return (
                 <SettingsListInput
-                        placeholder={placeholder != null ? placeholder : ''}
+                        placeholder={placeholder ?? ''}
                         value={value}
                         onChangeText={setValue}
                         onSave={handleSave}
-                        saveLabel={saveLabel != null ? saveLabel : ''}
+                        saveLabel={saveLabel ?? ''}
                         disableSave={disableSave}
                         multiline={multiline}
                         numberOfLines={numberOfLines}
@@ -127,12 +127,8 @@ const useModalTextInput = () => {
                                 children: (
                                         <ModalTextInputContent
                                                 initialValue={config.initialValue}
-                                                placeholder={config.placeholder != null ? config.placeholder : config.title}
-                                                saveLabel={
-                                                        config.saveLabel != null
-                                                                ? config.saveLabel
-                                                                : translate(TranslationKeys.save)
-                                                }
+                                                placeholder={config.placeholder ?? config.title}
+                                                saveLabel={config.saveLabel ?? translate(TranslationKeys.save)}
                                                 onSave={config.onSave}
                                                 keyboardType={config.keyboardType}
                                                 multiline={config.multiline}


### PR DESCRIPTION
### Motivation
- Undo the effects of the last merge commit that touched the modal text input hook.
- Restore the intended behavior of the modal input defaults and save handling in the frontend hook.
- Ensure the `useModalTextInput` changes are reverted cleanly to avoid regressions.

### Description
- Reverted changes in `apps/frontend/app/hooks/useModalTextInput.ts` to restore prior logic for modal text input handling.
- Updated defaulting for `placeholder` and `saveLabel` to use nullish-coalescing style defaults where applicable (`??`).
- Adjusted how `openModal` passes `placeholder` and `saveLabel` to `ModalTextInputContent` so defaults fall back to `config.title` and `translate(TranslationKeys.save)` respectively.
- The diff includes 1 file changed with 4 insertions and 8 deletions. 

### Testing
- No automated tests were run for this revert-only change.
- Git revert and reset commands completed successfully in the local workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eff9099708330bdf6b63f7e7b5ef2)