### PR TITLE
Fix foodoffer markings tab and clear markings on logout

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/index.tsx
@@ -208,14 +208,15 @@ export default function FoodDetailsScreen() {
 			case 'details':
 				return <Details groupedAttributes={groupedAttributes} loading={foodAttributesLoading} />;
                                 case 'labels':
-                                        return (
-                                                <Labels
-                                                        foodDetails={foodDetails}
-                                                        offerId={offerId ? offerId.toString() : undefined}
-                                                        handleMenuSheet={openMenuSheet}
-                                                        color={foods_area_color}
-                                                />
-                                        );
+							return (
+								<Labels
+									foodDetails={foodDetails}
+									offerId={offerId ? offerId.toString() : undefined}
+									foodOfferDetails={foodOfferDetails}
+									handleMenuSheet={openMenuSheet}
+									color={foods_area_color}
+								/>
+							);
                                 default:
                                         return null;
                         }

--- a/apps/frontend/app/components/Labels/index.tsx
+++ b/apps/frontend/app/components/Labels/index.tsx
@@ -16,20 +16,21 @@ import { MarkingGroupsHelper } from '@/redux/actions/MarkingGroups/MarkingGroups
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 
 interface LabelsProps {
-        foodDetails: any;
-        offerId?: string;
-        handleMenuSheet?: () => void;
-        color: string;
+	foodDetails: any;
+	offerId?: string;
+	foodOfferDetails?: DatabaseTypes.Foodoffers | null;
+	handleMenuSheet?: () => void;
+	color: string;
 }
 
 const selectMarkings = (state: RootState) => state.food.markings;
 
 export const selectFoodOffer = (offerId?: string) =>
-        createSelector([(state: RootState) => state.canteenReducer.selectedCanteenFoodOffers], foodOffers =>
-                offerId ? getFoodOffer(foodOffers, offerId) : undefined
-        );
+	createSelector([(state: RootState) => state.canteenReducer.selectedCanteenFoodOffers], foodOffers =>
+		offerId ? getFoodOffer(foodOffers, offerId) : undefined
+	);
 
-const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, color }) => {
+const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, foodOfferDetails, handleMenuSheet, color }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { primaryColor, appSettings } = useSelector((state: RootState) => state.settings);
@@ -42,12 +43,12 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 		Linking.openURL(food_responsible_organization_link).catch(err => console.error('Failed to open URL:', err));
 	};
 
-        const markings = useSelector(selectMarkings);
-        const foodOfferSelector = useMemo(
-                () => (offerId ? selectFoodOffer(offerId) : () => undefined),
-                [offerId]
-        );
-        const foodOffer = useSelector(foodOfferSelector as (state: RootState) => DatabaseTypes.Foodoffers | undefined);
+	const markings = useSelector(selectMarkings);
+	const foodOfferSelector = useMemo(
+		() => (offerId ? selectFoodOffer(offerId) : () => undefined),
+		[offerId]
+	);
+	const foodOffer = useSelector(foodOfferSelector as (state: RootState) => DatabaseTypes.Foodoffers | undefined);
 
 	// State for marking groups
 	const [markingGroups, setMarkingGroups] = useState<DatabaseTypes.MarkingsGroups[]>([]);
@@ -70,12 +71,13 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 	}, []);
 
 	const mappedFoodOfferMarkings = useMemo(() => {
-		if (!foodOffer?.markings) return [];
+		const offerMarkings = foodOfferDetails?.markings ?? foodOffer?.markings;
+		if (!offerMarkings) return [];
 
-		return foodOffer.markings
+		return offerMarkings
 			?.map((marking: DatabaseTypes.FoodoffersMarkings) => markings.find((mark: DatabaseTypes.Markings) => mark.id === marking?.markings_id))
 			.filter((mark: any): mark is DatabaseTypes.Markings => Boolean(mark));
-	}, [foodOffer, markings]);
+	}, [foodOffer, foodOfferDetails, markings]);
 
 	const foodMarkings = useMemo(() => {
 		return sortMarkingsByGroup(mappedFoodOfferMarkings, markingGroups);
@@ -85,15 +87,15 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 		<View style={styles.container}>
 			<Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.markings)}</Text>
 			<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_foodoffers_details_markings} />
