### PR TITLE
FoodOffersScrollList: move collectible below feedback and reduce spacing

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -304,8 +304,8 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 						<CustomMarkdown content={afterElement?.content || ''} backgroundColor={foods_area_color} imageWidth={440} imageHeight={293} />
 					</View>
 				)}
-				<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers} />
 				{feedbacks && feedbacks.length > 0 && <View style={styles.feebackContainer}>{feedbacks}</View>}
+				<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers} />
 				<View style={[styles.dayDivider, { backgroundColor: contrastColor }]} />
 			</View>
 		);

--- a/apps/frontend/app/components/FoodOffersScrollList/styles.ts
+++ b/apps/frontend/app/components/FoodOffersScrollList/styles.ts
@@ -31,7 +31,7 @@ export default StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'stretch',
 		flexWrap: 'wrap',
-		marginTop: 20,
+		marginTop: 12,
 	},
 	feebackContainer: {
 		width: '100%',


### PR DESCRIPTION
### Motivation
- Improve layout based on feedback by ensuring the collectible item is shown after the feedback component in the scroll list.
- Reduce vertical spacing between the date header and the food item cards for a more compact view.

### Description
- Moved the `<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers} />` rendering to appear after the feedback block in `FoodOffersScrollList` (`apps/frontend/app/components/FoodOffersScrollList/index.tsx`).
- Reduced the top margin of the food container from `20` to `12` in `FoodOffersScrollList` styles (`apps/frontend/app/components/FoodOffersScrollList/styles.ts`).
- Adjusted layout ordering so feedbacks are displayed before the collectible spot to match the intended visual flow.

### Testing
- No automated tests were executed as part of this change.
- A commit was created and the changes were staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b7c538448330985382233caf0c2c)