### PR TITLE
Add reusable useModalTextInput hook and wire to settings/feedback inputs

### DIFF
--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Dimensions, Keyboard, KeyboardTypeOptions, PixelRatio, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Dimensions, KeyboardTypeOptions, PixelRatio, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import FeedbackItem from '../../../components/FeedbackSupport/FeedbackSupport';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { deviceData, feedbackData } from '../../../constants/FeedbackSupportData';
-import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useSelector } from 'react-redux';
 import * as DeviceInfo from 'expo-device';
@@ -16,48 +15,12 @@ import { FontAwesome5, MaterialIcons, Octicons } from '@expo/vector-icons';
 import useToast from '@/hooks/useToast';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { DatabaseTypes } from 'repo-depkit-common';
+import { DatabaseTypes, EmailHelper } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import SettingsList from '@/components/SettingsList';
-import SettingsListInput from '@/components/SettingsListInput';
+import useModalTextInput from '@/hooks/useModalTextInput';
 import { excerpt } from '@/constants/HelperFunctions';
-
-type FeedbackFieldSheetProps = {
-	initialValue: string;
-	placeholder: string;
-	saveLabel: string;
-	onSave: (value: string) => void;
-	multiline?: boolean;
-	keyboardType?: KeyboardTypeOptions;
-};
-
-const FeedbackFieldSheet: React.FC<FeedbackFieldSheetProps> = ({ initialValue, placeholder, saveLabel, onSave, multiline = false, keyboardType }) => {
-	const [value, setValue] = useState(initialValue ?? '');
-	const disableSave = useMemo(() => value === initialValue, [initialValue, value]);
-
-	useEffect(() => {
-		setValue(initialValue ?? '');
-	}, [initialValue]);
-
-	const handleSave = useCallback(() => onSave(value), [onSave, value]);
-
-	return (
-		<SettingsListInput
-			placeholder={placeholder}
-			value={value}
-			onChangeText={setValue}
-			onSave={handleSave}
-			saveLabel={saveLabel}
-			disableSave={disableSave}
-			multiline={multiline}
-			numberOfLines={multiline ? 4 : 1}
-			textAlignVertical={multiline ? 'top' : 'center'}
-			keyboardType={keyboardType}
-			inputStyle={multiline ? { height: 150 } : undefined}
-		/>
-	);
-};
 
 const FeedbackScreen = () => {
 	useSetPageTitle(TranslationKeys.feedback_and_support);
@@ -76,7 +39,7 @@ const FeedbackScreen = () => {
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [errorJson, setErrorJson] = useState<string | null>(null);
 	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
-	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
+	const { openModalTextInput } = useModalTextInput();
 
 	useFocusEffect(
 		useCallback(() => {
@@ -152,11 +115,6 @@ const FeedbackScreen = () => {
 		setErrorJson(null);
 	};
 
-	const closeFeedbackSheet = useCallback(() => {
-		Keyboard.dismiss();
-		closeScrollViewModal();
-	}, [closeScrollViewModal]);
-
 	const feedbackSettingsItems = useMemo(
 		() =>
 			feedbackData
@@ -209,28 +167,36 @@ const FeedbackScreen = () => {
 			multiline?: boolean;
 			keyboardType?: KeyboardTypeOptions;
 		}) => {
-			showScrollViewModal({
+			const isEmailField = key === 'contact_email';
+			openModalTextInput({
 				title: translate(title as any),
-				onClose: closeFeedbackSheet,
-				children: (
-					<FeedbackFieldSheet
-						placeholder={translate(title as any)}
-						initialValue={String(inputValues[key] ?? '')}
-						saveLabel={translate(TranslationKeys.save)}
-						onSave={value => {
-							setInputValues(prevState => ({
-								...prevState,
-								[key]: value,
-							}));
-							closeFeedbackSheet();
-						}}
-						multiline={multiline}
-						keyboardType={keyboardType}
-					/>
-				),
+				placeholder: translate(title as any),
+				initialValue: String(inputValues[key] ?? ''),
+				saveLabel: translate(TranslationKeys.save),
+				onSave: value => {
+					setInputValues(prevState => ({
+						...prevState,
+						[key]: value,
+					}));
+				},
+				multiline,
+				keyboardType,
+				numberOfLines: multiline ? 4 : 1,
+				textAlignVertical: multiline ? 'top' : 'center',
+				inputStyle: multiline ? { height: 150 } : undefined,
+				checkTextInput: isEmailField
+					? value => {
+							const cleanedEmail = value.replace(/\s+/g, '');
+							if (cleanedEmail.trim().length === 0) {
+								return { isValid: true, value: '' };
+							}
+							const { trimmedEmail, isValid } = EmailHelper.sanitizeAndValidate(cleanedEmail);
+							return { isValid, value: trimmedEmail };
+						}
+					: value => ({ isValid: true, value }),
 			});
 		},
-		[closeFeedbackSheet, inputValues, showScrollViewModal, translate]
+		[inputValues, openModalTextInput, translate]
 	);
 
 	const handleCreateAppFeedback = async () => {

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Dimensions, Keyboard, SafeAreaView, ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, SafeAreaView, ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
 import MyImage from '@/components/MyImage';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -9,7 +9,7 @@ import { isWeb } from '@/constants/Constants';
 import SettingsList from '@/components/SettingsList';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
-import SettingsListNickname from '@/components/SettingsListNickname';
+import useModalTextInput from '@/hooks/useModalTextInput';
 import { router, useFocusEffect } from 'expo-router';
 import { ConfigCustomerEnum, getCustomerEnumForConfig, type CustomerConfig, getVersionInternalForAppsettingsScreen } from '@/config';
 import { useDispatch, useSelector } from 'react-redux';
@@ -85,6 +85,7 @@ const Settings = () => {
         const profileHelper = useMemo(() => new ProfileHelper(), []);
         const customerConfig = useCustomerConfig();
         const { openCustomerConfigModal } = useCustomerConfigModal();
+        const { openModalTextInput } = useModalTextInput();
 
         const languageCode = language;
 
@@ -134,11 +135,6 @@ const Settings = () => {
                 [sortBy, sortingOptionLabels, translate]
         );
 
-        const closeNicknameSheet = useCallback(() => {
-                Keyboard.dismiss();
-                closeScrollViewModal();
-        }, [closeScrollViewModal]);
-
         const saveNickname = useCallback(
                 async (value: string) => {
                         const nextNickname = value?.trim?.() ?? '';
@@ -159,9 +155,8 @@ const Settings = () => {
                                         payload: nextNickname,
                                 });
                         }
-                        closeNicknameSheet();
                 },
-                [closeNicknameSheet, dispatch, isRegisteredUser, profile, profileHelper]
+                [dispatch, isRegisteredUser, profile, profileHelper]
         );
 
 	useFocusEffect(
@@ -185,19 +180,18 @@ const Settings = () => {
 	}, []);
 
         const openNicknameSheet = useCallback(() => {
-                showScrollViewModal(
-                        {
-                                title: translate(TranslationKeys.nickname),
-                                onClose: closeNicknameSheet,
-                                children: (
-                                        <SettingsListNickname
-                                                initialValue={currentNickname}
-                                                onSave={saveNickname}
-                                        />
-                                ),
-                        }
-                );
-        }, [closeNicknameSheet, currentNickname, saveNickname, showScrollViewModal, translate]);
+                openModalTextInput({
+                        title: translate(TranslationKeys.nickname),
+                        placeholder: translate(TranslationKeys.nickname),
+                        initialValue: currentNickname,
+                        saveLabel: translate(TranslationKeys.save),
+                        onSave: saveNickname,
+                        checkTextInput: value => ({
+                                isValid: true,
+                                value: value.trim(),
+                        }),
+                });
+        }, [currentNickname, openModalTextInput, saveNickname, translate]);
 
         const openColorSchemeSheet = useCallback(() => {
                 openThemeSettingsModal({

--- a/apps/frontend/app/components/SettingsListInput/SettingsListInput.tsx
+++ b/apps/frontend/app/components/SettingsListInput/SettingsListInput.tsx
@@ -51,6 +51,14 @@ const SettingsListInput: React.FC<SettingsListInputProps> = ({
                                 multiline={multiline}
                                 numberOfLines={numberOfLines}
                                 textAlignVertical={textAlignVertical}
+                                blurOnSubmit={!multiline}
+                                returnKeyType={multiline ? 'default' : 'done'}
+                                onSubmitEditing={() => {
+                                        if (!multiline && !disableSave) {
+                                                Keyboard.dismiss();
+                                                onSave();
+                                        }
+                                }}
                         />
 
                         <View style={styles.buttonContainer}>

--- a/apps/frontend/app/hooks/useModalTextInput.tsx
+++ b/apps/frontend/app/hooks/useModalTextInput.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Keyboard, KeyboardTypeOptions } from 'react-native';
+
+import SettingsListInput from '@/components/SettingsListInput';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+
+export type CheckTextInputResult = {
+	isValid: boolean;
+	value: string;
+};
+
+export type CheckTextInput = (value: string) => CheckTextInputResult;
+
+type ModalTextInputSheetProps = {
+	initialValue?: string;
+	placeholder: string;
+	saveLabel: string;
+	onSave: (value: string) => void;
+	multiline?: boolean;
+	keyboardType?: KeyboardTypeOptions;
+	numberOfLines?: number;
+	textAlignVertical?: 'auto' | 'top' | 'bottom' | 'center';
+	inputStyle?: object;
+	autoFocus?: boolean;
+	checkTextInput?: CheckTextInput;
+};
+
+const defaultCheckTextInput: CheckTextInput = value => ({
+	isValid: true,
+	value,
+});
+
+const ModalTextInputSheet: React.FC<ModalTextInputSheetProps> = ({
+	initialValue,
+	placeholder,
+	saveLabel,
+	onSave,
+	multiline = false,
+	keyboardType,
+	numberOfLines,
+	textAlignVertical,
+	inputStyle,
+	autoFocus,
+	checkTextInput,
+}) => {
+	const [value, setValue] = useState(initialValue ?? '');
+
+	useEffect(() => {
+		setValue(initialValue ?? '');
+	}, [initialValue]);
+
+	const normalizedInitialValue = useMemo(
+		() => (checkTextInput ?? defaultCheckTextInput)(initialValue ?? '').value,
+		[checkTextInput, initialValue]
+	);
+
+	const validationResult = useMemo(
+		() => (checkTextInput ?? defaultCheckTextInput)(value),
+		[checkTextInput, value]
+	);
+
+	const hasChanges = validationResult.value !== normalizedInitialValue;
+	const disableSave = !validationResult.isValid || !hasChanges;
+
+	const handleSave = useCallback(() => {
+		if (!validationResult.isValid) return;
+		onSave(validationResult.value);
+	}, [onSave, validationResult.isValid, validationResult.value]);
+
+	return (
+		<SettingsListInput
+			placeholder={placeholder}
+			value={value}
+			onChangeText={setValue}
+			onSave={handleSave}
+			saveLabel={saveLabel}
+			disableSave={disableSave}
+			multiline={multiline}
+			numberOfLines={numberOfLines}
+			textAlignVertical={textAlignVertical}
+			keyboardType={keyboardType}
+			inputStyle={inputStyle}
+			autoFocus={autoFocus}
+		/>
+	);
+};
+
+type OpenModalTextInputOptions = {
+	title: string;
+	initialValue?: string;
+	placeholder: string;
+	saveLabel: string;
+	onSave: (value: string) => void | Promise<void>;
+	multiline?: boolean;
+	keyboardType?: KeyboardTypeOptions;
+	numberOfLines?: number;
+	textAlignVertical?: 'auto' | 'top' | 'bottom' | 'center';
+	inputStyle?: object;
+	autoFocus?: boolean;
+	checkTextInput?: CheckTextInput;
+};
+
+const useModalTextInput = () => {
+	const { show, close } = useMyScrollViewModal();
+
+	const closeModal = useCallback(() => {
+		Keyboard.dismiss();
+		close();
+	}, [close]);
+
+	const openModalTextInput = useCallback(
+		({
+			title,
+			initialValue,
+			placeholder,
+			saveLabel,
+			onSave,
+			multiline,
+			keyboardType,
+			numberOfLines,
+			textAlignVertical,
+			inputStyle,
+			autoFocus,
+			checkTextInput,
+		}: OpenModalTextInputOptions) => {
+			show({
+				title,
+				onClose: closeModal,
+				children: (
+					<ModalTextInputSheet
+						initialValue={initialValue}
+						placeholder={placeholder}
+						saveLabel={saveLabel}
+						onSave={async value => {
+							await onSave(value);
+							closeModal();
+						}}
+						multiline={multiline}
+						keyboardType={keyboardType}
+						numberOfLines={numberOfLines}
+						textAlignVertical={textAlignVertical}
+						inputStyle={inputStyle}
+						autoFocus={autoFocus}
+						checkTextInput={checkTextInput}
+					/>
+				),
+			});
+		},
+		[closeModal, show]
+	);
+
+	return { openModalTextInput, closeModalTextInput: closeModal };
+};
+
+export default useModalTextInput;


### PR DESCRIPTION
### Motivation
- Reduce duplication by providing a single modal text input abstraction used for nickname, feedback fields and similar inputs.
- Normalize and validate text input centrally so callers can receive sanitized values (e.g. trimmed text, cleaned email).
- Treat the mobile keyboard "done" action as a save for single-line inputs to improve UX on phones.
- Make it easy to add custom validation/normalization via a `checkTextInput` callback.

### Description
- Added a new hook `useModalTextInput` (`apps/frontend/app/hooks/useModalTextInput.tsx`) which opens a scroll-view modal with a reusable `ModalTextInputSheet` and supports a `checkTextInput` validator returning `{ isValid, value }`.
- Updated `SettingsListInput` to trigger save on keyboard done for single-line inputs by setting `blurOnSubmit`, `returnKeyType` and handling `onSubmitEditing`.
- Replaced the inline nickname modal with `useModalTextInput` in `apps/frontend/app/app/(app)/settings/index.tsx` and wired `checkTextInput` to trim the nickname before saving.
- Replaced the feedback field sheet usage with `useModalTextInput` in `apps/frontend/app/app/(app)/feedback-support/index.tsx` and added email sanitization/validation via `EmailHelper.sanitizeAndValidate` for the `contact_email` field.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f05c7e84c833097b4ea1894d46049)