### PR TITLE
Fix Foodoffers scroll list card layout and container width

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -178,11 +178,12 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 			<View style={styles.dayContainer}>
 				<Text style={[styles.dateHeader, { color: theme.screen.text }]}> {format(new Date(item.date), 'dd.MM.yyyy')} </Text>
 				<View
-					style={{
-						...styles.foodContainer,
-						gap: 10,
-						justifyContent: 'center',
-					}}
+					style={[
+						styles.foodContainer,
+						{
+							justifyContent: 'center',
+						},
+					]}
 					onLayout={event => {
 						const width = event.nativeEvent.layout.width;
 						if (!listWidth || width > listWidth) {

--- a/apps/frontend/app/components/FoodOffersScrollList/styles.ts
+++ b/apps/frontend/app/components/FoodOffersScrollList/styles.ts
@@ -1,8 +1,12 @@
 import { StyleSheet } from 'react-native';
+import { horizontalScreenPadding } from '@/constants/Constants';
 
 export default StyleSheet.create({
 	dayContainer: {
 		padding: 10,
+		width: '100%',
+		maxWidth: 1420,
+		alignSelf: 'center',
 	},
 	dateHeader: {
 		fontSize: 18,
@@ -23,5 +27,6 @@ export default StyleSheet.create({
 	feebackContainer: {
 		width: '100%',
 		marginTop: 20,
+		paddingHorizontal: horizontalScreenPadding,
 	},
 });


### PR DESCRIPTION
### Motivation

- The Foodoffers scroll view should show multiple cards per row like the main Foodoffers view, but width and container styles caused only one card to appear; the change aligns the scroll list layout and paddings with the main view.

### Description

- Constrain day rows to the main content width by adding `width: '100%'`, `maxWidth: 1420` and `alignSelf: 'center'` to `dayContainer` in `apps/frontend/app/components/FoodOffersScrollList/styles.ts`.
- Add horizontal padding to the feedback area by adding `paddingHorizontal: horizontalScreenPadding` to `feebackContainer` in the same stylesheet.
- Adjust the day-level food container in `apps/frontend/app/components/FoodOffersScrollList/index.tsx` to merge `styles.foodContainer` with an inline `justifyContent` object (removing the previous `gap` inline style) so the computed `cardWidth` can be applied correctly to each card.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f2d0895ec8330bf5193048d5ef69e)