### PR TITLE
Justify food labeling disclaimer text

### DIFF
--- a/apps/frontend/app/components/FoodLabelingInfo/styles.ts
+++ b/apps/frontend/app/components/FoodLabelingInfo/styles.ts
@@ -6,5 +6,6 @@ export default StyleSheet.create({
 		fontFamily: 'Poppins_400Regular',
 		fontStyle: 'italic',
 		marginTop: 20,
+		textAlign: 'justify',
 	},
 });


### PR DESCRIPTION
### Motivation
- Improve readability and visual alignment of the food labeling disclaimer by using justified text alignment in the FoodLabelingInfo component.

### Description
- Added `textAlign: 'justify'` to the `text` style in `apps/frontend/app/components/FoodLabelingInfo/styles.ts`.
- This change affects the paragraph rendered via `FoodLabelingInfo` that displays `TranslationKeys.FOOD_LABELING_INFO`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d6e88cfc8330b922560320f07866)