### PR TITLE
Rename smart date hook to method-returning helper

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -25,6 +25,7 @@ import EatingHabitsSheet from '@/components/EatingHabitsSheet/EatingHabitsSheet'
 import { Tooltip, TooltipContent, TooltipText } from '@gluestack-ui/themed';
 import * as Notifications from 'expo-notifications';
 import { sortFoodOffers } from '@/helper/foodOfferSortHelper';
+import { useSmartReadableDateMethod } from '@/helper/DateHelper';
 import { addDays, format } from 'date-fns';
 import { BusinessHoursHelper } from '@/redux/actions/BusinessHours/BusinessHours';
 import noFoodOffersFound from '@/assets/animations/noFoodOffersFound.json';
@@ -78,6 +79,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { openUtilizationModal } = useUtilizationModal();
 	const { openActiveModal, activePopupEvent } = usePopupEventModal();
 	const { openFoodofferSortingModal } = useFoodofferSortingModal();
+	const smartReadableDate = useSmartReadableDateMethod();
 
 	// Set Page Title
 	useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);
@@ -211,30 +213,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	};
 
 	const getDayLabel = (date: string) => {
-		const currentDate = new Date();
-		const day = new Date(date);
-
-		// Set both dates to midnight to avoid time differences affecting comparison
-		currentDate.setHours(0, 0, 0, 0);
-		day.setHours(0, 0, 0, 0);
-
-		if (currentDate.toDateString() === day.toDateString()) {
-			return 'today';
-		}
-
-		// Check for yesterday
-		currentDate.setDate(currentDate.getDate() - 1);
-		if (currentDate.toDateString() === day.toDateString()) {
-			return 'yesterday';
-		}
-
-		// Check for tomorrow
-		currentDate.setDate(currentDate.getDate() + 2);
-		if (currentDate.toDateString() === day.toDateString()) {
-			return 'tomorrow';
-		}
-
-		return format(day, 'dd.MM.yyyy'); // Return the date if it's not Today, Yesterday, or Tomorrow
+		return smartReadableDate(new Date(date));
 	};
 
 	const updateSort = (id: FoodSortOption, foodOffers: DatabaseTypes.Foodoffers[]) => {
@@ -576,7 +555,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 									</TooltipContent>
 								</Tooltip>
 
-								<Text style={{ ...styles.heading, color: theme.header.text }}>{selectedDate ? translate(getDayLabel(selectedDate)) : ''}</Text>
+								<Text style={{ ...styles.heading, color: theme.header.text }}>{selectedDate ? getDayLabel(selectedDate) : ''}</Text>
 							</View>
 							<View style={{ ...styles.col2, gap: 10 }}>
 								{/* ForeCast */}

--- a/apps/frontend/app/helper/DateHelper.ts
+++ b/apps/frontend/app/helper/DateHelper.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import * as Localization from 'expo-localization';
+import { DateHelper as CommonDateHelper } from 'repo-depkit-common';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+
+export const useSmartReadableDateMethod = () => {
+	const { translate } = useLanguage();
+	const dateLocale = Localization.locale || 'en';
+
+	const relativeDaysDiffTranslations = useMemo(
+		() => ({
+			[-1]: translate(TranslationKeys.yesterday),
+			[0]: translate(TranslationKeys.today),
+			[1]: translate(TranslationKeys.tomorrow),
+		}),
+		[translate]
+	);
+
+	return (date: Date) => CommonDateHelper.useSmartReadableDate(date, dateLocale, relativeDaysDiffTranslations);
+};

--- a/packages/common/src/DateHelper.ts
+++ b/packages/common/src/DateHelper.ts
@@ -407,42 +407,24 @@ export class DateHelper {
   }
 
   // returns "Yesterday", "Today", "Tomorrow", or "Tuesday", "Wednesday" or the date in the format "DD.MM.YYYY"
-  static useSmartReadableDate(date: Date, locale?: string) {
+  static useSmartReadableDate(date: Date, locale?: string, relativeDaysDiffTranslations?: Record<number, string>) {
     const dateCopy = new Date(date); // since the original date may be changed during the process of other functions we need to copy it in order have a reliable date
-    //console.log("useSmartReadableDate", dateCopy, locale)
-    const today = new Date();
-    const tomorrow = DateHelper.addDaysAndReturnNewDate(today, 1);
-    const yesterday = DateHelper.addDaysAndReturnNewDate(today, -1);
+    const dateStart = new Date(dateCopy.getFullYear(), dateCopy.getMonth(), dateCopy.getDate());
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
 
-    // const translationToday = useTranslation(TranslationKeys.today);
-    // const translationTomorrow = useTranslation(TranslationKeys.tomorrow);
-    // const translationYesterday = useTranslation(TranslationKeys.yesterday);
-
-    //console.log("check if date is today, then return 'today'", today, dateCopy)
-    // check if date is today, then return "today"
-    if (DateHelper.isSameDay(today, dateCopy)) {
-      // return translationToday;
-      return today;
+    const diffDays = Math.round((dateStart.getTime() - todayStart.getTime()) / (1000 * 60 * 60 * 24));
+    if (relativeDaysDiffTranslations && Object.prototype.hasOwnProperty.call(relativeDaysDiffTranslations, diffDays)) {
+      return relativeDaysDiffTranslations[diffDays];
     }
 
-    // check if date is tomorrow, then return "tomorrow"
-    if (DateHelper.isSameDay(tomorrow, dateCopy)) {
-      // return translationTomorrow;
-      return tomorrow;
-    }
-    // check if date is yesterday, then return "yesterday"
-
-    if (DateHelper.isSameDay(yesterday, dateCopy)) {
-      // return translationYesterday;
-      return yesterday;
-    }
-
-    const oneWeekLater = DateHelper.addDaysAndReturnNewDate(today, 6);
-    if (dateCopy >= yesterday && dateCopy <= oneWeekLater) {
-      return DateHelper.getWeekdayNameByDate(dateCopy, locale);
+    const yesterday = DateHelper.addDaysAndReturnNewDate(todayStart, -1);
+    const oneWeekLater = DateHelper.addDaysAndReturnNewDate(todayStart, 6);
+    if (dateStart >= yesterday && dateStart <= oneWeekLater) {
+      return DateHelper.getWeekdayNameByDate(dateStart, locale);
     }
     // else return "01.01.2021"
-    return DateHelper.formatOfferDateToReadable(dateCopy, false, false);
+    return DateHelper.formatOfferDateToReadable(dateStart, false, false);
   }
 
   static formatDateToTime(date: Date, withHours?: boolean, withMinutes?: boolean, withSeconds?: boolean) {


### PR DESCRIPTION
### Motivation
- Clarify that the frontend date helper hook resolves locale/translations once and returns a plain function to avoid invoking hooks during re-renders. 
- Consolidate date-label logic so UI code receives already-localized day labels rather than calling `translate` around raw keys. 
- Keep centralized date formatting in the shared `DateHelper` while letting the frontend supply localized short labels.

### Description
- Add `apps/frontend/app/helper/DateHelper.ts` which exports `useSmartReadableDateMethod` that resolves `useLanguage` and `expo-localization` and returns a function delegating to `CommonDateHelper.useSmartReadableDate` with `relativeDaysDiffTranslations`. 
- Update `apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx` to import and call `useSmartReadableDateMethod()` and replace the inline day-comparison logic with `smartReadableDate(new Date(date))`, and remove the extra `translate(...)` call when rendering the heading. 
- Update `packages/common/src/DateHelper.ts` to change `useSmartReadableDate` signature to accept `relativeDaysDiffTranslations?: Record<number,string>`, normalize dates to midnight, compute day diffs, return provided translations for -1/0/1 when present, fall back to weekday names for dates within the coming week, and otherwise return a formatted date string.

### Testing
- No automated tests were executed for these changes. 
- Local lint/format checks were not reported as run. 
- Manual verification consisted of updating usage and ensuring the project builds locally in prior rollouts (no formal test run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697098f797d08330948649f6329d715b)