### PR TITLE
Use PriceGroupKey enum for anonymous default price group

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx
@@ -39,6 +39,7 @@ import { RootState } from '@/redux/reducer';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
+import { PriceGroupKey } from '@/app/(app)/settings/types';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 
@@ -122,7 +123,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 		dispatch({
 			type: UPDATE_PROFILE,
-			payload: { ...(profile as any), price_group: 'student' },
+			payload: { ...(profile as any), price_group: PriceGroupKey.student },
 		});
 	};
 

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -38,6 +38,7 @@ import { RootState } from '@/redux/reducer';
 import MarkingBottomSheet from '@/components/MarkingBottomSheet';
 import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
 import usePopupEventModal from '@/hooks/usePopupEventModal';
+import { PriceGroupKey } from '@/app/(app)/settings/types';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import FoodOffersScrollList from '@/components/FoodOffersScrollList';
@@ -122,7 +123,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 		}
 		dispatch({
 			type: UPDATE_PROFILE,
-			payload: { ...(profile as any), price_group: 'student' },
+			payload: { ...(profile as any), price_group: PriceGroupKey.student },
 		});
 	};
 


### PR DESCRIPTION
### Motivation
- Replace hardcoded `'student'` string with the `PriceGroupKey` enum to improve type safety and avoid literal string usage for price group defaults.

### Description
- Added `import { PriceGroupKey } from '@/app/(app)/settings/types'` to the affected food offers screens.
- Replaced the anonymous default payload value `price_group: 'student'` with `price_group: PriceGroupKey.student` in `apps/frontend/app/app/(app)/foodoffers/index.tsx`.
- Made the same replacement in `apps/frontend/app/app/(app)/foodoffers-scroll/index.tsx` to keep behavior consistent.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fab1eabc8330a1e2f6e2b66fc680)