### PR TITLE
Make image edit cancel button standalone

### DIFF
--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -303,8 +303,36 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 	}, [buildUpdatePayload, collection, collectionFields, field, itemId, loading, onClose, onUpdated]);
 
 	const actionItems = useMemo(() => {
+		const withGrouping = (items: Array<Record<string, any>>) =>
+			items.map((item, index) => ({
+				...item,
+				groupPosition:
+					items.length === 1
+						? 'single'
+						: index === 0
+							? 'top'
+							: index === items.length - 1
+								? 'bottom'
+								: 'middle',
+				showSeparator: index !== items.length - 1,
+			}));
+
+		const cancelItem = {
+			key: isDelete ? 'delete-cancel' : 'cancel',
+			label: translate(TranslationKeys.cancel),
+			icon: <MaterialCommunityIcons name="close" size={24} />,
+			groupPosition: 'single',
+			showSeparator: false,
+			onPress: () => {
+				if (isDelete) {
+					setIsDelete(false);
+				}
+				onClose();
+			},
+		};
+
 		if (isDelete) {
-			return [
+			const deleteItems = withGrouping([
 				{
 					key: 'delete-confirm',
 					label: translate(TranslationKeys.delete),
@@ -313,21 +341,14 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 					onPress: handleDeleteImage,
 				},
 				{
-					key: 'delete-cancel',
-					label: translate(TranslationKeys.cancel),
-					icon: <MaterialCommunityIcons name="close" size={24} />,
-					onPress: () => {
-						setIsDelete(false);
-						onClose();
-					},
-				},
-				{
 					key: 'delete-back',
 					label: translate(TranslationKeys.navigate_back),
 					icon: <MaterialCommunityIcons name="keyboard-backspace" size={24} />,
 					onPress: () => setIsDelete(false),
 				},
-			];
+			]);
+
+			return [...deleteItems, cancelItem];
 		}
 
 		const items = [];
@@ -354,34 +375,20 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 			rightIcon: <MaterialCommunityIcons name="arrow-right" size={24} color={theme.screen.icon} />,
 			onPress: () => setIsDelete(true),
 		});
-		items.push({
-			key: 'cancel',
-			label: translate(TranslationKeys.cancel),
-			icon: <MaterialCommunityIcons name="close" size={24} />,
-			onPress: onClose,
-		});
-		return items;
+
+		return [...withGrouping(items), cancelItem];
 	}, [handleDeleteImage, handleImagePick, isDelete, loading, onClose, theme.screen.icon, translate]);
 
 	return (
 		<View style={{ width: '100%' }}>
 			{actionItems.map((item, index) => {
-				const groupPosition =
-					actionItems.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === actionItems.length - 1
-								? 'bottom'
-								: 'middle';
-
 				return (
 					<SettingsList
 						key={item.key}
 						label={item.label}
 						leftIcon={item.icon}
-						groupPosition={groupPosition}
-						showSeparator={index !== actionItems.length - 1}
+						groupPosition={item.groupPosition}
+						showSeparator={item.showSeparator}
 						rightElement={item.rightElement}
 						rightIcon={item.rightIcon}
 						handleFunction={item.onPress}


### PR DESCRIPTION
### Motivation
- Improve the UX of the Directus image edit modal by showing the cancel action as a single, clearly separated list item. 
- Keep the primary actions (camera/gallery/delete) visually grouped so it's easier to pick the main action without accidentally cancelling. 
- Apply the same grouping pattern to the delete-confirmation state to keep behavior consistent. 

### Description
- Updated `useMyScrollviewDirectusImageEditModal.tsx` / `DirectusImageEditModalContent` to compute grouped action items via a new `withGrouping` helper and to create a separate `cancelItem`. 
- Primary actions (`camera`, `gallery`, `delete`) are returned as a grouped list and the `cancel` action is appended as a standalone item with `groupPosition: 'single'`. 
- The delete-confirmation state now renders the confirm/back actions grouped and appends the standalone cancel item. 
- The rendering loop uses the per-item `groupPosition` and `showSeparator` properties instead of recomputing group position on render. 

### Testing
- No automated tests were run for this change. 
- The change is limited to UI action grouping logic in `useMyScrollviewDirectusImageEditModal.tsx` and does not modify network or storage behavior. 
- Manual verification is recommended to confirm the cancel item appears as a single list entry and grouped actions retain expected separators.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695591a5787083308a66f8d71652aacb)