### PR TITLE
Remove RateAppSettingsItem barrel export and switch to direct imports

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx
@@ -5,7 +5,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import styles from './styles';
-import RateAppSettingsItem from '@/components/RateAppSettingsItem/RateAppSettingsItem';
+import { RateAppSettingsItem } from '@/components/RateAppSettingsItem/RateAppSettingsItem';
 
 const RateApp = () => {
 	useSetPageTitle(TranslationKeys.rate_app);

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -26,7 +26,7 @@ import AIGeneratedHintSheet from '../AIGeneratedHintSheet';
 import useRatingPermissionModal from '@/hooks/useRatingPermissionModal';
 import { useMyContrastColor } from '@/helper/ColorHelper';
 import MyMarkdown from '@/components/MyMarkdown/MyMarkdown';
-import RateAppSettingsItem from '@/components/RateAppSettingsItem/RateAppSettingsItem';
+import { RateAppSettingsItem } from '@/components/RateAppSettingsItem/RateAppSettingsItem';
 
 
 const selectFoodState = (state: RootState) => state.food;

--- a/apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx
+++ b/apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx
@@ -13,7 +13,7 @@ type RateAppSettingsItemProps = {
 	onLog?: (message: string) => void;
 };
 
-const RateAppSettingsItem: React.FC<RateAppSettingsItemProps> = ({ groupPosition = 'single', showSeparator = false, onLog }) => {
+export const RateAppSettingsItem: React.FC<RateAppSettingsItemProps> = ({ groupPosition = 'single', showSeparator = false, onLog }) => {
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
 
@@ -44,5 +44,3 @@ const RateAppSettingsItem: React.FC<RateAppSettingsItemProps> = ({ groupPosition
 		/>
 	);
 };
-
-export default RateAppSettingsItem;


### PR DESCRIPTION
### Motivation
- Remove the unnecessary barrel `index.ts` for `RateAppSettingsItem` and use direct imports to satisfy the code review request and simplify module resolution. 

### Description
- Deleted `apps/frontend/app/components/RateAppSettingsItem/index.ts` and updated imports to reference `apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx` directly. 
- Updated the experimental rate screen at `apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx` to use `<RateAppSettingsItem onLog={addLog} />` instead of the old `TouchableOpacity`. 
- Embedded the `RateAppSettingsItem` in the FoodItem info modal by importing `RateAppSettingsItem` at `apps/frontend/app/components/FoodItem/FoodItem.tsx` and rendering it under the description. 
- Added the new component implementation at `apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx`, which renders a `SettingsList` row, calls `expo-store-review`, and accepts an optional `onLog` callback. 

### Testing
- Ran `yarn eslint apps/frontend/app/app/(app)/experimentell/rate-app/index.tsx apps/frontend/app/components/FoodItem/FoodItem.tsx apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx`, which could not complete in this environment because `node_modules` / install state is missing, so linting could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998459ed90083309517dc5f34cc01b4)