### PR TITLE
Fix initial Foodoffers column count

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, FlatList, RefreshControl, Text, View } from 'react-native';
+import { ActivityIndicator, FlatList, RefreshControl, Text, View, useWindowDimensions } from 'react-native';
 import { addDays } from 'date-fns';
 import { useTheme } from '@/hooks/useTheme';
 import { useSelector } from 'react-redux';
@@ -56,19 +56,26 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
         const [selectedSheet, setSelectedSheet] = useState<'menu' | keyof typeof SHEET_COMPONENTS | null>(null);
         const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
         const bottomSheetRef = useRef<BottomSheet>(null);
-        const [listWidth, setListWidth] = useState<number | null>(null);
+	const { width: windowWidth } = useWindowDimensions();
+	const [listWidth, setListWidth] = useState<number | null>(windowWidth || null);
         const MIN_CARD_WIDTH = 280;
 	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
         const foods_area_color = appSettings?.foods_area_color || primaryColor;
         const contrastColor = useMyContrastColor(theme.screen.background, theme, mode === 'dark');
 	const smartReadableDate = useSmartReadableDateMethod();
-        const openSheet = useCallback(
-                (sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
-                        setSelectedSheet(sheet);
-                        setSheetProps(props);
-                },
-                []
-        );
+	const openSheet = useCallback(
+			(sheet: 'menu' | keyof typeof SHEET_COMPONENTS, props = {}) => {
+				setSelectedSheet(sheet);
+				setSheetProps(props);
+			},
+			[]
+	);
+
+	useEffect(() => {
+		if (!listWidth && windowWidth) {
+			setListWidth(windowWidth);
+		}
+	}, [listWidth, windowWidth]);
 
 	const closeSheet = useCallback(() => {
 		bottomSheetRef.current?.snapToIndex(-1);


### PR DESCRIPTION
### Motivation
- The FoodOffers screen briefly rendered a single-column layout before the actual width was measured, causing a visual flash; the change ensures the correct column count is used immediately.

### Description
- Initialize `listWidth` from `useWindowDimensions()` and add an effect to keep `listWidth` in sync with `windowWidth` until the component's `onLayout` measurement runs so `numColumns` (computed against `MIN_CARD_WIDTH`) is correct on first render.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a103b6dc83308d3247868697aba6)