### PR TITLE
Standardize location modal title and update location label

### DIFF
--- a/apps/frontend/app/app/(app)/campus/details/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/index.tsx
@@ -93,7 +93,6 @@ const Details = () => {
     const [longitude, latitude] = coordinates;
     openLinkCoordinateModal({
       latlon: { latitude, longitude },
-      title: translate(TranslationKeys.location),
     });
   }, [campusDetails, openLinkCoordinateModal, translate]);
 

--- a/apps/frontend/app/app/(app)/housing/details/index.tsx
+++ b/apps/frontend/app/app/(app)/housing/details/index.tsx
@@ -75,7 +75,6 @@ const Details = () => {
 		const [longitude, latitude] = coordinates;
 		openLinkCoordinateModal({
 			latlon: { latitude, longitude },
-			title: translate(TranslationKeys.location),
 		});
 	};
 

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -59,7 +59,6 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, onEditImag
 		const [longitude, latitude] = coordinates;
 		openLinkCoordinateModal({
 			latlon: { latitude, longitude },
-			title: translate(TranslationKeys.open_navitation_to_location),
 		});
 	}, [campus, openLinkCoordinateModal, translate]);
 

--- a/apps/frontend/app/components/Information/index.tsx
+++ b/apps/frontend/app/components/Information/index.tsx
@@ -40,7 +40,6 @@ const Information: React.FC<any> = ({ campusDetails }) => {
 		const [longitude, latitude] = coordinates;
 		openLinkCoordinateModal({
 			latlon: { latitude, longitude },
-			title: translate(TranslationKeys.location),
 		});
 	};
 

--- a/apps/frontend/app/hooks/useLinkCoordinateModal.tsx
+++ b/apps/frontend/app/hooks/useLinkCoordinateModal.tsx
@@ -17,7 +17,6 @@ export type LinkCoordinate = {
 };
 
 type OpenLinkCoordinateModalOptions = {
-	title?: string;
 	latlon: LinkCoordinate;
 };
 
@@ -32,7 +31,7 @@ const useLinkCoordinateModal = () => {
 	}, [close]);
 
 	const openLinkCoordinateModal = useCallback(
-		({ title, latlon }: OpenLinkCoordinateModalOptions) => {
+		({ latlon }: OpenLinkCoordinateModalOptions) => {
 			if (!latlon || !Number.isFinite(latlon.latitude) || !Number.isFinite(latlon.longitude)) {
 				console.error('Invalid coordinates');
 				return;
@@ -79,7 +78,7 @@ const useLinkCoordinateModal = () => {
 			];
 
 			show({
-				title: title ?? translate(TranslationKeys.coordinates),
+				title: translate(TranslationKeys.location_information),
 				onClose: closeModal,
 				children: (
 					<View style={{ gap: 12 }}>

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -138,6 +138,7 @@ export enum TranslationKeys {
 	use_current_position_for_distance = 'use_current_position_for_distance',
 	distance = 'distance',
 	coordinates = 'coordinates',
+	location_information = 'location_information',
 	copy_url = 'copy_url',
 	copy = 'copy',
 	copied = 'copied',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1429,6 +1429,16 @@
     "tr": "Koordinatlar",
     "zh": "坐标"
   },
+  "location_information": {
+    "de": "Information zum Standort",
+    "en": "Location information",
+    "ar": "معلومات الموقع",
+    "es": "Información de la ubicación",
+    "fr": "Informations sur le lieu",
+    "ru": "Информация о местоположении",
+    "tr": "Konum bilgisi",
+    "zh": "位置信息"
+  },
   "copy_url": {
     "de": "URL kopieren",
     "en": "Copy URL",
@@ -2250,7 +2260,7 @@
     "zh": "删除账户"
   },
   "location": {
-    "de": "Ort",
+    "de": "Standort",
     "en": "Location",
     "ar": "موقع",
     "es": "Ubicación",


### PR DESCRIPTION
### Motivation
- Ensure the coordinate modal always shows a consistent, localized title for location actions across the app.  
- Provide a clearer German label for "location" by using a more appropriate term.  
- Simplify modal hook usage by removing the optional title parameter since the title is now standardized.  
- Reduce duplication and potential inconsistencies in callers that open the coordinate modal.

### Description
- Updated `useLinkCoordinateModal` to always set the modal title to `translate(TranslationKeys.location_information)` and removed the optional `title` parameter from `OpenLinkCoordinateModalOptions`.  
- Replaced callers that previously passed a `title` to `openLinkCoordinateModal` in `apps/frontend/app/app/(app)/campus/details/index.tsx`, `apps/frontend/app/app/(app)/housing/details/index.tsx`, `apps/frontend/app/components/Information/index.tsx`, and `apps/frontend/app/components/BuildingItem/BuildingItem.tsx`.  
- Added a new translation key `location_information` in `apps/frontend/app/locales/keys.ts` and `apps/frontend/app/locales/translations.json` with translations including German `"Information zum Standort"`.  
- Adjusted the German translation for the existing `location` key from `"Ort"` to `"Standort"`.

### Testing
- No automated tests were executed as part of this change.  
- The change is limited to UI strings and function signatures and was committed as `Standardize location modal title`.  
- Manual runtime verification is recommended to confirm the modal title and labels display correctly in supported locales.  
- No other automated validation failures were observed in the local edit/commit process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69555218d75883308d3827eeffef53d2)