### PR TITLE
Fix apartment distance badge overlay alignment

### DIFF
--- a/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
+++ b/apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx
@@ -107,44 +107,40 @@ const ApartmentItem: React.FC<BuildingItemProps> = ({ apartment, onEditImage, op
 										<Text style={{ ...styles.freeBadgeText, color: contrastColor }}>{translate(TranslationKeys.free_rooms)}</Text>
 									</TouchableOpacity>
 								)}
-								<View style={styles.imageActionContainer}>
-									{isManagement ? (
-										<Tooltip
-											placement="top"
-											trigger={triggerProps => (
-												<TouchableOpacity
-													{...triggerProps}
-													style={styles.editImageButton}
-													onPress={() => {
-														onEditImage?.(apartment);
-													}}
-												>
-													<MaterialCommunityIcons name="image-edit" size={20} color={'white'} />
-												</TouchableOpacity>
-											)}
-										>
-											<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
-												<TooltipText fontSize="$sm" color={theme.tooltip.text}>
-													{`${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.image)}`}
-												</TooltipText>
-											</TooltipContent>
-										</Tooltip>
-									) : (
-										<View />
-									)}
-									<View style={styles.distanceActions}>
-										<TouchableOpacity
-											style={{
-												...styles.directionButton,
-												backgroundColor: housing_area_color,
-											}}
-											onPress={openDistanceInformationModal}
-											onLongPress={openDistanceSheet}
-										>
-											<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
-											<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(apartment?.distance)}</Text>
-										</TouchableOpacity>
-									</View>
+								{isManagement && (
+									<Tooltip
+										placement="top"
+										trigger={triggerProps => (
+											<TouchableOpacity
+												{...triggerProps}
+												style={styles.editImageButton}
+												onPress={() => {
+													onEditImage?.(apartment);
+												}}
+											>
+												<MaterialCommunityIcons name="image-edit" size={20} color="white" />
+											</TouchableOpacity>
+										)}
+									>
+										<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
+											<TooltipText fontSize="$sm" color={theme.tooltip.text}>
+												{`${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.image)}`}
+											</TooltipText>
+										</TooltipContent>
+									</Tooltip>
+								)}
+								<View style={styles.distanceActions}>
+									<TouchableOpacity
+										style={{
+											...styles.directionButton,
+											backgroundColor: housing_area_color,
+										}}
+										onPress={openDistanceInformationModal}
+										onLongPress={openDistanceSheet}
+									>
+										<MaterialCommunityIcons name="map-marker-distance" size={20} color={contrastColor} />
+										<Text style={{ ...styles.distance, color: contrastColor }}>{getDistanceUnit(apartment?.distance)}</Text>
+									</TouchableOpacity>
 								</View>
 							</>
 						}

--- a/apps/frontend/app/components/ApartmentItem/styles.ts
+++ b/apps/frontend/app/components/ApartmentItem/styles.ts
@@ -28,15 +28,10 @@ export default StyleSheet.create({
 		borderTopLeftRadius: 18,
 		resizeMode: 'cover',
 	},
-	imageActionContainer: {
-		width: '100%',
-		position: 'absolute',
-		bottom: 0,
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		alignItems: 'center',
-	},
 	editImageButton: {
+		position: 'absolute',
+		bottom: 10,
+		left: 5,
 		width: 35,
 		height: 35,
 		borderRadius: 50,
@@ -54,6 +49,9 @@ export default StyleSheet.create({
 		paddingHorizontal: 10,
 	},
 	distanceActions: {
+		position: 'absolute',
+		top: 5,
+		right: 5,
 		flexDirection: 'row',
 		alignItems: 'center',
 		gap: 8,
@@ -61,7 +59,7 @@ export default StyleSheet.create({
 	freeBadge: {
 		position: 'absolute',
 		top: 5,
-		right: 5,
+		left: 5,
 		borderRadius: 8,
 		flexDirection: 'row',
 		justifyContent: 'center',


### PR DESCRIPTION
### Motivation

- The apartment card's distance badge was rendered too low compared to the `FoodItem` card and overlapped other image controls, making the UI inconsistent and hard to use.
- The change aims to place the distance action in the same visual position as `FoodItem` (top-right) and avoid overlaps with other overlays.

### Description

- Move the distance control out of the bottom action row and render it as an absolute overlay positioned top-right in `ApartmentItem` JSX.
- Position the management edit button as a bottom-left overlay and keep it visible only for management users by adjusting JSX and `styles.ts`.
- Move the `freeBadge` to the top-left to avoid collision with the distance control and remove the old `imageActionContainer` usage.
- Updated files: `apps/frontend/app/components/ApartmentItem/ApartmentItem.tsx` and `apps/frontend/app/components/ApartmentItem/styles.ts` to reflect the layout and style changes.

### Testing

- Ran `yarn lint` and it completed successfully.
- Attempted to start the web app with `yarn workspace rocket-meals-dev web`, but Metro/Expo failed to fully start due to `ENOSPC: System limit for number of file watchers reached`, so no runtime screenshot or visual smoke test could be produced.
- Attempted automated page screenshot with Playwright but it failed because the dev server was not reachable (`net::ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b6e6358c8330bf808d81fd3c4b4a)