### PR TITLE
Replace FoodItem info icon with Entypo info-with-circle

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -4,7 +4,7 @@ import MyImage from '@/components/MyImage';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import { useTheme } from '@/hooks/useTheme';
-import {AntDesign, MaterialCommunityIcons, MaterialIcons} from '@expo/vector-icons';
+import {AntDesign, Entypo, MaterialCommunityIcons, MaterialIcons} from '@expo/vector-icons';
 import { FoodItemProps } from './types';
 import { excerpt, getImageUrl, getpreviousFeedback, showFormatedPrice, showPrice } from '@/constants/HelperFunctions';
 import {getDescriptionFromTranslation, getTextFromTranslation} from '@/helper/resourceHelper';
@@ -294,7 +294,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                         style={[styles.favContainer, { backgroundColor: foods_area_color }]}
                         onPress={handleDescriptionModal}
                       >
-                        <MaterialIcons name="info-outline" size={20} color={contrastColor} />
+                        <Entypo name="info-with-circle" size={18} color={contrastColor} />
                       </TouchableOpacity>
                     )}
                   </View>


### PR DESCRIPTION
### Motivation
- Improve the visual appearance of the info icon on the `FoodItem` card by using the `Entypo` `info-with-circle` glyph instead of the current `MaterialIcons` `info-outline`.

### Description
- Imported `Entypo` from `@expo/vector-icons` and replaced the `MaterialIcons` usage with `<Entypo name="info-with-circle" size={18} color={contrastColor} />` in `apps/frontend/app/components/FoodItem/FoodItem.tsx`.

### Testing
- Ran `yarn eslint apps/frontend/app/components/FoodItem/FoodItem.tsx --max-warnings=0`, which failed due to a missing local dev plugin (`eslint-plugin-react`).
- Attempted a Playwright screenshot of the running frontend at `http://localhost:8081`, which failed because no local frontend server responded (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bc9b260c8330a107b0a9ec94bbe0)