### PR TITLE
Improve Docker CLI install fallback and consolidate tooling in backend-sync Dockerfile

### DIFF
--- a/apps/backend-sync/Dockerfile
+++ b/apps/backend-sync/Dockerfile
@@ -1,16 +1,18 @@
 FROM node:22-bookworm
 
 # Install cron, basic tools and Docker CLI
-RUN apt-get update \
-    && apt-get install -y git curl gpg \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli \
-    && rm -rf /var/lib/apt/lists/*
-
-## Install openssl and xxd for Apple Token generation
-RUN apt-get install -y openssl xxd
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y git curl gpg openssl xxd; \
+    arch="$(dpkg --print-architecture)"; \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg; \
+    echo "deb [arch=${arch} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list; \
+    apt-get update; \
+    if ! apt-get install -y docker-ce-cli; then \
+      echo "docker-ce-cli unavailable for ${arch}, falling back to docker.io"; \
+      apt-get install -y docker.io; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
 
 # Install yarn
 RUN corepack enable && corepack prepare yarn@stable --activate


### PR DESCRIPTION
### Motivation

- The backend-sync image build failed when `docker-ce-cli` was not available for the target architecture (e.g., Raspberry Pi), so a resilient fallback was needed.  
- Reduce image layer churn by consolidating related package installs and ensuring necessary tools (`openssl`, `xxd`) are present for Apple token generation.  
- Make the Dockerfile more robust and verbose (`set -eux`) and ensure apt lists are cleaned up after installation.

### Description

- Replaced multiple `RUN` steps with a single `RUN set -eux; ...` block to make the install sequence atomic and fail-fast.  
- Install `git`, `curl`, `gpg`, `openssl`, and `xxd` together with `apt-get install -y` to remove the separate `openssl/xxd` step.  
- Detect the image architecture with `dpkg --print-architecture`, add Docker's apt repo key and source list for that arch, then attempt to install `docker-ce-cli` and fall back to installing `docker.io` if `docker-ce-cli` is unavailable.  
- Remove apt lists at the end of the RUN to keep the image smaller (`rm -rf /var/lib/apt/lists/*`).

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd4982f94833084e7a33057b2fdfc)