### PR TITLE
Settings avatar lock, update-check modal, and campus building favorites

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -28,6 +28,7 @@ import useSetPageTitle from '@/hooks/useSetPageTitle';
 import useCampusSortingModal from '@/hooks/useCampusSortingModal';
 import useMyScrollviewDirectusImageEditModal from '@/hooks/useMyScrollviewDirectusImageEditModal';
 import useLastOpenedBuildings from '@/hooks/useLastOpenedBuildings';
+import useBuildingFavorites from '@/hooks/useBuildingFavorites';
 
 import { RootDrawerParamList } from './types';
 import CampusHeader from './components/CampusHeader';
@@ -89,6 +90,7 @@ const Index: React.FC = () => {
 	const { openCampusSortingModal } = useCampusSortingModal();
 	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
 	const { buildingsLastOpenedIds } = useLastOpenedBuildings();
+	const { buildingsFavoriteIds } = useBuildingFavorites();
 
 	// Handlers
 	const openDistanceSheet = useCallback(() => setDistanceModalVisible(true), []);
@@ -261,12 +263,23 @@ const Index: React.FC = () => {
 		return [...lastOpenedItems, ...otherItems];
 	}, [sortedCampuses, buildingsLastOpenedIds, campusesSortBy]);
 
+	// Favorited buildings always come first for INTELLIGENT sorting, on top of the
+	// last-opened boost above (applied last so it wins: favorites are pulled to the
+	// very front while preserving whatever order the previous steps produced).
+	const sortedWithFavorites = useMemo(() => {
+		if (campusesSortBy !== CampusSortOption.INTELLIGENT || !buildingsFavoriteIds || buildingsFavoriteIds.length === 0) return sortedWithLastOpened;
+		const favoriteSet = new Set(buildingsFavoriteIds);
+		const favoriteItems = sortedWithLastOpened.filter(c => c.id && favoriteSet.has(c.id));
+		const otherItems = sortedWithLastOpened.filter(c => !(c.id && favoriteSet.has(c.id)));
+		return [...favoriteItems, ...otherItems];
+	}, [sortedWithLastOpened, buildingsFavoriteIds, campusesSortBy]);
+
 	const visibleCampuses: BuildingWithDistance[] = useMemo(() => {
-		const src = sortedWithLastOpened;
+		const src = sortedWithFavorites;
 		if (!query || query.trim() === '') return src;
 		const q = query.toLowerCase().trim();
 		return src.filter(campus => (campus?.alias ?? '').toLowerCase().includes(q));
-	}, [sortedWithLastOpened, query]);
+	}, [sortedWithFavorites, query]);
 
 	const onRefresh = useCallback(() => {
 		setRefreshing(true);

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -9,7 +9,7 @@ import { horizontalScreenPadding, isWeb } from '@/constants/Constants';
 import SettingsList from '@/components/SettingsList';
 import SettingsListEditable from '@/components/SettingsListEditable';
 import SettingsListBoolean from '@/components/SettingsListBoolean/SettingsListBoolean';
-import { useExpoUpdateChecker } from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
+import { useUpdateCheckModal } from '@/hooks/useUpdateCheckModal';
 import SettingsGroupTitle from '@/components/SettingsGroupTitle';
 import useMyScrollviewTextInputModal from '@/hooks/useMyScrollviewTextInputModal';
 import { router } from 'expo-router';
@@ -74,7 +74,7 @@ const Settings = () => {
         const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
         const { openConfirmLogoutModal } = useConfirmLogoutModal();
         const { openAccountRequiredModal } = useAccountRequiredModal();
-        const { manualCheck } = useExpoUpdateChecker();
+        const { openUpdateCheckModal } = useUpdateCheckModal();
         const { user, profile, termsAndPrivacyConsentAcceptedDate, isManagement, isDevMode } = useAppSelector((state) => state.authReducer);
         const isRegisteredUser = UserHelper.isRegisteredUser(user);
         const { buttonLabel: logoutButtonLabel } = useLogoutButtonTranslation();
@@ -383,7 +383,7 @@ const Settings = () => {
         }, [collectibleRandomPosition, dispatch]);
 
         const handleCheckForUpdates = () => {
-                manualCheck();
+                openUpdateCheckModal();
         };
 
         const handleLogout = useCallback(() => openConfirmLogoutModal(), [openConfirmLogoutModal]);
@@ -502,35 +502,35 @@ const Settings = () => {
 				<View style={sectionStyle}>
 					<SettingsGroupTitle>{translate(TranslationKeys.group_personalization)}</SettingsGroupTitle>
 					<View style={groupStyle}>
-						{isRegisteredUser && (
-							<SettingsList
-								leftIconComponent={
-									settingsAvatarConfig ? (
-										<MyAvatar
-											config={settingsAvatarConfig}
-											size={AVATAR_SETTINGS_ROW_SIZE / 2}
-											rounded={true}
-											backgroundColor={AVATAR_BACKGROUND}
-										/>
-									) : (
-										<View style={{ width: AVATAR_SETTINGS_ROW_SIZE / 2, height: AVATAR_SETTINGS_ROW_SIZE / 2, borderRadius: AVATAR_SETTINGS_ROW_SIZE / 4, backgroundColor: primaryColor + '22', alignItems: 'center', justifyContent: 'center' }}>
-											<MaterialCommunityIcons name="account-outline" size={20} color={theme.screen.icon} />
-										</View>
-									)
-								}
-								value={translate(TranslationKeys.avatar_appearance)}
-								rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}
-								handleFunction={() => openAvatarEditor(false)}
-								groupPosition="top"
-							/>
-						)}
+						<SettingsList
+							leftIconComponent={
+								settingsAvatarConfig ? (
+									<MyAvatar
+										config={settingsAvatarConfig}
+										size={AVATAR_SETTINGS_ROW_SIZE / 2}
+										rounded={true}
+										backgroundColor={AVATAR_BACKGROUND}
+									/>
+								) : (
+									<View style={{ width: AVATAR_SETTINGS_ROW_SIZE / 2, height: AVATAR_SETTINGS_ROW_SIZE / 2, borderRadius: AVATAR_SETTINGS_ROW_SIZE / 4, backgroundColor: primaryColor + '22', alignItems: 'center', justifyContent: 'center' }}>
+										<MaterialCommunityIcons name="account-outline" size={20} color={theme.screen.icon} />
+									</View>
+								)
+							}
+							value={translate(TranslationKeys.avatar_appearance)}
+							rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}
+							handleFunction={() => openAvatarEditor(false)}
+							isAccountRequired={!isRegisteredUser}
+							onAccountRequired={openAccountRequiredModal}
+							groupPosition="top"
+						/>
 						<SettingsListEditable
 							iconBgColor={primaryColor}
 							leftIcon={<MaterialCommunityIcons name="account" size={24} color={theme.screen.icon} />}
 							label={translate(TranslationKeys.nickname)}
 							value={profile?.id ? profile?.nickname ?? undefined : nickNameLocal}
 							handleFunction={openNicknameSheet}
-							groupPosition={isRegisteredUser ? 'middle' : 'top'}
+							groupPosition="middle"
 						/>
 						{showFriendsInSettings && (
 							<SettingsList

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -17,6 +17,11 @@ import CardDimensionHelper from '@/helper/CardDimensionHelper';
 import IconButton from '../UI/IconButton';
 import { CardLayoutProps } from '@/components/shared/cardLayoutProps';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import useBuildingFavorites from '@/hooks/useBuildingFavorites';
+
+// Positive/favorite border color - matches the "liked" food offer card border (#00B050)
+// used elsewhere in the app for a consistent good/positive accent.
+const FAVORITE_BORDER_COLOR = '#00B050';
 
 
 export interface BuildingItemPropsOptimized extends CardLayoutProps {
@@ -52,6 +57,8 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 	const { openDistanceInformationModal } = useMyScrollviewModalDistanceInformation();
 	const { openBuildingDetailsModal } = useBuildingDetailsModal();
 	const { show: showScrollViewModal } = useMyScrollViewModal();
+	const { isBuildingFavorite, toggleBuildingFavorite } = useBuildingFavorites();
+	const isFavorite = isBuildingFavorite(campus?.id ?? '');
 
 	const defaultImage = useMemo(() => getImageUrl(projectLogo ?? ''), [projectLogo]);
 	const campus_area_color = campusAreaColor ? campusAreaColor : primaryColor;
@@ -72,6 +79,11 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 			),
 		});
 	}, [showScrollViewModal, translate, theme.screen.text]);
