### PR TITLE
Pass divider color to FoodItem cards

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -33,7 +33,7 @@ const selectPreviousFeedback = createSelector([selectFoodState, (_: RootState, f
 const selectMarkings = createSelector([selectFoodState], foodState => foodState.markings);
 
 const FoodItem: React.FC<FoodItemProps> = memo(
-  ({ item, canteen, handleMenuSheet, handleImageSheet, handleEatingHabitsSheet, cardWidth }) => {
+  ({ item, canteen, handleMenuSheet, handleImageSheet, handleEatingHabitsSheet, cardWidth, dividerColor }) => {
     const toast = useToast();
     const dispatch = useDispatch();
     const { theme } = useTheme();
@@ -49,7 +49,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
     const previousFeedback = useSelector(state => selectPreviousFeedback(state as RootState, foodItem.id));
     const markings = useSelector(selectMarkings);
 
-    const foods_area_color = appSettings?.foods_area_color || primaryColor;
+    const foods_area_color = dividerColor || appSettings?.foods_area_color || primaryColor;
     const defaultImage =
       getImageUrl(String(appSettings.foods_placeholder_image)) ||
       appSettings.foods_placeholder_image_remote_url ||
@@ -299,7 +299,10 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       </>
     );
   },
-  (prev, next) => prev.item === next.item
+  (prev, next) =>
+    prev.item === next.item &&
+    prev.dividerColor === next.dividerColor &&
+    prev.cardWidth === next.cardWidth
 );
 
 export default FoodItem;

--- a/apps/frontend/app/components/FoodItem/types.ts
+++ b/apps/frontend/app/components/FoodItem/types.ts
@@ -9,5 +9,6 @@ export interface FoodItemProps {
 	handleImageSheet: (item: DatabaseTypes.Foods) => void;
 	handleEatingHabitsSheet: (sheet: keyof typeof SHEET_COMPONENTS) => void;
 	// setItemMarkings: React.Dispatch<React.SetStateAction<DatabaseTypes.FoodoffersMarkings[]>>;
-	cardWidth?: number; 
+	cardWidth?: number;
+	dividerColor?: string;
 }

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -285,6 +285,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 									handleImageSheet={openManagementSheet}
 									handleEatingHabitsSheet={openSheet}
 									cardWidth={cardWidth}
+									dividerColor={foods_area_color}
 								/>
 							) : dayItem.foodofferInfoItem ? (
 								<FoodOfferInfoItem


### PR DESCRIPTION
### Motivation
- Allow the parent to provide the divider color so `FoodItem` cards can reflect a color that may load asynchronously and trigger a re-render when it becomes available. 
- Prefer an externally provided color over `appSettings`/`primaryColor` to support dynamic theming and delayed loads.

### Description
- Added an optional `dividerColor?: string` to `FoodItemProps` in `apps/frontend/app/components/FoodItem/types.ts`.
- Accepted `dividerColor` in the `FoodItem` component and compute `foods_area_color = dividerColor || appSettings?.foods_area_color || primaryColor` in `apps/frontend/app/components/FoodItem/FoodItem.tsx`.
- Updated the `memo` comparator for `FoodItem` to include `prev.dividerColor === next.dividerColor` and `prev.cardWidth === next.cardWidth` so prop changes cause re-renders.
- Propagated `dividerColor={foods_area_color}` from `apps/frontend/app/components/FoodOffersScrollList/index.tsx` when rendering each `FoodItem`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972bac488f083309a32a6eb707bf351)