### PR TITLE
feat: Account-Required-Guards für Freunde, Friendships-Clear beim Logout, Settings-Umstrukturierung

### DIFF
--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -39,6 +39,7 @@ import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewMo
 import useToast from '@/hooks/useToast';
 import { useLanguageModal } from '@/hooks/useLanguageModal';
 import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
+import useAccountRequiredModal from '@/hooks/useAccountRequiredModal';
 import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 import useCustomerConfig from '@/hooks/useCustomerConfig';
 import useCustomerConfigModal from '@/hooks/useCustomerConfigModal';
@@ -72,6 +73,7 @@ const Settings = () => {
         const isOpeningNestedCollectibleModal = useRef(false);
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { openConfirmLogoutModal } = useConfirmLogoutModal();
+        const { openAccountRequiredModal } = useAccountRequiredModal();
         const { manualCheck } = useExpoUpdateChecker();
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useAppSelector((state) => state.authReducer);
         const isRegisteredUser = UserHelper.isRegisteredUser(user);
@@ -493,12 +495,12 @@ const Settings = () => {
 		const sectionStyle = { gap: 10 } as const;
 		const groupStyle = { gap: 0 } as const;
 
-		// === Account & Personalization ===
+		// === Personalization ===
 		rows.push({
 			key: 'section-account',
 			element: (
 				<View style={sectionStyle}>
-					<SettingsGroupTitle>{translate(TranslationKeys.group_account_personalization)}</SettingsGroupTitle>
+					<SettingsGroupTitle>{translate(TranslationKeys.group_personalization)}</SettingsGroupTitle>
 					<View style={groupStyle}>
 						{isRegisteredUser && (
 							<SettingsList
@@ -530,7 +532,6 @@ const Settings = () => {
 							handleFunction={openNicknameSheet}
 							groupPosition={isRegisteredUser ? 'middle' : 'top'}
 						/>
-						<SettingsList iconBgColor={primaryColor} leftIcon={<Ionicons name="language" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.language)} value={languageName} rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />} handleFunction={() => openLanguageModal()} groupPosition={showFriendsInSettings ? 'middle' : 'bottom'} nativeID={ComponentIds.SETTINGS_LANGUAGE} />
 						{showFriendsInSettings && (
 							<SettingsList
 								iconBgColor={primaryColor}
@@ -538,10 +539,11 @@ const Settings = () => {
 								label={translate(TranslationKeys.friendships)}
 								value={String(acceptedFriendsCount)}
 								rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
-								handleFunction={openFriendsModal}
-								groupPosition="bottom"
+								handleFunction={isRegisteredUser ? openFriendsModal : openAccountRequiredModal}
+								groupPosition="middle"
 							/>
 						)}
+						<SettingsList iconBgColor={primaryColor} leftIcon={<Ionicons name="language" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.language)} value={languageName} rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />} handleFunction={() => openLanguageModal()} groupPosition="bottom" nativeID={ComponentIds.SETTINGS_LANGUAGE} />
 					</View>
 				</View>
 			),
@@ -704,25 +706,21 @@ const Settings = () => {
 			),
 		});
 
-		// === Account Actions (Logout / Delete) ===
+		// === Account (Login/Logout, Delete) ===
 		rows.push({
-			key: 'section-account-logout',
+			key: 'section-account-actions',
 			element: (
-				<View style={groupStyle}>
-					<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={logoutButtonLabel} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={logoutButtonHandler} groupPosition="single" />
+				<View style={sectionStyle}>
+					<SettingsGroupTitle>{translate(TranslationKeys.group_account)}</SettingsGroupTitle>
+					<View style={groupStyle}>
+						<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} label={logoutButtonLabel} rightIcon={<Entypo name="login" size={24} color={theme.screen.icon} />} handleFunction={logoutButtonHandler} groupPosition={isRegisteredUser ? 'top' : 'single'} />
+						{isRegisteredUser && (
+							<SettingsList iconBgColor={primaryColor} leftIcon={<AntDesign name="user-delete" size={22} color={theme.screen.icon} />} label={`${translate(TranslationKeys.account_delete)}`} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={handleDeleteAccount} groupPosition="bottom" />
+						)}
+					</View>
 				</View>
 			),
 		});
-		if (isRegisteredUser) {
-			rows.push({
-				key: 'section-account-delete',
-				element: (
-					<View style={groupStyle}>
-						<SettingsList iconBgColor={primaryColor} leftIcon={<AntDesign name="user-delete" size={22} color={theme.screen.icon} />} label={`${translate(TranslationKeys.account_delete)}`} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={handleDeleteAccount} groupPosition="single" />
-					</View>
-				),
-			});
-		}
 
 		// === Footer ===
 		rows.push({
@@ -866,7 +864,7 @@ const Settings = () => {
 		serverInfo, selectedCustomerDisplayName, foodOffersNextDayThreshold, useWebpForAssets,
 		debugMode, simulateExpoUpdateAvailable, openServerSheet, openFoodOffersTimeSheet,
 		toggleWebpForAssets, toggleDebugMode, toggleSimulateExpoUpdate, osmVectorMapStyleKey, osmConsent,
-		acceptedFriendsCount, showFriendsInSettings, canteenVisitsVisibilityLabel, openCanteenVisitsVisibilityModal, openFriendsModal,
+		acceptedFriendsCount, showFriendsInSettings, canteenVisitsVisibilityLabel, openCanteenVisitsVisibilityModal, openFriendsModal, openAccountRequiredModal,
 		appRatingScore, openAppRatingScoreSheet, showDebugRatingModal, appRatingData,
 		settingsAvatarConfig, openAvatarEditor,
 		appSettings?.foods_ratings_average_display,

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -539,7 +539,9 @@ const Settings = () => {
 								label={translate(TranslationKeys.friendships)}
 								value={String(acceptedFriendsCount)}
 								rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
-								handleFunction={isRegisteredUser ? openFriendsModal : openAccountRequiredModal}
+								handleFunction={openFriendsModal}
+								isAccountRequired={!isRegisteredUser}
+								onAccountRequired={openAccountRequiredModal}
 								groupPosition="middle"
 							/>
 						)}

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -541,6 +541,7 @@ const Settings = () => {
 								rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />}
 								handleFunction={openFriendsModal}
 								isAccountRequired={!isRegisteredUser}
+								accountRequiredGroupPosition="single"
 								onAccountRequired={openAccountRequiredModal}
 								groupPosition="middle"
 							/>

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -22,6 +22,8 @@ import { CameraView, useCameraPermissions } from 'expo-camera';
 import * as Clipboard from 'expo-clipboard';
 import { MyAvatar, AvatarSize } from 'repo-depkit-common-ui';
 import { useAvatarProfileEditor, AVATAR_BACKGROUND, AVATAR_SETTINGS_ROW_SIZE, parseProfileAvatar } from '@/hooks/useAvatarProfileEditor';
+import { UserHelper } from '@/helper/UserHelper';
+import useAccountRequiredModal from '@/hooks/useAccountRequiredModal';
 
 const isWeb = Platform.OS === 'web';
 
@@ -424,9 +426,13 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 	const showToast = useToast();
 	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 
-	const { profile } = useAppSelector((state) => state.authReducer);
+	const { profile, user } = useAppSelector((state) => state.authReducer);
 	const { primaryColor } = useAppSelector((state) => state.settings);
 	const { friendships } = useAppSelector((state) => state.friendships);
+	// Anonymous sessions have no server profile, so none of the friendship actions can work -
+	// they get the account-required modal instead (same pattern as rating in the food details).
+	const isAnonymousUser = UserHelper.isAnonymousUser(user);
+	const { openAccountRequiredModal } = useAccountRequiredModal();
 
 	const { avatarConfig: ownAvatarConfig, openEditor: openAvatarEditor } = useAvatarProfileEditor();
 
@@ -486,6 +492,10 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 	}, [reloadFriendships]);
 
 	const handleGenerateQR = useCallback(() => {
+		if (isAnonymousUser) {
+			openAccountRequiredModal();
+			return;
+		}
 		if (!profile?.id) return;
 		showScrollViewModal({
 			title: translate(TranslationKeys.friendships_generate_qr),
@@ -506,9 +516,13 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 				/>
 			),
 		});
-	}, [profile?.id, friendshipsHelper, dispatch, showScrollViewModal, closeScrollViewModal, translate]);
+	}, [profile?.id, isAnonymousUser, openAccountRequiredModal, friendshipsHelper, dispatch, showScrollViewModal, closeScrollViewModal, translate]);
 
 	const openScanModal = useCallback((noCamera: boolean) => {
+		if (isAnonymousUser) {
+			openAccountRequiredModal();
+			return;
+		}
 		showScrollViewModal({
 			title: noCamera ? translate(TranslationKeys.friendships_add_manual) : translate(TranslationKeys.friendships_scan_qr),
 			children: (
@@ -532,7 +546,7 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 				/>
 			),
 		});
-	}, [profile?.id, friendshipsHelper, friendships, dispatch, showScrollViewModal, closeScrollViewModal, translate, showToast, getProfileIdFromField, isAlreadyFriendsWith]);
+	}, [profile?.id, isAnonymousUser, openAccountRequiredModal, friendshipsHelper, friendships, dispatch, showScrollViewModal, closeScrollViewModal, translate, showToast, getProfileIdFromField, isAlreadyFriendsWith]);
 
 	const handleScanQR = useCallback(() => {
 		openScanModal(false);
@@ -732,7 +746,7 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 					}
 					value={translate(TranslationKeys.avatar_appearance)}
 					rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}
