### PR TITLE
Add debug JSON output for foodoffer details

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -35,6 +35,7 @@ import { RootState } from '@/redux/reducer';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import useRatingPermissionModal from '@/hooks/useRatingPermissionModal';
 import { ConfigCustomerEnum } from '@/config';
+import DebugView from '@/components/DebugView';
 
 const selectFoodState = (state: RootState) => state.food;
 
@@ -55,7 +56,7 @@ export default function FoodDetailsScreen() {
 	const dispatch = useDispatch();
 	const menuSheetRef = useRef<BottomSheet>(null);
 	const { isSmartPhone, isAndroid, isIOS } = usePlatformHelper();
-	const { user, profile } = useSelector((state: RootState) => state.authReducer);
+	const { user, profile, isDevMode } = useSelector((state: RootState) => state.authReducer);
 	const { primaryColor, language: languageCode, appSettings, serverInfo, selectedTheme: mode, selectedCustomer } = useSelector((state: RootState) => state.settings);
         const previousFeedback = useSelector(state => selectPreviousFeedback(state, initialFoodId));
 	const profileHelper = useMemo(() => new ProfileHelper(), []);
@@ -70,6 +71,7 @@ export default function FoodDetailsScreen() {
 	const selectedCanteen = useSelectedCanteen();
 	const foodOfferCanteenId = selectedCanteen?.id as string | undefined;
 	const [foodDetails, setFoodDetails] = useState<any>(null);
+	const [foodOfferDetails, setFoodOfferDetails] = useState<any>(null);
         const { openRatingPermissionModal } = useRatingPermissionModal();
 
 	const [activeTab, setActiveTab] = useState('feedbacks');
@@ -267,8 +269,9 @@ export default function FoodDetailsScreen() {
                 try {
                         if (offerId) {
                                 const foodData = await fetchFoodOffersDetailsById(offerId.toString());
-                                if (foodData && foodData.data) {
-                                        const { food, attribute_values, foodoffer_category } = foodData?.data ?? {};
+				if (foodData && foodData.data) {
+					const { food, attribute_values, foodoffer_category } = foodData?.data ?? {};
+					setFoodOfferDetails(foodData.data);
 
                                         const translation = food?.translations?.find((val: FoodsTranslations) => String(val?.languages_code)?.split('-')[0] === languageCode);
                                         setFoodDetails({
@@ -283,10 +286,11 @@ export default function FoodDetailsScreen() {
                                 } else {
                                         console.log('No food data found');
                                 }
-                        } else if (initialFoodId) {
-                                const foodData = await fetchFoodDetailsById(initialFoodId.toString());
-                                if (foodData && foodData.data) {
-                                        const food = foodData.data;
+			} else if (initialFoodId) {
+				const foodData = await fetchFoodDetailsById(initialFoodId.toString());
+				if (foodData && foodData.data) {
+					const food = foodData.data;
+					setFoodOfferDetails(null);
                                         const translation = food?.translations?.find((val: FoodsTranslations) => String(val?.languages_code)?.split('-')[0] === languageCode);
                                         setFoodDetails({
                                                 ...food,
@@ -774,6 +778,11 @@ export default function FoodDetailsScreen() {
                                         {foodDetails?.id && renderContent(foodDetails)}
                                 </View>
                         </View>
+                        <DebugView title="Foodoffer Details" isVisible={isDevMode}>
+                                <Text style={{ color: theme.screen.text }}>
+                                        {foodOfferDetails ? JSON.stringify(foodOfferDetails, null, 2) : 'No foodoffer details available.'}
+                                </Text>
+                        </DebugView>
                         <CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_details} />
                 </View>
         </ScrollView>


### PR DESCRIPTION
### Motivation
- Provide a developer-only debug output of the full foodoffer response so Foodoffer details can be inspected as JSON in the Food Details screen.

### Description
- Import `DebugView` and read `isDevMode` from `authReducer` via `useSelector` to gate the debug output. 
- Store the raw foodoffer response in a new `foodOfferDetails` state when `fetchFoodOffersDetailsById` returns data and clear it when loading plain food details. 
- Render a `DebugView` titled "Foodoffer Details" under the details/pager view that shows `JSON.stringify(foodOfferDetails, null, 2)` inside a `Text` node. 
- Minimal UI placement ensures the JSON is visible only in developer mode and does not affect normal users.

### Testing
- No automated unit or integration tests were run against the change. 
- An attempt was made to capture a screenshot with a Playwright script, but `http://localhost:3000` responded with `net::ERR_EMPTY_RESPONSE`, so the run failed and no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756bfdec2083308c9cd7c12c0a1a94)