### PR TITLE
Switch server selection modal to use SettingsList rows

### DIFF
--- a/apps/frontend/app/hooks/useCustomerConfigModal.tsx
+++ b/apps/frontend/app/hooks/useCustomerConfigModal.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useMemo } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
-import ServerOption from '@/components/ServerOption/ServerOption';
+import SettingsList from '@/components/SettingsList';
 import { CustomerConfig, getCustomerConfigurations, getCustomerEnumForConfig } from '@/config';
 import { TranslationKeys } from '@/locales/keys';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
+import { useSelector } from 'react-redux';
+import type { RootState } from '@/redux/reducer';
 
 type CustomerConfigModalProps = {
         selectedServer: string;
@@ -17,6 +20,7 @@ const useCustomerConfigModal = () => {
         const { show, close } = useMyScrollViewModal();
         const { translate } = useLanguage();
         const { theme } = useTheme();
+        const { primaryColor } = useSelector((state: RootState) => state.settings);
 
         const servers = useMemo(() => getCustomerConfigurations(), []);
 
@@ -28,36 +32,46 @@ const useCustomerConfigModal = () => {
         const openCustomerConfigModal = useCallback(
                 ({ selectedServer, onSelect }: CustomerConfigModalProps) => {
                         show({
+                                title: translate(TranslationKeys.backend_server),
                                 children: (
-                                        <View style={{ gap: 16 }}>
-                                                <Text
-                                                        style={{
-                                                                fontSize: 18,
-                                                                fontWeight: '600',
-                                                                color: theme.sheet.text,
-                                                        }}
-                                                >
-                                                        {translate(TranslationKeys.backend_server)}
-                                                </Text>
-                                                <View style={{ gap: 10 }}>
-                                                        {servers.map(srv => (
-                                                                <ServerOption
+                                        <View style={{ gap: 0 }}>
+                                                {servers.map((srv, index) => {
+                                                        const isSelected = selectedServer === srv.server_url;
+                                                        const groupPosition =
+                                                                servers.length === 1
+                                                                        ? 'single'
+                                                                        : index === 0
+                                                                                ? 'top'
+                                                                                : index === servers.length - 1
+                                                                                        ? 'bottom'
+                                                                                        : 'middle';
+                                                        return (
+                                                                <SettingsList
                                                                         key={srv.projectSlug}
-                                                                        server={srv}
                                                                         label={getDisplayName(srv)}
-                                                                        isSelected={selectedServer === srv.server_url}
-                                                                        onPress={() => {
+                                                                        leftIcon={<MaterialCommunityIcons name="server" size={24} />}
+                                                                        iconBgColor={primaryColor}
+                                                                        groupPosition={groupPosition}
+                                                                        showSeparator={index !== servers.length - 1}
+                                                                        rightIcon={
+                                                                                <MaterialCommunityIcons
+                                                                                        name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+                                                                                        size={24}
+                                                                                        color={isSelected ? primaryColor : theme.screen.icon}
+                                                                                />
+                                                                        }
+                                                                        handleFunction={() => {
                                                                                 onSelect(srv);
                                                                                 close();
                                                                         }}
                                                                 />
-                                                        ))}
-                                                </View>
+                                                        );
+                                                })}
                                         </View>
                                 ),
                         });
                 },
-                [close, getDisplayName, servers, show, theme.sheet.text, translate]
+                [close, getDisplayName, onSelect, primaryColor, selectedServer, servers, show, theme.screen.icon, translate]
         );
 
         return { openCustomerConfigModal, closeCustomerConfigModal: close };


### PR DESCRIPTION
### Motivation
- Make the server selection modal match other settings UIs by using the same `SettingsList` rows and radio indicators as the theme modal.
- Move the modal title into the scroll view header for consistent modal presentation.
- Remove the specialized `ServerOption` row component and simplify rendering inside the modal.

### Description
- Replaced `ServerOption` usage with `SettingsList` rows in `apps/frontend/app/hooks/useCustomerConfigModal.tsx` and added `MaterialCommunityIcons` for the server and radio icons.
- Moved the backend server title into the `show` call as the modal header via `title: translate(TranslationKeys.backend_server)` instead of rendering an inline `Text` header.
- Read `primaryColor` from the Redux `settings` state to style the item backgrounds and selected radio color, and compute `groupPosition`/`showSeparator` for list grouping.
- Updated the `openCustomerConfigModal` callback dependencies and cleaned up imports accordingly.

### Testing
- No automated tests were executed for this change.
- The change was committed locally and the modified file is `apps/frontend/app/hooks/useCustomerConfigModal.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ed5a82cc8330b34638956fdfa830)