-					handleFunction={() => openAvatarEditor(false)}
+					handleFunction={isAnonymousUser ? openAccountRequiredModal : () => openAvatarEditor(false)}
 					groupPosition="top"
 				/>
 				<SettingsList

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -746,7 +746,9 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 					}
 					value={translate(TranslationKeys.avatar_appearance)}
 					rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}
-					handleFunction={isAnonymousUser ? openAccountRequiredModal : () => openAvatarEditor(false)}
+					handleFunction={() => openAvatarEditor(false)}
+					isAccountRequired={isAnonymousUser}
+					onAccountRequired={openAccountRequiredModal}
 					groupPosition="top"
 				/>
 				<SettingsList
@@ -768,6 +770,8 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 					label={translate(TranslationKeys.friendships_generate_qr)}
 					rightIcon={<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />}
 					handleFunction={handleGenerateQR}
+					isAccountRequired={isAnonymousUser}
+					onAccountRequired={openAccountRequiredModal}
 					groupPosition="top"
 				/>
 				<SettingsList
@@ -776,6 +780,8 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 					label={translate(TranslationKeys.friendships_scan_qr)}
 					rightIcon={<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />}
 					handleFunction={handleScanQR}
+					isAccountRequired={isAnonymousUser}
+					onAccountRequired={openAccountRequiredModal}
 					groupPosition="middle"
 				/>
 				<SettingsList
