### PR TITLE
Add experimental SettingsList component showcase screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -124,13 +124,20 @@ const Index = () => {
 					</View>
 					<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
 				</TouchableOpacity>
-                                <TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/settings-list-check')}>
-                                        <View style={styles.col}>
-                                                <MaterialCommunityIcons name="format-list-text" color={theme.screen.icon} size={24} />
-                                                <Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.settings_list_check)}</Text>
-                                        </View>
-                                        <Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
-                                </TouchableOpacity>
+				<TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/settings-list-check')}>
+					<View style={styles.col}>
+						<MaterialCommunityIcons name="format-list-text" color={theme.screen.icon} size={24} />
+						<Text style={{ ...styles.body, color: theme.screen.text }}>{translate(TranslationKeys.settings_list_check)}</Text>
+					</View>
+					<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
+				</TouchableOpacity>
+				<TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/settings-list-components')}>
+					<View style={styles.col}>
+						<MaterialCommunityIcons name="format-list-bulleted" color={theme.screen.icon} size={24} />
+						<Text style={{ ...styles.body, color: theme.screen.text }}>SettingsList Komponenten</Text>
+					</View>
+					<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />
+				</TouchableOpacity>
                                 <TouchableOpacity style={{ ...styles.listItem, backgroundColor: theme.screen.iconBg }} onPress={() => router.push('/experimentell/test-use-modal')}>
                                         <View style={styles.col}>
                                                 <MaterialCommunityIcons name="test-tube" color={theme.screen.icon} size={24} />

--- a/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSelector } from 'react-redux';
+
+import { RootState } from '@/redux/reducer';
+import { useTheme } from '@/hooks/useTheme';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import SettingsList from '@/components/SettingsList';
+import SettingsListEditable from '@/components/SettingsListEditable';
+import SettingsListDate from '@/components/SettingsListDate';
+import SettingsListInput from '@/components/SettingsListInput';
+import SettingsListNickname from '@/components/SettingsListNickname';
+import styles from './styles';
+
+const SettingsListComponents = () => {
+	useSetPageTitle('SettingsList Komponenten');
+	const { theme } = useTheme();
+	const { primaryColor } = useSelector((state: RootState) => state.settings);
+	const [dateValue, setDateValue] = useState('01.01.2024');
+	const [dateError, setDateError] = useState('');
+	const [inputValue, setInputValue] = useState('Beispieltext');
+	const [nickname, setNickname] = useState('Tester');
+
+	return (
+		<ScrollView
+			style={{ ...styles.container, backgroundColor: theme.screen.background }}
+			contentContainerStyle={{
+				...styles.contentContainer,
+				backgroundColor: theme.screen.background,
+			}}
+		>
+			<View style={styles.content}>
+				<Text style={{ ...styles.heading, color: theme.screen.text }}>SettingsList Komponenten</Text>
+
+				<Text style={{ ...styles.sectionTitle, color: theme.screen.text }}>SettingsList</Text>
+				<SettingsList
+					iconBgColor={primaryColor}
+					leftIcon={<MaterialCommunityIcons name="format-list-text" size={24} color={theme.screen.icon} />}
+					title="SettingsList Titel"
+					value="Beispielwert"
+					groupPosition="single"
+				/>
+
+				<Text style={{ ...styles.sectionTitle, color: theme.screen.text }}>SettingsListEditable</Text>
+				<SettingsListEditable
+					iconBgColor={primaryColor}
+					leftIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
+					label="Bearbeitbar"
+					value="Tippe zum Editieren"
+					groupPosition="single"
+				/>
+
+				<Text style={{ ...styles.sectionTitle, color: theme.screen.text }}>SettingsListDate</Text>
+				<SettingsListDate
+					id="test-date"
+					value={dateValue}
+					onChange={(_id, value, _customType) => setDateValue(value)}
+					onError={(_id, error) => setDateError(error)}
+					error={dateError}
+					custom_type="date"
+					label="Datum"
+					iconBgColor={primaryColor}
+					leftIcon={<MaterialCommunityIcons name="calendar" size={24} color={theme.screen.icon} />}
+					groupPosition="single"
+				/>
+
+				<Text style={{ ...styles.sectionTitle, color: theme.screen.text }}>SettingsListInput</Text>
+				<SettingsListInput
+					placeholder="Eingabe"
+					value={inputValue}
+					onChangeText={setInputValue}
+					onSave={() => setInputValue(inputValue.trim())}
+					saveLabel="Speichern"
+					disableSave={inputValue.trim().length === 0}
+					autoFocus={false}
+				/>
+
+				<Text style={{ ...styles.sectionTitle, color: theme.screen.text }}>SettingsListNickname</Text>
+				<SettingsListNickname initialValue={nickname} onSave={setNickname} />
+			</View>
+		</ScrollView>
+	);
+};
+
+export default SettingsListComponents;

