### PR TITLE
Revert merge #1126 and restore previous customer config modal

### DIFF
--- a/apps/frontend/app/hooks/useCustomerConfigModal.tsx
+++ b/apps/frontend/app/hooks/useCustomerConfigModal.tsx
@@ -1,15 +1,12 @@
 import React, { useCallback, useMemo } from 'react';
-import { View } from 'react-native';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Text, View } from 'react-native';
 
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
-import SettingsList from '@/components/SettingsList';
+import ServerOption from '@/components/ServerOption/ServerOption';
 import { CustomerConfig, getCustomerConfigurations, getCustomerEnumForConfig } from '@/config';
 import { TranslationKeys } from '@/locales/keys';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
-import { useSelector } from 'react-redux';
-import type { RootState } from '@/redux/reducer';
 
 type CustomerConfigModalProps = {
         selectedServer: string;
@@ -20,7 +17,6 @@ const useCustomerConfigModal = () => {
         const { show, close } = useMyScrollViewModal();
         const { translate } = useLanguage();
         const { theme } = useTheme();
-        const { primaryColor } = useSelector((state: RootState) => state.settings);
 
         const servers = useMemo(() => getCustomerConfigurations(), []);
 
@@ -32,46 +28,36 @@ const useCustomerConfigModal = () => {
         const openCustomerConfigModal = useCallback(
                 ({ selectedServer, onSelect }: CustomerConfigModalProps) => {
                         show({
-                                title: translate(TranslationKeys.backend_server),
                                 children: (
-                                        <View style={{ gap: 0 }}>
-                                                {servers.map((srv, index) => {
-                                                        const isSelected = selectedServer === srv.server_url;
-                                                        const groupPosition =
-                                                                servers.length === 1
-                                                                        ? 'single'
-                                                                        : index === 0
-                                                                                ? 'top'
-                                                                                : index === servers.length - 1
-                                                                                        ? 'bottom'
-                                                                                        : 'middle';
-                                                        return (
-                                                                <SettingsList
+                                        <View style={{ gap: 16 }}>
+                                                <Text
+                                                        style={{
+                                                                fontSize: 18,
+                                                                fontWeight: '600',
+                                                                color: theme.sheet.text,
+                                                        }}
+                                                >
+                                                        {translate(TranslationKeys.backend_server)}
+                                                </Text>
+                                                <View style={{ gap: 10 }}>
+                                                        {servers.map(srv => (
+                                                                <ServerOption
                                                                         key={srv.projectSlug}
+                                                                        server={srv}
                                                                         label={getDisplayName(srv)}
-                                                                        leftIcon={<MaterialCommunityIcons name="server" size={24} />}
-                                                                        iconBgColor={primaryColor}
-                                                                        groupPosition={groupPosition}
-                                                                        showSeparator={index !== servers.length - 1}
-                                                                        rightIcon={
-                                                                                <MaterialCommunityIcons
-                                                                                        name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
-                                                                                        size={24}
-                                                                                        color={isSelected ? primaryColor : theme.screen.icon}
-                                                                                />
-                                                                        }
-                                                                        handleFunction={() => {
+                                                                        isSelected={selectedServer === srv.server_url}
+                                                                        onPress={() => {
                                                                                 onSelect(srv);
                                                                                 close();
                                                                         }}
                                                                 />
-                                                        );
-                                                })}
+                                                        ))}
+                                                </View>
                                         </View>
                                 ),
                         });
                 },
-                [close, getDisplayName, onSelect, primaryColor, selectedServer, servers, show, theme.screen.icon, translate]
+                [close, getDisplayName, servers, show, theme.sheet.text, translate]
         );
 
         return { openCustomerConfigModal, closeCustomerConfigModal: close };


### PR DESCRIPTION
### Motivation
- Revert the merge of pull request #1126 to restore the previous `useCustomerConfigModal` behavior and UI.
- Replace the merged `SettingsList`-based server selector with the prior, simpler server selection flow.
- Remove the Redux `useSelector` dependency on `primaryColor` and rely on theme-driven styling instead.
- Reintroduce a header `Text` and adjust spacing for improved modal layout.

### Description
- Reverted `apps/frontend/app/hooks/useCustomerConfigModal.tsx` to remove the merged changes from PR #1126.
- Replaced `SettingsList` usage with `ServerOption` components and added a header `Text` plus updated gap/spacing.
- Removed `useSelector` and `primaryColor` usage and switched styling to use `theme.sheet.text` and other `theme` values.
- Updated `openCustomerConfigModal` to pass `isSelected` and `onPress` to `ServerOption` and adjusted the hook dependency array.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f5f147948330b38e1019100fc762)