### PR TITLE
Add smart date preview to FoodOffers scroll headers

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -21,6 +21,7 @@ import FoodOfferInfoItem from '@/components/FoodOfferInfoItem/FoodOfferInfoItem'
 import { getAppElementTranslation } from '@/helper/resourceHelper';
 import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 import { useMyContrastColor } from '@/helper/ColorHelper';
+import { useSmartReadableDateMethod } from '@/helper/DateHelper';
 
 interface FoodOffersScrollListProps {
 	canteenId: string;
@@ -59,6 +60,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
         const foods_area_color = appSettings?.foods_area_color || primaryColor;
         const contrastColor = useMyContrastColor(theme.screen.background, theme, mode === 'dark');
+	const smartReadableDate = useSmartReadableDateMethod();
         const openSheet = useCallback(
                 (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
                         setSelectedSheet(sheet);
@@ -266,6 +268,14 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		[translate]
 	);
 
+	const parseDateOnly = useCallback((date: string) => {
+		const [year, month, day] = date.split('-').map(Number);
+		if (!year || !month || !day) {
+			return new Date(date);
+		}
+		return new Date(year, month - 1, day);
+	}, []);
+
 	const renderDay = ({ item }: { item: DayData }) => {
 		const feedbacks = canteenFeedbackLabels?.map((label, idx) => <CanteenFeedbackLabels key={`fl-${idx}`} label={label} date={item.date} />);
 		const dayItems = buildDayItems(item.offers);
@@ -273,7 +283,10 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 
 		return (
 			<View style={styles.dayContainer}>
-				<Text style={[styles.dateHeader, { color: theme.screen.text }]}> {getDayLabel(item.date)} </Text>
+				<View style={styles.dateHeaderRow}>
+					<Text style={[styles.dateHeader, { color: theme.screen.text }]}>{getDayLabel(item.date)}</Text>
+					<Text style={[styles.dateHeaderRight, { color: theme.screen.text }]}>{smartReadableDate(parseDateOnly(item.date))}</Text>
+				</View>
 				{beforeElement && (
 					<View style={styles.elementContainer}>
 						<CustomMarkdown content={beforeElement?.content || ''} backgroundColor={foods_area_color} imageWidth={440} imageHeight={293} />

--- a/apps/frontend/app/components/FoodOffersScrollList/styles.ts
+++ b/apps/frontend/app/components/FoodOffersScrollList/styles.ts
@@ -5,9 +5,21 @@ export default StyleSheet.create({
 		paddingVertical: 10,
 		paddingHorizontal: 0,
 	},
+	dateHeaderRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		marginBottom: 8,
+		paddingHorizontal: 10,
+	},
 	dateHeader: {
 		fontSize: 18,
-		marginBottom: 8,
+		flex: 1,
+	},
+	dateHeaderRight: {
+		fontSize: 14,
+		textAlign: 'right',
+		paddingLeft: 12,
 	},
 	loader: {
 		flex: 1,


### PR DESCRIPTION
### Motivation
- Provide the same smart/relative date preview in the FoodOffers scroll view as shown in the experimental date preview, so users see a human-friendly date label in addition to the regular header date.

### Description
- Render a smart readable date to the right of each day header in `FoodOffersScrollList` using `useSmartReadableDateMethod` and a local `parseDateOnly` helper for directus date strings.
- Replace the single header `Text` with a header row composed of `dateHeader` and `dateHeaderRight` and wire the smart date rendering into the row.
- Add styles `dateHeaderRow` and `dateHeaderRight` and adjust `dateHeader` layout in `apps/frontend/app/components/FoodOffersScrollList/styles.ts` to align the two labels.
- Changed files: `apps/frontend/app/components/FoodOffersScrollList/index.tsx` and `apps/frontend/app/components/FoodOffersScrollList/styles.ts`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971596cfe608330884fc902741ae004)