### PR TITLE
Fix SettingsList switch overflow in settings

### DIFF
--- a/apps/frontend/app/components/SettingsList/SettingsList.tsx
+++ b/apps/frontend/app/components/SettingsList/SettingsList.tsx
@@ -144,8 +144,8 @@ const styles = StyleSheet.create({
 		textAlign: 'right', // Text rechtsbündig
 	},
 	rightWrapper: {
-		width: 34,
-		height: 34,
+		minWidth: 34,
+		minHeight: 34,
 		borderRadius: 8,
 		alignItems: 'center',
 		justifyContent: 'center',


### PR DESCRIPTION
### Motivation
- The boolean `Switch` in the app settings was overflowing the row because the right-side wrapper was constrained to a fixed 34x34 size. 
- The same boolean usage in the monitor screen renders correctly, indicating the problem is specific to the `SettingsList` layout. 
- Allowing right-side controls (e.g. `Switch` passed via `rightElement`) to size naturally prevents clipping and improves layout robustness. 

### Description
- Updated `apps/frontend/app/components/SettingsList/SettingsList.tsx` to use `minWidth`/`minHeight` for the `rightWrapper` style instead of fixed `width`/`height` so right-side elements can expand as needed. 
- This change keeps the previous minimum spacing while preventing controls like `Switch` from overflowing the row. 

### Testing
- Committed the change (`Fix SettingsList switch layout`) and created the PR. 
- Attempted an automated Playwright screenshot to visually verify the fix, but the app at `http://127.0.0.1:3000` was not reachable and the run failed with `net::ERR_EMPTY_RESPONSE`. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a1b87d748330b44649e58b1992d6)