### PR TITLE
Replace image edit sheets with scrollview modal

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -24,18 +24,16 @@ import { CampusHelper } from '@/redux/actions/Campus/Campus';
 import { SET_CAMPUSES, SET_CAMPUSES_DICT, SET_CAMPUSES_LOCAL, SET_UNSORTED_CAMPUSES } from '@/redux/Types/types';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { calculateDistanceInMeter } from '@/helper/distanceHelper';
-import BaseBottomSheet from '@/components/BaseBottomSheet';
-import type BottomSheet from '@gorhom/bottom-sheet';
 import DistanceModal from '@/components/DistanceModal';
 import * as Location from 'expo-location';
 import useToast from '@/hooks/useToast';
 import { useLanguage } from '@/hooks/useLanguage';
-import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import useCampusSortingModal from '@/hooks/useCampusSortingModal';
+import useMyScrollviewDirectusImageEditModal from '@/hooks/useMyScrollviewDirectusImageEditModal';
 
 import IconButton from '@/components/UI/IconButton';
 import Button from '@/components/UI/Button';
@@ -59,22 +57,20 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 	const [campusesDispatched, setCampusesDispatched] = useState(false);
 	const [selectedBuilding, setSelectedBuilding] = useState<DatabaseTypes.Buildings | null>(null);
 	const [distanceAdded, setDistanceAdded] = useState(false);
-	const [selectedApartmentId, setSelectedApartementId] = useState<string>('');
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const [listWidth, setListWidth] = useState<number | null>(null);
 
 	const { drawerPosition, campusesSortBy, amountColumnsForcard, primaryColor, serverInfo, appSettings, selectedTheme } =
 		useSelector((state: RootState) => state.settings);
 	const { campuses, campusesLocal, unSortedCampuses } = useSelector((state: RootState) => state.campus);
+	const { isManagement } = useSelector((state: RootState) => state.authReducer);
 	const selectedCanteen = useSelectedCanteen();
 	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
 
-	const imageManagementSheetRef = useRef<BottomSheet>(null);
 	const [distanceModalVisible, setDistanceModalVisible] = useState(false);
 	const { openCampusSortingModal } = useCampusSortingModal();
+	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
 
-	const openImageManagementSheet = useCallback(() => imageManagementSheetRef.current?.expand(), []);
-	const closeImageManagementSheet = useCallback(() => imageManagementSheetRef.current?.close(), []);
 	const openDistanceSheet = useCallback(() => setDistanceModalVisible(true), []);
 	const closeDistanceSheet = useCallback(() => setDistanceModalVisible(false), []);
 
@@ -273,7 +269,24 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 		appSettings,
 		selectedTheme,
 		screenWidth,
-	}), [amountColumnsForcard, primaryColor, serverInfo, appSettings, selectedTheme, screenWidth]);
+		isManagement,
+	}), [amountColumnsForcard, primaryColor, serverInfo, appSettings, selectedTheme, screenWidth, isManagement]);
+
+	const openImageManagementModal = useCallback(
+		(campus: DatabaseTypes.Buildings) => {
+			if (!campus?.id) return;
+			openDirectusImageEditModal({
+				item: campus,
+				imageField: 'image',
+				collection: 'buildings',
+				onUpdated: () => {
+					setCampusesDispatched(false);
+					fetchAllCampuses();
+				},
+			});
+		},
+		[fetchAllCampuses, openDirectusImageEditModal]
+	);
 
 	const renderItem = useCallback(
 		({ item }: { item: DatabaseTypes.Buildings }) => {
@@ -288,8 +301,7 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 				>
 					<BuildingItem
 						campus={item}
-						setSelectedApartementId={setSelectedApartementId}
-						openImageManagementSheet={openImageManagementSheet}
+						onEditImage={openImageManagementModal}
 						openDistanceSheet={openDistanceSheet}
 						settings={settingsForItem}
 					/>
@@ -297,9 +309,8 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 			);
 		},
 		[
-			openImageManagementSheet,
+			openImageManagementModal,
 			openDistanceSheet,
-			setSelectedApartementId,
 			settingsForItem,
 			itemGap,
 		]
@@ -419,27 +430,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 						/>
 					</View>
 				</View>
