### PR TITLE
chore: Auslastung-Prognose aus Foodoffers-Optionsmodal entfernen

### DIFF
--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -26,7 +26,6 @@ import AIGeneratedHintSheet from '@/components/AIGeneratedHintSheet';
 import useChatUnreadStatus from '@/hooks/useChatUnreadStatus';
 
 import usePopupEventModal from '@/hooks/usePopupEventModal';
-import useUtilizationModal from '@/hooks/useUtilizationModal';
 import useFoodofferSortingModal from '@/hooks/useFoodofferSortingModal';
 import FoodOffersScrollList from '@/components/FoodOffersScrollList';
 import useAppForegroundUpdateCheckModal from '@/hooks/useAppForegroundUpdateCheckModal';
@@ -70,7 +69,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 	useFoodOffersDefaultDate();
 	const kioskMode = useKioskMode();
 	const { hasUnreadChats } = useChatUnreadStatus();
-	const { openUtilizationModal } = useUtilizationModal();
 	const { openActiveModal, activePopupEvent } = usePopupEventModal();
 	const { openFoodofferSortingModal } = useFoodofferSortingModal();
 	useAppForegroundUpdateCheckModal();
@@ -108,10 +106,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 	const { openPriceGroupSettingsModal } = useMyScrollviewModalPriceGroupSettings();
 	const router = useRouter();
 
-	const handleOpenUtilization = useCallback(() => {
-		openUtilizationModal(selectedDate, selectedCanteen);
-	}, [openUtilizationModal, selectedDate, selectedCanteen]);
-
 	const { openFoodOffersOptionsModal } = useMyScrollviewModalFoodOffersOptions({
 		onSort: openFoodofferSortingModal,
 		onPriceGroup: openPriceGroupSettingsModal,
@@ -119,7 +113,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 		onCanteen: openChangeMyCanteenSelectionModal,
 		onCalendar: () => openDatePickerModal({ updateGlobal: true }),
 		onBusinessHours: openBusinessHoursModal,
-		onUtilization: handleOpenUtilization,
 		onSettings: () => router.navigate('/settings'),
 	});
 

--- a/apps/frontend/app/hooks/useMyScrollviewModalFoodOffersOptions.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewModalFoodOffersOptions.tsx
@@ -17,7 +17,6 @@ interface FoodOffersOptionsContentProps {
 	onCanteen: () => void;
 	onCalendar: () => void;
 	onBusinessHours: () => void;
-	onUtilization: (() => void) | null;
 	onSettings: () => void;
 }
 
@@ -50,7 +49,6 @@ const FoodOffersOptionsContent: React.FC<FoodOffersOptionsContentProps> = ({
 	onCanteen,
 	onCalendar,
 	onBusinessHours,
-	onUtilization,
 	onSettings,
 }) => {
 	const { translate } = useLanguage();
@@ -100,16 +98,6 @@ const FoodOffersOptionsContent: React.FC<FoodOffersOptionsContentProps> = ({
 			onPress: () => { onBusinessHours(); },
 		},
 	];
-
-	if (onUtilization && appSettings?.utilization_display_enabled) {
-		options.push({
-			key: 'utilization',
-			kind: 'navigation',
-			title: `${translate(TranslationKeys.forecast)}: ${translate(TranslationKeys.utilization)}`,
-			icon: <FontAwesome6 name="people-group" size={20} />,
-			onPress: () => { onUtilization(); },
-		});
-	}
 
 	if (appSettings?.foods_ratings_average_display === true) {
 		options.push({
@@ -170,7 +158,6 @@ interface UseMyScrollviewModalFoodOffersOptionsParams {
 	onCanteen: () => void;
 	onCalendar: () => void;
 	onBusinessHours: () => void;
-	onUtilization: (() => void) | null;
 	onSettings: () => void;
 }
 
@@ -190,12 +177,11 @@ export const useMyScrollviewModalFoodOffersOptions = (params: UseMyScrollviewMod
 					onCanteen={params.onCanteen}
 					onCalendar={params.onCalendar}
 					onBusinessHours={params.onBusinessHours}
-					onUtilization={params.onUtilization}
 					onSettings={params.onSettings}
 				/>
 			),
 		});
-	}, [closeScrollViewModal, showScrollViewModal, translate, params.onSort, params.onPriceGroup, params.onEatingHabits, params.onCanteen, params.onCalendar, params.onBusinessHours, params.onUtilization, params.onSettings]);
+	}, [closeScrollViewModal, showScrollViewModal, translate, params.onSort, params.onPriceGroup, params.onEatingHabits, params.onCanteen, params.onCalendar, params.onBusinessHours, params.onSettings]);
 
 	return { openFoodOffersOptionsModal };
 };


### PR DESCRIPTION
## Summary
Im „Weitere Optionen und Information"-Modal des Food-Offers-Screens gab es einen Eintrag „Prognose: Auslastung" (hinter `appSettings.utilization_display_enabled`). Da das Feature dort aktuell nicht genutzt wird und ggf. später im Infinite Scroller eingebunden werden soll, bleiben `useUtilizationModal` und `ForecastSheet` selbst unangetastet — nur die Verdrahtung in dieses spezielle Modal wird entfernt:

- `useMyScrollviewModalFoodOffersOptions`: `onUtilization`-Prop und der zugehörige Options-Eintrag komplett entfernt.
- `foodoffers/index.tsx`: den dadurch überflüssigen `useUtilizationModal`-Import/Hook-Aufruf sowie `handleOpenUtilization` entfernt.

## Test plan
- [x] Im Browser verifiziert: Optionen-Modal zeigt jetzt Mensa, Datum, Sortieren, Preisgruppe, Essgewohnheiten, Öffnungszeiten, Durchschnittsbewertung, Weitere Einstellungen — kein Auslastung-Eintrag mehr
- [x] `yarn tsc --noEmit` — keine neuen Fehler gegenüber Baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)