### PR TITLE
Add housing and campus settings sections with sort options

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -48,7 +48,9 @@ import useThemeSettingsModal from '@/hooks/useThemeSettingsModal';
 import useMenuPositionModal from '@/hooks/useMenuPositionModal';
 import useCardColumnsModal from '@/hooks/useCardColumnsModal';
 import useFirstDayOfWeekModal from '@/hooks/useFirstDayOfWeekModal';
-import { FoodSortOption } from 'repo-depkit-common';
+import useHousingSortingModal from '@/hooks/useHousingSortingModal';
+import useCampusSortingModal from '@/hooks/useCampusSortingModal';
+import { ApartmentSortOption, CampusSortOption, FoodSortOption } from 'repo-depkit-common';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
 
@@ -75,8 +77,10 @@ const Settings = () => {
         const { openMenuPositionModal } = useMenuPositionModal();
         const { openCardColumnsModal } = useCardColumnsModal();
         const { openFirstDayOfWeekModal } = useFirstDayOfWeekModal();
+        const { openHousingSortingModal } = useHousingSortingModal();
+        const { openCampusSortingModal } = useCampusSortingModal();
 
-        const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, simulateExpoUpdateAvailable, collectibleItemSize, collectibleRandomPosition, selectedCustomer, sortBy } = useSelector((state: RootState) => state.settings);
+        const { primaryColor, drawerPosition, selectedTheme, nickNameLocal, firstDayOfTheWeek, amountColumnsForcard, serverInfo, appSettings, useWebpForAssets, foodOffersNextDayThreshold, debugMode, simulateExpoUpdateAvailable, collectibleItemSize, collectibleRandomPosition, selectedCustomer, sortBy, apartmentsSortBy, campusesSortBy } = useSelector((state: RootState) => state.settings);
         const currentNickname = useMemo(
                 () => (profile?.id ? profile?.nickname ?? '' : nickNameLocal ?? ''),
                 [nickNameLocal, profile?.id, profile?.nickname]
@@ -98,6 +102,8 @@ const Settings = () => {
         );
 
         const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
+        const housing_area_color = appSettings?.housing_area_color ? appSettings?.housing_area_color : primaryColor;
+        const campus_area_color = appSettings?.campus_area_color ? appSettings?.campus_area_color : primaryColor;
 
         const customerServerUrl = useCustomerServerUrl();
 
@@ -134,6 +140,37 @@ const Settings = () => {
         const sortingLabel = useMemo(
                 () => translate(sortingOptionLabels[sortBy as FoodSortOption] ?? 'sort_option_none'),
                 [sortBy, sortingOptionLabels, translate]
+        );
+
+        const housingSortingOptionLabels: Partial<Record<ApartmentSortOption, string>> = useMemo(
+                () => ({
+                        [ApartmentSortOption.INTELLIGENT]: 'sort_option_intelligent',
+                        [ApartmentSortOption.FREE_ROOMS]: 'free_rooms',
+                        [ApartmentSortOption.DISTANCE]: 'sort_option_distance',
+                        [ApartmentSortOption.ALPHABETICAL]: 'sort_option_alphabetical',
+                        [ApartmentSortOption.NONE]: 'sort_option_none',
+                }),
+                []
+        );
+
+        const housingSortingLabel = useMemo(
+                () => translate(housingSortingOptionLabels[apartmentsSortBy as ApartmentSortOption] ?? 'sort_option_none'),
+                [apartmentsSortBy, housingSortingOptionLabels, translate]
+        );
+
+        const campusSortingOptionLabels: Partial<Record<CampusSortOption, string>> = useMemo(
+                () => ({
+                        [CampusSortOption.INTELLIGENT]: 'sort_option_intelligent',
+                        [CampusSortOption.DISTANCE]: 'sort_option_distance',
+                        [CampusSortOption.ALPHABETICAL]: 'sort_option_alphabetical',
+                        [CampusSortOption.NONE]: 'sort_option_none',
+                }),
+                []
+        );
+
+        const campusSortingLabel = useMemo(
+                () => translate(campusSortingOptionLabels[campusesSortBy as CampusSortOption] ?? 'sort_option_none'),
+                [campusSortingOptionLabels, campusesSortBy, translate]
         );
 
         const saveNickname = useCallback(
@@ -460,6 +497,38 @@ const Settings = () => {
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<FontAwesome5 name="columns" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.amount_columns_for_cards)} value={amountColumnsForcard === 0 ? translate(TranslationKeys.automatic) : amountColumnsForcard} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openCardColumnsModal} groupPosition="middle" />
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<Feather name="calendar" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.first_day_of_week)} value={translate(firstDayOfTheWeek?.name)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFirstDayOfWeekModal} groupPosition="bottom" />
                                         </View>
