### PR TITLE
Open distance info on badge tap; show distance sheet on long-press

### DIFF
--- a/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
+++ b/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
@@ -135,19 +135,11 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, onEditImage, op
 									<View style={styles.distanceActions}>
 										<TouchableOpacity
 											style={{
-												...styles.infoButton,
-												backgroundColor: housing_area_color,
-											}}
-											onPress={openDistanceInformationModal}
-										>
-											<MaterialCommunityIcons name="information-outline" size={18} color={contrastColor} />
-										</TouchableOpacity>
-										<TouchableOpacity
-											style={{
 												...styles.directionButton,
 												backgroundColor: housing_area_color,
 											}}
-											onPress={openDistanceSheet}
+											onPress={openDistanceInformationModal}
+											onLongPress={openDistanceSheet}
 										>
 											<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
 											<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(apartment?.distance)}</Text>

--- a/apps/frontend/app/components/ApartmentItem/styles.ts
+++ b/apps/frontend/app/components/ApartmentItem/styles.ts
@@ -58,12 +58,6 @@ export default StyleSheet.create({
 		alignItems: 'center',
 		gap: 8,
 	},
-	infoButton: {
-		borderRadius: 8,
-		justifyContent: 'center',
-		alignItems: 'center',
-		padding: 6,
-	},
 	freeBadge: {
 		position: 'absolute',
 		top: 5,

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -143,19 +143,11 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ campus, onEditImag
 								<View style={styles.distanceActions}>
 									<TouchableOpacity
 										style={{
-											...styles.infoButton,
-											backgroundColor: campus_area_color,
-										}}
-										onPress={openDistanceInformationModal}
-									>
-										<MaterialCommunityIcons name="information-outline" size={18} color={contrastColor} />
-									</TouchableOpacity>
-									<TouchableOpacity
-										style={{
 											...styles.directionButton,
 											backgroundColor: campus_area_color,
 										}}
-										onPress={openDistanceSheet}
+										onPress={openDistanceInformationModal}
+										onLongPress={openDistanceSheet}
 									>
 										<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
 										<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(campus?.distance)}</Text>
@@ -247,12 +239,6 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		gap: 8,
-	},
-	infoButton: {
-		borderRadius: 8,
-		justifyContent: 'center',
-		alignItems: 'center',
-		padding: 6,
 	},
 	distance: {
 		fontSize: 16,


### PR DESCRIPTION
### Motivation
- The distance info was previously exposed via a separate `information-outline` icon on building/housing cards, causing UI clutter and redundancy.  
- The intent is to consolidate interactions so the visible distance badge serves as the main entry to distance info.  
- Keep the existing distance sheet behavior available while reducing the number of action icons.  

### Description
- Replaced the separate info icon with direct behavior on the distance badge in `BuildingItem` and `ApartmentItem` so a tap calls `openDistanceInformationModal` and a long press calls `openDistanceSheet`.  
- Removed the unused `infoButton` style from both `apps/frontend/app/components/BuildingItem/BuildingItem.tsx` and `apps/frontend/app/components/ApartmentItem/styles.ts`.  
- Modified `BuildingItem` and `ApartmentItem` components to attach `onPress={openDistanceInformationModal}` and `onLongPress={openDistanceSheet}` to the distance badge `TouchableOpacity`.  

### Testing
- No automated tests were executed as part of this change.  
- Manual verification recommended: tap the distance badge to open the distance info modal and long-press it to open the distance sheet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69566a764e9c8330b0a0f8c111f86eec)