### PR TITLE
Remove inner background from attention sheet

### DIFF
--- a/apps/frontend/app/components/Login/AttentionSheet.tsx
+++ b/apps/frontend/app/components/Login/AttentionSheet.tsx
@@ -30,7 +30,7 @@ const AttentionSheet: React.FC<AttentionSheetProps> = ({ closeSheet, handleLogin
 	}, [hasPlayed, appSettings]);
 
 	return (
-		<View style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }}>
+		<View style={[styles.sheetView, styles.attentionSheetView]}>
 			<View style={styles.contentContainer}>
 				<View style={styles.attentionSheetHeader}>
 					<View />

--- a/apps/frontend/app/components/Login/styles.ts
+++ b/apps/frontend/app/components/Login/styles.ts
@@ -176,6 +176,10 @@ export const styles = StyleSheet.create({
 		borderTopLeftRadius: 28,
 		padding: 15,
 	},
+	attentionSheetView: {
+		backgroundColor: 'transparent',
+		padding: 0,
+	},
 	sheetHeader: {
 		width: '100%',
 		alignItems: 'flex-end',


### PR DESCRIPTION
### Motivation
- Align the Anonymous Login attention modal content with the outer sheet by removing the inner background and extra padding so there is no visual gap between the modal content and the sheet.

### Description
- Replace the inline background on the attention sheet root in `apps/frontend/app/components/Login/AttentionSheet.tsx` to use a new style and add `attentionSheetView` in `apps/frontend/app/components/Login/styles.ts` with `backgroundColor: 'transparent'` and `padding: 0`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f07e51ec8330a86d73466f7f34d4)