### PR TITLE
Use AttributeItem with SettingsList

### DIFF
--- a/apps/frontend/app/components/Details/AttributeItem.tsx
+++ b/apps/frontend/app/components/Details/AttributeItem.tsx
@@ -1,139 +1,95 @@
 import React from 'react';
-import { Image, Pressable, Text, View } from 'react-native';
-import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
+import { Image, StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
-import { RootState } from '@/redux/reducer';
 import { useTheme } from '@/hooks/useTheme';
-import { useLanguage } from '@/hooks/useLanguage';
-import { iconLibraries } from '../Drawer/CustomDrawerContent';
+import { RootState } from '@/redux/reducer';
+import SettingsList from '@/components/SettingsList';
+import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
 import { formatFoodInformationValue, getImageUrl } from '@/constants/HelperFunctions';
 import { getFoodAttributesTranslation } from '@/helper/resourceHelper';
 import { useMyContrastColor } from '@/helper/ColorHelper';
-import styles from './styles';
+
+type GroupPosition = 'top' | 'middle' | 'bottom' | 'single';
 
 interface AttributeItemProps {
 	attr: any;
+	groupPosition: GroupPosition;
+	showSeparator?: boolean;
 }
 
-const AttributeItem: React.FC<AttributeItemProps> = ({ attr }) => {
+const AttributeItem: React.FC<AttributeItemProps> = ({ attr, groupPosition, showSeparator }) => {
 	const { theme } = useTheme();
 	const { language, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
-	const { translate } = useLanguage();
 
-	let value;
 	const prefix = attr?.food_attribute?.prefix || '';
 	const suffix = attr?.food_attribute?.suffix || '';
 	const status = attr?.food_attribute?.status;
-	const full_width = attr?.food_attribute?.full_width;
-	const background_color = attr?.food_attribute?.background_color || '';
-	const image = attr?.food_attribute?.image_remote_url ? { uri: attr?.food_attribute?.image_remote_url } : { uri: getImageUrl(attr?.food_attribute?.image) };
+	const backgroundColor = attr?.food_attribute?.background_color || 'transparent';
 	const label = attr?.food_attribute?.translations ? getFoodAttributesTranslation(attr?.food_attribute?.translations, language) : '';
 
-	const iconParts = attr?.food_attribute?.icon_expo?.split(':') || [];
-	const [library, name] = iconParts;
-	const Icon = library && iconLibraries[library];
-
-	const attributeIconParts = attr?.icon_value?.split(':') || [];
-	const [attributeIconLibrary, attributeIconName] = attributeIconParts;
-	const AttributeIcon = attributeIconLibrary && iconLibraries[attributeIconLibrary];
-	const colorValue = attr?.color_value || theme.screen.text;
-
-	if (attr?.number_value) {
+	let value: string | undefined;
+	if (attr?.number_value !== null && attr?.number_value !== undefined) {
 		value = formatFoodInformationValue(attr?.number_value, suffix);
 	} else if (attr?.string_value) {
-		value = attr?.string_value + suffix;
+		value = `${attr?.string_value}${suffix}`;
 	}
+
 	if (prefix && value) {
 		value = `${prefix} ${value}`;
 	}
 
-	const contrastColor = useMyContrastColor(background_color, theme, mode === 'dark');
-
-	if ((label || value) && status === 'published') {
-		return (
-			<View
-				style={{
-					...styles.averageNutrition,
-					minWidth: full_width ? '100%' : 120,
-				}}
-			>
-				<View style={styles.iconContainer}>
-					{attr?.food_attribute?.icon_expo ? (
-						<Tooltip
-							placement="top"
-							trigger={triggerProps => (
-								<Pressable {...triggerProps}>
-									<Icon
-										name={name}
-										size={18}
-										color={background_color ? contrastColor : theme.screen.text}
-										style={{
-											backgroundColor: background_color,
-											borderRadius: 4,
-											padding: 2,
-										}}
-									/>
-								</Pressable>
-							)}
-						>
-							<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
-								<TooltipText fontSize="$sm" color={theme.tooltip.text}>
-									{`${translate(label)}`}
-								</TooltipText>
-							</TooltipContent>
-						</Tooltip>
-					) : image ? (
-						<Image
-							source={image}
-							style={[
-								{
-									width: 24,
-									height: 24,
-									resizeMode: 'contain',
-								},
-								image?.uri && {
-									backgroundColor: background_color,
-									borderRadius: background_color ? 8 : 0,
-								},
-							]}
-						/>
-					) : (
-						<View style={{ width: 20 }} />
-					)}
-				</View>
-				<View style={styles.nutritionDetails}>
-					{value && (
-						<View
-							style={{
-								flexDirection: 'row',
-								alignItems: 'center',
-								gap: 10,
-							}}
-						>
-							<Text
-								style={{
-									...styles.label,
-									color: theme.screen.text,
-								}}
-							>
-								{value !== null && value !== undefined ? value : 'N/A'}
-							</Text>
-							{attr?.icon_value ? <AttributeIcon name={attributeIconName} size={20} color={colorValue} /> : <View style={{ width: 20 }} />}
-						</View>
-					)}
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-						}}
-					>
-						{label}
-					</Text>
-				</View>
-			</View>
-		);
+	if (!(label || value) || status !== 'published') {
+		return null;
 	}
-	return null;
+
+	const iconParts = attr?.food_attribute?.icon_expo?.split(':') || [];
+	const [library, name] = iconParts;
+	const Icon = library && iconLibraries[library];
+	const iconColor = useMyContrastColor(backgroundColor, theme, mode === 'dark');
+
+	const imageUri = attr?.food_attribute?.image_remote_url || getImageUrl(attr?.food_attribute?.image);
+	const imageSource = imageUri ? { uri: imageUri } : null;
+
+	const attributeIconParts = attr?.icon_value?.split(':') || [];
+	const [attributeIconLibrary, attributeIconName] = attributeIconParts;
+	const AttributeIcon = attributeIconLibrary && iconLibraries[attributeIconLibrary];
+	const attributeIconColor = attr?.color_value || theme.screen.text;
+
+	const leftIconComponent =
+		!Icon && imageSource ? (
+			<View style={[styles.attributeIconWrapper, backgroundColor ? { backgroundColor } : null]}>
+				<Image source={imageSource} style={styles.attributeImage} />
+			</View>
+		) : undefined;
+
+	return (
+		<SettingsList
+			label={label || undefined}
+			value={value}
+			leftIcon={Icon ? <Icon name={name} size={18} color={iconColor} /> : undefined}
+			leftIconComponent={leftIconComponent}
+			rightIcon={AttributeIcon ? <AttributeIcon name={attributeIconName} size={20} color={attributeIconColor} /> : undefined}
+			iconBgColor={backgroundColor}
+			groupPosition={groupPosition}
+			showSeparator={showSeparator}
+		/>
+	);
 };
 
 export default AttributeItem;
+
+const styles = StyleSheet.create({
+	attributeIconWrapper: {
+		width: 34,
+		height: 34,
+		borderRadius: 8,
+		alignItems: 'center',
+		justifyContent: 'center',
+		marginRight: 10,
+	},
+	attributeImage: {
+		width: 20,
+		height: 20,
+		resizeMode: 'contain',
+	},
+});

--- a/apps/frontend/app/components/Details/index.tsx
+++ b/apps/frontend/app/components/Details/index.tsx
@@ -12,6 +12,7 @@ import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
+import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
@@ -38,25 +39,52 @@ const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 				groupedAttributes &&
 				groupedAttributes?.map((item: any) => {
 					const title = item?.translations ? getFoodAttributesTranslation(item?.translations, language) : '';
+					const attributeItems =
+						item?.attributes?.filter((attr: any) => {
+							const status = attr?.food_attribute?.status;
+							if (status !== 'published') {
+								return false;
+							}
+							const label = attr?.food_attribute?.translations ? getFoodAttributesTranslation(attr?.food_attribute?.translations, language) : '';
+							const hasValue = attr?.number_value !== null && attr?.number_value !== undefined ? true : Boolean(attr?.string_value);
+							return Boolean(label || hasValue);
+						}) || [];
+
+					if (!attributeItems.length && !title) {
+						return null;
+					}
+
 					return (
 						<View style={styles.groupedAttributes} key={item?.id}>
-							<Text style={{ ...styles.body, color: theme.screen.text }}>{title}</Text>
-							<View
-								style={{
-									...styles.nutritionsContainer,
-									justifyContent: 'flex-start',
-								}}
-							>
-								{item?.attributes && item?.attributes?.map((attr: any) => <AttributeItem attr={attr} key={attr?.id} />)}
+							{title ? <SettingsGroupTitle>{title}</SettingsGroupTitle> : null}
+							<View style={styles.attributeList}>
+								{attributeItems.map((attribute: any, index: number) => {
+									const groupPosition =
+										attributeItems.length === 1
+											? 'single'
+											: index === 0
+												? 'top'
+												: index === attributeItems.length - 1
+													? 'bottom'
+													: 'middle';
+									return (
+										<AttributeItem
+											key={attribute?.id ?? `${item?.id}-${index}`}
+											attr={attribute}
+											groupPosition={groupPosition}
+											showSeparator={index !== attributeItems.length - 1}
+										/>
+									);
+								})}
 							</View>
 						</View>
 					);
 				})
-                        )}
-                        <FoodLabelingInfo textStyle={styles.body1} backgroundColor={foods_area_color} />
-                        <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_details_nutritions} />
-                </View>
-        );
+			)}
+			<FoodLabelingInfo textStyle={styles.body1} backgroundColor={foods_area_color} />
+			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_details_nutritions} />
+		</View>
+	);
 };
 
 export default Details;

