### PR TITLE
Improve manual date input formatting in CalendarSheet

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -46,6 +46,21 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
         setCurrentMonth(newMonth);
     };
 
+    const formatManualInput = (value: string) => {
+        const digitsOnly = value.replace(/\D/g, '').slice(0, 8);
+        const day = digitsOnly.slice(0, 2);
+        const month = digitsOnly.slice(2, 4);
+        const year = digitsOnly.slice(4, 8);
+        let formatted = day;
+        if (month.length > 0) {
+            formatted = `${formatted}.${month}`;
+        }
+        if (year.length > 0) {
+            formatted = `${formatted}.${year}`;
+        }
+        return formatted;
+    };
+
     const parseManualDate = (value: string) => {
         const trimmed = value.trim();
         if (/^\d{2}\.\d{2}\.\d{4}$/.test(trimmed)) {
@@ -108,11 +123,13 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
                     placeholder="DD.MM.YYYY"
                     value={manualDate}
                     onChangeText={text => {
-                        setManualDate(text);
+                        setManualDate(formatManualInput(text));
                         if (manualError) setManualError('');
                     }}
                     onSubmitEditing={handleManualSubmit}
                     returnKeyType="done"
+                    keyboardType="number-pad"
+                    inputMode="numeric"
                 />
                 {manualError ? <Text style={[styles.manualErrorText, { color: theme.sheet.inputBorderInvalid }]}>{manualError}</Text> : null}
             </View>


### PR DESCRIPTION
### Motivation
- Improve usability of the calendar manual-date input by making it easier to type valid dates on mobile devices.
- Ensure numeric input and automatic insertion of separators so users don't need to type dots manually.
- Preserve existing manual validation and calendar selection behavior while reducing input errors.

### Description
- Added a new helper `formatManualInput` that strips non-digits, limits input to 8 digits and formats them as `DD.MM.YYYY` while typing.
- Applied the formatter to the manual input handler (via `onChangeText`) so the field auto-inserts dots as the user types.
- Set `keyboardType="number-pad"` and `inputMode="numeric"` on the `TextInput` to surface a numeric keyboard on supported platforms.
- Kept existing `parseManualDate` and `handleManualSubmit` logic unchanged to preserve validation and submit behavior.

### Testing
- No automated tests were run for this change.
- The repository commit succeeded locally and the file `apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx` was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f31e534708330ae61c6655d10810d)