--- a/apps/frontend/app/app/(app)/experimentell/settings-list-components/styles.ts
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-components/styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	contentContainer: {},
+	content: {
+		width: '100%',
+		height: '100%',
+		padding: 20,
+		rowGap: 12,
+	},
+	heading: {
+		fontSize: 24,
+		fontFamily: 'Poppins_700Bold',
+		marginVertical: 10,
+	},
+	sectionTitle: {
+		fontSize: 16,
+		fontFamily: 'Poppins_600SemiBold',
+		marginTop: 16,
+	},
+});

--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -1,3 +1,4 @@
+// Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
 import React from 'react';
 import { StyleSheet, Text, TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';

--- a/apps/frontend/app/components/SettingsListDate/SettingsListDate.tsx
+++ b/apps/frontend/app/components/SettingsListDate/SettingsListDate.tsx
@@ -1,3 +1,4 @@
+// Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
 import React from 'react';
 import { Text, View } from 'react-native';
 import { parse, format } from 'date-fns';

--- a/apps/frontend/app/components/SettingsListEditable/SettingsListEditable.tsx
+++ b/apps/frontend/app/components/SettingsListEditable/SettingsListEditable.tsx
@@ -1,3 +1,4 @@
+// Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
 import React from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 

--- a/apps/frontend/app/components/SettingsListInput/SettingsListInput.tsx
+++ b/apps/frontend/app/components/SettingsListInput/SettingsListInput.tsx
@@ -1,3 +1,4 @@
+// Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
 import React, { useCallback } from 'react';
 import { KeyboardAvoidingView, Platform, Text, TextInput, TouchableOpacity, View, Keyboard } from 'react-native';
 import { useSelector } from 'react-redux';

--- a/apps/frontend/app/components/SettingsListNickname/SettingsListNickname.tsx
+++ b/apps/frontend/app/components/SettingsListNickname/SettingsListNickname.tsx
@@ -1,3 +1,4 @@
+// Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import SettingsListInput from '@/components/SettingsListInput';


### PR DESCRIPTION
### Motivation
- Provide an experimental screen to preview and test all `SettingsList`-related component variants in one place.
- Make it easier for developers to visually verify `SettingsList` behavior across variants during development.
- Ensure future `SettingsList` components are remembered to be added to the experimental showcase.

### Description
- Add a new experimental screen at `apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx` with accompanying `styles.ts` that renders `SettingsList`, `SettingsListEditable`, `SettingsListDate`, `SettingsListInput`, and `SettingsListNickname` examples.
- Link the new screen from the experimental index by updating `apps/frontend/app/app/(app)/experimentell/index.tsx`.
- Insert reminder comments at the top of the existing `SettingsList`-related component files (`SettingsList`, `SettingsListEditable`, `SettingsListInput`, `SettingsListDate`, `SettingsListNickname`) instructing developers to add new `SettingsList` components to the experimental screen.
- Adjust the example `onChange` usage in the experimental screen for `SettingsListDate` to accept the third `custom_type` parameter and ignore it in the local handler.

### Testing
- No automated tests were executed for this change.
- Files were added and modified and changes were committed to the working branch successfully.
- Manual visual testing is intended use for the new experimental screen (no CI/UI tests run).
- Typechecking or build verification was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f99c4aa408330a1e8ebb66b9859b2)