### PR TITLE
Wrap MyScrollViewModal content in SafeAreaView

### DIFF
--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { View, Text } from 'react-native';
 import { BottomSheetFlatList, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export interface MyScrollViewModalProps {
   title?: string;
@@ -62,38 +62,42 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const scrollInsets = { bottom: insets.bottom };
 
   const containerStyle = { backgroundColor: resolvedBackgroundColor };
+  const safeAreaStyle = { flex: 1, backgroundColor: resolvedBackgroundColor };
 
   if (useFlatList && renderItem && keyExtractor) {
     return (
-      <BottomSheetFlatList
-        data={data}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-        ListHeaderComponent={headerComponent}
-        ListFooterComponent={footerComponent}
-        style={containerStyle}
-        contentContainerStyle={contentStyle}
-        showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-        scrollIndicatorInsets={scrollInsets}
-      />
+      <SafeAreaView style={safeAreaStyle} edges={['top', 'bottom']}>
+        <BottomSheetFlatList
+          data={data}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          ListHeaderComponent={headerComponent}
+          ListFooterComponent={footerComponent}
+          style={[containerStyle, { flex: 1 }]}
+          contentContainerStyle={contentStyle}
+          showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+          keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+          scrollIndicatorInsets={scrollInsets}
+        />
+      </SafeAreaView>
     );
   }
 
   return (
-    <BottomSheetScrollView
-      style={containerStyle}
-      contentContainerStyle={contentStyle}
-      showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-      keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-      scrollIndicatorInsets={scrollInsets}
-    >
-      {headerComponent}
-      {children}
-      {footerComponent}
-    </BottomSheetScrollView>
+    <SafeAreaView style={safeAreaStyle} edges={['top', 'bottom']}>
+      <BottomSheetScrollView
+        style={[containerStyle, { flex: 1 }]}
+        contentContainerStyle={contentStyle}
+        showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+        scrollIndicatorInsets={scrollInsets}
+      >
+        {headerComponent}
+        {children}
+        {footerComponent}
+      </BottomSheetScrollView>
+    </SafeAreaView>
   );
 };
 
 export default MyScrollViewModal;
-


### PR DESCRIPTION
### Motivation
- Ensure `MyScrollViewModal` header and scroll content remain inside the device safe areas to avoid being dragged into non-safe screen regions.
- Fix reported behavior where the modal `ScrollView` / `FlatList` could be pulled into the unsafe area around device edges.
- Preserve existing background and scroll behavior while respecting device insets.

### Description
- Import `SafeAreaView` from `react-native-safe-area-context` and add a `safeAreaStyle` that uses the resolved modal background color.
- Wrap both `BottomSheetFlatList` and `BottomSheetScrollView` in a `SafeAreaView` with `edges={['top', 'bottom']}` to enforce safe-area bounds.
- Apply `flex: 1` to the inner list/scroll styles and keep `contentContainerStyle` padding computed from `useSafeAreaInsets` to preserve header/footer spacing.
- Keep the existing header and footer components and existing `scrollIndicatorInsets` and `keyboardShouldPersistTaps` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69506ef5edcc8330a98bc8848379869d)