### PR TITLE
Localize "Done" return key in CalendarSheet

### DIFF
--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -128,6 +128,7 @@ const CalendarSheet: React.FC<CalendarSheetProps> = ({ closeSheet, onSelect, sel
                     }}
                     onSubmitEditing={handleManualSubmit}
                     returnKeyType="done"
+                    returnKeyLabel={translate(TranslationKeys.done)}
                     keyboardType="number-pad"
                     inputMode="numeric"
                 />

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -229,6 +229,7 @@ export enum TranslationKeys {
 	color = 'color',
 	cancel = 'cancel',
 	submit = 'submit',
+	done = 'done',
 	warning = 'warning',
 	for_example = 'for_example',
 	courseTimetableDescriptionEmpty = 'courseTimetableDescriptionEmpty',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -2309,6 +2309,16 @@
     "tr": "Gönder",
     "zh": "提交"
   },
+  "done": {
+    "de": "Fertig",
+    "en": "Done",
+    "ar": "تم",
+    "es": "Listo",
+    "fr": "Terminé",
+    "ru": "Готово",
+    "tr": "Tamam",
+    "zh": "完成"
+  },
   "warning": {
     "de": "Warnung",
     "en": "Warning",


### PR DESCRIPTION
### Motivation
- Provide a localized label for the keyboard return/action button when entering a manual date in the calendar modal to improve i18n support.
- Ensure the manual input experience uses the app's translation mechanism for consistency across languages.

### Description
- Added a new translation key `done` to `apps/frontend/app/locales/keys.ts` and provided localized strings in `apps/frontend/app/locales/translations.json`.
- Updated `apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx` to pass `returnKeyLabel={translate(TranslationKeys.done)}` on the manual date `TextInput`.
- The change is limited to the calendar modal manual input and translation files and does not alter other behavior.

### Testing
- No automated tests were executed for this change.
- Files were committed successfully and the branch changes are staged as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950367467648330a75c30d0481e2185)