### PR TITLE
Adjust foodoffers day divider placement

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -289,10 +289,10 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 				{afterElement && (
 					<View style={styles.elementContainer}>
 						<CustomMarkdown content={afterElement?.content || ''} backgroundColor={foods_area_color} imageWidth={440} imageHeight={293} />
-						<View style={{ height: 1, backgroundColor: contrastColor, marginTop: 12, marginHorizontal: 10 }} />
 					</View>
 				)}
 				{feedbacks && feedbacks.length > 0 && <View style={styles.feebackContainer}>{feedbacks}</View>}
+				<View style={[styles.dayDivider, { backgroundColor: contrastColor }]} />
 			</View>
 		);
 	};

--- a/apps/frontend/app/components/FoodOffersScrollList/styles.ts
+++ b/apps/frontend/app/components/FoodOffersScrollList/styles.ts
@@ -23,11 +23,16 @@ export default StyleSheet.create({
 	},
 	feebackContainer: {
 		width: '100%',
-		marginTop: 20,
+		marginTop: 12,
 	},
 	elementContainer: {
 		width: '100%',
-		marginTop: 20,
+		marginTop: 12,
 		paddingHorizontal: 10,
+	},
+	dayDivider: {
+		height: 1,
+		marginTop: 12,
+		marginHorizontal: 10,
 	},
 });


### PR DESCRIPTION
### Motivation
- The horizontal divider in the Foodoffers experimental scroll appeared too early in the day's content; it should be the last element for each day, use the contrast color, and have reduced spacing to match design intent.

### Description
- Moved the divider rendering to the end of each day in `apps/frontend/app/components/FoodOffersScrollList/index.tsx`, removed the inline divider, and render a dedicated `dayDivider` using the computed `contrastColor`.
- Added `dayDivider` style and tightened spacing by reducing `marginTop` for `elementContainer` and `feebackContainer` in `apps/frontend/app/components/FoodOffersScrollList/styles.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697027cff51c8330a019bcb7ad8e9aa8)