### PR TITLE
Add shared container border radius constant

### DIFF
--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -6,9 +6,9 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { SettingsListProps } from './types';
+import { borderRadiusContainer } from '@/constants/Constants';
 
 const padding = 0; // px used for additional padding and border radius
-const borderRadius = 10;
 const basePaddingVertical = 10;
 
 const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, leftIconComponent, title, label, value, rightElement, rightIcon, onPress, handleFunction, iconBackgroundColor, iconBgColor, showSeparator = true, groupPosition, noIconIndent = false }) => {
@@ -39,19 +39,19 @@ const SettingsList: React.FC<SettingsListProps> = ({ leftIcon, leftIconComponent
 
 	if (groupPosition === 'top') {
 		containerStyles.push({
-			borderTopLeftRadius: borderRadius,
-			borderTopRightRadius: borderRadius,
+			borderTopLeftRadius: borderRadiusContainer,
+			borderTopRightRadius: borderRadiusContainer,
 			paddingTop: basePaddingVertical + padding,
 		});
 	} else if (groupPosition === 'bottom') {
 		containerStyles.push({
-			borderBottomLeftRadius: borderRadius,
-			borderBottomRightRadius: borderRadius,
+			borderBottomLeftRadius: borderRadiusContainer,
+			borderBottomRightRadius: borderRadiusContainer,
 			paddingBottom: basePaddingVertical + padding,
 		});
 	} else if (groupPosition === 'single') {
 		containerStyles.push({
-			borderRadius: borderRadius,
+			borderRadius: borderRadiusContainer,
 			paddingTop: basePaddingVertical + padding,
 			paddingBottom: basePaddingVertical + padding,
 		});

--- a/apps/frontend/app/components/SettingsListTextInput.tsx
+++ b/apps/frontend/app/components/SettingsListTextInput.tsx
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
 	},
 	buttonContainer: {
 		width: '100%',
-		marginTop: 8,
+		marginTop: 4,
 		alignItems: 'stretch',
 	},
 });

--- a/apps/frontend/app/constants/Constants.ts
+++ b/apps/frontend/app/constants/Constants.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 
 export const isWeb = Platform.OS === 'web';
+export const borderRadiusContainer = 10;
 
 export const links = [
 	{ title: 'about_us', path: '/about-us' },

--- a/apps/frontend/app/hooks/useMyScrollviewTextInputModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewTextInputModal.tsx
@@ -4,6 +4,7 @@ import { Keyboard, KeyboardTypeOptions } from 'react-native';
 import { SettingsListTextInputSheet } from '@/components/SettingsListTextInput';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import type { CheckTextInput } from '@/components/SettingsListTextInput';
+import { borderRadiusContainer } from '@/constants/Constants';
 
 type ModalTextInputSheetProps = {
 	initialValue?: string;
@@ -138,7 +139,7 @@ const useMyScrollviewTextInputModal = () => {
 						keyboardType={keyboardType}
 						numberOfLines={numberOfLines}
 						textAlignVertical={textAlignVertical}
-						inputStyle={inputStyle}
+						inputStyle={{ ...(inputStyle ?? {}), borderRadius: borderRadiusContainer }}
 						autoFocus={autoFocus}
 						checkTextInput={checkTextInput}
 						allowSubmitWhenDisabled={allowSubmitWhenDisabled ?? true}


### PR DESCRIPTION
### Motivation

- Centralize the container border radius to ensure consistent corner radii across settings-related components by adding a single shared constant `borderRadiusContainer` in `Constants.ts`.
- Use the shared radius in `SettingsList` so grouped list items share the same corner values instead of a local hard-coded value.
- Apply the same radius to the modal text input so the text input visually matches other container corners.
- Reduce the vertical gap between the text input and the save button to tighten the layout.

### Description

- Added `borderRadiusContainer` to `apps/frontend/app/constants/Constants.ts` and exported it.
- Replaced the local `borderRadius` usage in `apps/frontend/app/components/SettingsList/SettingsList.tsx` with an import of `borderRadiusContainer` and removed the local constant.
- Passed `borderRadiusContainer` into the modal text input via `inputStyle` in `apps/frontend/app/hooks/useMyScrollviewTextInputModal.tsx` so the `TextInput` uses the shared corner radius.
- Reduced the spacing between the text input and save button by changing `marginTop` from `8` to `4` in `apps/frontend/app/components/SettingsListTextInput.tsx`.

### Testing

- No automated tests were run as part of this change.
- Changes are limited to styling and constants and do not modify runtime logic or backend code.
- A visual verification is recommended on supported platforms (iOS/Android/Web) to confirm consistent radii and the tighter spacing.
- Manual QA was not performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bcd274ac8330a977119493352383)