### PR TITLE
Swap apartment card free and distance badge positions

### DIFF
--- a/apps/frontend/app/components/ApartmentItem/styles.ts
+++ b/apps/frontend/app/components/ApartmentItem/styles.ts
@@ -50,7 +50,7 @@ export default StyleSheet.create({
 	},
 	distanceActions: {
 		position: 'absolute',
-		top: 5,
+		bottom: 5,
 		right: 5,
 		flexDirection: 'row',
 		alignItems: 'center',
@@ -59,7 +59,7 @@ export default StyleSheet.create({
 	freeBadge: {
 		position: 'absolute',
 		top: 5,
-		left: 5,
+		right: 5,
 		borderRadius: 8,
 		flexDirection: 'row',
 		justifyContent: 'center',


### PR DESCRIPTION
### Motivation
- Adjust the Apartment Card UI to place the distance badge at the bottom-right and the free/available badge at the top-right for improved layout and user clarity.

### Description
- Update `apps/frontend/app/components/ApartmentItem/styles.ts` to set `distanceActions` from `top: 5` to `bottom: 5` and move `freeBadge` from `left: 5` to `right: 5`.

### Testing
- Ran `yarn lint` which passed; attempted a static export and a Playwright screenshot (automated) but the Chromium instance crashed in this environment so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974dc87dbec83309c92a49baeff5d29)