### PR TITLE
Make FoodOffersScrollList card spacing responsive to screen width

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, FlatList, RefreshControl, Text, View } from 'react-native';
+import { ActivityIndicator, Dimensions, FlatList, RefreshControl, Text, View } from 'react-native';
 import { addDays, format } from 'date-fns';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
@@ -42,6 +42,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 	const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
 	const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
 	const [listWidth, setListWidth] = useState<number | null>(null);
+	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const bottomSheetRef = useRef<BottomSheet>(null);
 	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
         const openSheet = useCallback(
@@ -82,15 +83,25 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		return Math.max(2, cols);
 	}, [amountColumnsForcard, listWidth]);
 
+	const itemGap = useMemo(() => {
+		if (screenWidth >= 1600) return 28;
+		if (screenWidth >= 1300) return 24;
+		if (screenWidth >= 1000) return 20;
+		if (screenWidth >= 700) return 16;
+		if (screenWidth >= 500) return 12;
+		if (screenWidth >= 300) return 10;
+		return 8;
+	}, [screenWidth]);
+
 	const cardWidth = useMemo(() => {
 		if (!listWidth || !numColumns) return undefined;
 
-		const horizontalMargin = 10;
+		const horizontalMargin = itemGap;
 		const totalMargin = horizontalMargin * 2 * numColumns;
 
 		const availableWidth = listWidth - totalMargin;
 		return availableWidth / numColumns;
-	}, [listWidth, numColumns]);
+	}, [itemGap, listWidth, numColumns]);
 
 	const sortOffers = useCallback(
 		(foodOffers: DatabaseTypes.Foodoffers[]) =>
@@ -154,6 +165,12 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		init();
 	}, [init]);
 
+	useEffect(() => {
+		const handleResize = () => setScreenWidth(Dimensions.get('window').width);
+		const subscription = Dimensions.addEventListener('change', handleResize);
+		return () => subscription?.remove();
+	}, []);
+
 	const loadNext = async () => {
 		const lastDate = days[days.length - 1].date;
 		const nextDate = addDays(new Date(lastDate), 1).toISOString().split('T')[0];
@@ -196,8 +213,8 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 							key={offer.id}
 							style={{
 								width: cardWidth || '100%',
-								marginHorizontal: 10,
-								marginVertical: 10,
+								marginHorizontal: itemGap,
+								marginVertical: itemGap,
 								alignItems: 'center',
 							}}
 						>


### PR DESCRIPTION
### Motivation
- Improve card layout and spacing so FoodOffers cards adapt to different screen sizes and keep consistent gaps across breakpoints.

### Description
- Import `Dimensions` and add `screenWidth` state initialized from `Dimensions.get('window').width` to track viewport width.
- Add an `itemGap` `useMemo` with breakpoints and replace the fixed horizontal margin with `itemGap` for `marginHorizontal`/`marginVertical` on each card.
- Update `cardWidth` calculation to use `itemGap` and include `itemGap` in its dependency array.
- Add an effect that listens to `Dimensions` changes to update `screenWidth` and cleans up the subscription.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4d4f138c8330af61691ccb806692)