### PR TITLE
Add distance info modal hook and info badge for campus/housing cards

### DIFF
--- a/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
+++ b/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
@@ -17,6 +17,7 @@ import { RootState } from '@/redux/reducer';
 import CardWithText from '../CardWithText/CardWithText';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 import AvailableFromModal from '../AvailableFromModal';
+import useMyScrollviewModalDistanceInformation from '@/hooks/useMyScrollviewModalDistanceInformation';
 
 const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, onEditImage, openDistanceSheet }) => {
 	const { theme } = useTheme();
@@ -24,6 +25,7 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, onEditImage, op
 	const { primaryColor: projectColor, appSettings, serverInfo, selectedTheme: mode, amountColumnsForcard } = useSelector((state: RootState) => state.settings);
 	const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
 	const { isManagement } = useSelector((state: RootState) => state.authReducer);
+	const { openDistanceInformationModal } = useMyScrollviewModalDistanceInformation();
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const [showFreeModal, setShowFreeModal] = useState(false);
 	const housing_area_color = appSettings?.housing_area_color ? appSettings?.housing_area_color : projectColor;
@@ -130,16 +132,27 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, onEditImage, op
 									) : (
 										<View />
 									)}
-									<TouchableOpacity
-										style={{
-											...styles.directionButton,
-											backgroundColor: housing_area_color,
-										}}
-										onPress={openDistanceSheet}
-									>
-										<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
-										<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(apartment?.distance)}</Text>
-									</TouchableOpacity>
+									<View style={styles.distanceActions}>
+										<TouchableOpacity
+											style={{
+												...styles.infoButton,
+												backgroundColor: housing_area_color,
+											}}
+											onPress={openDistanceInformationModal}
+										>
+											<MaterialCommunityIcons name="information-outline" size={18} color={contrastColor} />
+										</TouchableOpacity>
+										<TouchableOpacity
+											style={{
+												...styles.directionButton,
+												backgroundColor: housing_area_color,
+											}}
+											onPress={openDistanceSheet}
+										>
+											<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
+											<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(apartment?.distance)}</Text>
+										</TouchableOpacity>
+									</View>
 								</View>
 							</>
 						}

--- a/apps/frontend/app/components/ApartmentItem/styles.ts
+++ b/apps/frontend/app/components/ApartmentItem/styles.ts
@@ -53,6 +53,17 @@ export default StyleSheet.create({
 		paddingVertical: 5,
 		paddingHorizontal: 10,
 	},
+	distanceActions: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+	},
+	infoButton: {
+		borderRadius: 8,
+		justifyContent: 'center',
+		alignItems: 'center',
+		padding: 6,
+	},
 	freeBadge: {
 		position: 'absolute',
 		top: 5,

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import useLinkCoordinateModal from '@/hooks/useLinkCoordinateModal';
+import useMyScrollviewModalDistanceInformation from '@/hooks/useMyScrollviewModalDistanceInformation';
 import CardWithText from '../CardWithText/CardWithText';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 
@@ -34,6 +35,7 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, onEditImag
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { openLinkCoordinateModal } = useLinkCoordinateModal();
+	const { openDistanceInformationModal } = useMyScrollviewModalDistanceInformation();
 
 	const { amountColumnsForcard, primaryColor, serverInfo, appSettings, selectedTheme: mode, screenWidth, isManagement = false } = settings;
 
@@ -138,16 +140,27 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, onEditImag
 									<View />
 								)}
 
-								<TouchableOpacity
-									style={{
-										...styles.directionButton,
-										backgroundColor: campus_area_color,
-									}}
-									onPress={openDistanceSheet}
-								>
-									<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
-									<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(campus?.distance)}</Text>
-								</TouchableOpacity>
+								<View style={styles.distanceActions}>
+									<TouchableOpacity
+										style={{
+											...styles.infoButton,
+											backgroundColor: campus_area_color,
+										}}
+										onPress={openDistanceInformationModal}
+									>
+										<MaterialCommunityIcons name="information-outline" size={18} color={contrastColor} />
+									</TouchableOpacity>
+									<TouchableOpacity
+										style={{
+											...styles.directionButton,
+											backgroundColor: campus_area_color,
+										}}
+										onPress={openDistanceSheet}
+									>
+										<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
+										<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(campus?.distance)}</Text>
+									</TouchableOpacity>
+								</View>
 							</View>
 						</>
 					}
