### PR TITLE
Campus favorites: resort only on next screen visit, not live

### DIFF
--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -94,7 +94,8 @@ const Index: React.FC = () => {
 
 	// Sorting by favorites should not jump around live while the user is toggling
 	// hearts on this screen - it should only be re-evaluated the next time the
-	// screen is opened (i.e. gains focus again), using a frozen snapshot.
+	// screen is opened (i.e. gains focus again) or the user pulls to refresh,
+	// using a frozen snapshot.
 	const buildingsFavoriteIdsRef = useRef(buildingsFavoriteIds);
 	buildingsFavoriteIdsRef.current = buildingsFavoriteIds;
 	const [favoriteIdsSortSnapshot, setFavoriteIdsSortSnapshot] = useState<string[]>(buildingsFavoriteIds);
@@ -298,6 +299,7 @@ const Index: React.FC = () => {
 
 	const onRefresh = useCallback(() => {
 		setRefreshing(true);
+		setFavoriteIdsSortSnapshot(buildingsFavoriteIdsRef.current);
 		fetchAllCampuses(selectedBuilding ?? null).finally(() => setRefreshing(false));
 	}, [fetchAllCampuses, selectedBuilding]);
 

--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -10,7 +10,7 @@ import { CampusSortOption, CollectionNames, DatabaseTypes, shouldApplyLastOpened
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
-import { useNavigation } from 'expo-router';
+import { useFocusEffect, useNavigation } from 'expo-router';
 import BuildingItem from '@/components/BuildingItem/BuildingItem';
 import { useDispatch, shallowEqual } from 'react-redux';
 import { useAppSelector } from '@/redux/hooks';
@@ -91,6 +91,18 @@ const Index: React.FC = () => {
 	const { openDirectusImageEditModal } = useMyScrollviewDirectusImageEditModal();
 	const { buildingsLastOpenedIds } = useLastOpenedBuildings();
 	const { buildingsFavoriteIds } = useBuildingFavorites();
+
+	// Sorting by favorites should not jump around live while the user is toggling
+	// hearts on this screen - it should only be re-evaluated the next time the
+	// screen is opened (i.e. gains focus again), using a frozen snapshot.
+	const buildingsFavoriteIdsRef = useRef(buildingsFavoriteIds);
+	buildingsFavoriteIdsRef.current = buildingsFavoriteIds;
+	const [favoriteIdsSortSnapshot, setFavoriteIdsSortSnapshot] = useState<string[]>(buildingsFavoriteIds);
+	useFocusEffect(
+		useCallback(() => {
+			setFavoriteIdsSortSnapshot(buildingsFavoriteIdsRef.current);
+		}, [])
+	);
 
 	// Handlers
 	const openDistanceSheet = useCallback(() => setDistanceModalVisible(true), []);
@@ -266,13 +278,16 @@ const Index: React.FC = () => {
 	// Favorited buildings always come first for INTELLIGENT sorting, on top of the
 	// last-opened boost above (applied last so it wins: favorites are pulled to the
 	// very front while preserving whatever order the previous steps produced).
+	// Uses the frozen favoriteIdsSortSnapshot (updated on screen focus) rather than
+	// the live buildingsFavoriteIds, so toggling a heart doesn't reorder the list
+	// while the user is still looking at it.
 	const sortedWithFavorites = useMemo(() => {
-		if (campusesSortBy !== CampusSortOption.INTELLIGENT || !buildingsFavoriteIds || buildingsFavoriteIds.length === 0) return sortedWithLastOpened;
-		const favoriteSet = new Set(buildingsFavoriteIds);
+		if (campusesSortBy !== CampusSortOption.INTELLIGENT || !favoriteIdsSortSnapshot || favoriteIdsSortSnapshot.length === 0) return sortedWithLastOpened;
+		const favoriteSet = new Set(favoriteIdsSortSnapshot);
 		const favoriteItems = sortedWithLastOpened.filter(c => c.id && favoriteSet.has(c.id));
 		const otherItems = sortedWithLastOpened.filter(c => !(c.id && favoriteSet.has(c.id)));
 		return [...favoriteItems, ...otherItems];
-	}, [sortedWithLastOpened, buildingsFavoriteIds, campusesSortBy]);
+	}, [sortedWithLastOpened, favoriteIdsSortSnapshot, campusesSortBy]);
 
 	const visibleCampuses: BuildingWithDistance[] = useMemo(() => {
 		const src = sortedWithFavorites;


### PR DESCRIPTION
## Summary
- Toggling a building's favorite heart on the Campus screen was immediately reordering the list, which felt jarring since the card could jump away right as you tapped it.
- The favorite-boost sorting (intelligent sort mode) now uses a snapshot of favorite IDs that is only refreshed when the campus screen regains focus (`useFocusEffect`), so the reorder happens the next time the screen is opened rather than live while browsing.
- Heart fill state and the positive green border still update immediately on tap - only the list order is deferred.

## Test plan
- [x] `yarn tsc --noEmit` - 92 baseline errors, no new errors introduced
- [x] Verified live via Puppeteer against `yarn expo start --web`: favoriting a card mid-list does not reorder it while staying on the screen
- [x] Verified live: navigating away and back to the campus screen re-sorts the favorited building to the top