### PR TITLE
RateAppSettingsItem: left star icon with yellow background and persisted rated state

### DIFF
--- a/apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx
+++ b/apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx
@@ -1,11 +1,17 @@
-import React, { useCallback } from 'react';
-import { MaterialIcons } from '@expo/vector-icons';
+import React, { useCallback, useEffect, useState } from 'react';
+import { MaterialIcons, Octicons } from '@expo/vector-icons';
 import * as StoreReview from 'expo-store-review';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSelector } from 'react-redux';
 
 import SettingsList from '@/components/SettingsList/SettingsList';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
 import { TranslationKeys } from '@/locales/keys';
+import { RootState } from '@/redux/reducer';
+
+const RATED_APP_STORAGE_KEY = 'rate_app_review_completed';
+const RATE_APP_ICON_BACKGROUND = '#F7D21F';
 
 type RateAppSettingsItemProps = {
 	groupPosition?: 'top' | 'middle' | 'bottom' | 'single';
@@ -16,8 +22,28 @@ type RateAppSettingsItemProps = {
 export const RateAppSettingsItem: React.FC<RateAppSettingsItemProps> = ({ groupPosition = 'single', showSeparator = false, onLog }) => {
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
+	const { primaryColor } = useSelector((state: RootState) => state.settings);
+	const [alreadyRated, setAlreadyRated] = useState(false);
+
+	useEffect(() => {
+		const loadRatedState = async () => {
+			try {
+				const storedRatedState = await AsyncStorage.getItem(RATED_APP_STORAGE_KEY);
+				setAlreadyRated(storedRatedState === 'true');
+				onLog?.(`Already rated: ${storedRatedState === 'true'}`);
+			} catch (error: any) {
+				onLog?.(`Read error: ${error?.message || error}`);
+			}
+		};
+
+		loadRatedState();
+	}, [onLog]);
 
 	const handleRate = useCallback(async () => {
+		if (alreadyRated) {
+			return;
+		}
+
 		try {
 			onLog?.('Checking availability');
 			const available = await StoreReview.isAvailableAsync();
@@ -25,22 +51,26 @@ export const RateAppSettingsItem: React.FC<RateAppSettingsItemProps> = ({ groupP
 
 			if (available) {
 				await StoreReview.requestReview();
+				await AsyncStorage.setItem(RATED_APP_STORAGE_KEY, 'true');
+				setAlreadyRated(true);
 				onLog?.('Review requested');
 			}
 		} catch (error: any) {
 			onLog?.(`Error: ${error?.message || error}`);
 			console.log('Error requesting review', error);
 		}
-	}, [onLog]);
+	}, [alreadyRated, onLog]);
 
 	return (
 		<SettingsList
 			label={translate(TranslationKeys.rate_app)}
-			handleFunction={handleRate}
+			handleFunction={alreadyRated ? undefined : handleRate}
 			groupPosition={groupPosition}
 			showSeparator={showSeparator}
-			noIconIndent
-			rightIcon={<MaterialIcons name="star" size={22} color={theme.screen.icon} />}
+			iconBgColor={RATE_APP_ICON_BACKGROUND}
+			leftIcon={<MaterialIcons name="star" size={22} color={primaryColor} />}
+			value={alreadyRated ? 'Dankeschön' : undefined}
+			rightIcon={alreadyRated ? undefined : <Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
 		/>
 	);
 };


### PR DESCRIPTION
### Motivation
- Der Stern soll wie in anderen `SettingsList`-Einträgen als linkes Icon mit projektspezifischer Sternfarbe und gelbem Icon-Hintergrund angezeigt werden. 
- Die Komponente soll prüfen, ob der Nutzer die App bereits bewertet hat, und das UI entsprechend (keine Aktion + „Dankeschön“) anpassen und den Zustand persistieren.

### Description
- Verschoben: der Stern wird nun als `leftIcon` gerendert und erhält `iconBgColor` `#F7D21F`, während die Sternfarbe aus der Projektfarbe (`primaryColor`) kommt. 
- Neu: Imports für `AsyncStorage`, `Octicons` und `useSelector` sowie Konstanten `RATED_APP_STORAGE_KEY` und `RATE_APP_ICON_BACKGROUND` wurden hinzugefügt. 
- Verhalten: Beim Rendern liest ein `useEffect` den Persistenz-Flag `rate_app_review_completed` aus `AsyncStorage` und setzt `alreadyRated`; bei `alreadyRated` ist `handleFunction` deaktiviert, rechts wird `value` auf `Dankeschön` gesetzt und der Chevron ausgeblendet. 
- Persistenz: Nach erfolgreichem `StoreReview.requestReview()` wird der Flag in `AsyncStorage` gesetzt und `alreadyRated` im State aktualisiert. 

### Testing
- Lint: `npx eslint apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx` wurde ausgeführt und schlug fehl wegen fehlender Umgebung (`eslint-plugin-react` nicht installiert). 
- UI snapshot: Versuch mit Playwright ein Screenshot zu erstellen schlug fehl, da kein App-Server unter `http://127.0.0.1:8081` erreichbar war (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986277fddc83309ca82e19456021f7)