### PR TITLE
Highlight liked food offers with green borders

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -66,7 +66,27 @@ const FoodItem: React.FC<FoodItemProps> = memo(
       [item?.markings, profile?.markings]
     );
 
-    const { screenWidth, containerStyle, imageContainerStyle, contentStyle } = useFoodCard(dislikedMarkings.length > 0 ? 3 : 0);
+    const likedMarkings = useMemo(
+      () =>
+        item?.markings?.filter(marking =>
+          profile?.markings?.some(
+            (profileMarking: DatabaseTypes.ProfilesMarkings) =>
+              profileMarking?.markings_id === marking?.markings_id && profileMarking?.like === true
+          )
+        ) ?? [],
+      [item?.markings, profile?.markings]
+    );
+
+    const isLiked = useMemo(
+      () =>
+        RatingHelper.isMaxRating(previousFeedback?.rating) ||
+        likedMarkings.length > 0,
+      [likedMarkings.length, previousFeedback?.rating]
+    );
+
+    const borderWidth = dislikedMarkings.length > 0 ? 3 : isLiked ? 3 : 0;
+    const borderColor = dislikedMarkings.length > 0 ? '#FF000095' : '#00B050';
+    const { screenWidth, containerStyle, imageContainerStyle, contentStyle } = useFoodCard(borderWidth, borderColor);
 
     const markingsData = useMemo(
       () =>

--- a/apps/frontend/app/hooks/useFoodCard.ts
+++ b/apps/frontend/app/hooks/useFoodCard.ts
@@ -6,7 +6,7 @@ import { isWeb } from '@/constants/Constants';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
 import { useTheme } from '@/hooks/useTheme';
 
-export const useFoodCard = (borderWidth: number = 0) => {
+export const useFoodCard = (borderWidth: number = 0, borderColor: string = '#FF000095') => {
 	const { theme } = useTheme();
 	const { amountColumnsForcard } = useSelector((state: RootState) => state.settings);
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
@@ -27,7 +27,7 @@ export const useFoodCard = (borderWidth: number = 0) => {
 		width: dimension,
 		backgroundColor: theme.card.background,
 		borderWidth,
-		borderColor: '#FF000095',
+		borderColor,
 	};
 
 	const imageContainerStyle: ViewStyle = {


### PR DESCRIPTION
### Motivation
- Food offers that the user explicitly likes (via markings or a max rating) should be visually highlighted with a green border, but not when a disliked marking already forces the red border.

### Description
- Detect liked markings for a food offer and compute `isLiked` by combining liked markings and `previousFeedback` max rating in `FoodItem` (`apps/frontend/app/components/FoodItem/FoodItem.tsx`).
- Compute `borderWidth` and `borderColor` so disliked markings keep a red border and liked offers get a green border, and pass these values into the card hook via `useFoodCard(borderWidth, borderColor)`.
- Extend the `useFoodCard` hook signature to accept `borderColor` and apply it to the returned `containerStyle` (`apps/frontend/app/hooks/useFoodCard.ts`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756867e63083309ee00e6ff8118237)