### PR TITLE
Update developer homepage link in support FAQ

### DIFF
--- a/apps/frontend/app/app/(app)/support-FAQ/index.tsx
+++ b/apps/frontend/app/app/(app)/support-FAQ/index.tsx
@@ -126,7 +126,7 @@ const SupportFaq = () => {
 							value="Baumgartner Software UG"
 							rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
 							handleFunction={() => {
-								openInBrowser('https://baumgartner-software.de/homepage/');
+								openInBrowser('https://baumgartner-software.de');
 							}}
 							groupPosition="middle"
 						/>


### PR DESCRIPTION
### Motivation
- The support FAQ linked to the developer homepage including a trailing `/homepage/` path which should instead point to the root domain.
- This change ensures the FAQ opens the canonical company site without the extra path.

### Description
- Updated the `openInBrowser` call in `apps/frontend/app/app/(app)/support-FAQ/index.tsx` to use `https://baumgartner-software.de` instead of `https://baumgartner-software.de/homepage/`.
- The change is limited to the support FAQ entry for the developer link and does not alter labels or other links.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1442bf088330876ea49cce6d67f6)