### PR TITLE
Preserve anonymous price group selection

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -117,6 +117,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	}, [autoPlay, animationJson]);
 
 	const setDefaultPriceGroupForAnonymousUser = () => {
+		if (profile?.price_group) {
+			return;
+		}
 		dispatch({
 			type: UPDATE_PROFILE,
 			payload: { ...(profile as any), price_group: 'student' },

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -117,6 +117,9 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	}, [autoPlay, animationJson]);
 
 	const setDefaultPriceGroupForAnonymousUser = () => {
+		if (profile?.price_group) {
+			return;
+		}
 		dispatch({
 			type: UPDATE_PROFILE,
 			payload: { ...(profile as any), price_group: 'student' },


### PR DESCRIPTION
### Motivation
- Prevent anonymous users' selected `price_group` from being overwritten (and thus lost after app restart) when the app sets a default in the food offers screens.

### Description
- Add a guard in `apps/frontend/app/app/(app)/foodoffers/index.tsx` and `apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx` to skip dispatching `UPDATE_PROFILE` when `profile?.price_group` is already present.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f7ca4c848330b9020b47d3d0b9f4)