### PR TITLE
Add horizontal padding to food offers footer

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/styles.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/styles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import { horizontalScreenPadding } from '@/constants/Constants';
 
 export default StyleSheet.create({
 	foodOfferContainer: {
@@ -63,6 +64,7 @@ export default StyleSheet.create({
 	feebackContainer: {
 		width: '100%',
 		marginTop: 20,
+		paddingHorizontal: horizontalScreenPadding,
 	},
 	foodLabels: {
 		fontSize: 24,
@@ -71,6 +73,7 @@ export default StyleSheet.create({
 	elementContainer: {
 		width: '100%',
 		marginTop: 20,
+		paddingHorizontal: horizontalScreenPadding,
 	},
 	noFoodContainer: {
 		width: '100%',


### PR DESCRIPTION
### Motivation
- Ensure the feedback list and markdown footer inside the Food Offers screen follow the app-wide horizontal spacing convention.
- Keep layout consistent with other lists (e.g. `SettingsList`) which use the shared horizontal padding constant.

### Description
- Imported `horizontalScreenPadding` from `@/constants/Constants` in `apps/frontend/app/app/(app)/foodoffers/styles.ts`.
- Applied `paddingHorizontal: horizontalScreenPadding` to the `feebackContainer` style to add consistent horizontal spacing for feedback labels.
- Applied `paddingHorizontal: horizontalScreenPadding` to the `elementContainer` style to add consistent horizontal spacing for rendered markdown/footer content.

### Testing
- No automated tests were executed for this change.
- Manual visual verification was expected when running the app, but was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b383815c8330a70c73924cec07c1)