### PR TITLE
Reset auth state on logout to hide management buttons

### DIFF
--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -1,6 +1,21 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Dispatch } from 'redux';
-import { CLEAR_APARTMENTS, CLEAR_CAMPUSES, CLEAR_CANTEENS, CLEAR_CHATS, CLEAR_COLLECTION_DATES_LAST_UPDATED, CLEAR_DEVELOPER_MODE, CLEAR_FOODS, CLEAR_MANAGEMENT, CLEAR_NEWS, CLEAR_POPUP_EVENTS_HASH, CLEAR_PROFILE, CLEAR_SETTINGS, CLEAR_COLLECTIBLE_EVENTS } from '@/redux/Types/types';
+import {
+	CLEAR_APARTMENTS,
+	CLEAR_CAMPUSES,
+	CLEAR_CANTEENS,
+	CLEAR_CHATS,
+	CLEAR_COLLECTION_DATES_LAST_UPDATED,
+	CLEAR_COLLECTIBLE_EVENTS,
+	CLEAR_DEVELOPER_MODE,
+	CLEAR_FOODS,
+	CLEAR_MANAGEMENT,
+	CLEAR_NEWS,
+	CLEAR_POPUP_EVENTS_HASH,
+	CLEAR_PROFILE,
+	CLEAR_SETTINGS,
+	ON_LOGOUT,
+} from '@/redux/Types/types';
 import { persistor } from '@/redux/store';
 import { clearChatReadStatus } from '@/helper/chatReadStatus';
 
@@ -11,6 +26,7 @@ export const performLogout = async (
 	}
 ) => {
 	try {
+		dispatch({ type: ON_LOGOUT });
 		dispatch({ type: CLEAR_CANTEENS });
 		dispatch({ type: CLEAR_CAMPUSES });
 		dispatch({ type: CLEAR_APARTMENTS });


### PR DESCRIPTION
### Motivation
- After logging out as a non-management user the app could still show management-only UI (e.g. image upload buttons) because the auth reducer was not reset on logout, so dispatch `ON_LOGOUT` to clear the auth state.

### Description
- Add `ON_LOGOUT` to the imports and dispatch `ON_LOGOUT` at the start of `performLogout` in `apps/frontend/app/helper/logoutHelper.ts` so the auth reducer is reset before persisted state is cleared.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a6b06b2c833095eb95146b45c8db)