### PR TITLE
Keep image edit modal open on upload error

### DIFF
--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -348,7 +348,6 @@ const useMyScrollviewDirectusImageEditModal = () => {
 			if (!item) return;
 			show({
 				title: title ?? `${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.image)}`,
-				onClose: closeModal,
 				children: (
 					<DirectusImageEditModalContent
 						item={item}


### PR DESCRIPTION
### Motivation
- Prevent the image-edit scrollview modal from being auto-closed when an upload error opens an error modal.
- The current behavior caused the edit modal to disappear briefly because another modal was shown on error.

### Description
- Remove the `onClose: closeModal` prop passed into `show({...})` in `useMyScrollviewDirectusImageEditModal.tsx` so the shown scrollview modal is not automatically tied to the outer close handler.
- Continue passing `onClose={closeModal}` to the `DirectusImageEditModalContent` component so the content can still close the modal itself when appropriate.
- Modified file: `apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx`.

### Testing
- No automated tests were run for this change.
- Basic manual verification was performed during development to ensure the error modal no longer closes the underlying image edit modal (no automated validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505d52f9148330a27b28450381a44c)