+                                        {appSettings?.housing_enabled && (
+                                                <>
+                                                        <SettingsGroupTitle>{translate(TranslationKeys.housing)}</SettingsGroupTitle>
+                                                        <View style={{ gap: 0 }}>
+                                                                <SettingsList
+                                                                        iconBgColor={housing_area_color}
+                                                                        leftIcon={<MaterialIcons name="sort" size={24} color={theme.screen.icon} />}
+                                                                        label={translate(TranslationKeys.sort)}
+                                                                        value={housingSortingLabel}
+                                                                        rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+                                                                        handleFunction={openHousingSortingModal}
+                                                                        groupPosition="single"
+                                                                />
+                                                        </View>
+                                                </>
+                                        )}
+                                        {appSettings?.campus_enabled && (
+                                                <>
+                                                        <SettingsGroupTitle>{translate(TranslationKeys.campus)}</SettingsGroupTitle>
+                                                        <View style={{ gap: 0 }}>
+                                                                <SettingsList
+                                                                        iconBgColor={campus_area_color}
+                                                                        leftIcon={<MaterialIcons name="sort" size={24} color={theme.screen.icon} />}
+                                                                        label={translate(TranslationKeys.sort)}
+                                                                        value={campusSortingLabel}
+                                                                        rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
+                                                                        handleFunction={openCampusSortingModal}
+                                                                        groupPosition="single"
+                                                                />
+                                                        </View>
+                                                </>
+                                        )}
 					<SettingsGroupTitle>{translate(TranslationKeys.group_app_management)}</SettingsGroupTitle>
 					<View style={{ gap: 0 }}>
                                                 <SettingsList iconBgColor={primaryColor} leftIcon={<Ionicons name="cloud-download-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.CHECK_FOR_APP_UPDATES)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={handleCheckForUpdates} groupPosition="top" />


### PR DESCRIPTION
### Motivation
- Expose per-feature settings for `housing` and `campus` in the app settings similar to the existing foodoffers section.  
- Show these sections only when the corresponding flags in `appSettings` are enabled.  
- Allow users to open the respective sort modal from the settings screen for each area.  

### Description
- Added imports for `useHousingSortingModal`, `useCampusSortingModal`, and sort enums `ApartmentSortOption` and `CampusSortOption`, and wired `openHousingSortingModal`/`openCampusSortingModal`.  
- Extended the settings selector to read `apartmentsSortBy` and `campusesSortBy` and created `housingSortingLabel` and `campusSortingLabel` via `useMemo` to display the current sort label.  
- Added area color variables `housing_area_color` and `campus_area_color` and inserted conditional UI blocks that render a `SettingsGroupTitle` and a `SettingsList` entry calling the respective sort modal when `appSettings?.housing_enabled` or `appSettings?.campus_enabled` is true.  
- Reused existing components and translations and did not introduce new data stores or API changes.  

### Testing
- No automated tests were executed for this change.  
- The modified file was committed (`apps/frontend/app/app/(app)/settings/index.tsx`) and the change compiles in-editor checks but no CI run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951cc3201d8833081592b90d2fbcb80)