### PR TITLE
Add manual date input to CalendarSheet modal

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -1,4 +1,4 @@
-import { TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
 import React, { useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -15,12 +15,15 @@ import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
+import { format, isValid, parse } from 'date-fns';
 
 const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, selectedDateProp, updateGlobal }) => {
     const { theme } = useTheme();
     const { translate } = useLanguage();
     const dispatch = useDispatch();
     const [currentMonth, setCurrentMonth] = useState(new Date());
+    const [manualDate, setManualDate] = useState('');
+    const [manualError, setManualError] = useState('');
     const { primaryColor, appSettings, selectedTheme: mode, firstDayOfTheWeek } = useSelector((state: RootState) => state.settings);
     const { selectedDate } = useSelector((state: RootState) => state.food);
     const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
@@ -43,6 +46,38 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
         setCurrentMonth(newMonth);
     };
 
+    const parseManualDate = (value: string) => {
+        const trimmed = value.trim();
+        if (/^\d{2}\.\d{2}\.\d{4}$/.test(trimmed)) {
+            const parsed = parse(trimmed, 'dd.MM.yyyy', new Date());
+            return isValid(parsed) ? parsed : null;
+        }
+        if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+            const parsed = parse(trimmed, 'yyyy-MM-dd', new Date());
+            return isValid(parsed) ? parsed : null;
+        }
+        return null;
+    };
+
+    const handleManualSubmit = () => {
+        const parsed = parseManualDate(manualDate);
+        if (!parsed) {
+            setManualError('Invalid date format (e.g., DD.MM.YYYY)');
+            return;
+        }
+        const formatted = format(parsed, 'yyyy-MM-dd');
+        if (onSelect) {
+            onSelect(formatted);
+        } else if (updateGlobal) {
+            dispatch({
+                type: SET_SELECTED_DATE,
+                payload: formatted,
+            });
+        }
+        setManualError('');
+        closeSheet();
+    };
+
     LocaleConfig.locales['custom'] = {
         monthNames: [translate(TranslationKeys.January), translate(TranslationKeys.February), translate(TranslationKeys.March), translate(TranslationKeys.April), translate(TranslationKeys.May), translate(TranslationKeys.June), translate(TranslationKeys.July), translate(TranslationKeys.August), translate(TranslationKeys.September), translate(TranslationKeys.October), translate(TranslationKeys.November), translate(TranslationKeys.December)],
         monthNamesShort: [translate(TranslationKeys.Jan), translate(TranslationKeys.Feb), translate(TranslationKeys.Mar), translate(TranslationKeys.Apr), translate(TranslationKeys.MayShort), translate(TranslationKeys.Jun), translate(TranslationKeys.Jul), translate(TranslationKeys.Aug), translate(TranslationKeys.Sep), translate(TranslationKeys.Oct), translate(TranslationKeys.Nov), translate(TranslationKeys.Dec)],
@@ -58,6 +93,29 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
             title={`${translate(TranslationKeys.select)} : ${translate(TranslationKeys.date)}`}
             closeSheet={closeSheet}
         >
+            <View style={styles.manualInputWrapper}>
+                <TextInput
+                    style={[
+                        styles.manualInput,
+                        {
+                            color: theme.screen.text,
+                            backgroundColor: theme.sheet.inputBg,
+                            borderColor: manualError ? theme.sheet.inputBorderInvalid : theme.sheet.inputBg,
+                        },
+                    ]}
+                    cursorColor={theme.screen.text}
+                    placeholderTextColor={theme.sheet.placeholder}
+                    placeholder="DD.MM.YYYY"
+                    value={manualDate}
+                    onChangeText={text => {
+                        setManualDate(text);
+                        if (manualError) setManualError('');
+                    }}
+                    onSubmitEditing={handleManualSubmit}
+                    returnKeyType="done"
+                />
+                {manualError ? <Text style={[styles.manualErrorText, { color: theme.sheet.inputBorderInvalid }]}>{manualError}</Text> : null}
+            </View>
             <View
                 style={{
                     ...styles.calendarView,

--- a/apps/frontend/app/components/CalendarSheet/styles.ts
+++ b/apps/frontend/app/components/CalendarSheet/styles.ts
@@ -55,4 +55,21 @@ export default StyleSheet.create({
 		fontSize: 18,
 		fontWeight: 'bold',
 	},
+	manualInputWrapper: {
+		width: '100%',
+		marginTop: 12,
+		marginBottom: 12,
+	},
+	manualInput: {
+		width: '100%',
+		borderRadius: 10,
+		borderWidth: 1,
+		paddingHorizontal: 12,
+		paddingVertical: 10,
+		fontSize: 16,
+	},
+	manualErrorText: {
+		marginTop: 6,
+		fontSize: 12,
+	},
 });


### PR DESCRIPTION
### Motivation
- Provide a way to type a valid date into the calendar modal (in addition to tapping the calendar) so users can enter a date via keyboard.
- Accept the typed date when the user presses Enter / keyboard "done" and use it as the selected date.
- Support common typed formats (`DD.MM.YYYY` and `YYYY-MM-DD`) and show inline validation feedback for invalid input.

### Description
- Added a `TextInput` field to `CalendarSheet` with component state `manualDate` and `manualError` and wired it into the modal UI above the calendar. 
- Implemented `parseManualDate` (uses `date-fns` `parse`/`isValid`) and `handleManualSubmit` which validates/normalizes the typed date and then calls `onSelect` or dispatches `SET_SELECTED_DATE` with `yyyy-MM-dd` formatted date before closing the sheet.
- Updated theming and styles (`manualInputWrapper`, `manualInput`, `manualErrorText`) and used `theme.sheet` colors for input background/placeholder/invalid state.
- Kept existing calendar selection behavior intact and added text-entry validation messaging shown under the input.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f2da76db48330a185fe483f135722)