-
-				<BaseBottomSheet
-					ref={imageManagementSheetRef}
-					index={-1}
-					backgroundStyle={{ ...styles.sheetBackground }}
-					handleComponent={null}
-					enablePanDownToClose
-					enableHandlePanningGesture={false}
-					enableContentPanningGesture={false}
-					onClose={closeImageManagementSheet}
-				>
-					<ImageManagementSheet
-						closeSheet={closeImageManagementSheet}
-						selectedFoodId={selectedApartmentId}
-						handleFetch={() => {
-							setCampusesDispatched(false);
-							fetchAllCampuses();
-						}}
-						fileName="buildings"
-					/>
-				</BaseBottomSheet>
 
 				<DistanceModal visible={distanceModalVisible} onClose={closeDistanceSheet} onUseCurrentPosition={useCurrentLocationForDistance} />
 			</View>

--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -22,7 +22,6 @@ import HourSheet from '@/components/HoursSheet/HoursSheet';
 import CalendarSheet from '@/components/CalendarSheet/CalendarSheet';
 import { excerpt } from '@/constants/HelperFunctions';
 import { useLanguage } from '@/hooks/useLanguage';
-import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import * as Notifications from 'expo-notifications';
@@ -48,7 +47,6 @@ export const SHEET_COMPONENTS = {
         sort: SortSheet,
         hours: HourSheet,
         calendar: CalendarSheet,
-        imageManagement: ImageManagementSheet,
         aiGeneratedInfo: AIGeneratedHintSheet,
         eatingHabits: EatingHabitsSheet,
 };
@@ -64,7 +62,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const [loading, setLoading] = useState(false);
 	const [isActive, setIsActive] = useState(false);
 	const [refreshing, setRefreshing] = useState(false);
-	const [selectedFoodId, setSelectedFoodId] = useState('');
 	const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
@@ -161,16 +158,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 [closeScrollViewModal, showScrollViewModal, translate]
         );
 
-	const openManagementSheet = (id: string) => {
-		if (id) {
-			openSheet('imageManagement', {
-				selectedFoodId: id,
-				fileName: 'foods',
-				closeSheet: closeSheet,
-				handleFetch: fetchFoods,
-			});
-		}
-	};
 
 	useEffect(() => {
 		openActiveModal();

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -41,7 +41,6 @@ import HourSheet from '@/components/HoursSheet/HoursSheet';
 import CalendarSheet from '@/components/CalendarSheet/CalendarSheet';
 import {excerpt} from '@/constants/HelperFunctions';
 import {useLanguage} from '@/hooks/useLanguage';
-import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet';
 import {CanteenFeedbackLabelHelper} from '@/redux/actions/CanteenFeedbacksLabel/CanteenFeedbacksLabel';
 import CanteenFeedbackLabels from '@/components/CanteenFeedbackLabels/CanteenFeedbackLabels';
@@ -72,13 +71,13 @@ import useUtilizationModal from '@/hooks/useUtilizationModal';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import useAppForegroundUpdateCheckModal from '@/hooks/useAppForegroundUpdateCheckModal';
+import useMyScrollviewDirectusImageEditModal from '@/hooks/useMyScrollviewDirectusImageEditModal';
 
 export const SHEET_COMPONENTS = {
         canteen: CanteenSelectionSheet,
         sort: SortSheet,
         hours: HourSheet,
         calendar: CalendarSheet,
-        imageManagement: ImageManagementSheet,
         aiGeneratedInfo: AIGeneratedHintSheet,
         eatingHabits: EatingHabitsSheet,
 };
@@ -103,7 +102,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const [refreshing, setRefreshing] = useState(false);
         const [beforeElement, setBeforeElement] = useState<any>(null);
         const [afterElement, setAfterElement] = useState<any>(null);
-        const [selectedFoodId, setSelectedFoodId] = useState('');
         const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
 	const [feedbackLabelsLoading, setFeedbackLabelsLoading] = useState(true);
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
@@ -139,6 +137,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
         const { openActiveModal, activePopupEvent } = usePopupEventModal();
         const { openFoodofferSortingModal } = useFoodofferSortingModal();
+        const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
         useAppForegroundUpdateCheckModal();
 
 	const MIN_CARD_WIDTH = 280;
@@ -309,17 +308,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 setSheetProps(props);
         }, [openFoodofferSortingModal]);
 
-        const openManagementSheet = useCallback((id: string) => {
-                if (id) {
-                        openSheet('imageManagement', {
-				selectedFoodId: id,
-				fileName: 'foods',
-				closeSheet: closeSheet,
-				handleFetch: fetchFoods,
-			});
-		}
-	}, []);
-
 	useEffect(() => {
 		openActiveModal();
 	}, [activePopupEvent, openActiveModal]);
