### PR TITLE
Add editable SettingsList and SettingsListDate (calendar modal)

### DIFF
--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -19,6 +19,7 @@ import { DatabaseTypes, EmailHelper } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import SettingsList from '@/components/SettingsList';
+import SettingsListEditable from '@/components/SettingsListEditable';
 import useModalTextInput from '@/hooks/useModalTextInput';
 import { excerpt } from '@/constants/HelperFunctions';
 
@@ -298,13 +299,12 @@ const FeedbackScreen = () => {
 							{translate(TranslationKeys.your_request)}
 						</Text>
 						{feedbackSettingsItems.map((item, index) => (
-							<SettingsList
+							<SettingsListEditable
 								key={item.key}
 								iconBgColor={primaryColor}
 								leftIcon={getFeedbackIcon(item.icon)}
 								label={translate(item.title as any)}
 								value={excerpt(String(inputValues[item.key] ?? ''), windowWidth > 850 ? 50 : 20)}
-								rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
 								handleFunction={() => {
 									openFeedbackSheet({
 										key: item.key,

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -19,7 +19,8 @@ import MultiLineInput from '@/components/MultiLineInput/MultiLineInput';
 import IBANInput from '@/components/IBANInput/IBANInput';
 import NumberInput from '@/components/NumberInput/NumberInput';
 import EmailInput from '@/components/EmailInput/EmailInput';
-import { DateInput, DateWithTimeInput, PreciseTimestampInput, TimeInput } from '@/components/DateTimeInputs';
+import { DateWithTimeInput, PreciseTimestampInput, TimeInput } from '@/components/DateTimeInputs';
+import SettingsListDate from '@/components/SettingsListDate';
 import DebugView from '@/components/DebugView';
 import TriStateCheckbox from '@/components/TriStateCheckbox/TriStateCheckbox';
 import FileUpload from '@/components/FileUpload/FileUpload';
@@ -831,7 +832,7 @@ const Index = () => {
 											{custom_id === 'number' && showInForm && <NumberInput id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
 											{custom_id === 'email' && showInForm && <EmailInput id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} onError={handleError} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
 											{custom_id === 'date_hh_mm' && showInForm && <DateWithTimeInput id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} onError={handleError} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
-											{custom_id === 'date' && showInForm && <DateInput id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} onError={handleError} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
+											{custom_id === 'date' && showInForm && <SettingsListDate id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} onError={handleError} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
 											{custom_id === 'hh_mm' && showInForm && <TimeInput id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} onError={handleError} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
 											{custom_id === 'timestamp' && showInForm && <PreciseTimestampInput id={fieldId} value={formData[fieldId]?.value || ''} onChange={handleChange} onError={handleError} error={formData[fieldId]?.error} isDisabled={isDisabled} custom_type={custom_type} prefix={prefix} suffix={suffix} />}
                                                                                         {custom_id === 'checkbox' &&

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -7,6 +7,7 @@ import { Languages, PriceGroupKey } from './types';
 import { AntDesign, Entypo, Feather, FontAwesome5, Ionicons, MaterialCommunityIcons, MaterialIcons, Octicons } from '@expo/vector-icons';
 import { isWeb } from '@/constants/Constants';
 import SettingsList from '@/components/SettingsList';
+import SettingsListEditable from '@/components/SettingsListEditable';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import useModalTextInput from '@/hooks/useModalTextInput';
@@ -425,17 +426,16 @@ const Settings = () => {
 					<View style={{ gap: 0 }}>
 						<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clipboard-account" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.account)} value={isRegisteredUser ? user?.id : translate(TranslationKeys.without_account)} handleFunction={() => {}} groupPosition="top" />
 						{/* NickName */}
-						<SettingsList
+						<SettingsListEditable
 							iconBgColor={primaryColor}
 							leftIcon={<MaterialCommunityIcons name="account" size={24} color={theme.screen.icon} />}
-                                                        label={translate(TranslationKeys.nickname)}
-                                                        value={profile?.id ? profile?.nickname : nickNameLocal}
-                                                        rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
-                                                        handleFunction={() => {
-                                                                openNicknameSheet();
-                                                        }}
-                                                        groupPosition="middle"
-                                                />
+							label={translate(TranslationKeys.nickname)}
+							value={profile?.id ? profile?.nickname : nickNameLocal}
+							handleFunction={() => {
+								openNicknameSheet();
+							}}
+							groupPosition="middle"
+						/>
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={logoutButtonLabel} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={logoutButtonHandler} groupPosition="middle" />
                                                 {isRegisteredUser ? (
                                                         <SettingsList iconBgColor={primaryColor} leftIcon={<AntDesign name="user-delete" size={22} color={theme.screen.icon} />} label={`${translate(TranslationKeys.account_delete)}`} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={handleDeleteAccount} groupPosition="middle" />

--- a/apps/frontend/app/components/SettingsListDate/SettingsListDate.tsx
+++ b/apps/frontend/app/components/SettingsListDate/SettingsListDate.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { parse, format } from 'date-fns';
+
+import SettingsListEditable from '@/components/SettingsListEditable';
+import CalendarSheet from '@/components/CalendarSheet/CalendarSheet';
+import { useModal } from '@/components/GlobalModal/useModal';
+import { useTheme } from '@/hooks/useTheme';
+import styles from './styles';
+import { SettingsListDateProps } from './types';
+
+const SettingsListDate: React.FC<SettingsListDateProps> = ({
+	id,
+	value,
+	onChange,
+	onError,
+	error,
+	custom_type,
+	isDisabled = false,
+	label,
+	placeholder = 'DD.MM.YYYY',
+	editable = true,
+	prefix,
+	suffix,
+	...settingsListProps
+}) => {
+	const { theme } = useTheme();
+	const { show, close } = useModal();
+	const isEditable = editable && !isDisabled;
+
+	const openCalendar = () => {
+		if (!isEditable) return;
+		let selectedDate = null;
+		if (value && /^\d{2}\.\d{2}\.\d{4}$/.test(value)) {
+			try {
+				const parsed = parse(value, 'dd.MM.yyyy', new Date());
+				selectedDate = parsed.toISOString().split('T')[0];
+			} catch (e) {
+				// ignore
+			}
+		}
+
+		show(
+			<CalendarSheet
+				selectedDateProp={selectedDate || undefined}
+				onSelect={(dateString: string) => {
+					try {
+						const parsed = parse(dateString, 'yyyy-MM-dd', new Date());
+						const formatted = format(parsed, 'dd.MM.yyyy');
+						onChange(id, formatted, custom_type);
+						onError(id, '');
+					} catch (e) {
+						// ignore
+					}
+					close();
+				}}
+				closeSheet={() => close()}
+			/>
+		, { backgroundStyle: { backgroundColor: theme.sheet?.sheetBg } }
+		);
+	};
+
+	const decoratedValue = value ? `${prefix ?? ''}${value}${suffix ?? ''}` : '';
+
+	return (
+		<View style={styles.container}>
+			<SettingsListEditable
+				{...settingsListProps}
+				label={label ?? placeholder}
+				value={decoratedValue || undefined}
+				editable={isEditable}
+				handleFunction={openCalendar}
+			/>
+			{Boolean(error) && <Text style={styles.errorText}>{error}</Text>}
+		</View>
+	);
+};
+
+export default SettingsListDate;

--- a/apps/frontend/app/components/SettingsListDate/index.ts
+++ b/apps/frontend/app/components/SettingsListDate/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SettingsListDate';
+export type { SettingsListDateProps } from './types';

--- a/apps/frontend/app/components/SettingsListDate/styles.ts
+++ b/apps/frontend/app/components/SettingsListDate/styles.ts
@@ -1,0 +1,14 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+	container: {
+		width: '100%',
+	},
+	errorText: {
+		color: 'red',
+		fontSize: 10,
+		marginTop: 5,
+		marginLeft: 5,
+		fontFamily: 'Poppins_400Regular',
+	},
+});

--- a/apps/frontend/app/components/SettingsListDate/types.ts
+++ b/apps/frontend/app/components/SettingsListDate/types.ts
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from 'react';
+import type { SettingsListProps } from '@/components/SettingsList';
+
+type SettingsListDatePropsOwn = {
+	id: string;
+	value: string;
+	onChange: (id: string, value: string, custom_type: string) => void;
+	onError: (id: string, error: string) => void;
+	error: string;
+	isDisabled?: boolean;
+	custom_type: string;
+	label?: string;
+	placeholder?: string;
+	editable?: boolean;
+	prefix?: string | null;
+	suffix?: string | null;
+};
+
+export type SettingsListDateProps = PropsWithChildren<
+	Omit<SettingsListProps, 'label' | 'title' | 'value' | 'handleFunction' | 'onPress' | 'rightIcon' | 'rightElement'> & SettingsListDatePropsOwn
+>;

--- a/apps/frontend/app/components/SettingsListEditable/SettingsListEditable.tsx
+++ b/apps/frontend/app/components/SettingsListEditable/SettingsListEditable.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+import SettingsList from '@/components/SettingsList';
+import { useTheme } from '@/hooks/useTheme';
+import { SettingsListEditableProps } from './types';
+
+const SettingsListEditable: React.FC<SettingsListEditableProps> = ({ editable = true, rightElement, rightIcon, ...props }) => {
+	const { theme } = useTheme();
+	const resolvedRightIcon = editable && !rightElement && !rightIcon ? <MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} /> : rightIcon;
+
+	return <SettingsList {...props} rightElement={rightElement} rightIcon={resolvedRightIcon} />;
+};
+
+export default SettingsListEditable;

--- a/apps/frontend/app/components/SettingsListEditable/index.ts
+++ b/apps/frontend/app/components/SettingsListEditable/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SettingsListEditable';
+export type { SettingsListEditableProps } from './types';

--- a/apps/frontend/app/components/SettingsListEditable/types.ts
+++ b/apps/frontend/app/components/SettingsListEditable/types.ts
@@ -1,0 +1,8 @@
+import type { PropsWithChildren } from 'react';
+import type { SettingsListProps } from '@/components/SettingsList';
+
+type SettingsListEditablePropsOwn = {
+	editable?: boolean;
+};
+
+export type SettingsListEditableProps = PropsWithChildren<SettingsListProps & SettingsListEditablePropsOwn>;


### PR DESCRIPTION
### Motivation
- Centralize the editable behavior (default pencil icon + touch-to-edit) for settings rows to avoid duplicated icon logic across multiple screens.
- Provide a settings-style date input that opens the existing calendar modal so form date fields can reuse the settings row appearance and interaction.
- Replace ad-hoc pencil/icon usage in the nickname and feedback screens with a single abstraction to make editable rows consistent.
- Use the new settings-style date row in form submissions for `date` fields so users get a unified UI for date selection.

### Description
- Added `SettingsListEditable` which wraps `SettingsList` and supplies a default pencil icon when `editable` is true and no `rightIcon`/`rightElement` is provided. 
- Added `SettingsListDate` which composes `SettingsListEditable`, opens `CalendarSheet` via `useModal`, formats/parses dates, and displays field errors. 
- Wired `SettingsListEditable` into the settings screen nickname row and into the feedback-support list items to replace manual pencil icons. 
- Switched form handling for `custom_id === 'date'` to use `SettingsListDate` and added related type/style files under `apps/frontend/app/components/SettingsListDate`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f35f80a548330885265e0a4b3e295)