### PR TITLE
Fix drawer icon spacing for settings and logout

### DIFF
--- a/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -381,16 +381,20 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({ navigation
                                                         </TouchableOpacity>
                                                 ))}
                                                 <View style={styles.divider} />
-                                                <TouchableOpacity style={getMenuItemStyle('settings/index')} onPress={() => navigation.navigate('settings/index')}>
-							<Ionicons name="settings-outline" size={28} color={isActive('settings/index') ? getContrastColor('settings/index') : theme.inactiveIcon} />
+						<TouchableOpacity style={getMenuItemStyle('settings/index')} onPress={() => navigation.navigate('settings/index')}>
+							<View style={styles.menuIconWrapper}>
+								<Ionicons name="settings-outline" size={28} color={isActive('settings/index') ? getContrastColor('settings/index') : theme.inactiveIcon} />
+							</View>
 							<Text style={getMenuLabelStyle('settings/index')}>{translate(TranslationKeys.settings)}</Text>
 						</TouchableOpacity>
                                                 <TouchableOpacity
                                                         style={getMenuItemStyle('faq-living/index')}
                                                         onPress={openConfirmLogoutModal}
                                                 >
-                                                        <MaterialCommunityIcons name="logout" size={28} color={theme.inactiveIcon} />
-                                                        <Text style={getMenuLabelStyle('faq-living/index')}>{logoutButtonLabel}</Text>
+							<View style={styles.menuIconWrapper}>
+								<MaterialCommunityIcons name="logout" size={28} color={theme.inactiveIcon} />
+							</View>
+							<Text style={getMenuLabelStyle('faq-living/index')}>{logoutButtonLabel}</Text>
                                                 </TouchableOpacity>
                                                 <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_drawer} />
                                         </View>


### PR DESCRIPTION
### Motivation
- The Settings and Logout entries in the app drawer had inconsistent spacing between their icons and labels compared to other menu items.  
- Other menu items use a shared wrapper (`styles.menuIconWrapper`) which provides consistent icon spacing and positioning.  
- The goal is to reuse the same layout pattern so icon/label gaps and notification dot alignment are uniform.  

### Description
- Wrapped the Settings `Ionicons` icon with a `View` using `styles.menuIconWrapper` to match other menu entries.  
- Wrapped the Logout `MaterialCommunityIcons` icon with the same `styles.menuIconWrapper` wrapper.  
- Changes were made in `apps/frontend/app/components/Drawer/CustomDrawerContent.tsx` and do not modify existing styles.  

### Testing
- No automated tests were executed for this change because it is a UI-only layout adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530b774e8483309ccd91e2a88c62ee)