### PR TITLE
Close attention modal on accept

### DIFF
--- a/apps/frontend/app/components/Login/AttentionSheet.tsx
+++ b/apps/frontend/app/components/Login/AttentionSheet.tsx
@@ -46,6 +46,7 @@ const AttentionSheet: React.FC<AttentionSheetProps> = ({ closeSheet, handleLogin
 						<TouchableOpacity
 							style={[styles.confirmButton, { backgroundColor: primaryColor }]}
 							onPress={() => {
+								closeSheet();
 								handleLogin();
 							}}
 						>


### PR DESCRIPTION
### Motivation
- Ensure the anonymous "Attention" modal is dismissed immediately when the user confirms so the anonymous login flow proceeds without leaving the modal open.

### Description
- Call `closeSheet()` before `handleLogin()` in `apps/frontend/app/components/Login/AttentionSheet.tsx` so the attention sheet closes when the confirm button is pressed.

### Testing
- No automated tests were run for this small UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f4a0906c833092715e915186763b)