### PR TITLE
Fix theme handler initialization in settings

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -194,6 +194,10 @@ const Settings = () => {
                 });
         }, [currentNickname, openTextInputModal, saveNickname, translate]);
 
+        const handleTheme = (theme: any) => {
+                setThemeMode(theme);
+        };
+
         const openColorSchemeSheet = useCallback(() => {
                 openThemeSettingsModal({
                         selectedTheme,
@@ -278,10 +282,6 @@ const Settings = () => {
         const handleCheckForUpdates = () => {
                 manualCheck();
         };
-
-	const handleTheme = (theme: any) => {
-		setThemeMode(theme);
-	};
 
         const handleLogout = useCallback(() => openConfirmLogoutModal(), [openConfirmLogoutModal]);
 


### PR DESCRIPTION
### Motivation
- A runtime error occurred because `handleTheme` was referenced before it was initialized in the settings screen.
- The `openThemeSettingsModal` callback uses `onSelect: handleTheme`, which requires `handleTheme` to be defined earlier in the component.
- Moving the handler prevents the "can't access lexical declaration 'handleTheme' before initialization" error at runtime.

### Description
- Moved the `handleTheme` function above the `openColorSchemeSheet` definition in `apps/frontend/app/app/(app)/settings/index.tsx` so it is defined before use.
- Removed the duplicate `handleTheme` declaration that appeared later in the file to avoid redundancy.
- Kept the `openColorSchemeSheet` callback to call `openThemeSettingsModal` with `selectedTheme` and `onSelect: handleTheme`.

### Testing
- No automated tests were run as part of this change.
- The change was committed with the message `Fix theme handler initialization in settings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69512f4dac4c833087e2622be0df629c)