### PR TITLE
Replace FoodItem megaphone icon with info icon

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -4,7 +4,7 @@ import MyImage from '@/components/MyImage';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import { useTheme } from '@/hooks/useTheme';
-import {AntDesign, Entypo, MaterialCommunityIcons, MaterialIcons} from '@expo/vector-icons';
+import {AntDesign, MaterialCommunityIcons, MaterialIcons} from '@expo/vector-icons';
 import { FoodItemProps } from './types';
 import { excerpt, getImageUrl, getpreviousFeedback, showFormatedPrice, showPrice } from '@/constants/HelperFunctions';
 import {getDescriptionFromTranslation, getTextFromTranslation} from '@/helper/resourceHelper';
@@ -294,7 +294,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                         style={[styles.favContainer, { backgroundColor: foods_area_color }]}
                         onPress={handleDescriptionModal}
                       >
-                        <Entypo name="megaphone" size={20} color={contrastColor} />
+                        <MaterialIcons name="info-outline" size={20} color={contrastColor} />
                       </TouchableOpacity>
                     )}
                   </View>


### PR DESCRIPTION
### Motivation
- The FoodItem card used a megaphone icon for showing the description; this replaces it with the requested “i” info icon to match the design intent.

### Description
- Updated `apps/frontend/app/components/FoodItem/FoodItem.tsx` to remove the unused `Entypo` import and use `MaterialIcons` `info-outline` instead of `Entypo` `megaphone` for the description action.

### Testing
- Ran the automated checks: attempted `yarn eslint apps/frontend/app/components/FoodItem/FoodItem.tsx`, which failed in this environment due to a missing `eslint-plugin-react`, and attempted to start the frontend with `yarn workspace rocket-meals-dev start --web --port 19006`, which failed due to an `ENOSPC` file-watcher limit so the visual validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956fef3c8c8330924348ab81fa3856)