### PR TITLE
Render food offer card divider as bottom border and tighten card spacing

### DIFF
--- a/apps/frontend/app/components/CardWithText/CardWithText.tsx
+++ b/apps/frontend/app/components/CardWithText/CardWithText.tsx
@@ -66,14 +66,21 @@ const CardWithText: React.FC<Props> = ({
       {...rest}
     >
       {/* square wrapper ensures a stable 1:1 image area */}
-      <View style={[styles.squareWrapper, { borderTopLeftRadius: topRadius, borderTopRightRadius: topRadius }]}>
+      <View
+        style={[
+          styles.squareWrapper,
+          {
+            borderTopLeftRadius: topRadius,
+            borderTopRightRadius: topRadius,
+            borderBottomWidth: borderColor ? 3 : 0,
+            borderBottomColor: borderColor,
+          },
+        ]}
+      >
         <View style={[{ borderTopLeftRadius: topRadius, borderTopRightRadius: topRadius }, ...resolvedImageContainerStyle as any]}>
           {imageSource ? (
             <ExpoImage {...forwardedImageProps} source={imageSource as any} style={[styles.image, imageStyle]} />
           ) : null}
-
-          {/* absolute divider glued to bottom of image area */}
-          {borderColor ? <View style={[styles.topDivider, { backgroundColor: borderColor }]} /> : null}
 
           {imageChildren}
         </View>
@@ -115,18 +122,10 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
-  topDivider: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    height: 3,
-    bottom: 0, // glued to bottom of 1:1 image area
-    zIndex: 5,
-  },
   cardContent: {
     // remove a hard fixed minHeight; we compute it dynamically
-    paddingTop: 12,
-    paddingBottom: 14,
+    paddingTop: 8,
+    paddingBottom: 10,
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'transparent',

--- a/apps/frontend/app/hooks/useFoodCard.ts
+++ b/apps/frontend/app/hooks/useFoodCard.ts
@@ -35,7 +35,7 @@ export const useFoodCard = (borderWidth: number = 0) => {
 	};
 
 	const contentStyle: ViewStyle = {
-		gap: 5,
+		gap: 3,
 		paddingHorizontal: 5,
 	};
 


### PR DESCRIPTION
### Motivation
- The food offer card divider wasn’t rendering reliably as an absolute element and the caption/gap felt too large on cards, so the visual divider and spacing needed adjustment.

### Description
- In `CardWithText.tsx` render the divider as a `borderBottom` on the image wrapper by setting `borderBottomWidth` and `borderBottomColor` and remove the absolute `topDivider` element.
- In `CardWithText.tsx` reduce caption vertical padding by changing `paddingTop`/`paddingBottom` to make the caption area more compact.
- In `useFoodCard.ts` reduce the card content `gap` from `5` to `3` to tighten the spacing inside cards.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5fb561d88330988ba6c654bf386c)