-                        {foodMarkings?.map((marking: DatabaseTypes.Markings) => (
-                                <MarkingLabels key={marking.id} markingId={marking.id} handleMenuSheet={handleMenuSheet} />
-                        ))}
+			{foodMarkings?.map((marking: DatabaseTypes.Markings) => (
+				<MarkingLabels key={marking.id} markingId={marking.id} handleMenuSheet={handleMenuSheet} />
+			))}
 
 			<DebugView title="Foodoffer Markings Data" isVisible={isDevMode}>
 				<Text style={{ ...styles.body, color: theme.screen.text }}>
 					{JSON.stringify(
 						{
-							foodOfferMarkings: foodOffer?.markings ?? [],
+							foodOfferMarkings: foodOfferDetails?.markings ?? foodOffer?.markings ?? [],
 							mappedMarkings: mappedFoodOfferMarkings,
 							sortedMarkings: foodMarkings,
 						},
@@ -104,13 +106,12 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, handleMenuSheet, 
 			</DebugView>
 
 			<DebugView title="Foodoffer Markings Count" isVisible={isDevMode}>
-				<Text style={{ ...styles.body, color: theme.screen.text }}>{foodOffer?.markings?.length ?? 0}</Text>
+				<Text style={{ ...styles.body, color: theme.screen.text }}>{foodOfferDetails?.markings?.length ?? foodOffer?.markings?.length ?? 0}</Text>
 			</DebugView>
 
-                        <FoodLabelingInfo textStyle={styles.body} backgroundColor={foods_area_color} />
-
-                </View>
-        );
+			<FoodLabelingInfo textStyle={styles.body} backgroundColor={foods_area_color} />
+		</View>
+	);
 };
 
 export default Labels;

--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -15,6 +15,9 @@ import {
 	CLEAR_PROFILE,
 	CLEAR_SETTINGS,
 	ON_LOGOUT,
+	SET_MARKING_DETAILS,
+	SET_SELECTED_FOOD_MARKINGS,
+	UPDATE_MARKINGS,
 } from '@/redux/Types/types';
 import { persistor } from '@/redux/store';
 import { clearChatReadStatus } from '@/helper/chatReadStatus';
@@ -30,6 +33,9 @@ export const performLogout = async (
 		dispatch({ type: CLEAR_CANTEENS });
 		dispatch({ type: CLEAR_CAMPUSES });
 		dispatch({ type: CLEAR_APARTMENTS });
+		dispatch({ type: UPDATE_MARKINGS, payload: [] });
+		dispatch({ type: SET_SELECTED_FOOD_MARKINGS, payload: [] });
+		dispatch({ type: SET_MARKING_DETAILS, payload: {} });
 		dispatch({ type: CLEAR_FOODS });
                 dispatch({ type: CLEAR_MANAGEMENT });
                 dispatch({ type: CLEAR_DEVELOPER_MODE });


### PR DESCRIPTION
### Motivation
- The Foodoffer Details page showed markings in the debug view but the Markings tab was empty because the labels component used the store-selected offer instead of the detailed payload returned for the current foodoffer.  
- Markings state persisted across sessions and logout did not explicitly reset marking-related local state, so markings could remain after sign-out.

### Description
- Extended the `Labels` component to accept a new `foodOfferDetails` prop and prefer `foodOfferDetails.markings` when mapping and rendering labels.  
- Updated the Foodoffer Details view to pass the `foodOfferDetails` object into `Labels` so the tab can show the detailed markings payload.  
- Adjusted `mappedFoodOfferMarkings` memo to use `foodOfferDetails?.markings ?? foodOffer?.markings` and added `foodOfferDetails` to the memo deps.  
- Clear marking-related local state on logout by dispatching `UPDATE_MARKINGS` (empty array), `SET_SELECTED_FOOD_MARKINGS` (empty array) and `SET_MARKING_DETAILS` (empty object) in `performLogout`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697573e80b5883308dd2193a62e77554)