### PR TITLE
Remove `value` prop from SettingsListBoolean, add `valueActive`/`valueInactive` defaults

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
@@ -81,7 +81,6 @@ const SettingsListComponents = () => {
 					iconBgColor={primaryColor}
 					leftIcon={<MaterialCommunityIcons name="toggle-switch-outline" size={24} color={theme.screen.icon} />}
 					label="Boolean Setting"
-					value={boolValue ? 'Aktiv' : 'Inaktiv'}
 					isEnabled={boolValue}
 					onToggle={() => setBoolValue(current => !current)}
 					groupPosition="single"

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -416,11 +416,6 @@ const Settings = () => {
                                                         iconBgColor={primaryColor}
                                                         leftIcon={<MaterialIcons name="my-location" size={24} color={theme.screen.icon} />}
                                                         label={translate(TranslationKeys.collectible_event_random_position)}
-                                                        value={
-                                                                collectibleRandomPosition
-                                                                        ? translate(TranslationKeys.checked)
-                                                                        : translate(TranslationKeys.unchecked)
-                                                        }
                                                         isEnabled={collectibleRandomPosition}
                                                         onToggle={toggleCollectibleRandomPosition}
                                                         groupPosition="bottom"
@@ -578,12 +573,18 @@ const Settings = () => {
 						<View style={{ gap: 0 }}>
                                                         <SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="server" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.backend_server)} value={selectedCustomerDisplayName} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openServerSheet} groupPosition="top" />
 							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="clock-outline" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.foodoffers_next_day_time)} value={(foodOffersNextDayThreshold || '18:00').toString()} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFoodOffersTimeSheet} groupPosition="middle" />
-							<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />} label="Use WebP images" value={useWebpForAssets ? 'WebP' : 'Default'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={toggleWebpForAssets} groupPosition="middle" />
+							<SettingsListBoolean
+								iconBgColor={primaryColor}
+								leftIcon={<MaterialIcons name="image" size={24} color={theme.screen.icon} />}
+								label="Use WebP images"
+								isEnabled={useWebpForAssets}
+								onToggle={toggleWebpForAssets}
+								groupPosition="middle"
+							/>
 							<SettingsListBoolean
 								iconBgColor={primaryColor}
 								leftIcon={<MaterialCommunityIcons name="bank-transfer" size={24} color={theme.screen.icon} />}
 								label={translate(TranslationKeys.debug_mode)}
-								value={debugMode ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
 								isEnabled={debugMode}
 								onToggle={toggleDebugMode}
 								groupPosition="middle"
@@ -592,7 +593,6 @@ const Settings = () => {
 								iconBgColor={primaryColor}
 								leftIcon={<MaterialCommunityIcons name="update" size={24} color={theme.screen.icon} />}
 								label={translate(TranslationKeys.simulate_expo_update_available)}
-								value={simulateExpoUpdateAvailable ? translate(TranslationKeys.checked) : translate(TranslationKeys.unchecked)}
 								isEnabled={simulateExpoUpdateAvailable}
 								onToggle={toggleSimulateExpoUpdate}
 								groupPosition="bottom"

--- a/apps/frontend/app/components/SettingsListBoolean/SettingsListBoolean.tsx
+++ b/apps/frontend/app/components/SettingsListBoolean/SettingsListBoolean.tsx
@@ -12,19 +12,29 @@ type SettingsListBooleanPropsOwn = {
         isEnabled: boolean;
         onToggle: () => void;
         disabled?: boolean;
+        valueActive?: string;
+        valueInactive?: string;
 };
 
 export type SettingsListBooleanProps = PropsWithChildren<
-        Omit<SettingsListProps, 'rightElement' | 'rightIcon' | 'onPress' | 'handleFunction'> & SettingsListBooleanPropsOwn
+        Omit<SettingsListProps, 'rightElement' | 'rightIcon' | 'onPress' | 'handleFunction' | 'value'> & SettingsListBooleanPropsOwn
 >;
 
-const SettingsListBoolean: React.FC<SettingsListBooleanProps> = ({ isEnabled, onToggle, disabled = false, ...props }) => {
+const SettingsListBoolean: React.FC<SettingsListBooleanProps> = ({
+        isEnabled,
+        onToggle,
+        disabled = false,
+        valueActive = 'Aktiv',
+        valueInactive = 'Inaktiv',
+        ...props
+}) => {
         const { theme } = useTheme();
         const { primaryColor } = useSelector((state: RootState) => state.settings);
 
         return (
                 <SettingsList
                         {...props}
+                        value={isEnabled ? valueActive : valueInactive}
                         rightElement={
                                 <Switch
                                         value={isEnabled}


### PR DESCRIPTION
### Motivation
- Standardize boolean settings handling by moving the displayed label logic into `SettingsListBoolean` instead of passing a `value` string from each call site.
- Provide explicit option labels for enabled/disabled states via `valueActive`/`valueInactive` while preserving the previous default text used in the experimental screen.
- Clean up call sites so boolean rows no longer pass `value` and instead rely on the component to derive the label.

### Description
- Updated `SettingsListBoolean` to `Omit` the `value` prop and added optional `valueActive` and `valueInactive` props with defaults `"Aktiv"` and `"Inaktiv"`.
- `SettingsListBoolean` now derives the list `value` internally as `isEnabled ? valueActive : valueInactive` and keeps the switch and `handleFunction` wiring.
- Removed explicit `value` usages at call sites, including the experimental example and the settings screen where the WebP toggle is now a `SettingsListBoolean`.
- Minor cleanup to align boolean settings usage across the codebase and follow the requested API change.

### Testing
- No automated tests were executed for this change.
- Type/compile checks were not run as part of this rollout.
- A commit was created and files were updated successfully.
- Manual inspection of modified files was performed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958294a12708330b18f43fe9f392be4)