### PR TITLE
Fix weekday labels in foodoffers scroll

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -212,8 +212,16 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		});
 	};
 
+	const parseDateOnly = (date: string) => {
+		const [year, month, day] = date.split('-').map(Number);
+		if (!year || !month || !day) {
+			return new Date(date);
+		}
+		return new Date(year, month - 1, day);
+	};
+
 	const getDayLabel = (date: string) => {
-		return smartReadableDate(new Date(date));
+		return smartReadableDate(parseDateOnly(date));
 	};
 
 	const updateSort = (id: FoodSortOption, foodOffers: DatabaseTypes.Foodoffers[]) => {
@@ -326,7 +334,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
 	const getWeekdayKey = (date: string) => {
 		const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-		return days[new Date(date).getDay()];
+		return days[parseDateOnly(date).getDay()];
 	};
 
 	const SheetComponent = selectedSheet && selectedSheet !== 'menu' ? SHEET_COMPONENTS[selectedSheet as keyof typeof SHEET_COMPONENTS] : null;


### PR DESCRIPTION
### Motivation
- The foodoffers list showed untranslated/wrong weekday names because ISO date-only strings (`YYYY-MM-DD`) were passed to `new Date(...)`, causing timezone/UTC shifts and incorrect weekday resolution for the smart date helper.

### Description
- Add `parseDateOnly(date: string)` to normalize `YYYY-MM-DD` strings into local `Date` objects and use it in `getDayLabel` and `getWeekdayKey` in `apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx` so the smart-readable labels and weekday translations resolve correctly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69715501c8308330a84c6a941ab5e5ee)