### PR TITLE
Use settings-based default start date in Food Offers (useFoodOffersDefaultDate -> startDate)

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -42,6 +42,7 @@ import { PriceGroupKey } from '@/app/(app)/settings/types';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import FoodOffersScrollList from '@/components/FoodOffersScrollList';
+import useFoodOffersDefaultDate from '@/hooks/useFoodOffersDefaultDate';
 
 export const SHEET_COMPONENTS = {
 	canteen: CanteenSelectionSheet,
@@ -81,6 +82,8 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { openActiveModal, activePopupEvent } = usePopupEventModal();
 	const { openFoodofferSortingModal } = useFoodofferSortingModal();
 	const smartReadableDate = useSmartReadableDateMethod();
+	const { defaultDate } = useFoodOffersDefaultDate();
+	const startDate = selectedDate || defaultDate;
 
 	// Set Page Title
 	useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);
@@ -204,7 +207,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	}, []);
 
 	const handleDateChange = (direction: 'prev' | 'next') => {
-		const currentDate = new Date(selectedDate);
+		const currentDate = new Date(startDate);
 		if (direction === 'prev') {
 			currentDate.setDate(currentDate.getDate() - 1);
 		} else {
@@ -272,21 +275,21 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
                 try {
                         setLoading(true);
                         const canteenId = selectedCanteen?.id as string;
-                        let foodOffers = getCachedOffers(canteenId, selectedDate);
+                        let foodOffers = getCachedOffers(canteenId, startDate);
 
                         if (!foodOffers) {
-                                const foodData = await fetchFoodOffersByCanteen(canteenId, selectedDate);
+                                const foodData = await fetchFoodOffersByCanteen(canteenId, startDate);
                                 foodOffers = foodData?.data || [];
                         }
 
                         setPrefetchedFoodOffers(prev => ({
                                 ...prev,
-                                [getCacheKey(canteenId, selectedDate)]: foodOffers,
+                                [getCacheKey(canteenId, startDate)]: foodOffers,
                         }));
 
 			// Prefetch next two days
 			for (let i = 1; i <= 2; i++) {
-                                const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
+                                const date = addDays(new Date(startDate), i).toISOString().split('T')[0];
                                 const cacheKey = getCacheKey(canteenId, date);
                                 if (!prefetchedFoodOffers[cacheKey]) {
                                         fetchFoodOffersByCanteen(canteenId, date)
@@ -316,7 +319,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 
 	useEffect(() => {
 		fetchFoods();
-	}, [selectedCanteen, selectedDate]);
+	}, [selectedCanteen, startDate]);
 
 	const onRefresh = useCallback(() => {
 		setRefreshing(true);
@@ -327,14 +330,14 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
         const nextAvailableDate = useMemo(() => {
                 const canteenId = selectedCanteen?.id as string;
                 for (let i = 1; i <= 2; i++) {
-                        const date = addDays(new Date(selectedDate), i).toISOString().split('T')[0];
+                        const date = addDays(new Date(startDate), i).toISOString().split('T')[0];
                         const offers = getCachedOffers(canteenId, date);
                         if (offers && offers.length > 0) {
                                 return date;
                         }
                 }
                 return null;
-        }, [prefetchedFoodOffers, selectedCanteen, selectedDate]);
+        }, [prefetchedFoodOffers, selectedCanteen, startDate]);
 
 	const getWeekdayKey = (date: string) => {
 		const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -542,7 +545,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 								>
 									<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
 										<TooltipText fontSize="$sm" color={theme.tooltip.text}>
-											{` ${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.date)}: ${selectedDate}`}
+											{` ${translate(TranslationKeys.edit)}: ${translate(TranslationKeys.date)}: ${startDate}`}
 										</TooltipText>
 									</TooltipContent>
 								</Tooltip>
@@ -567,7 +570,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 									</TooltipContent>
 								</Tooltip>
 
-								<Text style={{ ...styles.heading, color: theme.header.text }}>{selectedDate ? getDayLabel(selectedDate) : ''}</Text>
+								<Text style={{ ...styles.heading, color: theme.header.text }}>{startDate ? getDayLabel(startDate) : ''}</Text>
 							</View>
 							<View style={{ ...styles.col2, gap: 10 }}>
 								{/* ForeCast */}
@@ -577,7 +580,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 										trigger={triggerProps => (
 											<TouchableOpacity
 												{...triggerProps}
-                                                                                                onPress={() => openUtilizationModal(selectedDate, selectedCanteen)}
+                                                                                                onPress={() => openUtilizationModal(startDate, selectedCanteen)}
 												style={{
 													padding: isWeb ? (screenWidth < 500 ? 2 : 5) : 2,
 												}}
@@ -624,7 +627,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 							backgroundColor: theme.screen.background,
 						}}
 					>
-						{selectedCanteen && <FoodOffersScrollList canteenId={selectedCanteen.id} startDate={selectedDate} />}
+						{selectedCanteen && <FoodOffersScrollList canteenId={selectedCanteen.id} startDate={startDate} />}
 					</View>
 				</View>
 				{isActive &&


### PR DESCRIPTION
### Motivation
- Reinstate and surface the settings-driven default date so the Food Offers screen respects the configured next-day threshold via the `useFoodOffersDefaultDate` hook. 
- Ensure the default date is actually used as a base value across navigation, fetches, UI labels, and modal calls rather than calling the hook without using its result.

### Description
- Import `useFoodOffersDefaultDate` and destructure `defaultDate`, then introduce `startDate = selectedDate || defaultDate` to centralize the effective start date. 
- Replace usages of `selectedDate` with `startDate` for date-navigation (`handleDateChange`), data fetching (`fetchFoods` and prefetch logic), caching keys, memoized `nextAvailableDate`, and component props like `FoodOffersScrollList` and `openUtilizationModal`. 
- Update effect dependencies to watch `startDate` instead of `selectedDate` so fetch and memo hooks react to the effective start date.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769eeaac04833099f0dceab7f1113e)