+
+	const handleToggleFavorite = useCallback(() => {
+		if (!campus?.id) return;
+		toggleBuildingFavorite(campus.id);
+	}, [campus?.id, toggleBuildingFavorite]);
 
 	const handleOpenNavigation = useCallback(() => {
 		const coordinates = campus?.coordinates?.coordinates;
@@ -111,6 +123,7 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 				width: '100%',
 				backgroundColor: theme.card.background,
 				flex: 1,
+				...(isFavorite ? { borderWidth: 3, borderColor: FAVORITE_BORDER_COLOR } : {}),
 			}}
 			imageContainerStyle={{
 				height: cardSize,
@@ -157,6 +170,16 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 							<MaterialCommunityIcons name="navigation-variant" size={20} color={contrastColor} />
 						</IconButton>
 					)}
+
+					<View style={styles.favoriteButtonContainer}>
+						<TouchableOpacity style={styles.favoriteButton} onPress={handleToggleFavorite}>
+							{isFavorite ? (
+								<MaterialCommunityIcons name="heart" size={20} color={campus_area_color} />
+							) : (
+								<MaterialCommunityIcons name="heart-outline" size={20} color="white" />
+							)}
+						</TouchableOpacity>
+					</View>
 
 					<View style={styles.imageActionContainer}>
 						{isManagement ? (
@@ -273,10 +296,23 @@ const styles = StyleSheet.create({
 	navigationButton: {
 		position: 'absolute',
 		top: 10,
-		right: 10,
+		left: 10,
 		width: 36,
 		height: 36,
 		borderRadius: 18,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	favoriteButtonContainer: {
+		position: 'absolute',
+		top: 10,
+		right: 10,
+	},
+	favoriteButton: {
+		width: 35,
+		height: 35,
+		borderRadius: 50,
+		backgroundColor: 'rgba(0,0,0,0.45)',
 		justifyContent: 'center',
 		alignItems: 'center',
 	},

--- a/apps/frontend/app/hooks/useBuildingFavorites.ts
+++ b/apps/frontend/app/hooks/useBuildingFavorites.ts
@@ -1,0 +1,80 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { DatabaseTypes } from 'repo-depkit-common';
+import { UPDATE_PROFILE } from '@/redux/Types/types';
+import { ProfileHelper } from '@/redux/actions/Profile/Profile';
+import { UserHelper } from '@/helper/UserHelper';
+import { useAppSelector } from '@/redux/hooks';
+
+type FavoriteEntry = DatabaseTypes.ProfilesBuildingsFavorites | string;
+
+const resolveBuildingId = (entry: FavoriteEntry): string => {
+	const id = typeof entry === 'string' ? entry : entry?.buildings_id;
+	if (typeof id === 'string') return id;
+	if (typeof id === 'object' && id !== null) return (id as any)?.id ? String((id as any).id) : '';
+	return '';
+};
+
+/**
+ * Favoriting a building works the same way as marking eating habits: the local
+ * redux profile (persisted to AsyncStorage via redux-persist) is always updated
+ * immediately, for anonymous and registered users alike. Only registered users
+ * additionally get the change synced to the backend profile.
+ */
+const useBuildingFavorites = () => {
+	const dispatch = useDispatch();
+	const profile = useAppSelector(state => state.authReducer.profile);
+	const user = useAppSelector(state => state.authReducer.user);
+	const profileHelper = useMemo(() => new ProfileHelper(), []);
+	const isAnonymousUser = useMemo(() => UserHelper.isAnonymousUser(user), [user]);
+
+	// Keep a ref to avoid stale closures when profileHelper is used in async callbacks
+	const profileRef = useRef(profile);
+	profileRef.current = profile;
+
+	const buildingsFavoriteIds: string[] = useMemo(() => {
+		const entries = (profile?.buildings_favorites ?? []) as FavoriteEntry[];
+		return entries.map(resolveBuildingId).filter((id): id is string => Boolean(id));
+	}, [profile?.buildings_favorites]);
+
+	const isBuildingFavorite = useCallback(
+		(buildingId: string) => buildingsFavoriteIds.includes(buildingId),
+		[buildingsFavoriteIds]
+	);
+
+	const toggleBuildingFavorite = useCallback(
+		async (buildingId: string) => {
+			const currentProfile = profileRef.current;
+			const current = (currentProfile?.buildings_favorites ?? []) as FavoriteEntry[];
+			const alreadyFavorite = current.some(entry => resolveBuildingId(entry) === buildingId);
+
+			const updated = alreadyFavorite
+				? current.filter(entry => resolveBuildingId(entry) !== buildingId)
+				: [
+						...current,
+						{
+							buildings_id: buildingId,
+							...(currentProfile?.id ? { profiles_id: currentProfile.id } : {}),
+						} as Partial<DatabaseTypes.ProfilesBuildingsFavorites>,
+					];
+
+			const profileData = { ...currentProfile, buildings_favorites: updated };
+			dispatch({ type: UPDATE_PROFILE, payload: profileData });
+
+			if (isAnonymousUser) return;
+
+			try {
+				await profileHelper.updateProfile(profileData);
+			} catch (e) {
+				console.error('Error updating buildings_favorites:', e);
+				// Revert Redux state to previous value on backend failure
+				dispatch({ type: UPDATE_PROFILE, payload: currentProfile });
+			}
+		},
+		[dispatch, profileHelper, isAnonymousUser]
+	);
+
+	return { buildingsFavoriteIds, isBuildingFavorite, toggleBuildingFavorite };
+};
+
+export default useBuildingFavorites;

--- a/apps/frontend/app/hooks/useUpdateCheckModal.tsx
+++ b/apps/frontend/app/hooks/useUpdateCheckModal.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import * as Updates from 'expo-updates';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+import { TranslationKeys } from '@/locales/keys';
+import SettingsList from '@/components/SettingsList';
+import usePlatformHelper from '@/helper/platformHelper';
+import { isInExpoGo } from '@/helper/DeviceRuntimeHelper';
+
+type UpdateStep = 'checking' | 'no_update' | 'update_available' | 'downloading' | 'downloaded' | 'reloading' | 'unavailable';
+
+const UpdateCheckModalContent: React.FC = () => {
+	const { translate } = useLanguage();
+	const { theme } = useTheme();
+	const { isSmartPhone } = usePlatformHelper();
+
+	const [step, setStep] = useState<UpdateStep>('checking');
+
+	const runCheck = useCallback(async () => {
+		if (!isSmartPhone() || isInExpoGo()) {
+			setStep('unavailable');
+			return;
+		}
+		setStep('checking');
+		try {
+			const result = await Updates.checkForUpdateAsync();
+			setStep(result.isAvailable ? 'update_available' : 'no_update');
+		} catch {
+			setStep('no_update');
+		}
+	}, [isSmartPhone]);
+
+	// Auto-check as soon as the modal opens - the point is to skip the extra
+	// tap that the debug "experimentell Expo Update" screen requires.
+	useEffect(() => {
+		runCheck();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const runDownload = useCallback(async () => {
+		setStep('downloading');
+		try {
+			const result = await Updates.fetchUpdateAsync();
+			setStep(result?.isNew ? 'downloaded' : 'no_update');
+		} catch {
+			// Stay on update_available so the user can retry the download.
+			setStep('update_available');
+		}
+	}, []);
+
+	const runReload = useCallback(async () => {
+		setStep('reloading');
+		try {
+			await Updates.reloadAsync();
+		} catch {
+			setStep('downloaded');
+		}
+	}, []);
+
+	const checkValue =
+		step === 'checking'
+			? undefined
+			: step === 'unavailable'
+				? translate(TranslationKeys.update_not_available_on_platform)
+				: step === 'no_update'
+					? translate(TranslationKeys.update_current_version)
+					: undefined;
+
+	return (
+		<View style={{ width: '100%', gap: 0 }}>
+			<SettingsList
+				leftIcon={<MaterialCommunityIcons name="cloud-search-outline" size={24} color={theme.screen.icon} />}
+				rightIcon={step === 'checking' ? <ActivityIndicator size="small" color={theme.screen.icon} /> : undefined}
+				label={translate(TranslationKeys.CHECK_FOR_APP_UPDATES)}
+				value={checkValue}
+				groupPosition={step === 'update_available' || step === 'downloading' || step === 'downloaded' || step === 'reloading' ? 'top' : 'single'}
+			/>
+			{(step === 'update_available' || step === 'downloading' || step === 'downloaded' || step === 'reloading') && (
+				<>
+					<View style={{ opacity: step === 'update_available' ? 1 : 0.5 }}>
+						<SettingsList
+							leftIcon={<MaterialCommunityIcons name="cloud-download-outline" size={24} color={theme.screen.icon} />}
+							rightIcon={step === 'downloading' ? <ActivityIndicator size="small" color={theme.screen.icon} /> : undefined}
+							label={translate(TranslationKeys.DOWNLOAD_NEW_APP_UPDATE)}
+							handleFunction={step === 'update_available' ? runDownload : undefined}
+							groupPosition="middle"
+						/>
+					</View>
+					<View style={{ opacity: step === 'downloaded' ? 1 : 0.5 }}>
+						<SettingsList
+							leftIcon={<MaterialCommunityIcons name="reload" size={24} color={theme.screen.icon} />}
+							rightIcon={step === 'reloading' ? <ActivityIndicator size="small" color={theme.screen.icon} /> : undefined}
+							label={translate(TranslationKeys.RELOAD_APP)}
+							handleFunction={step === 'downloaded' ? runReload : undefined}
+							groupPosition="bottom"
+						/>
+					</View>
+				</>
+			)}
+		</View>
+	);
+};
+
+export const useUpdateCheckModal = () => {
+	const { show: showScrollViewModal } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openUpdateCheckModal = useCallback(() => {
+		showScrollViewModal({
+			title: translate(TranslationKeys.CHECK_FOR_APP_UPDATES),
+			children: <UpdateCheckModalContent />,
+		});
+	}, [showScrollViewModal, translate]);
+
+	return { openUpdateCheckModal };
+};
+
+export default useUpdateCheckModal;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -528,6 +528,8 @@ export enum TranslationKeys {
 	update_available = 'update_available',
 	update_available_message = 'update_available_message',
 	no_updates_available = 'no_updates_available',
+	update_current_version = 'update_current_version',
+	update_not_available_on_platform = 'update_not_available_on_platform',
 	updates = 'updates',
 	send = 'send',
 	button_disabled = 'button_disabled',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -5857,6 +5857,26 @@
     "tr": "Uygulama güncel",
     "zh": "应用已是最新版本"
   },
+  "update_current_version": {
+    "de": "Aktuellste Version",
+    "en": "Latest version",
+    "ar": "أحدث إصدار",
+    "es": "Última versión",
+    "fr": "Dernière version",
+    "ru": "Последняя версия",
+    "tr": "En güncel sürüm",
+    "zh": "最新版本"
+  },
+  "update_not_available_on_platform": {
+    "de": "Updates sind auf dieser Plattform nicht verfügbar",
+    "en": "Updates are not available on this platform",
+    "ar": "التحديثات غير متوفرة على هذه المنصة",
+    "es": "Las actualizaciones no están disponibles en esta plataforma",
+    "fr": "Les mises à jour ne sont pas disponibles sur cette plateforme",
+    "ru": "Обновления недоступны на этой платформе",
+    "tr": "Güncellemeler bu platformda kullanılamıyor",
+    "zh": "此平台不支持更新"
+  },
   "updates": {
     "de": "Updates",
     "en": "Updates",


### PR DESCRIPTION
## Summary
- Settings avatar row: instead of hiding it for anonymous users, it now uses the same account-required lock styling/behavior as the Freundschaften row.
- Settings "Nach Update suchen": opens a modal (instead of a plain confirm dialog) that auto-checks for updates on open, shows a disabled "Update herunterladen" row that becomes tappable once an update is found, a "Aktuellste Version" hint when already up to date, or a not-available hint on unsupported platforms.
- Campus: new heart quick-favorite button on building cards (mirrors the food offer quick-rating star), moved the existing quick-navigate button to the top-left to make room. Favorites are stored locally (redux-persist/AsyncStorage) for all users including anonymous ones - the same pattern used for eating-habit markings - with backend sync additionally happening for registered users. Favorited buildings get a positive green border and are boosted to the top under intelligent sorting.

## Test plan
- [x] `yarn tsc --noEmit` - 92 baseline errors, no new errors introduced
- [x] Verified live via Puppeteer against `yarn expo start --web`: avatar lock renders/reroutes correctly for anonymous users
- [x] Verified live: update-check modal opens, auto-checks, shows "Updates sind auf dieser Plattform nicht verfügbar" on web
- [x] Verified live: heart button renders top-right, navigate button top-left, tapping toggles favorite for anonymous users (no account-required gate), green border appears, favorited building persists and sorts to top after reload