### PR TITLE
Fix food offers list imports in app screens

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -5,7 +5,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { DrawerContentComponentProps, DrawerNavigationProp } from '@react-navigation/drawer';
 import { isWeb } from '@/constants/Constants';
-import FoodOfferFlatList from '@/components/FoodOfferFlatList';
+import FoodOffersScrollList from '@/components/FoodOffersScrollList';
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
@@ -620,7 +620,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 							backgroundColor: theme.screen.background,
 						}}
 					>
-						{selectedCanteen && <FoodOfferFlatList canteenId={selectedCanteen.id} startDate={selectedDate} />}
+						{selectedCanteen && <FoodOffersScrollList canteenId={selectedCanteen.id} startDate={selectedDate} />}
 					</View>
 				</View>
 				{isActive &&

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -5,7 +5,6 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { DrawerContentComponentProps, DrawerNavigationProp } from '@react-navigation/drawer';
 import { isWeb } from '@/constants/Constants';
-import FoodOfferFlatList from '@/components/FoodOfferFlatList';
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
@@ -41,7 +40,7 @@ import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
-import FoodOffersScrollList from "@/components/FoodoffersScrollList";
+import FoodOffersScrollList from '@/components/FoodOffersScrollList';
 
 export const SHEET_COMPONENTS = {
 	canteen: CanteenSelectionSheet,


### PR DESCRIPTION
### Motivation
- Resolve a bundling error where `@/components/FoodOfferFlatList` could not be found during Expo export by replacing a stale/incorrect import and usage. 
- Ensure the food offers screens consistently use the existing `FoodOffersScrollList` component and correct import casing to avoid runtime/module resolution failures.

### Description
- Replaced the stale `FoodOfferFlatList` import and usage in `apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx` with `FoodOffersScrollList` and updated the JSX usage to `<FoodOffersScrollList />`.
- Fixed the import casing and path in `apps/frontend/app/app/(app)/foodoffers/index.tsx` to use `import FoodOffersScrollList from '@/components/FoodOffersScrollList';`.
- Touched two files total to standardize the component used to render the food offers list and remove the missing-module reference.

### Testing
- No automated tests were run for this change. 
- The change was verified by ensuring the codebase no longer references `@/components/FoodOfferFlatList` and that imports for `FoodOffersScrollList` are consistent in the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b4d6cccc8330963cd27577c2706f)