### PR TITLE
Refine Directus image edit modal inputs

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -10,7 +10,7 @@ import {
 	StyleSheet,
 } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { CampusSortOption, CollectibleAt, DatabaseTypes } from 'repo-depkit-common';
+import { CampusSortOption, CollectibleAt, CollectionNames, DatabaseTypes } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -276,9 +276,9 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 		(campus: DatabaseTypes.Buildings) => {
 			if (!campus?.id) return;
 			openDirectusImageEditModal({
-				item: campus,
-				imageField: 'image',
-				collection: 'buildings',
+				itemId: campus.id,
+				field: 'image',
+				collection: CollectionNames.BUILDINGS,
 				onUpdated: () => {
 					setCampusesDispatched(false);
 					fetchAllCampuses();

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -10,7 +10,7 @@ import {
 	View,
 } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { CollectibleAt, DatabaseTypes, FoodSortOption, sortBySortField } from 'repo-depkit-common';
+import { CollectibleAt, CollectionNames, DatabaseTypes, FoodSortOption, sortBySortField } from 'repo-depkit-common';
 import styles from './styles';
 import {useTheme} from '@/hooks/useTheme';
 import {DrawerContentComponentProps, DrawerNavigationProp} from '@react-navigation/drawer';
@@ -431,9 +431,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		(food: DatabaseTypes.Foods) => {
 			if (!food?.id) return;
 			openDirectusImageEditModal({
-				item: food,
-				imageField: 'image',
-				collection: 'foods',
+				itemId: food.id,
+				field: 'image',
+				collection: CollectionNames.FOODS,
 				onUpdated: fetchFoods,
 			});
 		},

--- a/apps/frontend/app/app/(app)/housing/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/index.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, Dimensions, RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ApartmentSortOption, CollectibleAt, DatabaseTypes } from 'repo-depkit-common';
+import { ApartmentSortOption, CollectibleAt, CollectionNames, DatabaseTypes } from 'repo-depkit-common';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
@@ -216,10 +216,12 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const openImageManagementModal = useCallback(
 		(apartment: DatabaseTypes.Apartments) => {
 			if (!apartment?.id) return;
+			const buildingId = typeof apartment.building === 'object' ? apartment.building?.id : apartment.building;
+			if (!buildingId) return;
 			openDirectusImageEditModal({
-				itemId: apartment?.building,
-				imageField: 'image',
-				collection: 'buildings',
+				itemId: buildingId,
+				field: 'image',
+				collection: CollectionNames.BUILDINGS,
 				onUpdated: () => {
 					setApartmentsDispatched(false);
 					fetchAllApartments();

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { fetchFoodOffersByCanteen } from '@/redux/actions/FoodOffers/FoodOffers';
-import { DatabaseTypes, FoodSortOption } from 'repo-depkit-common';
+import { CollectionNames, DatabaseTypes, FoodSortOption } from 'repo-depkit-common';
 import FoodItem from '@/components/FoodItem/FoodItem';
 import CanteenFeedbackLabels from '@/components/CanteenFeedbackLabels/CanteenFeedbackLabels';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -119,9 +119,9 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		(food: DatabaseTypes.Foods) => {
 			if (!food?.id) return;
 			openDirectusImageEditModal({
-				item: food,
-				imageField: 'image',
-				collection: 'foods',
+				itemId: food.id,
+				field: 'image',
+				collection: CollectionNames.FOODS,
 				onUpdated: init,
 			});
 		},

--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -17,35 +17,34 @@ import { CollectionHelper } from '@/helper/collectionHelper';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { fetchSpecificField } from '@/redux/actions/Fields/Fields';
+import { CollectionNames } from 'repo-depkit-common';
 
 type DirectusImageEditModalOptions = {
-	item?: Record<string, any> | null;
-	itemId?: string | number | null;
-	imageField: string;
-	collection: string;
+	itemId: string | number;
+	field: string;
+	collection: CollectionNames;
 	onUpdated?: () => void;
 	title?: string;
 };
 
 type DirectusImageEditModalContentProps = {
-	item?: Record<string, any> | null;
 	itemId: string;
-	imageField: string;
-	collection: string;
+	field: string;
+	collection: CollectionNames;
 	onUpdated?: () => void;
 	onClose: () => void;
 };
 
 const MAX_IMAGE_DIMENSION = 6000;
 
-const useCollectionFolder = (collection: string) => {
+const useCollectionFolder = (collection: CollectionNames) => {
 	const { foodCollection } = useSelector((state: RootState) => state.food);
 	const [collectionFolder, setCollectionFolder] = useState('');
 
 	useEffect(() => {
 		let isMounted = true;
 		const loadFolder = async () => {
-			if (collection === 'foods') {
+			if (collection === CollectionNames.FOODS) {
 				const id = foodCollection?.meta?.options?.folder;
 				if (isMounted) {
 					setCollectionFolder(id || '');
@@ -78,20 +77,43 @@ const useCollectionFolder = (collection: string) => {
 	return collectionFolder;
 };
 
-const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps> = ({
-	item,
-	imageField,
-	collection,
-	itemId,
-	onUpdated,
-	onClose,
-}) => {
+const useCollectionFields = (collection: CollectionNames) => {
+	const [collectionFields, setCollectionFields] = useState<Record<string, any>>({});
+
+	useEffect(() => {
+		let isMounted = true;
+		const loadFields = async () => {
+			try {
+				const fieldResponse: any = await fetchSpecificField(collection);
+				if (isMounted) {
+					setCollectionFields(fieldResponse || {});
+				}
+			} catch (error) {
+				console.error('Error fetching collection fields:', error);
+				if (isMounted) {
+					setCollectionFields({});
+				}
+			}
+		};
+
+		loadFields();
+
+		return () => {
+			isMounted = false;
+		};
+	}, [collection]);
+
+	return collectionFields;
+};
+
+const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps> = ({ field, collection, itemId, onUpdated, onClose }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { show: showScrollViewModal } = useMyScrollViewModal();
 	const [loading, setLoading] = useState({ camera: false, image: false, delete: false });
 	const [isDelete, setIsDelete] = useState(false);
 	const storage = useCollectionFolder(collection);
+	const collectionFields = useCollectionFields(collection);
 
 	const imageRemoteUrlField = 'image_remote_url';
 	const imageGeneratedField = 'image_generated';
@@ -100,12 +122,12 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 		(payload: Record<string, any>) => {
 			const basePayload = { ...payload };
 
-			if (item && Object.prototype.hasOwnProperty.call(item, imageGeneratedField)) {
+			if (collectionFields?.[imageGeneratedField]) {
 				basePayload[imageGeneratedField] = false;
 			}
 			return basePayload;
 		},
-		[item]
+		[collectionFields]
 	);
 
 	const handleImagePick = useCallback(
@@ -217,7 +239,7 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 				const fileId = resultFileUpload.id;
 
 				const collectionHelper = new CollectionHelper(collection);
-				await collectionHelper.updateItem(String(itemId), buildUpdatePayload({ [imageField]: fileId }));
+				await collectionHelper.updateItem(String(itemId), buildUpdatePayload({ [field]: fileId }));
 
 				onUpdated?.();
 				onClose();
@@ -244,7 +266,7 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 		[
 			buildUpdatePayload,
 			collection,
-			imageField,
+			field,
 			itemId,
 			loading,
 			onClose,
@@ -263,10 +285,10 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 			setLoading(prev => ({ ...prev, delete: true }));
 			const collectionHelper = new CollectionHelper(collection);
 			const payload: Record<string, any> = {
-				[imageField]: null,
+				[field]: null,
 			};
 
-			if (item && Object.prototype.hasOwnProperty.call(item, imageRemoteUrlField)) {
+			if (collectionFields?.[imageRemoteUrlField]) {
 				payload[imageRemoteUrlField] = null;
 			}
 
@@ -278,7 +300,7 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 		} finally {
 			setLoading(prev => ({ ...prev, delete: false }));
 		}
-	}, [buildUpdatePayload, collection, imageField, item, itemId, loading, onClose, onUpdated]);
+	}, [buildUpdatePayload, collection, collectionFields, field, itemId, loading, onClose, onUpdated]);
 
 	const actionItems = useMemo(() => {
 		if (isDelete) {
@@ -379,16 +401,14 @@ const useMyScrollviewDirectusImageEditModal = () => {
 	}, [close]);
 
 	const openDirectusImageEditModal = useCallback(
-		({ item, itemId, imageField, collection, onUpdated, title }: DirectusImageEditModalOptions) => {
-			const resolvedItemId = itemId ?? item?.id;
-			if (!resolvedItemId) return;
+		({ itemId, field, collection, onUpdated, title }: DirectusImageEditModalOptions) => {
+			if (!itemId) return;
 			show({
 				title: title ?? `${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.image)}`,
 				children: (
 					<DirectusImageEditModalContent
-						item={item}
-						itemId={String(resolvedItemId)}
-						imageField={imageField}
+						itemId={String(itemId)}
+						field={field}
 						collection={collection}
 						onUpdated={onUpdated}
 						onClose={closeModal}


### PR DESCRIPTION
### Motivation
- The image edit modal accepted whole item objects which allowed passing extra data; the intent is to require only the `itemId`, `collection` and `field` to simplify usage and avoid leaking objects. 
- The `collection` should be typed using the shared `CollectionNames` enum and the hook should use field metadata for special image fields like `image_generated` and `image_remote_url`.

### Description
- Updated `useMyScrollviewDirectusImageEditModal` to accept `{ itemId, collection: CollectionNames, field }` and added `useCollectionFields` and `useCollectionFolder` helpers to fetch field metadata and folder info. 
- `buildUpdatePayload` now consults field metadata to unset `image_generated` and `image_remote_url` where applicable, and all updates use the provided `field` key. 
- Updated all callers to the new API and imports to include `CollectionNames` in `apps/frontend/app/components/FoodOffersScrollList`, `apps/frontend/app/app/(app)/foodoffers`, `apps/frontend/app/app/(app)/campus`, and `apps/frontend/app/app/(app)/housing`, and added safe `buildingId` resolution in housing. 
- Minor formatting and refactor to stop passing full item objects into the modal and use typed collection names instead.

### Testing
- No automated tests were executed on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695068e87a7c83309be4ffb4602a4416)