### PR TITLE
Revert translate-and-style-done-button merge

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -4,7 +4,6 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { CalendarSheetProps, Direction } from './types';
 import MyScrollViewModal from '@/components/MyScrollViewModal';
-import ProjectButton from '@/components/ProjectButton';
 import { isWeb } from '@/constants/Constants';
 import { Entypo } from '@expo/vector-icons';
 import { Calendar, LocaleConfig } from 'react-native-calendars';
@@ -18,7 +17,7 @@ import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
 import { format, isValid, parse } from 'date-fns';
 
-const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, selectedDateProp, updateGlobal, buttonColor }) => {
+const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, selectedDateProp, updateGlobal }) => {
     const { theme } = useTheme();
     const { translate } = useLanguage();
     const dispatch = useDispatch();
@@ -29,7 +28,6 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
     const { selectedDate } = useSelector((state: RootState) => state.food);
     const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
     const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
-    const actionColor = buttonColor ?? foods_area_color;
 
     const weekStartMap: Record<string, number> = {
         monday: 1,
@@ -134,11 +132,6 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
                     inputMode="numeric"
                 />
                 {manualError ? <Text style={[styles.manualErrorText, { color: theme.sheet.inputBorderInvalid }]}>{manualError}</Text> : null}
-                <ProjectButton
-                    text={translate(TranslationKeys.done)}
-                    onPress={handleManualSubmit}
-                    backgroundColor={actionColor}
-                />
             </View>
             <View
                 style={{

--- a/apps/frontend/app/components/CalendarSheet/types.ts
+++ b/apps/frontend/app/components/CalendarSheet/types.ts
@@ -3,7 +3,6 @@ export interface CalendarSheetProps {
 	onSelect?: (dateString: string) => void;
 	selectedDateProp?: string;
 	updateGlobal?: boolean;
-	buttonColor?: string;
 }
 
 export type Direction = 'left' | 'right';

--- a/apps/frontend/app/components/ProjectButton/index.tsx
+++ b/apps/frontend/app/components/ProjectButton/index.tsx
@@ -1,30 +1,21 @@
-import React, { ReactNode } from 'react';
-import { Appearance, StyleProp, StyleSheet, Text, TouchableOpacity, ViewStyle } from 'react-native';
+import React from 'react';
+import { Appearance, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { darkTheme, lightTheme } from '@/styles/themes';
+import { ProjectButtonProps } from './types';
 
-export interface ProjectButtonProps {
-	text: string;
-	onPress?: () => void;
-	iconLeft?: ReactNode;
-	iconRight?: ReactNode;
-	backgroundColor?: string;
-	style?: StyleProp<ViewStyle>;
-}
-
-const ProjectButton: React.FC<ProjectButtonProps> = ({ text, onPress, iconLeft, iconRight, backgroundColor, style }) => {
+const ProjectButton: React.FC<ProjectButtonProps> = ({ text, onPress, iconLeft, iconRight, style }) => {
 	const { primaryColor, selectedTheme } = useSelector((state: RootState) => state.settings);
 
 	const colorScheme = Appearance.getColorScheme();
 	const theme = selectedTheme === 'systematic' ? (colorScheme === 'dark' ? darkTheme : lightTheme) : selectedTheme === 'dark' ? darkTheme : lightTheme;
 
-	const resolvedBackgroundColor = backgroundColor ?? primaryColor;
-	const contrastColor = myContrastColor(resolvedBackgroundColor, theme, selectedTheme === 'dark');
+	const contrastColor = myContrastColor(primaryColor, theme, selectedTheme === 'dark');
 
 	return (
-		<TouchableOpacity style={[styles.container, { backgroundColor: resolvedBackgroundColor }, style]} onPress={onPress}>
+		<TouchableOpacity style={[styles.container, { backgroundColor: primaryColor }, style]} onPress={onPress}>
 			{iconLeft}
 			<Text style={[styles.label, { color: contrastColor }]}>{text}</Text>
 			{iconRight}

--- a/apps/frontend/app/components/ProjectButton/types.ts
+++ b/apps/frontend/app/components/ProjectButton/types.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+
+export interface ProjectButtonProps {
+	text: string;
+	onPress?: () => void;
+	iconLeft?: ReactNode;
+	iconRight?: ReactNode;
+	style?: StyleProp<ViewStyle>;
+}

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -53,7 +53,6 @@ export enum TranslationKeys {
 	without_account = 'without_account',
 	reset = 'reset',
 	confirm = 'confirm',
-	done = 'done',
 	are_you_sure_to_delete_your_account = 'are_you_sure_to_delete_your_account',
 	account_deletion_info = 'account_deletion_info',
 	dataAccess = 'dataAccess',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -539,16 +539,6 @@
     "tr": "Onayla",
     "zh": "确认"
   },
-  "done": {
-    "de": "Fertig",
-    "en": "Done",
-    "ar": "تم",
-    "es": "Hecho",
-    "fr": "Terminé",
-    "ru": "Готово",
-    "tr": "Bitti",
-    "zh": "完成"
-  },
   "are_you_sure_to_delete_your_account": {
     "de": "Sind Sie sicher, dass Sie Ihren Account löschen möchten?",
     "en": "Are you sure to delete your account?",


### PR DESCRIPTION
### Motivation
- Undo the changes introduced by the `translate-and-style-done-button` merge to restore prior UI behavior.
- Remove the ad-hoc `done` localization and the altered `ProjectButton` styling approach.
- Restore `CalendarSheet` to its previous handling of manual date input and selection flow.

### Description
- Reverted changes in `CalendarSheet.tsx`, removing the `ProjectButton` usage for the manual input done action and dropping the `buttonColor` prop from the component API.
- Updated `ProjectButton` to no longer accept a `backgroundColor` prop and to use the app `primaryColor` from settings, and added `ProjectButton/types.ts` for the prop interface.
- Removed the `TranslationKeys.done` entry and deleted the corresponding `done` translations from `apps/frontend/app/locales/translations.json`.
- Overall change set restores previous behavior and removes the new styling/localization changes from the reverted merge.

### Testing
- No automated tests or CI runs were executed for this revert.
- No unit or integration tests were run locally as part of this change.
- Manual verification was not recorded in automated test output.
- The revert operation completed successfully in the repository history.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501f839f84833083fde58cd4d87609)