--- a/apps/frontend/app/components/Details/styles.ts
+++ b/apps/frontend/app/components/Details/styles.ts
@@ -9,54 +9,12 @@ export default StyleSheet.create({
 		fontFamily: 'Poppins_700Bold',
 		marginVertical: 20,
 	},
-	row: {
-		width: '100%',
-		flexDirection: 'row',
-		alignItems: 'center',
-		gap: 10,
-		marginTop: 10,
-	},
-	nutritionsContainer: {
-		width: '100%',
-		flexDirection: 'row',
-		alignItems: 'flex-start',
-		flexWrap: 'wrap',
-		marginVertical: 20,
-		gap: 20,
-		columnGap: 10,
-	},
-	nutrition: {
-		flexDirection: 'row',
-		alignItems: 'flex-start',
-		gap: 5,
-		minWidth: 100,
-		maxWidth: 200,
-		height: 60,
-		justifyContent: 'flex-start',
-	},
 	groupedAttributes: {
 		width: '100%',
 	},
-	averageNutrition: {
-		flexDirection: 'row',
-		alignItems: 'flex-start',
-		justifyContent: 'flex-start',
-		gap: 5,
-		minWidth: 120,
-		flex: 1,
-		height: 60,
-	},
-	iconContainer: {
-		width: 24,
-	},
-	nutritionDetails: {
-		alignItems: 'flex-start',
-		flexShrink: 1,
-	},
-	label: {
-		fontSize: 14,
-		fontFamily: 'Poppins_400Regular',
-		flexShrink: 1,
+	attributeList: {
+		width: '100%',
+		gap: 0,
 	},
 	body: {
 		fontSize: 16,


### PR DESCRIPTION
### Motivation
- Restore the `AttributeItem` component to keep attribute-row rendering local to a component while computing group position in the list.
- Reuse `SettingsList` for each attribute row to match Settings-screen visuals and simplify markup in `Details`.
- Move attribute icon/image presentation and contrast-color logic into a single component to reduce duplicated styles and logic.

### Description
- Added `apps/frontend/app/components/Details/AttributeItem.tsx` which builds a single attribute row using `SettingsList`, handling label/value formatting via `formatFoodInformationValue`, image handling via `getImageUrl`, icon library lookup via `iconLibraries`, and contrast color via `useMyContrastColor`.
- Updated `apps/frontend/app/components/Details/index.tsx` to filter out unpublished or empty attributes, compute `groupPosition` (`top`/`middle`/`bottom`/`single`) and pass `groupPosition` and `showSeparator` to `AttributeItem` instead of rendering `SettingsList` inline.
- Moved attribute image/icon styles into `AttributeItem` and removed the duplicated styles from `apps/frontend/app/components/Details/styles.ts`, adding an `attributeList` style where needed.
- Kept existing helpers and translations (`getFoodAttributesTranslation`, `formatFoodInformationValue`, `getImageUrl`) and preserved the `SettingsGroupTitle` usage for group headers.

### Testing
- No automated tests were executed for this change.
- (No automated test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a6fd91c083309cb809a3656f786b)