### PR TITLE
SettingsListCoordinate: default right-side label to 'Show'

### DIFF
--- a/apps/frontend/app/components/SettingsListCoordinate/SettingsListCoordinate.tsx
+++ b/apps/frontend/app/components/SettingsListCoordinate/SettingsListCoordinate.tsx
@@ -43,7 +43,7 @@ const SettingsListCoordinate: React.FC<SettingsListCoordinateProps> = ({
 	}, [hasLocation, location, openLinkCoordinateModal]);
 
 	const resolvedLabel = label ?? translate(TranslationKeys.location);
-	const resolvedValue = value ?? translate(TranslationKeys.coordinates);
+	const resolvedValue = value ?? translate(TranslationKeys.show);
 	const resolvedLeftIcon = leftIcon ?? <Ionicons name="location-sharp" size={24} color={theme.screen.icon} />;
 	const resolvedRightIcon = rightIcon ?? <Entypo name="chevron-small-right" size={26} color={theme.screen.icon} />;
 


### PR DESCRIPTION
### Motivation
- The settings coordinate list should always display the label "Anzeigen" ("Show") on the right instead of "Koordinaten" ("Coordinates").
- This makes the action clearer to users and matches the requested localization change.

### Description
- Changed the default `value` in `SettingsListCoordinate` to use `translate(TranslationKeys.show)` instead of `translate(TranslationKeys.coordinates)`.
- Only the file `apps/frontend/app/components/SettingsListCoordinate/SettingsListCoordinate.tsx` was modified and the change is a single-line substitution of the default resolved value.
- No other UI behavior, icons, or modal handling were changed; `handleOpenLocation` and the open modal logic remain intact.

### Testing
- No automated tests were run for this change (no unit/integration/e2e executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695586e37b508330bd5206037de6b7e7)