### PR TITLE
Use scrollview modal for management login and add settings-style text input field

### DIFF
--- a/apps/frontend/app/app/(auth)/login.tsx
+++ b/apps/frontend/app/app/(auth)/login.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Dimensions, Image, ScrollView, Text, View } from 'react-native';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -25,6 +25,7 @@ import { getDetailedDescriptionTranslation, getIntroDescriptionTranslation } fro
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { RootState } from '@/redux/reducer';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 export default function Login() {
 	useSetPageTitle(TranslationKeys.sign_in);
@@ -34,9 +35,7 @@ export default function Login() {
 	const { deviceMock } = useGlobalSearchParams();
 	const appSettingsHelper = new AppSettingsHelper();
 	const wikisHelper = new WikisHelper();
-	const bottomSheetRef = useRef<BottomSheet>(null);
 	const [loading, setLoading] = useState(false);
-	const snapPoints = useMemo(() => ['50%'], []);
 	const [isActive, setIsActive] = useState(false);
 	const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
 	const attentionSheetRef = useRef<BottomSheet>(null);
@@ -46,6 +45,7 @@ export default function Login() {
 	const intro_description = appSettings?.login_screen_translations && getIntroDescriptionTranslation(appSettings?.login_screen_translations, language);
 	const detailed_description = appSettings?.login_screen_translations && getDetailedDescriptionTranslation(appSettings?.login_screen_translations, language);
 	const [heading, subHeading] = intro_description?.split('-') || ['', ''];
+	const { show: showManagementModal, close: closeManagementModal } = useMyScrollViewModal();
 	const getProviders = async () => {
 		const providers = await ServerAPI.getAuthProviders();
 		if (providers) {
@@ -68,14 +68,6 @@ export default function Login() {
 		getAppSettings();
 		getProviders();
 	}, []);
-
-	const openSheet = () => {
-		bottomSheetRef.current?.expand();
-	};
-
-	const closeSheet = () => {
-		bottomSheetRef?.current?.close();
-	};
 
 	const openAttentionSheet = () => {
 		setIsBottomSheetVisible(true);
@@ -135,6 +127,20 @@ export default function Login() {
 			}
 		}
 	};
+
+	const openSheet = useCallback(() => {
+		showManagementModal({
+			onClose: closeManagementModal,
+			backgroundColor: theme.sheet.sheetBg,
+			children: (
+				<ManagementSheet
+					closeSheet={closeManagementModal}
+					handleLogin={handleUserLogin}
+					loading={loading}
+				/>
+			),
+		});
+	}, [closeManagementModal, handleUserLogin, loading, showManagementModal, theme.sheet.sheetBg]);
 
 	const handleAnonymousLogin = () => {
 		// @ts-ignore
@@ -262,23 +268,6 @@ export default function Login() {
 						</View>
 						{renderContent()}
 					</View>
-				)}
-				{isActive && (
-					<BaseBottomSheet
-						ref={bottomSheetRef}
-						index={-1}
-						snapPoints={snapPoints}
-						handleComponent={null}
-						backgroundStyle={{
-							borderTopRightRadius: 30,
-							borderTopLeftRadius: 30,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						enablePanDownToClose
-						onClose={closeSheet}
-					>
-						<ManagementSheet closeSheet={closeSheet} handleLogin={handleUserLogin} loading={loading} />
-					</BaseBottomSheet>
 				)}
 				{isActive && (
 					<BaseBottomSheet

--- a/apps/frontend/app/components/Login/ManagementSheet.tsx
+++ b/apps/frontend/app/components/Login/ManagementSheet.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
-import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import React, { useMemo, useState } from 'react';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 import { styles } from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { SheetProps } from './types';
@@ -10,8 +9,9 @@ import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { EmailHelper } from 'repo-depkit-common';
+import { SettingsListTextInputField } from '@/components/SettingsListTextInput';
 
-const ManagementSheet: React.FC<SheetProps> = ({ closeSheet, handleLogin, loading }) => {
+const ManagementSheet: React.FC<SheetProps> = ({ handleLogin, loading }) => {
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
 	const { primaryColor, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
@@ -19,28 +19,16 @@ const ManagementSheet: React.FC<SheetProps> = ({ closeSheet, handleLogin, loadin
 	const [formState, setFormState] = useState({
 		email: '',
 		password: '',
-		isEmailValid: false,
-		isPasswordValid: false,
 	});
 
-	const validateEmail = (email: string) => {
-		const { trimmedEmail, isValid } = EmailHelper.sanitizeAndValidate(email);
-		setFormState(prevState => ({
-			...prevState,
-			email: trimmedEmail,
-			isEmailValid: isValid,
-		}));
-	};
+	const emailValidation = useMemo(
+		() => EmailHelper.sanitizeAndValidate(formState.email),
+		[formState.email]
+	);
+	const isEmailValid = emailValidation.isValid;
+	const isPasswordValid = formState.password.length > 0;
 
-	const validatePassword = (password: string) => {
-		setFormState(prevState => ({
-			...prevState,
-			password,
-			isPasswordValid: password.length > 0,
-		}));
-	};
-
-	const isFormValid = formState.isEmailValid && formState.isPasswordValid;
+	const isFormValid = isEmailValid && isPasswordValid;
 
 	const onSubmit = () => {
 		if (!isFormValid || loading) return;
@@ -53,41 +41,34 @@ const ManagementSheet: React.FC<SheetProps> = ({ closeSheet, handleLogin, loadin
 	};
 
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
+		<View style={styles.sheetView}>
 			<View style={styles.sheetHeader}></View>
-			<Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.show_login_for_management_with_email_and_password)}</Text>
-			<Text style={{ ...styles.sheetSubHeading, color: theme.sheet.text }}>{translate(TranslationKeys.management_login_description)}</Text>
-			<TextInput
-				style={{
-					...styles.sheetInput,
-					color: theme.sheet.text,
-					backgroundColor: theme.sheet.inputBg,
-					borderColor: formState.isEmailValid ? theme.sheet.inputBorderValid : theme.sheet.inputBorderInvalid,
-				}}
-				placeholderTextColor={theme.sheet.placeholder}
-				cursorColor={theme.sheet.text}
-				selectionColor={primaryColor}
-				onChangeText={validateEmail}
+			<Text style={{ ...styles.sheetHeading, color: theme.sheet.text }}>
+				{translate(TranslationKeys.show_login_for_management_with_email_and_password)}
+			</Text>
+			<Text style={{ ...styles.sheetSubHeading, color: theme.sheet.text }}>
+				{translate(TranslationKeys.management_login_description)}
+			</Text>
+			<SettingsListTextInputField
+				placeholder={translate(TranslationKeys.email)}
 				value={formState.email}
-				placeholder="E-Mail"
+				onChangeText={email => setFormState(prevState => ({ ...prevState, email }))}
 				keyboardType="email-address"
 				autoCapitalize="none"
 				autoCorrect={false}
+				textContentType="emailAddress"
+				returnKeyType="next"
 			/>
-			<TextInput
-				style={{
-					...styles.sheetInput,
-					color: theme.sheet.text,
-					backgroundColor: theme.sheet.inputBg,
-					borderColor: formState.isPasswordValid ? theme.sheet.inputBorderValid : theme.sheet.inputBorderInvalid,
-				}}
-				onChangeText={validatePassword}
-				placeholderTextColor={theme.sheet.placeholder}
-				cursorColor={theme.sheet.text}
-				selectionColor={primaryColor}
+			<SettingsListTextInputField
+				placeholder={translate(TranslationKeys.password)}
 				value={formState.password}
+				onChangeText={password => setFormState(prevState => ({ ...prevState, password }))}
 				secureTextEntry
-				placeholder="Password"
+				autoCapitalize="none"
+				autoCorrect={false}
+				textContentType="password"
+				returnKeyType="done"
+				onSubmitEditing={onSubmit}
 			/>
 			<TouchableOpacity
 				style={{
@@ -110,7 +91,7 @@ const ManagementSheet: React.FC<SheetProps> = ({ closeSheet, handleLogin, loadin
 					</Text>
 				)}
 			</TouchableOpacity>
-		</BottomSheetScrollView>
+		</View>
 	);
 };
 

--- a/apps/frontend/app/components/SettingsListTextInput.tsx
+++ b/apps/frontend/app/components/SettingsListTextInput.tsx
@@ -1,7 +1,7 @@
 // Hinweis: Wenn neue SettingsList-Komponenten entstehen, bitte auch im Experimental-Screen hinzufügen.
 import React, { useCallback, useMemo } from 'react';
 import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
-import type { KeyboardTypeOptions } from 'react-native';
+import type { KeyboardTypeOptions, TextInputProps } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSelector } from 'react-redux';
 
@@ -36,6 +36,21 @@ export interface SettingsListTextInputSheetProps {
 	allowSubmitWhenDisabled?: boolean;
 }
 
+export interface SettingsListTextInputFieldProps {
+	placeholder: string;
+	value: string;
+	onChangeText: (text: string) => void;
+	keyboardType?: KeyboardTypeOptions;
+	secureTextEntry?: boolean;
+	autoCapitalize?: TextInputProps['autoCapitalize'];
+	autoCorrect?: boolean;
+	textContentType?: TextInputProps['textContentType'];
+	inputStyle?: object;
+	autoFocus?: boolean;
+	returnKeyType?: TextInputProps['returnKeyType'];
+	onSubmitEditing?: TextInputProps['onSubmitEditing'];
+}
+
 export interface SettingsListTextInputProps extends Omit<SettingsListProps, 'onPress' | 'handleFunction'> {
 	modalTitle?: string;
 	placeholder: string;
@@ -51,6 +66,50 @@ export interface SettingsListTextInputProps extends Omit<SettingsListProps, 'onP
 	checkTextInput?: CheckTextInput;
 	allowSubmitWhenDisabled?: boolean;
 }
+
+export const SettingsListTextInputField: React.FC<SettingsListTextInputFieldProps> = ({
+	placeholder,
+	value,
+	onChangeText,
+	keyboardType,
+	secureTextEntry,
+	autoCapitalize = 'none',
+	autoCorrect = false,
+	textContentType,
+	inputStyle,
+	autoFocus,
+	returnKeyType,
+	onSubmitEditing,
+}) => {
+	const { theme } = useTheme();
+	const { primaryColor } = useSelector((state: RootState) => state.settings);
+
+	return (
+		<TextInput
+			style={{
+				...styles.sheetInput,
+				color: theme.sheet.text,
+				backgroundColor: theme.sheet.inputBg,
+				borderColor: theme.sheet.inputBorder,
+				...(inputStyle ?? {}),
+			}}
+			autoFocus={autoFocus}
+			placeholder={placeholder}
+			placeholderTextColor={theme.sheet.placeholder}
+			cursorColor={theme.sheet.text}
+			selectionColor={primaryColor}
+			value={value}
+			onChangeText={onChangeText}
+			keyboardType={keyboardType}
+			secureTextEntry={secureTextEntry}
+			autoCapitalize={autoCapitalize}
+			autoCorrect={autoCorrect}
+			textContentType={textContentType}
+			returnKeyType={returnKeyType}
+			onSubmitEditing={onSubmitEditing}
+		/>
+	);
+};
 
 export const SettingsListTextInputSheet: React.FC<SettingsListTextInputSheetProps> = ({
 	placeholder,


### PR DESCRIPTION
### Motivation
- Replace the old bottom-sheet usage for Management Login with the global scrollview modal so the login UI can reuse the same modal scaffolding as other settings modals. 
- Reuse the `SettingsList` styling for inline form fields to provide a consistent look with other settings screens. 

### Description
- Added a reusable `SettingsListTextInputField` component exported from `apps/frontend/app/components/SettingsListTextInput.tsx` to provide settings-styled `TextInput` fields with common props (`keyboardType`, `secureTextEntry`, `returnKeyType`, `onSubmitEditing`, etc.).
- Reworked management login sheet `apps/frontend/app/components/Login/ManagementSheet.tsx` to use the new `SettingsListTextInputField`, memoized email validation via `EmailHelper.sanitizeAndValidate`, and inline submission handling (`returnKeyType` / `onSubmitEditing`).
- Switched the management login trigger in `apps/frontend/app/app/(auth)/login.tsx` to open via the global `useMyScrollViewModal` (`show`) and applied the sheet background color via `backgroundColor: theme.sheet.sheetBg`, removing the previous local `BaseBottomSheet` ref and snap-point logic.
- Updated prop shapes so the `ManagementSheet` no longer expects a `closeSheet` prop and instead relies on the modal's `onClose` handling provided by `useMyScrollViewModal`.

### Testing
- No automated tests were executed for this change.
- Manual runtime verification was not performed as part of this PR generation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e2d08f0483308ff6cc05a662d185)