### PR TITLE
Restore foreground update check in Foodoffers and revert ExpoUpdateChecker initial check

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -42,6 +42,7 @@ import { PriceGroupKey } from '@/app/(app)/settings/types';
 import useUtilizationModal from '@/hooks/useUtilizationModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import FoodOffersScrollList from '@/components/FoodOffersScrollList';
+import useAppForegroundUpdateCheckModal from '@/hooks/useAppForegroundUpdateCheckModal';
 
 export const SHEET_COMPONENTS = {
 	canteen: CanteenSelectionSheet,
@@ -81,6 +82,7 @@ const Index: React.FC<DrawerContentComponentProps> = ({ navigation }) => {
 	const { openActiveModal, activePopupEvent } = usePopupEventModal();
 	const { openFoodofferSortingModal } = useFoodofferSortingModal();
 	const smartReadableDate = useSmartReadableDateMethod();
+	useAppForegroundUpdateCheckModal();
 
 	// Set Page Title
 	useSetPageTitle(selectedCanteen?.alias || TranslationKeys.food_offers);


### PR DESCRIPTION
### Motivation
- Restore the previous behavior where the app foreground update check runs on the Foodoffers screen so users see the Expo update modal when the app returns to the foreground.
- A recent change inadvertently removed the foreground hook call from the Foodoffers screen, preventing the modal from appearing consistently.
- Revert the prior change that made `ExpoUpdateChecker` run an initial `checkForUpdates()` on mount to keep checks limited to foreground transitions.

### Description
- Re-added the update-check hook by importing and invoking `useAppForegroundUpdateCheckModal` in `apps/frontend/app/app/(app)/foodoffers/index.tsx` so the screen regains the original behavior.
- Reverted `ExpoUpdateChecker` to not perform an initial `checkForUpdates()` on mount by removing the `useCallback` wrapper for `checkForUpdates` and removing the immediate call from the `useEffect` in `apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx` so updates are checked on foreground transitions only.
- Adjusted the `useEffect` in `ExpoUpdateChecker` to run once (empty dependency array) while `checkForUpdates` still guards with `isSmartPhone()` and `isInExpoGo()`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b57893088330b7e38fda388ce88d)