### PR TITLE
Fix backend-sync Docker CLI install on non-amd64

### DIFF
--- a/apps/backend-sync/Dockerfile
+++ b/apps/backend-sync/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:22-bookworm
 
 # Install cron, basic tools and Docker CLI
-RUN apt-get update && apt-get install -y git curl
-# Install Docker CLI
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bookworm stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN apt-get update && apt-get install -y docker-ce-cli
+RUN apt-get update \
+    && apt-get install -y git curl gpg \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
 
 ## Install openssl and xxd for Apple Token generation
 RUN apt-get install -y openssl xxd


### PR DESCRIPTION
### Motivation
- The Docker apt source in the backend-sync image was hardcoded to `amd64`, which caused `docker-ce-cli` to be unavailable on non-amd64 builds and led to failed image builds.
- Consolidating `apt` steps and cleaning apt lists improves install reliability and reduces image layer churn.

### Description
- Updated `apps/backend-sync/Dockerfile` to use `$(dpkg --print-architecture)` when writing the Docker apt source instead of hardcoding `amd64`.
- Combined `apt-get` steps and installed `gpg` in the same RUN layer while piping the Docker GPG key to `/usr/share/keyrings/docker-archive-keyring.gpg`.
- Added `rm -rf /var/lib/apt/lists/*` to remove apt caches after installation.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd3631754833085c8a9c42111d144)