@@ -439,6 +427,19 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 	};
 
+        const openManagementSheet = useCallback(
+		(food: DatabaseTypes.Foods) => {
+			if (!food?.id) return;
+			openDirectusImageEditModal({
+				item: food,
+				imageField: 'image',
+				collection: 'foods',
+				onUpdated: fetchFoods,
+			});
+		},
+		[fetchFoods, openDirectusImageEditModal]
+	);
+
 	const fetchCanteenLabels = async () => {
 		try {
 			setFeedbackLabelsLoading(true);
@@ -518,7 +519,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 							handleMenuSheet={openSheet}
 							handleImageSheet={openManagementSheet}
 							handleEatingHabitsSheet={openSheet}
-							setSelectedFoodId={setSelectedFoodId}
 							cardWidth={cardWidth}
 						/>
 					) : item.foodofferInfoItem ? (
@@ -538,7 +538,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 			openManagementSheet,
 			openSheet,
 			selectedCanteen,
-			setSelectedFoodId,
 			getInfoItemContent,
 			itemGap,
 			cardWidth

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -1,5 +1,5 @@
 import { ActivityIndicator, Dimensions, RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApartmentSortOption, CollectibleAt, DatabaseTypes } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -15,11 +15,8 @@ import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { calculateDistanceInMeter } from '@/helper/distanceHelper';
 import { ApartmentsHelper } from '@/redux/actions/Apartments/Apartments';
 import ApartmentItem from '@/components/ApartmentItem/ApartmentItem';
-import BaseBottomSheet from '@/components/BaseBottomSheet';
-import type BottomSheet from '@gorhom/bottom-sheet';
 import useToast from '@/hooks/useToast';
 import { useLanguage } from '@/hooks/useLanguage';
-import ImageManagementSheet from '@/components/ImageManagementSheet/ImageManagementSheet';
 import DistanceModal from '@/components/DistanceModal';
 import * as Location from 'expo-location';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -31,6 +28,7 @@ import { RootState } from '@/redux/reducer';
 import { FlashList } from '@shopify/flash-list';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import useHousingSortingModal from '@/hooks/useHousingSortingModal';
+import useMyScrollviewDirectusImageEditModal from '@/hooks/useMyScrollviewDirectusImageEditModal';
 
 const MIN_CARD_WIDTH = 280;
 
@@ -45,8 +43,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const [query, setQuery] = useState<string>('');
 	const [loading, setLoading] = useState(true);
 	const [isActive, setIsActive] = useState(false);
-	const imageManagementSheetRef = useRef<BottomSheet>(null);
-
 	const [distanceModalVisible, setDistanceModalVisible] = useState(false);
 	const [apartmentsDispatched, setApartmentsDispatched] = useState(false);
 	const [distanceAdded, setDistanceAdded] = useState(false);
@@ -54,7 +50,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
 	const [refreshing, setRefreshing] = useState(false);
 	const [selectedBuilding, setSelectedBuilding] = useState<DatabaseTypes.Buildings | null>();
-	const [selectedApartmentId, setSelectedApartementId] = useState<string>('');
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const [listWidth, setListWidth] = useState<number | null>(null);
 
@@ -64,16 +59,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
 	const housing_area_color = appSettings?.housing_area_color ? appSettings?.housing_area_color : projectColor;
 	const { openHousingSortingModal } = useHousingSortingModal();
+	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
 
 	const drawerNavigation = useNavigation<DrawerNavigationProp<RootDrawerParamList>>();
-
-	const openImageManagementSheet = () => {
-		imageManagementSheetRef?.current?.expand();
-	};
-
-	const closeImageManagementSheet = () => {
-		imageManagementSheetRef?.current?.close();
-	};
 
 	const openDistanceSheet = () => {
 		setDistanceModalVisible(true);
@@ -225,6 +213,22 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		fetchAllApartments();
 	}, []);
 
+	const openImageManagementModal = useCallback(
+		(apartment: DatabaseTypes.Apartments) => {
+			if (!apartment?.id) return;
+			openDirectusImageEditModal({
+				item: apartment,
+				imageField: 'image',
+				collection: 'buildings',
+				onUpdated: () => {
+					setApartmentsDispatched(false);
+					fetchAllApartments();
+				},
+			});
+		},
+		[fetchAllApartments, openDirectusImageEditModal]
+	);
+
 	const sortApartmentsIntelligently = (apartments: any[]) => {
 		if (!apartments) return apartments;
 
@@ -356,15 +360,14 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 					alignItems: 'center',
 				}}
 			>
