### PR TITLE
Load two initial days in experimental foodoffers scroll

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -127,7 +127,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 	const init = useCallback(async () => {
 		setLoading(true);
 		const baseDate = new Date(startDate);
-		const toLoad = [0, 1, 2];
+		const toLoad = [0, 1];
 		const loaded: DayData[] = [];
 		for (const offset of toLoad) {
 			const d = addDays(baseDate, offset).toISOString().split('T')[0];


### PR DESCRIPTION
### Motivation
- Align the experimental foodoffers scroll with the standard foodoffers behavior by loading only the first two days initially to fix the scrolling/prefetch mismatch.

### Description
- Reduce the initial preload window by changing `toLoad` from `[0, 1, 2]` to `[0, 1]` in `apps/frontend/app/components/FoodOffersScrollList/index.tsx` so only two days are fetched on init.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb547942883308c6d4ab3e42e4cb7)