@@ -229,6 +242,17 @@ const styles = StyleSheet.create({
 		gap: 10,
 		paddingVertical: 5,
 		paddingHorizontal: 10,
+	},
+	distanceActions: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+	},
+	infoButton: {
+		borderRadius: 8,
+		justifyContent: 'center',
+		alignItems: 'center',
+		padding: 6,
 	},
 	distance: {
 		fontSize: 16,

--- a/apps/frontend/app/hooks/useMyScrollviewModalDistanceInformation.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewModalDistanceInformation.tsx
@@ -1,0 +1,31 @@
+import React, { useCallback } from 'react';
+import { Text, View } from 'react-native';
+
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+
+const useMyScrollviewModalDistanceInformation = () => {
+	const { show, close } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+	const { theme } = useTheme();
+
+	const openDistanceInformationModal = useCallback(() => {
+		show({
+			title: translate(TranslationKeys.distance),
+			onClose: close,
+			children: (
+				<View>
+					<Text style={{ color: theme.screen.text, textAlign: 'center' }}>
+						{translate(TranslationKeys.distance_based_on_selected_canteen)}
+					</Text>
+				</View>
+			),
+		});
+	}, [close, show, theme.screen.text, translate]);
+
+	return { openDistanceInformationModal, closeDistanceInformationModal: close };
+};
+
+export default useMyScrollviewModalDistanceInformation;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -135,6 +135,7 @@ export enum TranslationKeys {
 	open_in_apple_maps = 'open_in_apple_maps',
 	copy_coordinates = 'copy_coordinates',
 	distance_based_canteen_selection_or_if_asked_on_real_location = 'distance_based_canteen_selection_or_if_asked_on_real_location',
+	distance_based_on_selected_canteen = 'distance_based_on_selected_canteen',
 	use_current_position_for_distance = 'use_current_position_for_distance',
 	distance = 'distance',
 	coordinates = 'coordinates',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1399,6 +1399,16 @@
     "tr": "Mesafe, seçtiğiniz kantine veya açıkça sorduysanız cihazınızın konumuna olan mesafeye göre hesaplanır.",
     "zh": "距离是根据您选择的食堂的距离或，如果您明确要求，根据您设备的位置计算的。"
   },
+  "distance_based_on_selected_canteen": {
+    "de": "Die Entfernung wird von deiner ausgewählten Mensa aus berechnet.",
+    "en": "The distance is calculated from your selected canteen.",
+    "ar": "يتم حساب المسافة انطلاقًا من المقصف الذي اخترته.",
+    "es": "La distancia se calcula a partir de tu comedor seleccionado.",
+    "fr": "La distance est calculée à partir de votre cantine sélectionnée.",
+    "ru": "Расстояние рассчитывается от выбранной вами столовой.",
+    "tr": "Mesafe, seçtiğiniz kantinden itibaren hesaplanır.",
+    "zh": "距离以你选择的食堂为起点计算。"
+  },
   "use_current_position_for_distance": {
     "de": "Aktuelle Position für Entfernung nutzen",
     "en": "Use current position for distance",


### PR DESCRIPTION
### Motivation

- Provide a lightweight way to show an explanatory modal when users tap the distance badge on campus or housing cards. 
- Make it clear that the displayed distance is calculated from the currently selected canteen. 
- Reuse existing scrollview modal infrastructure so the UI is consistent with other modal flows. 

### Description

- Added a new hook `useMyScrollviewModalDistanceInformation` which opens a `MyScrollViewModal` containing the distance origin message. 
- Wired an information button next to the distance chip in `BuildingItem` and `ApartmentItem` that calls `openDistanceInformationModal`, while keeping the existing `openDistanceSheet` behavior. 
- Added styles (`distanceActions`, `infoButton`) and updated component layouts to show the info badge alongside the distance chip. 
- Introduced a new translation key `distance_based_on_selected_canteen` and updated `keys.ts` and `translations.json` with localized copy. 

### Testing

- No automated tests were run for this change. 
- Changes were compiled and committed in the feature branch (files modified: `BuildingItem`, `ApartmentItem`, `ApartmentItem/styles`, `useMyScrollviewModalDistanceInformation.tsx`, `locales/keys.ts`, `locales/translations.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564d7693bc8330a5d11d7838828b4d)