### PR TITLE
Use scroll view modal for anonymous login warning

### DIFF
--- a/apps/frontend/app/app/(auth)/login.tsx
+++ b/apps/frontend/app/app/(auth)/login.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Dimensions, Image, ScrollView, Text, View } from 'react-native';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
@@ -6,8 +6,6 @@ import Form from '@/components/Login/Form';
 import Header from '@/components/Login/Header';
 import Footer from '@/components/Login/Footer';
 import ManagementSheet from '@/components/Login/ManagementSheet';
-import BaseBottomSheet from '@/components/BaseBottomSheet';
-import BottomSheet from '@gorhom/bottom-sheet';
 import { isWeb } from '@/constants/Constants';
 import { router, useFocusEffect, useGlobalSearchParams } from 'expo-router';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
@@ -36,9 +34,6 @@ export default function Login() {
 	const appSettingsHelper = new AppSettingsHelper();
 	const wikisHelper = new WikisHelper();
 	const [loading, setLoading] = useState(false);
-	const [isActive, setIsActive] = useState(false);
-	const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
-	const attentionSheetRef = useRef<BottomSheet>(null);
 	const [providers, setProviders] = useState<any>([]);
 	const [isWebVisible, setIsWebVisible] = useState(Dimensions.get('window').width > 500);
 	const { appSettings, language } = useSelector((state: RootState) => state.settings);
@@ -46,6 +41,7 @@ export default function Login() {
 	const detailed_description = appSettings?.login_screen_translations && getDetailedDescriptionTranslation(appSettings?.login_screen_translations, language);
 	const [heading, subHeading] = intro_description?.split('-') || ['', ''];
 	const { show: showManagementModal, close: closeManagementModal } = useMyScrollViewModal();
+	const { show: showAttentionModal, close: closeAttentionModal } = useMyScrollViewModal();
 	const getProviders = async () => {
 		const providers = await ServerAPI.getAuthProviders();
 		if (providers) {
@@ -68,16 +64,6 @@ export default function Login() {
 		getAppSettings();
 		getProviders();
 	}, []);
-
-	const openAttentionSheet = () => {
-		setIsBottomSheetVisible(true);
-		attentionSheetRef.current?.expand();
-	};
-
-	const closeAttentionSheet = () => {
-		setIsBottomSheetVisible(false);
-		attentionSheetRef?.current?.close();
-	};
 
         const handleUserLogin = async (token?: string, email?: string, password?: string) => {
                 try {
@@ -159,6 +145,18 @@ export default function Login() {
 		return currentDate;
 	};
 
+	const openAttentionSheet = useCallback(() => {
+		showAttentionModal({
+			onClose: closeAttentionModal,
+			children: (
+				<AttentionSheet
+					closeSheet={closeAttentionModal}
+					handleLogin={handleAnonymousLogin}
+				/>
+			),
+		});
+	}, [closeAttentionModal, handleAnonymousLogin, showAttentionModal]);
+
 	useEffect(() => {
 		const handleResize = () => {
 			setIsWebVisible(Dimensions.get('window').width > 650);
@@ -168,15 +166,6 @@ export default function Login() {
 
 		return () => subscription?.remove();
 	}, []);
-
-	useFocusEffect(
-		useCallback(() => {
-			setIsActive(true);
-			return () => {
-				setIsActive(false);
-			};
-		}, [])
-	);
 
 	const getWikis = async () => {
 		try {
@@ -267,20 +256,6 @@ export default function Login() {
 						</View>
 						{renderContent()}
 					</View>
-				)}
-				{isActive && (
-					<BaseBottomSheet
-						ref={attentionSheetRef}
-						index={-1}
-						backgroundStyle={{
-							borderTopRightRadius: 30,
-							borderTopLeftRadius: 30,
-							backgroundColor: theme.sheet.sheetBg,
-						}}
-						onClose={closeAttentionSheet}
-					>
-						<AttentionSheet closeSheet={closeAttentionSheet} handleLogin={handleAnonymousLogin} isBottomSheetVisible={isBottomSheetVisible} />
-					</BaseBottomSheet>
 				)}
 			</ScrollView>
 		</>

--- a/apps/frontend/app/components/Login/AttentionSheet.tsx
+++ b/apps/frontend/app/components/Login/AttentionSheet.tsx
@@ -1,6 +1,5 @@
 import { Text, TouchableOpacity, View } from 'react-native';
-import React, { useCallback, useRef, useState } from 'react';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { AttentionSheetProps } from './types';
 import { styles } from './styles';
@@ -10,12 +9,11 @@ import { useSelector } from 'react-redux';
 import LottieView from 'lottie-react-native';
 import { replaceLottieColors } from '@/helper/animationHelper';
 import animationJson from '@/assets/animations/astronaut-computer.json';
-import { useFocusEffect } from 'expo-router';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
 import { myContrastColor } from '@/helper/ColorHelper';
 
-const AttentionSheet: React.FC<AttentionSheetProps> = ({ closeSheet, handleLogin, isBottomSheetVisible }) => {
+const AttentionSheet: React.FC<AttentionSheetProps> = ({ closeSheet, handleLogin }) => {
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
 	const { primaryColor, appSettings, selectedTheme: mode } = useSelector((state: RootState) => state.settings);
@@ -24,44 +22,42 @@ const AttentionSheet: React.FC<AttentionSheetProps> = ({ closeSheet, handleLogin
 	const animationRef = useRef<LottieView>(null);
 	const [hasPlayed, setHasPlayed] = useState(false);
 
-	useFocusEffect(
-		useCallback(() => {
-			if (isBottomSheetVisible) {
-				if (!hasPlayed && appSettings?.animations_auto_start) {
-					animationRef.current?.play();
-					setHasPlayed(true);
-				}
-			}
-		}, [isBottomSheetVisible, hasPlayed, appSettings])
-	);
+	useEffect(() => {
+		if (!hasPlayed && appSettings?.animations_auto_start) {
+			animationRef.current?.play();
+			setHasPlayed(true);
+		}
+	}, [hasPlayed, appSettings]);
 
 	return (
-		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<View style={styles.attentionSheetHeader}>
-				<View />
-			</View>
+		<View style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
+			<View style={styles.contentContainer}>
+				<View style={styles.attentionSheetHeader}>
+					<View />
+				</View>
 
-			<View style={styles.gifContainer}>
-				<LottieView ref={animationRef} source={updatedAnimationJson} resizeMode="contain" style={{ width: '100%', height: '100%' }} autoPlay={false} loop={false} />
-			</View>
-			<Text style={{ ...styles.attentionSheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.attention)}</Text>
-			<View style={{ ...styles.attentionContent, width: isWeb ? '80%' : '100%' }}>
-				<Text style={{ ...styles.attentionBody, color: theme.sheet.text }}>{translate(TranslationKeys.without_account_limitations)}</Text>
-				<View style={{ ...styles.attentionActions, width: isWeb ? '60%' : '100%' }}>
-					<TouchableOpacity
-						style={[styles.confirmButton, { backgroundColor: primaryColor }]}
-						onPress={() => {
-							handleLogin();
-						}}
-					>
-						<Text style={[styles.confirmLabel, { color: contrastColor }]}>{translate(TranslationKeys.confirm)}</Text>
-					</TouchableOpacity>
-					<TouchableOpacity style={styles.cancleButton} onPress={closeSheet}>
-						<Text style={styles.confirmLabel}>{translate(TranslationKeys.cancel)}</Text>
-					</TouchableOpacity>
+				<View style={styles.gifContainer}>
+					<LottieView ref={animationRef} source={updatedAnimationJson} resizeMode="contain" style={{ width: '100%', height: '100%' }} autoPlay={false} loop={false} />
+				</View>
+				<Text style={{ ...styles.attentionSheetHeading, color: theme.sheet.text }}>{translate(TranslationKeys.attention)}</Text>
+				<View style={{ ...styles.attentionContent, width: isWeb ? '80%' : '100%' }}>
+					<Text style={{ ...styles.attentionBody, color: theme.sheet.text }}>{translate(TranslationKeys.without_account_limitations)}</Text>
+					<View style={{ ...styles.attentionActions, width: isWeb ? '60%' : '100%' }}>
+						<TouchableOpacity
+							style={[styles.confirmButton, { backgroundColor: primaryColor }]}
+							onPress={() => {
+								handleLogin();
+							}}
+						>
+							<Text style={[styles.confirmLabel, { color: contrastColor }]}>{translate(TranslationKeys.confirm)}</Text>
+						</TouchableOpacity>
+						<TouchableOpacity style={styles.cancleButton} onPress={closeSheet}>
+							<Text style={styles.confirmLabel}>{translate(TranslationKeys.cancel)}</Text>
+						</TouchableOpacity>
+					</View>
 				</View>
 			</View>
-		</BottomSheetScrollView>
+		</View>
 	);
 };
 

--- a/apps/frontend/app/components/Login/types.ts
+++ b/apps/frontend/app/components/Login/types.ts
@@ -17,5 +17,4 @@ export type SheetProps = {
 export type AttentionSheetProps = {
 	closeSheet: () => void;
 	handleLogin: () => void;
-	isBottomSheetVisible: boolean;
 }


### PR DESCRIPTION
### Motivation
- The anonymous-login attention sheet was implemented as a `BottomSheetScrollView` with explicit bottom-sheet wiring, which differs from how the management login modal is shown and led to a warning on anonymous login flows. 
- The goal is to show the warning via the shared `useMyScrollViewModal` API and make the attention component a plain view so it behaves consistently with other modals (like the management modal). 

### Description
- Replaced `BottomSheetScrollView` in `AttentionSheet` with a standard `View` layout and moved content into the `contentContainer` to match the `useMyScrollViewModal` pattern. 
- Simplified the animation trigger by removing `useFocusEffect` and `isBottomSheetVisible` and using a `useEffect` that respects `appSettings?.animations_auto_start`. 
- Removed the `isBottomSheetVisible` prop from `AttentionSheet` typing in `apps/frontend/app/components/Login/types.ts`. 
- Switched the login screen to open the attention modal via `useMyScrollViewModal` (`showAttentionModal`) and removed the dedicated `BaseBottomSheet` / `BottomSheet` ref and related `isActive` wiring in `apps/frontend/app/app/(auth)/login.tsx`. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ed943cec8330b0ef38e881f32ad5)