### PR TITLE
Add "Clear allergen selection" action to Eating Habits screen

### DIFF
--- a/apps/frontend/app/app/(app)/eating-habits/index.tsx
+++ b/apps/frontend/app/app/(app)/eating-habits/index.tsx
@@ -4,7 +4,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
 import FoodLabelingInfo from '@/components/FoodLabelingInfo';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import MarkingLabels from '@/components/MarkingLabels/MarkingLabels';
 import { useLanguage } from '@/hooks/useLanguage';
 import { excerpt } from '@/constants/HelperFunctions';
@@ -20,13 +20,21 @@ import type BottomSheet from '@gorhom/bottom-sheet';
 import { RootState } from '@/redux/reducer';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { CollectibleAt } from 'repo-depkit-common';
+import SettingsGroupTitle from '@/components/SettingsGroupTitle';
+import SettingsList from '@/components/SettingsList';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { ProfileHelper } from '@/redux/actions/Profile/Profile';
+import { UPDATE_PROFILE } from '@/redux/Types/types';
+import { UserHelper } from '@/helper/UserHelper';
 
 const Index = () => {
 	useSetPageTitle(TranslationKeys.eating_habits);
 	const { theme } = useTheme();
+	const dispatch = useDispatch();
 	const { translate } = useLanguage();
 	const { markings } = useSelector((state: RootState) => state.food);
 	const { primaryColor, appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
+	const { user, profile } = useSelector((state: RootState) => state.authReducer);
 	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 	const [readMore, setReadMore] = useState(false);
 	const [autoPlay, setAutoPlay] = useState(appSettings?.animations_auto_start);
@@ -35,6 +43,8 @@ const Index = () => {
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const menuSheetRef = useRef<BottomSheet>(null);
 	const [isActive, setIsActive] = useState(false);
+	const profileHelper = useMemo(() => new ProfileHelper(), []);
+	const isAnonymousUser = UserHelper.isAnonymousUser(user);
 
 	const openMenuSheet = () => {
 		menuSheetRef?.current?.expand();
@@ -102,6 +112,28 @@ const Index = () => {
 		setReadMore(!readMore);
 	};
 
+	const handleClearMarkings = useCallback(async () => {
+		if (!profile) return;
+
+		const updatedProfile = {
+			...profile,
+			markings: [],
+		};
+
+		dispatch({ type: UPDATE_PROFILE, payload: updatedProfile });
+
+		if (isAnonymousUser) return;
+
+		try {
+			const result = await profileHelper.updateProfile(updatedProfile);
+			if (result) {
+				dispatch({ type: UPDATE_PROFILE, payload: result });
+			}
+		} catch (error) {
+			console.error('Error clearing markings:', error);
+		}
+	}, [dispatch, isAnonymousUser, profile, profileHelper]);
+
 	return (
 		<SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.background }}>
 			<View style={{ flex: 1 }}>
@@ -126,6 +158,14 @@ const Index = () => {
 								<Text style={{ ...styles.readMore, color: contrastColor }}>{readMore ? translate(TranslationKeys.read_less) : translate(TranslationKeys.read_more)}</Text>
 							</TouchableOpacity>
 						</View>
+						<SettingsGroupTitle>{translate(TranslationKeys.settings)}</SettingsGroupTitle>
+						<SettingsList
+							iconBgColor={primaryColor}
+							leftIcon={<MaterialCommunityIcons name="broom" size={22} color={theme.screen.icon} />}
+							label={translate(TranslationKeys.clear_markings_selection)}
+							handleFunction={handleClearMarkings}
+							groupPosition="single"
+						/>
 						<View style={styles.feedbackLabelsContainer}>
                                                 {markings?.map(marking => {
                                                         return <MarkingLabels key={marking?.id} markingId={marking?.id} handleMenuSheet={openMenuSheet} />;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -147,6 +147,7 @@ export enum TranslationKeys {
 	unknown = 'unknown',
 	animation = 'animation',
 	allergene = 'allergene',
+	clear_markings_selection = 'clear_markings_selection',
 	eatinghabits_introduction = 'eatinghabits_introduction',
 	notification = 'notification',
 	notification_index_introduction = 'notification_index_introduction',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1519,6 +1519,16 @@
     "tr": "Alerjenler",
     "zh": "过敏原"
   },
+  "clear_markings_selection": {
+    "de": "Allergen-Auswahl zurücksetzen",
+    "en": "Clear allergen selection",
+    "ar": "مسح تحديد المواد المسببة للحساسية",
+    "es": "Restablecer la selección de alérgenos",
+    "fr": "Réinitialiser la sélection des allergènes",
+    "ru": "Сбросить выбор аллергенов",
+    "tr": "Alerjen seçimlerini sıfırla",
+    "zh": "清除过敏原选择"
+  },
   "eatinghabits_introduction": {
     "de": "Teile uns mit welche Essgewohnheiten du bevorzugst oder meiden möchtest. Wir sortieren und markieren dann die Mahlzeitenangebote für dich. Wir können diese Informationen nutzen, um unser Angebot zu verbessern. Deine Daten werden nicht an Dritte weitergegeben.",
     "en": "Tell us which eating habits you prefer or want to avoid. We will then sort and mark the meal offers for you. We can use this information to improve our offer. Your data will not be passed on to third parties.",


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to reset all selected markings/allergens from the Eating Habits screen and mirror that change in the profile state and backend when applicable.

### Description
- Inserted a settings group row using `SettingsGroupTitle` and `SettingsList` on the Eating Habits screen to expose a `Clear allergen selection` action. 
- Implemented `handleClearMarkings` which clears `profile.markings`, dispatches `UPDATE_PROFILE` locally and calls `ProfileHelper.updateProfile` for non-anonymous users. 
- Added imports and guards using `ProfileHelper`, `UserHelper`, `useDispatch`, and the `UPDATE_PROFILE` action in `apps/frontend/app/app/(app)/eating-habits/index.tsx`. 
- Added a translation key `clear_markings_selection` to `apps/frontend/app/locales/keys.ts` and localized strings in `apps/frontend/app/locales/translations.json`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680444eab483309ff1bb319cc9f178)