### PR TITLE
Use localized `rate_app` label in RateAppSettingsItem

### DIFF
--- a/apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx
+++ b/apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx
@@ -45,10 +45,10 @@ export const RateAppSettingsItem: React.FC<RateAppSettingsItemProps> = ({ groupP
 
 	const rows = useMemo(
 		() => [
-			{ key: 'ios', store: 'ios' as const, label: 'App Store (iOS)', url: iosStoreUrl, icon: STORE_ICON_BY_TARGET.ios },
-			{ key: 'android', store: 'android' as const, label: 'Google Play (Android)', url: androidStoreUrl, icon: STORE_ICON_BY_TARGET.android },
+			{ key: 'ios', store: 'ios' as const, label: translate(TranslationKeys.rate_app), url: iosStoreUrl, icon: STORE_ICON_BY_TARGET.ios },
+			{ key: 'android', store: 'android' as const, label: translate(TranslationKeys.rate_app), url: androidStoreUrl, icon: STORE_ICON_BY_TARGET.android },
 		],
-		[androidStoreUrl, iosStoreUrl]
+		[androidStoreUrl, iosStoreUrl, translate]
 	);
 
 	if (isWeb) {


### PR DESCRIPTION
### Motivation
- Show a generic, localized label (e.g. “App bewerten”) in the FoodItem description modal instead of platform-specific strings so the wording matches translations and language changes.

### Description
- In `apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx` replace the platform-specific labels with `translate(TranslationKeys.rate_app)` for both iOS and Android rows and add `translate` to the `useMemo` dependency list.

### Testing
- Ran lint via `yarn exec eslint apps/frontend/app/components/RateAppSettingsItem/RateAppSettingsItem.tsx`, which failed due to a missing `eslint-plugin-react` in the environment; no lint errors from the change itself were produced.
- Attempted a Playwright screenshot against `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because no local dev server was running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa5b2b6cc83309da0abc23be120a2)