### PR TITLE
Fix smart-readable date locale and add DateHelper preview screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/date-helper/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/date-helper/index.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import * as Localization from 'expo-localization';
+import { DateHelper as CommonDateHelper } from 'repo-depkit-common';
+
+import { useTheme } from '@/hooks/useTheme';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import { useSmartReadableDateMethod } from '@/helper/DateHelper';
+import styles from '../styles';
+
+const DateHelperPreview = () => {
+	useSetPageTitle(TranslationKeys.date_helper_preview);
+	const { theme } = useTheme();
+	const { translate, language } = useLanguage();
+	const smartReadableDate = useSmartReadableDateMethod();
+	const dateLocale = language || Localization.locale || 'en';
+
+	const dates = useMemo(() => {
+		const start = new Date();
+		start.setHours(0, 0, 0, 0);
+		return Array.from({ length: 15 }, (_, index) => CommonDateHelper.addDaysAndReturnNewDate(start, index));
+	}, []);
+
+	return (
+		<ScrollView
+			style={{ ...styles.container, backgroundColor: theme.screen.background }}
+			contentContainerStyle={{
+				...styles.contentContainer,
+				backgroundColor: theme.screen.background,
+			}}
+		>
+			<View style={styles.content}>
+				<Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.date_helper_preview)}</Text>
+				<View style={styles.section}>
+					{dates.map(date => {
+						const dateKey = CommonDateHelper.getDirectusDateOnlyString(date);
+						return (
+							<View key={dateKey} style={{ ...styles.listItem, backgroundColor: theme.card.background }}>
+								<View style={{ flex: 1, paddingRight: 12 }}>
+									<Text style={{ ...styles.body, color: theme.screen.text }}>{date.toLocaleDateString(dateLocale)}</Text>
+								</View>
+								<View style={{ flex: 1, alignItems: 'flex-end' }}>
+									<Text style={{ ...styles.body, color: theme.screen.text }}>{smartReadableDate(date)}</Text>
+								</View>
+							</View>
+						);
+					})}
+				</View>
+			</View>
+		</ScrollView>
+	);
+};
+
+export default DateHelperPreview;

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -65,6 +65,12 @@ const Index = () => {
 			onPress: () => router.push('/foodoffers-scroll'),
 		},
 		{
+			key: 'date-helper-preview',
+			label: translate(TranslationKeys.date_helper_preview),
+			leftIcon: <MaterialCommunityIcons name="calendar-week" size={24} color={theme.screen.icon} />,
+			onPress: () => router.push('/experimentell/date-helper'),
+		},
+		{
 			key: 'haptics-test',
 			label: translate(TranslationKeys.haptics_test),
 			leftIcon: <MaterialCommunityIcons name="vibrate" size={24} color={theme.screen.icon} />,

--- a/apps/frontend/app/helper/DateHelper.ts
+++ b/apps/frontend/app/helper/DateHelper.ts
@@ -5,8 +5,8 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 
 export const useSmartReadableDateMethod = () => {
-	const { translate } = useLanguage();
-	const dateLocale = Localization.locale || 'en';
+	const { translate, language } = useLanguage();
+	const dateLocale = language || Localization.locale || 'en';
 
 	const relativeDaysDiffTranslations = useMemo(
 		() => ({

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -317,6 +317,7 @@ export enum TranslationKeys {
 	haptics_test = 'haptics_test',
 	haptics_test_description = 'haptics_test_description',
 	haptics_test_empty = 'haptics_test_empty',
+	date_helper_preview = 'date_helper_preview',
 	last_haptic_event = 'last_haptic_event',
         open_modal_example = 'open_modal_example',
         modal_example_body = 'modal_example_body',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3173,6 +3173,16 @@
     "tr": "No haptic triggered yet.",
     "zh": "No haptic triggered yet."
   },
+  "date_helper_preview": {
+    "de": "DateHelper-Vorschau",
+    "en": "DateHelper preview",
+    "ar": "DateHelper preview",
+    "es": "DateHelper preview",
+    "fr": "DateHelper preview",
+    "ru": "DateHelper preview",
+    "tr": "DateHelper preview",
+    "zh": "DateHelper preview"
+  },
   "last_haptic_event": {
     "de": "Letztes Haptic-Ereignis",
     "en": "Last haptic event",


### PR DESCRIPTION
### Motivation
- Fix incorrect localization of the smart date labels where `useSmartReadableDate` used the device locale instead of the app language, causing weekday translations to be wrong for users who change language in-app.
- Provide an easy way to inspect `DateHelper` behavior in-app by adding an experimental preview screen showing today and the next 14 days with both raw date and smart label.

### Description
- Use the app language as the locale in `useSmartReadableDateMethod` by reading `language` from `useLanguage` and falling back to `Localization.locale` (`apps/frontend/app/helper/DateHelper.ts`).
- Add an experimental preview screen `DateHelperPreview` that lists today + 14 days with the left column showing the localized date and the right column showing the smart readable label (`apps/frontend/app/app/(app)/experimentell/date-helper/index.tsx`).
- Add a navigation entry for the preview under the experimental menu (`apps/frontend/app/app/(app)/experimentell/index.tsx`).
- Add the new translation key `date_helper_preview` to `apps/frontend/app/locales/keys.ts` and `apps/frontend/app/locales/translations.json`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971513f5834833089d232eee8d5cec2)