### PR TITLE
Adjust settings group title spacing

### DIFF
--- a/apps/frontend/app/components/SettingsGroupTitle/SettingsGroupTitle.tsx
+++ b/apps/frontend/app/components/SettingsGroupTitle/SettingsGroupTitle.tsx
@@ -18,6 +18,6 @@ const styles = StyleSheet.create({
 		fontSize: 16,
 		fontFamily: 'Poppins_400Regular',
 		marginTop: 20,
-		marginBottom: 10,
+		marginBottom: 4,
 	},
 });


### PR DESCRIPTION
### Motivation
- Reduce the vertical gap so settings group headings sit closer to the associated `SettingsList` entries.
- Improve visual grouping and alignment within the settings screen by tightening title spacing.

### Description
- Modify `apps/frontend/app/components/SettingsGroupTitle/SettingsGroupTitle.tsx` to change the `marginBottom` value from `10` to `4`.
- This is a styling-only change that does not touch runtime logic or component behavior.

### Testing
- No automated tests were run for this UI spacing change.
- The change is low-risk and only affects visual spacing in the settings UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952473419188330858a8d760f548651)