### PR TITLE
Ensure logout clears collection last update state

### DIFF
--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -46,12 +46,13 @@ export const performLogout = async (
                 await clearChatReadStatus();
                 dispatch({ type: CLEAR_SETTINGS });
 		dispatch({ type: CLEAR_POPUP_EVENTS_HASH });
-		dispatch({ type: CLEAR_COLLECTION_DATES_LAST_UPDATED });
 		await AsyncStorage.multiRemove(['auth_data', 'persist:root']);
 
 		persistor.purge();
 		router.replace({ pathname: '/(auth)/login', params: { logout: 'true' } });
 	} catch (error) {
 		console.error('Error during logout:', error);
+	} finally {
+		dispatch({ type: CLEAR_COLLECTION_DATES_LAST_UPDATED });
 	}
 };


### PR DESCRIPTION
### Motivation
- Guarantee the collection last-update map is cleared during logout even if earlier logout steps throw, so stale `lastUpdated` data isn't kept across sessions.

### Description
- Move dispatch of `CLEAR_COLLECTION_DATES_LAST_UPDATED` into a `finally` block inside `performLogout` in `apps/frontend/app/helper/logoutHelper.ts` so it always runs on logout and remove the previous dispatch location.

### Testing
- No automated tests were executed as part of this change (manual/integration testing not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757f5ae3dc83309e53e0f38874b04b)