### PR TITLE
Remove justified alignment from FoodLabelingInfo disclaimer

### DIFF
--- a/apps/frontend/app/components/FoodLabelingInfo/styles.ts
+++ b/apps/frontend/app/components/FoodLabelingInfo/styles.ts
@@ -6,6 +6,5 @@ export default StyleSheet.create({
 		fontFamily: 'Poppins_400Regular',
 		fontStyle: 'italic',
 		marginTop: 20,
-		textAlign: 'justify',
 	},
 });


### PR DESCRIPTION
### Motivation
- Restore the previous visual behavior of the FoodLabelingInfo disclaimer by undoing a recent styling change that set the text to justified.
- The justified alignment caused layout/visual issues and the change re-aligns the disclaimer with other text elements.

### Description
- Deleted the `textAlign: 'justify'` property from `apps/frontend/app/components/FoodLabelingInfo/styles.ts`.
- The stylesheet for the `text` style now omits the justification, returning to the prior italic Poppins styling and spacing.

### Testing
- No automated tests were run as part of this change.
- Code modifications are limited to a single-line style deletion, reducing risk of functional regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e5ec5a48833097e14317baff966b)