@@ -784,6 +790,8 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 					label={translate(TranslationKeys.friendships_add_manual)}
 					rightIcon={<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />}
 					handleFunction={handleManualAdd}
+					isAccountRequired={isAnonymousUser}
+					onAccountRequired={openAccountRequiredModal}
 					groupPosition="bottom"
 				/>
 

--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -9,6 +9,7 @@ import {
 	CLEAR_COLLECTIBLE_EVENTS,
 	CLEAR_DEVELOPER_MODE,
 	CLEAR_FOODS,
+	CLEAR_FRIENDSHIPS,
 	CLEAR_MANAGEMENT,
 	CLEAR_NEWS,
 	CLEAR_POPUP_EVENTS_HASH,
@@ -43,6 +44,7 @@ export const performLogout = async (
                 dispatch({ type: CLEAR_NEWS });
                 dispatch({ type: CLEAR_COLLECTIBLE_EVENTS });
                 dispatch({ type: CLEAR_PROFILE });
+                dispatch({ type: CLEAR_FRIENDSHIPS });
                 dispatch({ type: CLEAR_CHATS });
                 await clearChatReadStatus();
                 dispatch({ type: CLEAR_SETTINGS });

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -625,6 +625,8 @@ export enum TranslationKeys {
 	Nov = 'Nov',
 	Dec = 'Dec',
 	group_account_personalization = 'group_account_personalization',
+	group_personalization = 'group_personalization',
+	group_account = 'group_account',
 	group_canteen_usage = 'group_canteen_usage',
 	group_app_settings = 'group_app_settings',
 	pull_down_to_close = 'pull_down_to_close',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -5877,6 +5877,26 @@
     "tr": "Hesap ve kişiselleştirme",
     "zh": "账户和个性化"
   },
+  "group_personalization": {
+    "de": "Personalisierung",
+    "en": "Personalization",
+    "ar": "التخصيص",
+    "es": "Personalización",
+    "fr": "Personnalisation",
+    "ru": "Персонализация",
+    "tr": "Kişiselleştirme",
+    "zh": "个性化"
+  },
+  "group_account": {
+    "de": "Konto",
+    "en": "Account",
+    "ar": "الحساب",
+    "es": "Cuenta",
+    "fr": "Compte",
+    "ru": "Аккаунт",
+    "tr": "Hesap",
+    "zh": "账户"
+  },
   "group_canteen_usage": {
     "de": "Mensa & Nutzung",
     "en": "Canteen & Usage",

--- a/packages/common-ui/src/components/SettingsList/SettingsList.tsx
+++ b/packages/common-ui/src/components/SettingsList/SettingsList.tsx
@@ -32,6 +32,7 @@ const SettingsList: React.FC<SettingsListProps> = ({
 	italic = false,
 	titleNumberOfLines = 0,
 	isAccountRequired = false,
+	accountRequiredGroupPosition,
 	onAccountRequired,
 	nativeID,
 }) => {
@@ -120,8 +121,9 @@ const SettingsList: React.FC<SettingsListProps> = ({
 
 	const separator = showSeparator ? <View style={[styles.separator, { backgroundColor: theme.screen.background, marginLeft: noIconIndent ? 0 : 54 }]} /> : null;
 
+	const accountRequiredPosition = accountRequiredGroupPosition ?? groupPosition;
 	const accountRequiredBorderStyle: ViewStyle =
-		groupPosition === 'middle' || groupPosition === 'bottom'
+		accountRequiredPosition === 'middle' || accountRequiredPosition === 'bottom'
 			? { borderLeftWidth: 2, borderRightWidth: 2, borderBottomWidth: 2 }
 			: { borderWidth: 2 };
 

--- a/packages/common-ui/src/components/SettingsList/types.ts
+++ b/packages/common-ui/src/components/SettingsList/types.ts
@@ -72,6 +72,15 @@ type SettingsListPropsOwn = SettingsListItemBaseProps & {
 	 */
 	isAccountRequired?: boolean;
 	/**
+	 * Group position used for the account-required dashed border. Defaults to
+	 * `groupPosition`, where 'middle'/'bottom' rows skip the top border line on
+	 * the assumption that the row above is part of the same locked block and
+	 * already draws it. A locked row whose neighbours are NOT account-required
+	 * (e.g. a single locked row in the middle of a normal group) should pass
+	 * 'single' so its outline is fully closed.
+	 */
+	accountRequiredGroupPosition?: 'top' | 'middle' | 'bottom' | 'single';
+	/**
 	 * The primary/accent color used as the default icon background. Falls
 	 * back to the theme's primary color when omitted.
 	 */


### PR DESCRIPTION
## Summary

### Account-Required für anonyme Nutzer
- **Settings → Freundschaften**: öffnet für anonyme Nutzer jetzt das Account-Required-Modal statt des Friends-Modals — gleiches Muster wie das Bewerten im FoodOffer-Details-Modal (dort war der Guard bereits vorhanden; ebenso bei Kommentaren und Feedback-Labels — geprüft, keine Änderung nötig).
- **Innerhalb von FriendsContent**: alle serverbasierten Aktionen (Avatar-Editor, QR generieren, QR scannen, manuell hinzufügen) zeigen für anonyme Sitzungen das Account-Required-Modal, statt vorher stillschweigend nichts zu tun (`if (!profile?.id) return`).

### Logout
- `performLogout` dispatcht jetzt `CLEAR_FRIENDSHIPS` — bisher überlebte die Freundschaftsliste den Logout und erschien in der nächsten Session wieder. (Die Action existierte bereits im Reducer, wurde nur nie dispatcht.)

### Settings-Umstrukturierung
- **Sprache** ist jetzt der letzte Punkt der oberen Gruppe (nach Freundschaften).
- Obere Gruppe umbenannt: **„Konto & Personalisierung" → „Personalisierung"** (neuer Key `group_personalization`), da sie nur noch Avatar/Spitzname/Freundschaften/Sprache enthält.
- **Abmelden/Anmelden + Konto löschen** haben jetzt eine eigene Gruppen-Überschrift **„Konto"** (neuer Key `group_account`) statt titellos unter App-Verwaltung zu hängen; beide Zeilen bilden eine zusammenhängende Gruppe (top/bottom).
- Beide neuen Übersetzungsschlüssel in allen 8 Sprachen ergänzt.

## Test plan
- [x] Im Browser verifiziert (anonyme Kiosk-Session): Gruppenreihenfolge und Überschriften korrekt („Personalisierung" mit Sprache als letztem Punkt; „Konto" mit Anmelden-Zeile)
- [x] Tap auf „Freundschaften" als anonymer Nutzer → „Zugriff eingeschränkt"-Modal mit „Anmelden / Account erstellen"
- [x] `yarn tsc --noEmit` — keine neuen Fehler gegenüber Baseline
- [ ] Manuell: als registrierter Nutzer mit Freundschaften abmelden → Freundschaftsliste ist nach erneutem (anonymen) Start leer
- [ ] Manuell: als registrierter Nutzer öffnet „Freundschaften" weiterhin das Friends-Modal, „Konto löschen" erscheint unter „Konto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)