### PR TITLE
Show upload error details in image edit modal

### DIFF
--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { ActivityIndicator, Alert, Platform, View } from 'react-native';
+import { ActivityIndicator, Alert, Platform, Text, View } from 'react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
@@ -53,6 +53,7 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
+	const { show: showScrollViewModal } = useMyScrollViewModal();
 	const [loading, setLoading] = useState({ camera: false, image: false, delete: false });
 	const [isDelete, setIsDelete] = useState(false);
 	const storage = useFoodFolder(collection);
@@ -186,12 +187,38 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 				onUpdated?.();
 				onClose();
 			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				const errorDetails = JSON.stringify(error ?? null, null, 2);
+
+				showScrollViewModal({
+					title: translate(TranslationKeys.error),
+					children: (
+						<View style={{ gap: 12 }}>
+							<Text style={{ color: theme.screen.text }}>
+								Fehler beim Hochladen: {errorMessage}
+							</Text>
+							<Text style={{ color: theme.screen.text, fontFamily: 'monospace' }}>{errorDetails}</Text>
+						</View>
+					),
+				});
 				console.error('Error selecting image:', error);
 			} finally {
 				setLoading({ camera: false, image: false, delete: false });
 			}
 		},
-		[buildUpdatePayload, collection, imageField, item?.id, loading, onClose, onUpdated, storage]
+		[
+			buildUpdatePayload,
+			collection,
+			imageField,
+			item?.id,
+			loading,
+			onClose,
+			onUpdated,
+			showScrollViewModal,
+			storage,
+			theme.screen.text,
+			translate,
+		]
 	);
 
 	const handleDeleteImage = useCallback(async () => {


### PR DESCRIPTION
### Motivation
- Surface upload failures from the Directus image edit flow to help troubleshooting by showing the error and structured details in a modal.
- Provide more context when image uploads fail (e.g. permissions, network, Directus errors) so support/debugging is easier.

### Description
- Updated `apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx` to import `Text` and use `useMyScrollViewModal` and show a scrollview modal on upload errors.
- The `catch` block now builds an `errorMessage` and `errorDetails` (`JSON.stringify(error ?? null, null, 2)`) and calls `showScrollViewModal` with `translate(TranslationKeys.error)` as title and both pieces rendered inside the modal.
- Added the newly used values (`showScrollViewModal`, `theme.screen.text`, `translate`) to the `useCallback` dependency array for `handleImagePick`.

### Testing
- No automated tests were executed for this change.
- Manual runtime behavior: the modal will display when an image upload fails and show the error message plus JSON details (manual verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950595282788330834ff2425b4809d5)