### PR TITLE
Add shared horizontal screen padding constant and apply to Settings styles

### DIFF
--- a/apps/frontend/app/app/(app)/settings/styles.ts
+++ b/apps/frontend/app/app/(app)/settings/styles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import { horizontalScreenPadding } from '@/constants/Constants';
 
 export default StyleSheet.create({
 	container: {
@@ -6,7 +7,7 @@ export default StyleSheet.create({
 	},
 	contentContainer: {
 		width: '100%',
-		paddingHorizontal: 10,
+		paddingHorizontal: horizontalScreenPadding,
 		paddingVertical: 40,
 		alignItems: 'center',
 	},
@@ -57,11 +58,11 @@ export default StyleSheet.create({
 
 	languageContainer: {
 		marginTop: 10,
-		paddingHorizontal: 10,
+		paddingHorizontal: horizontalScreenPadding,
 	},
 	amountOfCardContainer: {
 		marginTop: 10,
-		paddingHorizontal: 10,
+		paddingHorizontal: horizontalScreenPadding,
 		maxHeight: '100%',
 		height: 400,
 	},

--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { SettingsListProps } from './types';
-import { borderRadiusContainer } from '@/constants/Constants';
+import { borderRadiusContainer, horizontalScreenPadding } from '@/constants/Constants';
 
 const padding = 0; // px used for additional padding and border radius
 const basePaddingVertical = 10;
@@ -98,7 +98,7 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		width: '100%',
 		alignItems: 'center',
-		paddingHorizontal: 16,
+		paddingHorizontal: horizontalScreenPadding,
 		paddingVertical: basePaddingVertical,
 	},
         iconWrapper: {

--- a/apps/frontend/app/constants/Constants.ts
+++ b/apps/frontend/app/constants/Constants.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 
 export const isWeb = Platform.OS === 'web';
 export const borderRadiusContainer = 10;
+export const horizontalScreenPadding = 16;
 
 export const links = [
 	{ title: 'about_us', path: '/about-us' },


### PR DESCRIPTION
### Motivation
- Centralize horizontal padding used by settings screens to ensure consistent spacing across components.
- Replace scattered hardcoded padding values with a single constant so future updates are easier and less error-prone.

### Description
- Add `horizontalScreenPadding = 16` to `apps/frontend/app/constants/Constants.ts` and export it.
- Update `apps/frontend/app/components/SettingsList/SettingsList.tsx` to import and use `horizontalScreenPadding` instead of the literal `16`.
- Update `apps/frontend/app/app/(app)/settings/styles.ts` to import and use `horizontalScreenPadding` for `contentContainer`, `languageContainer`, and `amountOfCardContainer` paddings.
- Adjusted imports in the modified files to include the new constant and removed the hardcoded values.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b15ef3088330bd38c56eeb0841ef)