### PR TITLE
Remove SettingsListBoolean index and import component directly

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
@@ -9,6 +9,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import SettingsList from '@/components/SettingsList';
 import SettingsListEditable from '@/components/SettingsListEditable';
 import SettingsListDate from '@/components/SettingsListDate';
+import SettingsListBoolean from '@/components/SettingsListBoolean/SettingsListBoolean';
 import SettingsListTextInput from '@/components/SettingsListTextInput';
 import SettingsListNickname from '@/components/SettingsListNickname';
 import SettingsListCoordinate from '@/components/SettingsListCoordinate/SettingsListCoordinate';
@@ -22,6 +23,7 @@ const SettingsListComponents = () => {
 	const [dateError, setDateError] = useState('');
 	const [inputValue, setInputValue] = useState('Beispieltext');
 	const [nickname, setNickname] = useState('Tester');
+	const [boolValue, setBoolValue] = useState(true);
 
 	return (
 		<ScrollView
@@ -71,6 +73,17 @@ const SettingsListComponents = () => {
 					label="Datum"
 					iconBgColor={primaryColor}
 					leftIcon={<MaterialCommunityIcons name="calendar" size={24} color={theme.screen.icon} />}
+					groupPosition="single"
+				/>
+
+				<Text style={{ ...styles.sectionTitle, color: theme.screen.text }}>SettingsListBoolean</Text>
+				<SettingsListBoolean
+					iconBgColor={primaryColor}
+					leftIcon={<MaterialCommunityIcons name="toggle-switch-outline" size={24} color={theme.screen.icon} />}
+					label="Boolean Setting"
+					value={boolValue ? 'Aktiv' : 'Inaktiv'}
+					isEnabled={boolValue}
+					onToggle={() => setBoolValue(current => !current)}
 					groupPosition="single"
 				/>
 

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Dimensions, SafeAreaView, ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, SafeAreaView, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import MyImage from '@/components/MyImage';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -8,6 +8,7 @@ import { AntDesign, Entypo, Feather, FontAwesome5, Ionicons, MaterialCommunityIc
 import { isWeb } from '@/constants/Constants';
 import SettingsList from '@/components/SettingsList';
 import SettingsListEditable from '@/components/SettingsListEditable';
+import SettingsListBoolean from '@/components/SettingsListBoolean/SettingsListBoolean';
 import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import useMyScrollviewTextInputModal from '@/hooks/useMyScrollviewTextInputModal';
@@ -411,7 +412,7 @@ const Settings = () => {
                                                         handleFunction={openCollectibleSizeModal}
                                                         groupPosition="middle"
                                                 />
-                                                <SettingsList
+                                                <SettingsListBoolean
                                                         iconBgColor={primaryColor}
                                                         leftIcon={<MaterialIcons name="my-location" size={24} color={theme.screen.icon} />}
                                                         label={translate(TranslationKeys.collectible_event_random_position)}
@@ -420,16 +421,8 @@ const Settings = () => {
                                                                         ? translate(TranslationKeys.checked)
                                                                         : translate(TranslationKeys.unchecked)
                                                         }
-                                                        rightElement={
-                                                                <Switch
-                                                                        value={collectibleRandomPosition}
-                                                                        onValueChange={toggleCollectibleRandomPosition}
-                                                                        trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
-                                                                        thumbColor={theme.screen.icon}
-                                                                        ios_backgroundColor={theme.screen.iconBg}
-                                                                />
-                                                        }
-                                                        handleFunction={toggleCollectibleRandomPosition}
+                                                        isEnabled={collectibleRandomPosition}
+                                                        onToggle={toggleCollectibleRandomPosition}
                                                         groupPosition="bottom"
                                                 />
                                         </View>
@@ -586,38 +579,22 @@ const Settings = () => {
                                                         <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={selectedCustomerDisplayName} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
-							<SettingsList
+							<SettingsListBoolean
 								iconBgColor={primaryColor}
 								leftIcon={<MaterialCommunityIcons name="bank-transfer" size={24} color={theme.screen.icon} />}
 								label={translate(TranslationKeys.debug_mode)}
 								value={debugMode ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
-								rightElement={
-									<Switch
-										value={debugMode}
-										onValueChange={toggleDebugMode}
-										trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
-										thumbColor={theme.screen.icon}
-										ios_backgroundColor={theme.screen.iconBg}
-									/>
-								}
-								handleFunction={toggleDebugMode}
+								isEnabled={debugMode}
+								onToggle={toggleDebugMode}
 								groupPosition="middle"
 							/>
-							<SettingsList
+							<SettingsListBoolean
 								iconBgColor={primaryColor}
 								leftIcon={<MaterialCommunityIcons name="update" size={24} color={theme.screen.icon} />}
 								label={translate(TranslationKeys.simulate_expo_update_available)}
 								value={simulateExpoUpdateAvailable ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
-								rightElement={
-									<Switch
-										value={simulateExpoUpdateAvailable}
-										onValueChange={toggleSimulateExpoUpdate}
-										trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
-										thumbColor={theme.screen.icon}
-										ios_backgroundColor={theme.screen.iconBg}
-									/>
-								}
-								handleFunction={toggleSimulateExpoUpdate}
+								isEnabled={simulateExpoUpdateAvailable}
+								onToggle={toggleSimulateExpoUpdate}
 								groupPosition="bottom"
 							/>
 						</View>

--- a/apps/frontend/app/components/SettingsListBoolean/SettingsListBoolean.tsx
+++ b/apps/frontend/app/components/SettingsListBoolean/SettingsListBoolean.tsx
@@ -1,0 +1,43 @@
+// Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
+import React from 'react';
+import { Switch } from 'react-native';
+import { useSelector } from 'react-redux';
+import SettingsList from '@/components/SettingsList';
+import { useTheme } from '@/hooks/useTheme';
+import { RootState } from '@/redux/reducer';
+import type { PropsWithChildren } from 'react';
+import type { SettingsListProps } from '@/components/SettingsList';
+
+type SettingsListBooleanPropsOwn = {
+        isEnabled: boolean;
+        onToggle: () => void;
+        disabled?: boolean;
+};
+
+export type SettingsListBooleanProps = PropsWithChildren<
+        Omit<SettingsListProps, 'rightElement' | 'rightIcon' | 'onPress' | 'handleFunction'> & SettingsListBooleanPropsOwn
+>;
+
+const SettingsListBoolean: React.FC<SettingsListBooleanProps> = ({ isEnabled, onToggle, disabled = false, ...props }) => {
+        const { theme } = useTheme();
+        const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+        return (
+                <SettingsList
+                        {...props}
+                        rightElement={
+                                <Switch
+                                        value={isEnabled}
+                                        onValueChange={onToggle}
+                                        trackColor={{ false: theme.screen.iconBg, true: primaryColor }}
+                                        thumbColor={theme.screen.icon}
+                                        ios_backgroundColor={theme.screen.iconBg}
+                                        disabled={disabled}
+                                />
+                        }
+                        handleFunction={disabled ? undefined : onToggle}
+                />
+        );
+};
+
+export default SettingsListBoolean;


### PR DESCRIPTION
### Motivation
- Avoid a redundant barrel `index.ts` for the `SettingsListBoolean` component and import the component module directly. 
- Consolidate boolean-toggle UI into a single reusable component to replace repeated `Switch` markup across screens. 
- Inline prop types into the component file to simplify exports and module layout. 

### Description
- Added `apps/frontend/app/components/SettingsListBoolean/SettingsListBoolean.tsx` which defines `SettingsListBoolean` and exports the inlined `SettingsListBooleanProps`. 
- Removed the barrel export `apps/frontend/app/components/SettingsListBoolean/index.ts`. 
- Updated imports to use the direct component path (e.g. `@/components/SettingsListBoolean/SettingsListBoolean`) in `apps/frontend/app/app/(app)/settings/index.tsx` and `apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx`. 
- Replaced inline `Switch` usages in settings screens with `SettingsListBoolean` and wired `isEnabled`/`onToggle` through to the component and `handleFunction` as appropriate. 

### Testing
- No automated tests were executed for these changes. 
- Static build or runtime verification was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e0c44cd083309144259126cb69fb)