### PR TITLE
Fix scroll view modal height on web

### DIFF
--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -61,7 +61,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
   const contentStyle = { paddingBottom: 24 + insets.bottom, paddingHorizontal: 20 };
   const scrollInsets = { bottom: insets.bottom };
 
-  const containerStyle = { backgroundColor: resolvedBackgroundColor };
+  const containerStyle = { backgroundColor: resolvedBackgroundColor, flex: 1 };
 
   if (useFlatList && renderItem && keyExtractor) {
     return (


### PR DESCRIPTION
### Motivation
- The scroll view inside the bottom sheet on web treated itself as if it had 100% of the outer height, causing the end of content to appear off-screen when scrolling.
- This produced an incorrect scrolling experience where content could be scrolled beyond the visible area.
- The change aims to make the scroll container size respect the available bottom-sheet space so content stays within the viewport.

### Description
- Add `flex: 1` to the `containerStyle` object in `apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx`.
- The `containerStyle` is now ` { backgroundColor: resolvedBackgroundColor, flex: 1 }`, ensuring both `BottomSheetScrollView` and `BottomSheetFlatList` fill remaining sheet space.
- No other functional changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9841e23c833091a427f937cae7c6)