### PR TITLE
Remove custom separator handling from food offer attribute items

### DIFF
--- a/apps/frontend/app/components/Details/AttributeItem.tsx
+++ b/apps/frontend/app/components/Details/AttributeItem.tsx
@@ -14,10 +14,9 @@ type GroupPosition = 'top' | 'middle' | 'bottom' | 'single';
 interface AttributeItemProps {
 	attr: any;
 	groupPosition: GroupPosition;
-	showSeparator?: boolean;
 }
 
-const AttributeItem: React.FC<AttributeItemProps> = ({ attr, groupPosition, showSeparator }) => {
+const AttributeItem: React.FC<AttributeItemProps> = ({ attr, groupPosition }) => {
 	const { theme } = useTheme();
 	const { language, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 
@@ -71,7 +70,6 @@ const AttributeItem: React.FC<AttributeItemProps> = ({ attr, groupPosition, show
 			rightIcon={AttributeIcon ? <AttributeIcon name={attributeIconName} size={20} color={attributeIconColor} /> : undefined}
 			iconBgColor={backgroundColor}
 			groupPosition={groupPosition}
-			showSeparator={showSeparator}
 		/>
 	);
 };

--- a/apps/frontend/app/components/Details/index.tsx
+++ b/apps/frontend/app/components/Details/index.tsx
@@ -72,7 +72,6 @@ const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 											key={attribute?.id ?? `${item?.id}-${index}`}
 											attr={attribute}
 											groupPosition={groupPosition}
-											showSeparator={index !== attributeItems.length - 1}
 										/>
 									);
 								})}


### PR DESCRIPTION
### Motivation
- The attribute rows in the foodoffer details should use the `SettingsList` component's default separator behavior instead of a custom override.
- The change follows a request to remove custom separator usage (`useSeperstor`/`useSeparator`) and rely on default values.

### Description
- Removed the optional `showSeparator` prop from `AttributeItemProps` in `apps/frontend/app/components/Details/AttributeItem.tsx`.
- Stopped forwarding `showSeparator` to the `SettingsList` component inside `AttributeItem` so `SettingsList` uses its default separator behavior.
- Removed the `showSeparator` argument when rendering `AttributeItem` in `apps/frontend/app/components/Details/index.tsx`.
- Modified only the details attribute rendering logic; no other UI behavior was changed.

### Testing
- No automated tests were executed as part of this change.
- The change is a small refactor restricted to two files: `AttributeItem.tsx` and `index.tsx` under `components/Details`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954af82b3e88330b055c793b17012c7)