### PR TITLE
Fix management login modal background

### DIFF
--- a/apps/frontend/app/app/(auth)/login.tsx
+++ b/apps/frontend/app/app/(auth)/login.tsx
@@ -131,7 +131,6 @@ export default function Login() {
 	const openSheet = useCallback(() => {
 		showManagementModal({
 			onClose: closeManagementModal,
-			backgroundColor: theme.sheet.sheetBg,
 			children: (
 				<ManagementSheet
 					closeSheet={closeManagementModal}
@@ -140,7 +139,7 @@ export default function Login() {
 				/>
 			),
 		});
-	}, [closeManagementModal, handleUserLogin, loading, showManagementModal, theme.sheet.sheetBg]);
+	}, [closeManagementModal, handleUserLogin, loading, showManagementModal]);
 
 	const handleAnonymousLogin = () => {
 		// @ts-ignore


### PR DESCRIPTION
### Motivation
- The management login bottom-sheet forced an explicit `backgroundColor: theme.sheet.sheetBg`, causing the sheet to use a different background than the default scroll modal behavior and producing the wrong background color.

### Description
- Remove the `backgroundColor: theme.sheet.sheetBg` option from the `showManagementModal` call in `apps/frontend/app/app/(auth)/login.tsx` and drop `theme.sheet.sheetBg` from the `useCallback` dependency array so the modal uses the default `MyScrollViewModal` background.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e85939948330a2fc7b294b7edc55)