### PR TITLE
Add gap before cancel action in image edit modal using shared constant

### DIFF
--- a/apps/frontend/app/constants/Constants.ts
+++ b/apps/frontend/app/constants/Constants.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 export const isWeb = Platform.OS === 'web';
 export const borderRadiusContainer = 10;
 export const horizontalScreenPadding = 16;
+export const settingsListSectionGap = 8;
 
 export const links = [
 	{ title: 'about_us', path: '/about-us' },

--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -11,7 +11,7 @@ import { ImagePickerMediaTypes } from '@/components/FileUpload/FileUpload';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
-import { isWeb } from '@/constants/Constants';
+import { isWeb, settingsListSectionGap } from '@/constants/Constants';
 import { ServerAPI } from '@/redux/actions';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { TranslationKeys } from '@/locales/keys';
@@ -323,6 +323,7 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 			icon: <MaterialCommunityIcons name="close" size={24} />,
 			groupPosition: 'single',
 			showSeparator: false,
+			isCancel: true,
 			onPress: () => {
 				if (isDelete) {
 					setIsDelete(false);
@@ -383,16 +384,17 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 		<View style={{ width: '100%' }}>
 			{actionItems.map((item, index) => {
 				return (
-					<SettingsList
-						key={item.key}
-						label={item.label}
-						leftIcon={item.icon}
-						groupPosition={item.groupPosition}
-						showSeparator={item.showSeparator}
-						rightElement={item.rightElement}
-						rightIcon={item.rightIcon}
-						handleFunction={item.onPress}
-					/>
+					<View key={item.key} style={item.isCancel && index > 0 ? { marginTop: settingsListSectionGap } : undefined}>
+						<SettingsList
+							label={item.label}
+							leftIcon={item.icon}
+							groupPosition={item.groupPosition}
+							showSeparator={item.showSeparator}
+							rightElement={item.rightElement}
+							rightIcon={item.rightIcon}
+							handleFunction={item.onPress}
+						/>
+					</View>
 				);
 			})}
 		</View>


### PR DESCRIPTION
### Motivation
- The Image Edit Modal had a small visual gap missing between the cancel action and the preceding settings list group, causing inconsistent spacing.
- Use a shared spacing constant so the same gap can be reused and kept consistent across settings list sections.

### Description
- Added `settingsListSectionGap = 8` to `apps/frontend/app/constants/Constants.ts` to expose a shared gap constant.
- Updated `apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx` to import `settingsListSectionGap` and annotate the cancel action with `isCancel: true`.
- Wrapped each rendered `SettingsList` in a `View` and apply `marginTop: settingsListSectionGap` for the cancel item when it follows other items to create the requested spacing.
- Kept existing `SettingsList` props and group positioning while only adding the visual wrapper to introduce the gap.

### Testing
- No automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69559bea9b088330940d6dd482a24ac4)