### PR TITLE
Fix food card image container sizing

### DIFF
--- a/apps/frontend/app/hooks/useFoodCard.ts
+++ b/apps/frontend/app/hooks/useFoodCard.ts
@@ -31,7 +31,8 @@ export const useFoodCard = (borderWidth: number = 0, borderColor: string = '#FF0
 	};
 
 	const imageContainerStyle: ViewStyle = {
-		height: dimension,
+		width: '100%',
+		height: '100%',
 	};
 
 	const contentStyle: ViewStyle = {


### PR DESCRIPTION
### Motivation
- Ensure the image area of food cards fills the square 1:1 wrapper so images are cropped/mapped correctly on wider/tablet screens instead of leaving empty space at the bottom.

### Description
- Update `useFoodCard` to set `imageContainerStyle` to `width: '100%', height: '100%'` (replacing the previous `height: dimension`) so the image container fully fills the square wrapper used by `CardWithText`.

### Testing
- Started the frontend dev server briefly with `yarn workspace rocket-meals-dev start --web` and observed Metro/Expo logs indicating the dev server boot, but no automated tests were executed and the visual change was not fully validated in a browser session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69780cc8dae08330a8b97e944c9f931c)