### PR TITLE
Add dev debug views for foodoffer markings in Labels component

### DIFF
--- a/apps/frontend/app/components/Labels/index.tsx
+++ b/apps/frontend/app/components/Labels/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
 import FoodLabelingInfo from '../FoodLabelingInfo';
+import DebugView from '@/components/DebugView';
 import MarkingLabels from '../MarkingLabels/MarkingLabels';
 import { getFoodOffer } from '@/constants/HelperFunctions';
 import { CollectibleAt, DatabaseTypes, sortMarkingsByGroup } from 'repo-depkit-common';
@@ -32,6 +33,7 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { primaryColor, appSettings } = useSelector((state: RootState) => state.settings);
+	const { isDevMode } = useSelector((state: RootState) => state.authReducer);
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 
 	let food_responsible_organization_name = appSettings?.food_responsible_organization_name || 'Verantwortliche Organisation';
@@ -67,15 +69,17 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 		fetchMarkingGroups();
 	}, []);
 
-	const foodMarkings = useMemo(() => {
+	const mappedFoodOfferMarkings = useMemo(() => {
 		if (!foodOffer?.markings) return [];
 
-		// First, map food offer markings to actual marking objects
-		const mappedMarkings = foodOffer.markings?.map((marking: DatabaseTypes.FoodoffersMarkings) => markings.find((mark: DatabaseTypes.Markings) => mark.id === marking?.markings_id)).filter((mark: any): mark is DatabaseTypes.Markings => Boolean(mark));
+		return foodOffer.markings
+			?.map((marking: DatabaseTypes.FoodoffersMarkings) => markings.find((mark: DatabaseTypes.Markings) => mark.id === marking?.markings_id))
+			.filter((mark: any): mark is DatabaseTypes.Markings => Boolean(mark));
+	}, [foodOffer, markings]);
 
-		// Then sort them using the sortMarkingsByGroup function
-		return sortMarkingsByGroup(mappedMarkings, markingGroups);
-	}, [foodOffer, markings, markingGroups]);
+	const foodMarkings = useMemo(() => {
+		return sortMarkingsByGroup(mappedFoodOfferMarkings, markingGroups);
+	}, [mappedFoodOfferMarkings, markingGroups]);
 
 	return (
 		<View style={styles.container}>
@@ -84,6 +88,24 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
                         {foodMarkings?.map((marking: DatabaseTypes.Markings) => (
                                 <MarkingLabels key={marking.id} markingId={marking.id} handleMenuSheet={handleMenuSheet} />
                         ))}
+
+			<DebugView title="Foodoffer Markings Data" isVisible={isDevMode}>
+				<Text style={{ ...styles.body, color: theme.screen.text }}>
+					{JSON.stringify(
+						{
+							foodOfferMarkings: foodOffer?.markings ?? [],
+							mappedMarkings: mappedFoodOfferMarkings,
+							sortedMarkings: foodMarkings,
+						},
+						null,
+						2
+					)}
+				</Text>
+			</DebugView>
+
+			<DebugView title="Foodoffer Markings Count" isVisible={isDevMode}>
+				<Text style={{ ...styles.body, color: theme.screen.text }}>{foodOffer?.markings?.length ?? 0}</Text>
+			</DebugView>
 
                         <FoodLabelingInfo textStyle={styles.body} backgroundColor={foods_area_color} />
 


### PR DESCRIPTION
### Motivation
- Debug why markings are not rendering by exposing the intermediate data used to render marking labels.  
- Make debug output available only in developer mode to avoid showing internal details in production.  
- Improve observability by showing both the mapped/sorted marking objects and the raw markings count.

### Description
- Imported and used `DebugView` in `apps/frontend/app/components/Labels/index.tsx`.  
- Exposed `isDevMode` from the auth reducer and wrapped debug output with `isVisible={isDevMode}`.  
- Split the mapping and sorting logic into two `useMemo` hooks: `mappedFoodOfferMarkings` (maps `foodOffer.markings` to marking objects) and `foodMarkings` (sorted result via `sortMarkingsByGroup`).  
- Added two debug panels: `Foodoffer Markings Data` that JSON-prints `foodOffer.markings`, `mappedMarkings`, and `sortedMarkings`, and `Foodoffer Markings Count` that prints the raw markings length.

### Testing
- No automated tests were executed for this change.  
- Change was applied to `apps/frontend/app/components/Labels/index.tsx` and compiled locally via the normal development workflow (no CI/test run included in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756f0327d48330b404d869b11f3de8)