### PR TITLE
Default SettingsListTextInput to autofocus

### DIFF
--- a/apps/frontend/app/components/SettingsListTextInput.tsx
+++ b/apps/frontend/app/components/SettingsListTextInput.tsx
@@ -151,7 +151,7 @@ const SettingsListTextInput: React.FC<SettingsListTextInputProps> = ({
 	numberOfLines,
 	textAlignVertical,
 	inputStyle,
-	autoFocus,
+	autoFocus = true,
 	checkTextInput,
 	allowSubmitWhenDisabled,
 	rightElement,

--- a/apps/frontend/app/hooks/useMyScrollviewTextInputModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewTextInputModal.tsx
@@ -35,7 +35,7 @@ const ModalTextInputSheet: React.FC<ModalTextInputSheetProps> = ({
 	numberOfLines,
 	textAlignVertical,
 	inputStyle,
-	autoFocus,
+	autoFocus = true,
 	checkTextInput,
 	allowSubmitWhenDisabled,
 }) => {


### PR DESCRIPTION
### Motivation
- Make `SettingsListTextInput` automatically receive focus by default when opened to match expected UX (used in Experimental and nickname flows). 
- Avoid having to explicitly pass `autoFocus` in each usage such as `SettingsListNickname`.
- Simplify modal text input behavior so keyboard/input is focused by default on mobile/web.

### Description
- Set the default prop `autoFocus = true` on the `SettingsListTextInput` component signature in `apps/frontend/app/components/SettingsListTextInput.tsx`.
- Set the default `autoFocus = true` in the `ModalTextInputSheet` inside `apps/frontend/app/hooks/useMyScrollviewTextInputModal.tsx` so the modal sheet also autofocuses when opened.
- Changes ensure `openTextInputModal` continues to forward the `autoFocus` option if provided by callers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950132dc92c8330b6a8c738bd1648b0)