### PR TITLE
Remove gap between settings list items in customer modal

### DIFF
--- a/apps/frontend/app/hooks/useCustomerConfigModal.tsx
+++ b/apps/frontend/app/hooks/useCustomerConfigModal.tsx
@@ -35,7 +35,7 @@ const useCustomerConfigModal = () => {
                                 title: translate(TranslationKeys.backend_server),
                                 onClose: close,
                                 children: (
-                                        <View style={{ gap: 12, width: '100%' }}>
+                                        <View style={{ width: '100%' }}>
                                                 {servers.map((srv, index) => {
                                                         const isSelected = selectedServer === srv.server_url;
                                                         const groupPosition =


### PR DESCRIPTION
### Motivation
- Remove the unwanted spacing between `SettingsList` items inside the customer configuration modal to match the intended compact layout.
- The extra `gap` styling caused visual separation that wasn't desired for this modal's list presentation.

### Description
- Deleted the inline `gap: 12` style from the wrapping `<View>` in `apps/frontend/app/hooks/useCustomerConfigModal.tsx`.
- The container now uses `style={{ width: '100%' }}` while retaining per-item `showSeparator` and `groupPosition` behavior.
- No other component logic or props for `SettingsList` were changed.

### Testing
- No automated tests were executed for this change.
- Change is a single-line style tweak and should be verified visually in the customer config modal UI during manual review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69543b9114b483308941a09054a69dbe)