### PR TITLE
Change FoodItem info icon to plain info

### DIFF
--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -294,7 +294,7 @@ const FoodItem: React.FC<FoodItemProps> = memo(
                         style={[styles.favContainer, { backgroundColor: foods_area_color }]}
                         onPress={handleDescriptionModal}
                       >
-                        <Entypo name="info-with-circle" size={18} color={contrastColor} />
+                        <Entypo name="info" size={18} color={contrastColor} />
                       </TouchableOpacity>
                     )}
                   </View>


### PR DESCRIPTION
### Motivation
- Replace the circular info icon with the plain info icon for the `FoodItem` card to match the requested UI change.

### Description
- Updated the Entypo icon in `apps/frontend/app/components/FoodItem/FoodItem.tsx` by changing `name="info-with-circle"` to `name="info"`.

### Testing
- Ran `rg -n "info-with-circle|name=\"info\"" apps/frontend/app/components/FoodItem/FoodItem.tsx` which confirmed the new `name="info"` occurrence was present; this succeeded.
- Ran `yarn prettier --check apps/frontend/app/components/FoodItem/FoodItem.tsx` which failed in this environment due to missing `node_modules` / Yarn state.
- Attempted a Playwright screenshot of the running frontend at `http://localhost:3000`, which failed because no local frontend server responded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995dc92c924833095680e63466e2921)