### PR TITLE
Open link-coordinate modal from detail screens and unify Information location entry

### DIFF
--- a/apps/frontend/app/app/(app)/campus/details/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/index.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Dimensions, Linking, Platform, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Dimensions, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -16,11 +16,13 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
 import { Image as ExpoImage } from 'expo-image';
+import useLinkCoordinateModal from '@/hooks/useLinkCoordinateModal';
 
 const Details = () => {
   useSetPageTitle(TranslationKeys.building_details);
   const { theme } = useTheme();
   const { translate } = useLanguage();
+  const { openLinkCoordinateModal } = useLinkCoordinateModal();
   const { id } = useLocalSearchParams();
   const { serverInfo, appSettings, primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
   const { campusesDict } = useSelector((state: RootState) => state.campus);
@@ -89,18 +91,11 @@ const Details = () => {
       return;
     }
     const [longitude, latitude] = coordinates;
-    const googleMapsUrl = `https://www.google.com/maps?q=${latitude},${longitude}`;
-
-    if (Platform.OS === 'web') {
-      window.open(googleMapsUrl, '_blank');
-    } else {
-      const mapsUrl = Platform.OS === 'ios' ? `maps://?q=${latitude},${longitude}` : `geo:${latitude},${longitude}?q=${latitude},${longitude}`;
-      Linking.openURL(mapsUrl).catch(err => {
-        console.error('Error opening navigation:', err);
-        Linking.openURL(googleMapsUrl).catch(() => {});
-      });
-    }
-  }, [campusDetails]);
+    openLinkCoordinateModal({
+      latlon: { latitude, longitude },
+      title: translate(TranslationKeys.location),
+    });
+  }, [campusDetails, openLinkCoordinateModal, translate]);
 
   const renderContent = useMemo(() => {
     if (activeTab === 'information') return <Information campusDetails={campusDetails} />;

--- a/apps/frontend/app/app/(app)/housing/details/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/details/index.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Dimensions, Image, Linking, Platform, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Dimensions, Image, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -16,11 +16,13 @@ import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
+import useLinkCoordinateModal from '@/hooks/useLinkCoordinateModal';
 
 const Details = () => {
 	useSetPageTitle(TranslationKeys.apartment_details);
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
+	const { openLinkCoordinateModal } = useLinkCoordinateModal();
 	const { id } = useLocalSearchParams();
 	const { appSettings, serverInfo, primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
 	const { apartmentsDict } = useSelector((state: RootState) => state.apartment);
@@ -62,32 +64,19 @@ const Details = () => {
 	}, []);
 
 	const handleOpenNavigation = () => {
-		if (apartmentDetails) {
-			const coordinates = apartmentDetails.coordinates?.coordinates; // [longitude, latitude]
+		if (!apartmentDetails) return;
+		const coordinates = apartmentDetails.coordinates?.coordinates; // [longitude, latitude]
 
-			if (!coordinates || coordinates.length !== 2) {
-				console.error('Invalid coordinates');
-				return;
-			}
-
-			const [longitude, latitude] = coordinates;
-			const googleMapsUrl = `https://www.google.com/maps?q=${latitude},${longitude}`;
-
-			if (Platform.OS === 'web') {
-				window.open(googleMapsUrl, '_blank');
-			} else {
-				const mapsUrl =
-					Platform.OS === 'ios'
-						? `maps://?q=${latitude},${longitude}` // Apple Maps
-						: `geo:${latitude},${longitude}?q=${latitude},${longitude}`; // Google Maps for Android
-
-				Linking.openURL(mapsUrl).catch(err => {
-					console.error('Error opening navigation:', err);
-					// Fallback to Google Maps URL
-					Linking.openURL(googleMapsUrl);
-				});
-			}
+		if (!coordinates || coordinates.length !== 2) {
+			console.error('Invalid coordinates');
+			return;
 		}
+
+		const [longitude, latitude] = coordinates;
+		openLinkCoordinateModal({
+			latlon: { latitude, longitude },
+			title: translate(TranslationKeys.location),
+		});
 	};
 
 	const renderContent = () => {

--- a/apps/frontend/app/components/Information/index.tsx
+++ b/apps/frontend/app/components/Information/index.tsx
@@ -1,4 +1,4 @@
-import { Linking, Platform, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import React from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -10,24 +10,18 @@ import { TranslationKeys } from '@/locales/keys';
 import SettingsList from '@/components/SettingsList';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/reducer';
+import useLinkCoordinateModal from '@/hooks/useLinkCoordinateModal';
 
 const Information: React.FC<any> = ({ campusDetails }) => {
 	const { theme } = useTheme();
 	const toast = useToast();
 	const { translate } = useLanguage();
+	const { openLinkCoordinateModal } = useLinkCoordinateModal();
 	const { appSettings, primaryColor } = useSelector((state: RootState) => state.settings);
 	const campusAreaColor = appSettings?.campus_area_color ?? primaryColor;
 
 	const coordinates = campusDetails?.coordinates?.coordinates;
 	const coordinatesLabel = coordinates?.length === 2 ? coordinates.join(', ') : undefined;
-
-	const copyCordsToClipboard = async () => {
-		const coordinates = campusDetails.coordinates?.coordinates;
-		const copied = await Clipboard.setStringAsync(coordinates?.join(', '));
-		if (copied) {
-			toast('Copied', 'success');
-		}
-	};
 
 	const handleCopyUrlToClipboard = async () => {
 		const googleMapsUrl = campusDetails?.url;
@@ -37,50 +31,32 @@ const Information: React.FC<any> = ({ campusDetails }) => {
 		}
 	};
 
-	const handleOpenNavigation = () => {
-		const coordinates = campusDetails.coordinates?.coordinates; // [longitude, latitude]
-
+	const handleOpenLocationOptions = () => {
 		if (!coordinates || coordinates.length !== 2) {
 			console.error('Invalid coordinates');
 			return;
 		}
 
 		const [longitude, latitude] = coordinates;
-		const googleMapsUrl = `https://www.google.com/maps?q=${latitude},${longitude}`;
-
-		if (Platform.OS === 'web') {
-			window.open(googleMapsUrl, '_blank');
-		} else {
-			const mapsUrl =
-				Platform.OS === 'ios'
-					? `maps://?q=${latitude},${longitude}` // Apple Maps
-					: `geo:${latitude},${longitude}?q=${latitude},${longitude}`; // Google Maps for Android
-
-			Linking.openURL(mapsUrl).catch(err => {
-				console.error('Error opening navigation:', err);
-				// Fallback to Google Maps URL
-				Linking.openURL(googleMapsUrl);
-			});
-		}
+		openLinkCoordinateModal({
+			latlon: { latitude, longitude },
+			title: translate(TranslationKeys.location),
+		});
 	};
 
 	const infoItems = [
-		{
-			key: 'navigation',
-			label: translate(TranslationKeys.open_navitation_to_location),
-			leftIcon: <Ionicons name="navigate" size={24} color={theme.screen.icon} />,
-			rightIcon: <Entypo name="chevron-small-right" size={26} color={theme.screen.icon} />,
-			handleFunction: handleOpenNavigation,
-			value: undefined,
-		},
-		{
-			key: 'coordinates',
-			label: translate(TranslationKeys.coordinates),
-			leftIcon: <Ionicons name="location-sharp" size={24} color={theme.screen.icon} />,
-			rightIcon: <MaterialCommunityIcons name="content-copy" size={24} color={theme.screen.icon} />,
-			handleFunction: copyCordsToClipboard,
-			value: coordinatesLabel,
-		},
+		...(coordinatesLabel
+			? [
+					{
+						key: 'location',
+						label: translate(TranslationKeys.location),
+						leftIcon: <Ionicons name="location-sharp" size={24} color={theme.screen.icon} />,
+						rightIcon: <Entypo name="chevron-small-right" size={26} color={theme.screen.icon} />,
+						handleFunction: handleOpenLocationOptions,
+						value: coordinatesLabel,
+					},
+				]
+			: []),
 		{
 			key: 'construction',
 			label: translate(TranslationKeys.year_of_construction),


### PR DESCRIPTION
### Motivation

- Consolidate navigation and coordinate actions into the shared coordinate modal to provide a consistent UX for location actions.
- Replace duplicated platform-specific navigation logic with a single reusable hook to reduce code duplication.
- Provide a single settings entry for location in the Information view instead of multiple separate entries.

### Description

- Replaced direct `Linking`/`Platform` navigation code with the `useLinkCoordinateModal` hook and call to `openLinkCoordinateModal` in `apps/frontend/app/app/(app)/campus/details/index.tsx` and `apps/frontend/app/app/(app)/housing/details/index.tsx`.
- Updated `apps/frontend/app/components/Information/index.tsx` to remove separate navigation and copy-coordinate items and introduce a single `location` entry that opens the coordinate modal via `openLinkCoordinateModal` (label uses `TranslationKeys.location`).
- Removed unused imports (`Linking`, `Platform`) and the old inline coordinate copy logic in favor of the modal which handles copy and map-opening options.

### Testing

- No automated tests were run for this change.
- Files modified: `campus/details/index.tsx`, `housing/details/index.tsx`, and `components/Information/index.tsx` and committed locally.
- Change compiles in-place during development workflows (no CI output included in this PR description).
- Manual/functional verification is recommended to confirm modal behavior on web, iOS and Android.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554cc825b083308a60969560e711a3)