### PR TITLE
Replace price group options with SettingsList rows and remove gap styling

### DIFF
--- a/apps/frontend/app/app/(app)/price-group/index.tsx
+++ b/apps/frontend/app/app/(app)/price-group/index.tsx
@@ -1,9 +1,8 @@
-import { Text, TouchableOpacity, View } from 'react-native';
-import React, { cloneElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
-import { FontAwesome, FontAwesome5, Ionicons } from '@expo/vector-icons';
-import Checkbox from 'expo-checkbox';
+import { FontAwesome, FontAwesome5, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { isWeb } from '@/constants/Constants';
 import { useDispatch, useSelector } from 'react-redux';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
@@ -17,10 +16,10 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { CollectibleAt, DatabaseTypes } from 'repo-depkit-common';
 import { RootState } from '@/redux/reducer';
-import { myContrastColor } from '@/helper/ColorHelper';
 import { PriceGroupKey } from '@/app/(app)/settings/types';
 import { UserHelper } from '@/helper/UserHelper';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
+import SettingsList from '@/components/SettingsList';
 
 const Index = () => {
 	useSetPageTitle(TranslationKeys.price_group);
@@ -32,8 +31,7 @@ const Index = () => {
 	const { user, profile } = useSelector((state: RootState) => state.authReducer);
 	const isRegisteredUser = UserHelper.isRegisteredUser(user);
 
-	const { primaryColor, appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+	const { primaryColor, appSettings } = useSelector((state: RootState) => state.settings);
 	const [autoPlay, setAutoPlay] = useState(appSettings?.animations_auto_start);
 	const animationRef = useRef<LottieView>(null);
 	const [animationJson, setAmimationJson] = useState<any>(null);
@@ -42,17 +40,17 @@ const Index = () => {
 		{
 			id: PriceGroupKey.student,
 			label: translate(TranslationKeys.price_group_student),
-			icon: <FontAwesome name="graduation-cap" size={24} />,
+			icon: <FontAwesome name="graduation-cap" size={24} color={theme.screen.icon} />,
 		},
 		{
 			id: PriceGroupKey.employee,
 			label: translate(TranslationKeys.price_group_employee),
-			icon: <Ionicons name="bag" size={24} />,
+			icon: <Ionicons name="bag" size={24} color={theme.screen.icon} />,
 		},
 		{
 			id: PriceGroupKey.guest,
 			label: translate(TranslationKeys.price_group_guest),
-			icon: <FontAwesome5 name="users" size={24} />,
+			icon: <FontAwesome5 name="users" size={24} color={theme.screen.icon} />,
 		},
 	];
 
@@ -117,48 +115,40 @@ const Index = () => {
 		<View style={{ ...styles.container, backgroundColor: theme.screen.background }}>
 			<View style={styles.gifContainer}>{renderLottie}</View>
 			<View style={{ ...styles.priceGroupContainer, width: isWeb ? '80%' : '100%' }}>
-				{sortingOptions.map(option => (
-					<TouchableOpacity
-						key={option.id}
-						style={[
-							styles.actionItem,
-							selectedOption === option.id
-								? {
-										backgroundColor: primaryColor,
-									}
-								: {
-										backgroundColor: theme.card.background,
-									},
-						]}
-						onPress={() => updatePricing(option.id)}
-					>
-						<View style={styles.col}>
-							{cloneElement(option.icon, selectedOption === option.id ? { color: contrastColor } : { color: theme.screen.icon })}
-							<Text
-								style={[
-									styles.label,
-									selectedOption === option.id
-										? {
-												color: contrastColor,
-											}
-										: { color: theme.screen.text },
-								]}
-							>
-								{option.label}
-							</Text>
-						</View>
-						<Checkbox
-							style={styles.checkbox}
-							value={selectedOption === option.id}
-							// onValueChange={() => updatePricing(option.id)}
-							color={selectedOption === option.id ? '#000000' : undefined}
+				{sortingOptions.map((option, index) => {
+					const isSelected = selectedOption === option.id;
+					const groupPosition =
+						sortingOptions.length === 1
+							? 'single'
+							: index === 0
+								? 'top'
+								: index === sortingOptions.length - 1
+									? 'bottom'
+									: 'middle';
+
+					return (
+						<SettingsList
+							key={option.id}
+							label={option.label}
+							leftIcon={option.icon}
+							iconBgColor={primaryColor}
+							groupPosition={groupPosition}
+							showSeparator={index !== sortingOptions.length - 1}
+							rightIcon={
+								<MaterialCommunityIcons
+									name={isSelected ? 'radiobox-marked' : 'radiobox-blank'}
+									size={24}
+									color={isSelected ? primaryColor : theme.screen.icon}
+								/>
+							}
+							handleFunction={() => updatePricing(option.id)}
 						/>
-					</TouchableOpacity>
-                                ))}
-                        <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_price_group_selection} />
-                        </View>
-                </View>
-        );
+					);
+				})}
+				<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_price_group_selection} />
+			</View>
+		</View>
+	);
 };
 
 export default Index;

--- a/apps/frontend/app/app/(app)/price-group/styles.ts
+++ b/apps/frontend/app/app/(app)/price-group/styles.ts
@@ -18,30 +18,6 @@ export default StyleSheet.create({
 	},
 	priceGroupContainer: {
 		paddingHorizontal: 10,
-		gap: 20,
 		marginTop: 40,
-	},
-	actionItem: {
-		width: '100%',
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		alignItems: 'center',
-		padding: 10,
-		paddingHorizontal: 20,
-		borderRadius: 10,
-	},
-	col: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		gap: 10,
-	},
-	label: {
-		fontSize: 18,
-		fontFamily: 'Poppins_400Regular',
-	},
-	checkbox: {
-		width: 20,
-		height: 20,
-		borderRadius: 50,
 	},
 });


### PR DESCRIPTION
### Motivation

- Replace the three custom price-group selection cards with the same `SettingsList` row components used by the theme modal to improve consistency.
- Remove gap-based spacing that caused undesired layout spacing in the price-group list.
- Simplify selection rendering by using radio-style icons instead of a separate `Checkbox` implementation.
- Reduce duplicate styling and remove unused helper logic related to contrast/color cloning.

### Description

- Replaced custom `TouchableOpacity` selection items in `apps/frontend/app/app/(app)/price-group/index.tsx` with mapped `SettingsList` rows and radio icons from `MaterialCommunityIcons`.
- Added `SettingsList` import and set per-row `leftIcon` colors from the theme while using `rightIcon` to indicate the selected option.
- Removed the `Checkbox`, `cloneElement` usage and the `myContrastColor` dependent logic from the screen component.
- Removed `gap` and several unused style blocks from `apps/frontend/app/app/(app)/price-group/styles.ts` to avoid gap-based spacing.

### Testing

- No automated tests were executed for this change.
- No unit or integration test runs were performed in this rollout.
- Changes were type-compatible in the edited files and committed to the working branch.
- Manual visual verification is recommended on device/ emulator to confirm styling and selection behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695453bfd3f88330ac701a3112366324)