-				<ApartmentItem
-					apartment={item}
-					setSelectedApartementId={setSelectedApartementId}
-					openImageManagementSheet={openImageManagementSheet}
-					openDistanceSheet={openDistanceSheet}
-				/>
+					<ApartmentItem
+						apartment={item}
+						onEditImage={openImageManagementModal}
+						openDistanceSheet={openDistanceSheet}
+					/>
 			</View>
 		),
-		[openImageManagementSheet, openDistanceSheet]
+		[openImageManagementModal, openDistanceSheet]
 	);
 
 	const keyExtractor = useCallback(
@@ -525,32 +528,6 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 						/>
 					</View>
 				</View>
-				{isActive && (
-					<BaseBottomSheet
-						ref={imageManagementSheetRef}
-						index={-1}
-						backgroundStyle={{
-							...styles.sheetBackground,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						handleComponent={null}
-						enablePanDownToClose
-						enableHandlePanningGesture={false}
-						enableContentPanningGesture={false}
-						onClose={closeImageManagementSheet}
-					>
-						<ImageManagementSheet
-							closeSheet={closeImageManagementSheet}
-							selectedFoodId={selectedApartmentId}
-							handleFetch={() => {
-								setApartmentsDispatched(false);
-								fetchAllApartments();
-							}}
-							fileName="buildings"
-						/>
-					</BaseBottomSheet>
-				)}
-
 				{isActive && <DistanceModal visible={distanceModalVisible} onClose={closeDistanceSheet} onUseCurrentPosition={useCurrentLocationForDistance} />}
 			</View>
 		</SafeAreaView>

--- a/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
+++ b/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
@@ -18,7 +18,7 @@ import CardWithText from '../CardWithText/CardWithText';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 import AvailableFromModal from '../AvailableFromModal';
 
-const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, setSelectedApartementId, openImageManagementSheet, openDistanceSheet }) => {
+const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, onEditImage, openDistanceSheet }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { primaryColor: projectColor, appSettings, serverInfo, selectedTheme: mode, amountColumnsForcard } = useSelector((state: RootState) => state.settings);
@@ -114,8 +114,7 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, setSelectedApar
 													{...triggerProps}
 													style={styles.editImageButton}
 													onPress={() => {
-														setSelectedApartementId(apartment.id);
-														openImageManagementSheet();
+														onEditImage?.(apartment);
 													}}
 												>
 													<MaterialCommunityIcons name="image-edit" size={20} color={'white'} />

--- a/apps/frontend/app/components/ApartmentItem/types.ts
+++ b/apps/frontend/app/components/ApartmentItem/types.ts
@@ -1,6 +1,5 @@
 export interface BuildingItemProps {
 	apartment: any;
-	setSelectedApartementId: React.Dispatch<React.SetStateAction<string>>;
-	openImageManagementSheet: () => void;
+	onEditImage?: (apartment: any) => void;
 	openDistanceSheet: () => void;
 }

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -6,7 +6,6 @@ import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
 import { useTheme } from '@/hooks/useTheme';
 import { myContrastColor } from '@/helper/ColorHelper';
 import styles from './styles';
-import { BuildingItemProps } from './types';
 import { router } from 'expo-router';
 import { getDistanceUnit } from '@/helper/distanceHelper';
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
@@ -18,8 +17,7 @@ import CardDimensionHelper from '@/helper/CardDimensionHelper';
 
 export interface BuildingItemPropsOptimized {
 	campus: any;
-	setSelectedApartementId: React.Dispatch<React.SetStateAction<string>>;
-	openImageManagementSheet?: () => void;
+	onEditImage?: (campus: any) => void;
 	openDistanceSheet: () => void;
 	settings: {
 		amountColumnsForcard: number;
@@ -32,7 +30,7 @@ export interface BuildingItemPropsOptimized {
 	};
 }
 
-const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, openDistanceSheet, setSelectedApartementId, settings }) => {
+const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, onEditImage, openDistanceSheet, settings }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 
@@ -92,8 +90,12 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, openDistan
 					imageChildren={
 						<View style={styles.imageActionContainer}>
 							{isManagement ? (
-								<TouchableOpacity style={styles.editImageButton} onPress={() => {
-								}}>
+								<TouchableOpacity
+									style={styles.editImageButton}
+									onPress={() => {
+										onEditImage?.(campus);
+									}}
+								>
 									<View />
 								</TouchableOpacity>
 							) : (

--- a/apps/frontend/app/components/BuildingItem/types.ts
+++ b/apps/frontend/app/components/BuildingItem/types.ts
@@ -1,6 +1,5 @@
 export interface BuildingItemProps {
 	campus: any;
-	setSelectedApartementId: React.Dispatch<React.SetStateAction<string>>;
-	openImageManagementSheet: () => void;
+	onEditImage?: (campus: any) => void;
 	openDistanceSheet: () => void;
 }

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -33,7 +33,7 @@ const selectPreviousFeedback = createSelector([selectFoodState, (_: RootState, f
 const selectMarkings = createSelector([selectFoodState], foodState => foodState.markings);
 
 const FoodItem: React.FC<FoodItemProps> = memo(
-  ({ item, canteen, handleMenuSheet, handleImageSheet, setSelectedFoodId, handleEatingHabitsSheet, cardWidth }) => {
+  ({ item, canteen, handleMenuSheet, handleImageSheet, handleEatingHabitsSheet, cardWidth }) => {
     const toast = useToast();
     const dispatch = useDispatch();
     const { theme } = useTheme();
@@ -197,8 +197,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                     <TouchableOpacity
                       style={styles.editImageButton}
                       onPress={() => {
-                        setSelectedFoodId(foodItem?.id);
-                        handleImageSheet(foodItem?.id);
+                        handleImageSheet(foodItem);
                       }}
                     >
                       <MaterialCommunityIcons name="image-edit" size={20} color="white" />

--- a/apps/frontend/app/components/FoodItem/types.ts
+++ b/apps/frontend/app/components/FoodItem/types.ts
@@ -6,9 +6,8 @@ export interface FoodItemProps {
 	canteen: DatabaseTypes.Canteens;
 	// handleNavigation: (id: string, foodId: string) => void;
 	handleMenuSheet: (sheet: keyof typeof SHEET_COMPONENTS) => void;
-	handleImageSheet: (id: string) => void;
+	handleImageSheet: (item: DatabaseTypes.Foods) => void;
 	handleEatingHabitsSheet: (sheet: keyof typeof SHEET_COMPONENTS) => void;
 	// setItemMarkings: React.Dispatch<React.SetStateAction<DatabaseTypes.FoodoffersMarkings[]>>;
-	setSelectedFoodId: React.Dispatch<React.SetStateAction<string>>;
 	cardWidth?: number; 
 }

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -16,6 +16,7 @@ import BaseBottomSheet from '@/components/BaseBottomSheet';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import { SHEET_COMPONENTS } from '@/app/(app)/foodoffers';
+import useMyScrollviewDirectusImageEditModal from '@/hooks/useMyScrollviewDirectusImageEditModal';
 
 interface FoodOffersScrollListProps {
 	canteenId: string;
@@ -40,8 +41,8 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
         const [refreshing, setRefreshing] = useState(false);
         const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
         const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
-        const [selectedFoodId, setSelectedFoodId] = useState('');
         const bottomSheetRef = useRef<BottomSheet>(null);
+	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
         const openSheet = useCallback(
                 (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
                         setSelectedSheet(sheet);
@@ -58,17 +59,6 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 			setSheetProps({});
 		}, 150);
 	}, []);
-
-	const openManagementSheet = (id: string) => {
-		if (id) {
-			openSheet('imageManagement', {
-				selectedFoodId: id,
-				fileName: 'foods',
-				closeSheet,
-				handleFetch: init,
-			});
-		}
-	};
 
 	useEffect(() => {
 		if (selectedSheet) {
@@ -125,6 +115,19 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		setLoading(false);
 	}, [startDate, loadDay]);
 
+	const openManagementSheet = useCallback(
+		(food: DatabaseTypes.Foods) => {
+			if (!food?.id) return;
+			openDirectusImageEditModal({
+				item: food,
+				imageField: 'image',
+				collection: 'foods',
+				onUpdated: init,
+			});
+		},
+		[init, openDirectusImageEditModal]
+	);
+
 	useEffect(() => {
 		init();
 	}, [init]);
@@ -160,7 +163,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 					}}
 				>
 					{item.offers.map(offer => (
-						<FoodItem key={offer.id} item={offer} canteen={selectedCanteen as DatabaseTypes.Canteens} handleMenuSheet={openSheet} handleImageSheet={openManagementSheet} handleEatingHabitsSheet={openSheet} setSelectedFoodId={setSelectedFoodId} />
+						<FoodItem key={offer.id} item={offer} canteen={selectedCanteen as DatabaseTypes.Canteens} handleMenuSheet={openSheet} handleImageSheet={openManagementSheet} handleEatingHabitsSheet={openSheet} />
 					))}
 					{item.offers.length === 0 && <Text style={{ color: theme.screen.text }}>{translate(TranslationKeys.no_foodoffers_found_for_selection)}</Text>}
 				</View>

--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -1,0 +1,342 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Platform, View } from 'react-native';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { useSelector } from 'react-redux';
+import { uploadFiles } from '@directus/sdk';
+
+import SettingsList from '@/components/SettingsList';
+import { ImagePickerMediaTypes } from '@/components/FileUpload/FileUpload';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { isWeb } from '@/constants/Constants';
+import { ServerAPI } from '@/redux/actions';
+import { CollectionHelper } from '@/helper/collectionHelper';
+import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+
+type DirectusImageEditModalOptions = {
+	item: Record<string, any> | null | undefined;
+	imageField: string;
+	collection: string;
+	onUpdated?: () => void;
+	title?: string;
+};
+
+type DirectusImageEditModalContentProps = {
+	item: Record<string, any>;
+	imageField: string;
+	collection: string;
+	onUpdated?: () => void;
+	onClose: () => void;
+};
+
+const MAX_IMAGE_DIMENSION = 6000;
+
+const useFoodFolder = (collection: string) => {
+	const { foodCollection } = useSelector((state: RootState) => state.food);
+
+	if (collection !== 'foods') return '';
+
+	const id = foodCollection?.meta?.options?.folder;
+	return id || '';
+};
+
+const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps> = ({
+	item,
+	imageField,
+	collection,
+	onUpdated,
+	onClose,
+}) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const [loading, setLoading] = useState({ camera: false, image: false, delete: false });
+	const [isDelete, setIsDelete] = useState(false);
+	const storage = useFoodFolder(collection);
+
+	const imageRemoteUrlField = 'image_remote_url';
+	const imageGeneratedField = 'image_generated';
+
+	const buildUpdatePayload = useCallback(
+		(payload: Record<string, any>) => {
+			const basePayload = { ...payload };
+
+			if (Object.prototype.hasOwnProperty.call(item, imageGeneratedField)) {
+				basePayload[imageGeneratedField] = false;
+			}
+			return basePayload;
+		},
+		[item]
+	);
+
+	const handleImagePick = useCallback(
+		async (useCamera: boolean) => {
+			if (!item?.id) return;
+			if (loading.camera || loading.image || loading.delete) return;
+			try {
+				const permissionResponse = useCamera
+					? await ImagePicker.requestCameraPermissionsAsync()
+					: await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+				if (!permissionResponse.granted) {
+					Alert.alert('Permission Denied', 'Please grant permissions to access the camera or gallery.');
+					return;
+				}
+
+				const pickerResult = useCamera
+					? await ImagePicker.launchCameraAsync({
+							mediaTypes: [ImagePickerMediaTypes.Images],
+							allowsEditing: true,
+							aspect: [1, 1],
+							allowsMultipleSelection: false,
+							selectionLimit: 1,
+							quality: 1,
+						})
+					: await ImagePicker.launchImageLibraryAsync({
+							mediaTypes: [ImagePickerMediaTypes.Images],
+							allowsEditing: true,
+							aspect: [1, 1],
+							allowsMultipleSelection: false,
+							selectionLimit: 1,
+							quality: 1,
+						});
+
+				if (pickerResult.canceled) {
+					Alert.alert('Canceled the image');
+					return;
+				}
+
+				const { uri, width, height } = pickerResult.assets[0];
+				let finalUri = uri;
+
+				if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
+					const aspectRatio = width / height;
+					const newDimensions =
+						width > height
+							? {
+									width: MAX_IMAGE_DIMENSION,
+									height: MAX_IMAGE_DIMENSION / aspectRatio,
+								}
+							: {
+									width: MAX_IMAGE_DIMENSION * aspectRatio,
+									height: MAX_IMAGE_DIMENSION,
+								};
+
+					const resizedImage = await ImageManipulator.manipulateAsync(
+						uri,
+						[{ resize: newDimensions }],
+						{ compress: 1, format: ImageManipulator.SaveFormat.JPEG }
+					);
+
+					finalUri = resizedImage.uri;
+				}
+
+				setLoading(prev => ({ ...prev, camera: useCamera, image: !useCamera }));
+
+				const formData = new FormData();
+				const fileName = `${collection}_${item.id}`;
+
+				if (Platform.OS === 'web') {
+					const blob: Blob = await new Promise((resolve, reject) => {
+						const xhr = new XMLHttpRequest();
+						xhr.onload = function () {
+							resolve(xhr.response);
+						};
+						xhr.onerror = function (e) {
+							console.log(e);
+							reject(new TypeError('Network request failed'));
+						};
+						xhr.responseType = 'blob';
+						xhr.open('GET', finalUri, true);
+						xhr.send(null);
+					});
+
+					if (storage) {
+						formData.append('folder', storage);
+					}
+					formData.append('image', blob, fileName);
+				} else {
+					const uriParts = finalUri.split('.');
+					const fileType = uriParts[uriParts.length - 1];
+					const fileExtension = `.${fileType}`;
+					const file: any = {
+						uri: finalUri,
+						name: fileName + fileExtension,
+						type: `image/${fileType}`,
+					};
+
+					if (storage) {
+						formData.append('folder', storage);
+					}
+					formData.append('image', file, fileName);
+				}
+
+				const client = ServerAPI.getClient();
+				formData.append('title', fileName);
+
+				const resultFileUpload = await client.request(uploadFiles(formData));
+				const fileId = resultFileUpload.id;
+
+				const collectionHelper = new CollectionHelper(collection);
+				await collectionHelper.updateItem(String(item.id), buildUpdatePayload({ [imageField]: fileId }));
+
+				onUpdated?.();
+				onClose();
+			} catch (error) {
+				console.error('Error selecting image:', error);
+			} finally {
+				setLoading({ camera: false, image: false, delete: false });
+			}
+		},
+		[buildUpdatePayload, collection, imageField, item?.id, loading, onClose, onUpdated, storage]
+	);
+
+	const handleDeleteImage = useCallback(async () => {
+		if (!item?.id) return;
+		if (loading.camera || loading.image || loading.delete) return;
+		try {
+			setLoading(prev => ({ ...prev, delete: true }));
+			const collectionHelper = new CollectionHelper(collection);
+			const payload: Record<string, any> = {
+				[imageField]: null,
+			};
+
+			if (Object.prototype.hasOwnProperty.call(item, imageRemoteUrlField)) {
+				payload[imageRemoteUrlField] = null;
+			}
+
+			await collectionHelper.updateItem(String(item.id), buildUpdatePayload(payload));
+			onUpdated?.();
+			onClose();
+		} catch (error) {
+			console.error('Error deleting image:', error);
+		} finally {
+			setLoading(prev => ({ ...prev, delete: false }));
+		}
+	}, [buildUpdatePayload, collection, imageField, item, loading, onClose, onUpdated]);
+
+	const actionItems = useMemo(() => {
+		if (isDelete) {
+			return [
+				{
+					key: 'delete-confirm',
+					label: translate(TranslationKeys.delete),
+					icon: <MaterialCommunityIcons name="delete" size={24} />,
+					rightElement: loading.delete ? <ActivityIndicator size="small" color={theme.screen.icon} /> : null,
+					onPress: handleDeleteImage,
+				},
+				{
+					key: 'delete-cancel',
+					label: translate(TranslationKeys.cancel),
+					icon: <MaterialCommunityIcons name="close" size={24} />,
+					onPress: () => {
+						setIsDelete(false);
+						onClose();
+					},
+				},
+				{
+					key: 'delete-back',
+					label: translate(TranslationKeys.navigate_back),
+					icon: <MaterialCommunityIcons name="keyboard-backspace" size={24} />,
+					onPress: () => setIsDelete(false),
+				},
+			];
+		}
+
+		const items = [];
+		if (!isWeb) {
+			items.push({
+				key: 'camera',
+				label: translate(TranslationKeys.camera),
+				icon: <Ionicons name="camera" size={24} />,
+				rightElement: loading.camera ? <ActivityIndicator size="small" color={theme.screen.icon} /> : null,
+				onPress: () => handleImagePick(true),
+			});
+		}
+		items.push({
+			key: 'gallery',
+			label: translate(TranslationKeys.gallery),
+			icon: <MaterialCommunityIcons name="folder-image" size={24} />,
+			rightElement: loading.image ? <ActivityIndicator size="small" color={theme.screen.icon} /> : null,
+			onPress: () => handleImagePick(false),
+		});
+		items.push({
+			key: 'delete',
+			label: translate(TranslationKeys.delete),
+			icon: <MaterialCommunityIcons name="delete" size={24} />,
+			rightIcon: <MaterialCommunityIcons name="arrow-right" size={24} color={theme.screen.icon} />,
+			onPress: () => setIsDelete(true),
+		});
+		items.push({
+			key: 'cancel',
+			label: translate(TranslationKeys.cancel),
+			icon: <MaterialCommunityIcons name="close" size={24} />,
+			onPress: onClose,
+		});
+		return items;
+	}, [handleDeleteImage, handleImagePick, isDelete, loading, onClose, theme.screen.icon, translate]);
+
+	return (
+		<View style={{ width: '100%' }}>
+			{actionItems.map((item, index) => {
+				const groupPosition =
+					actionItems.length === 1
+						? 'single'
+						: index === 0
+							? 'top'
+							: index === actionItems.length - 1
+								? 'bottom'
+								: 'middle';
+
+				return (
+					<SettingsList
+						key={item.key}
+						label={item.label}
+						leftIcon={item.icon}
+						groupPosition={groupPosition}
+						showSeparator={index !== actionItems.length - 1}
+						rightElement={item.rightElement}
+						rightIcon={item.rightIcon}
+						handleFunction={item.onPress}
+					/>
+				);
+			})}
+		</View>
+	);
+};
+
+const useMyScrollviewDirectusImageEditModal = () => {
+	const { show, close } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const closeModal = useCallback(() => {
+		close();
+	}, [close]);
+
+	const openDirectusImageEditModal = useCallback(
+		({ item, imageField, collection, onUpdated, title }: DirectusImageEditModalOptions) => {
+			if (!item) return;
+			show({
+				title: title ?? `${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.image)}`,
+				onClose: closeModal,
+				children: (
+					<DirectusImageEditModalContent
+						item={item}
+						imageField={imageField}
+						collection={collection}
+						onUpdated={onUpdated}
+						onClose={closeModal}
+					/>
+				),
+			});
+		},
+		[closeModal, show, translate]
+	);
+
+	return { openDirectusImageEditModal, closeDirectusImageEditModal: closeModal };
+};
+
+export default useMyScrollviewDirectusImageEditModal;


### PR DESCRIPTION
### Motivation
- Replace the existing bottom-sheet `ImageManagementSheet` pattern with a reusable scrollview modal to consolidate image edit UX across different collections. 
- Provide a single hook-based API that passes `item`, `imageField` and `collection` so the same modal can be reused for foods, campus buildings and housing. 
- Implement the existing actions (`camera`, `gallery`, `delete`) as `SettingsList` entries inside the new scrollview modal so behaviour remains consistent. 
- Follow the established `useMyScrollViewModal` patterns (similar to `useMyScrollviewTextInputModal`) for nested/stacked modal usage.

### Description
- Added a new hook `useMyScrollviewDirectusImageEditModal` in `apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx` which renders a `MyScrollViewModal` children component that shows a `SettingsList` with camera/gallery/delete actions and performs Directus upload/update/delete via `ServerAPI` and `CollectionHelper`.
- Rewired image-edit flows to use the new hook: updated `FoodItem`/`FoodOffersScrollList`/`app/(app)/foodoffers` and `foodoffers-scroll`, and replaced previous bottom-sheet usages in `campus` and `housing` to call `openDirectusImageEditModal` (collection `foods` or `buildings`).
- Updated component APIs and types to pass objects instead of ids for the image-edit callback by changing `handleImageSheet` to accept `item` and replacing `setSelectedFoodId` flows with direct handler calls, and added `onEditImage` props on building/apartment items.
- Removed the old `ImageManagementSheet`/inline `BaseBottomSheet` usages where replaced and left Directus upload/delete logic intact in the new modal implementation (`uploadFiles`, `CollectionHelper.updateItem`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504d15908c8330ab13bb2eb0c1f986)