### PR TITLE
Fix: render geo: markdown links as buttons instead of literal text

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/markdown-test/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/markdown-test/index.tsx
@@ -9,6 +9,7 @@ import { TranslationKeys } from '@/locales/keys';
 import SettingsList from '@/components/SettingsList';
 import useMyScrollviewTextInputModal from '@/hooks/useMyScrollviewTextInputModal';
 import MyMarkdown from '@/components/MyMarkdown';
+import CustomMarkdown from '@/components/CustomMarkdown/CustomMarkdown';
 
 type MarkdownExample = {
 	id: string;
@@ -40,9 +41,16 @@ const MarkdownTestScreen = () => {
 				title: translate(TranslationKeys.markdown_example_links),
 				content: '[Webseite](https://www.swosy.de)\\n\\n[Mail](mailto:test@swosy.de)\\n\\n[Telefon](tel:+49123456789)',
 			},
+			{
+				id: 'geo',
+				title: translate(TranslationKeys.markdown_example_geo),
+				content: '[Route anzeigen](geo:52.27158519499881, 8.04527493587901)',
+			},
 		],
 		[translate]
 	);
+
+	const geoMarkdownContent = '[Route anzeigen](geo:52.27158519499881, 8.04527493587901)';
 
 	const openEditor = () => {
 		openTextInputModal({
@@ -77,6 +85,13 @@ const MarkdownTestScreen = () => {
 						<MyMarkdown content={example.content} textColor={theme.screen.text} />
 					</View>
 				))}
+
+				{/* Building/campus/housing description text uses CustomMarkdown (not MyMarkdown) -
+				    keep a geo: example here too so both renderers stay covered. */}
+				<View style={[styles.section, { backgroundColor: theme.screen.iconBg }]}>
+					<Text style={[styles.sectionTitle, { color: theme.screen.text }]}>{`${translate(TranslationKeys.markdown_example_geo)} (CustomMarkdown)`}</Text>
+					<CustomMarkdown content={geoMarkdownContent} backgroundColor={theme.screen.iconBg} />
+				</View>
 			</View>
 		</ScrollView>
 	);

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -8,6 +8,7 @@ import { myContrastColor } from '@/helper/ColorHelper';
 import { useAppSelector } from '@/redux/hooks';
 import { useTheme } from '@/hooks/useTheme';
 import { StringHelper } from 'repo-depkit-common';
+import { resolveLocationHref } from '@/helper/MarkdownLinkHelper';
 
 const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColor, imageWidth, imageHeight }) => {
 	const { theme } = useTheme();
@@ -17,6 +18,7 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 		// Regex patterns for different content types
 		const contentPatterns = {
 			email: /\[([^\]]+)]\((mailto:[^\)]+)\)/,
+			location: /\[([^\]]+)]\(((?:geo|maps):[^\)]+)\)/i,
 			link: /\[([^\]]+)]\((https?:\/\/[^\)]+)\)/,
 			image: /!\[([^\]]*)]\(([^)]+)\)/,
 			heading: /^#{1,3}\s*(.*)$/,
@@ -128,6 +130,18 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 							type: 'email',
 							displayText: match?.[1],
 							email: match?.[2],
+							indent: indentLength,
+						});
+						continue;
+					}
+
+					if (contentPatterns.location.test(trimmedForMatch)) {
+						flushTextContent();
+						const match = trimmedForMatch.match(contentPatterns.location);
+						stack[stack.length - 1].items.push({
+							type: 'location',
+							displayText: match?.[1],
+							url: match?.[2],
 							indent: indentLength,
 						});
 						continue;
@@ -274,6 +288,15 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 								<RedirectButton type="link" label={item.displayText} onClick={() => Linking.openURL(item.url)} backgroundColor={backgroundColor || ''} color={contrastColor} />
 							</View>
 						);
+
+					case 'location': {
+						const { resolvedHref } = resolveLocationHref(item.url);
+						return (
+							<View key={`location-${level}-${index}`} style={{ marginLeft: calculateMarginLeft(level, item.indent || 0), marginBottom: 10 }}>
+								<RedirectButton type="location" label={item.displayText} onClick={() => resolvedHref && Linking.openURL(resolvedHref)} backgroundColor={backgroundColor || ''} color={contrastColor} />
+							</View>
+						);
+					}
 
 					case 'image':
 						return <ImageContent key={`image-${level}-${index}`} url={item.url} altText={item.altText} level={level} indent={item.indent || 0} />;

--- a/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -10,11 +10,23 @@ import ProjectButton from '../ProjectButton';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
 import { StringHelper } from 'repo-depkit-common';
+import { UriScheme } from '@/constants/UriScheme';
+import { resolveLocationHref } from '@/helper/MarkdownLinkHelper';
 
 export interface MyMarkdownProps {
 	content: string;
 	textColor?: string;
 }
+
+// CommonMark link destinations can't contain a raw, unescaped space, so a
+// `[text](geo:52.1, 8.0)`-style link (space after the comma) silently fails to
+// parse as a link and falls through as literal text. Location links are the
+// only ones content authors realistically write with a space in the
+// coordinates, so strip whitespace from just those destinations before parsing.
+const LOCATION_LINK_DESTINATION_PATTERN = new RegExp(`\\((${UriScheme.GEO}|${UriScheme.MAPS}|latlon:)([^)]*)\\)`, 'gi');
+
+export const sanitizeLocationLinkWhitespace = (sourceContent: string) =>
+	sourceContent.replace(LOCATION_LINK_DESTINATION_PATTERN, (_match, scheme, coordinates) => `(${scheme}${coordinates.replace(/\s+/g, '')})`);
 
 export const replaceLinebreaks = (sourceContent: string) => {
 	const option_find_linebreaks = true;
@@ -45,6 +57,7 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 	if (option_find_linebreaks) {
 		sourceContent = replaceLinebreaks(sourceContent);
 	}
+	sourceContent = sanitizeLocationLinkWhitespace(sourceContent);
 
 	const result = md.render(sourceContent);
 	const source = { html: result || '' };
@@ -88,8 +101,12 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 			const { data } = props.tnode;
 			const text = data || props.children[0]?.data;
 
+			const hrefLower = href?.toLowerCase() ?? '';
+			const isLatLonLink = hrefLower.startsWith('latlon:');
+			const isLocationLink = isLatLonLink || hrefLower.startsWith(UriScheme.GEO) || hrefLower.startsWith(UriScheme.MAPS);
+
 			let finalHref = href;
-			if (href?.toLowerCase().startsWith('latlon:')) {
+			if (isLatLonLink) {
 				const coordinateString = href.slice('latlon:'.length);
 				const [latitudeRaw, longitudeRaw] = coordinateString.split(',');
 
@@ -99,6 +116,9 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 				if (!Number.isNaN(latitude) && !Number.isNaN(longitude)) {
 					finalHref = CommonSystemActionHelper.getGoogleMapsUrl(latitude, longitude);
 				}
+			} else if (isLocationLink) {
+				const { resolvedHref } = resolveLocationHref(href);
+				finalHref = resolvedHref ?? href;
 			}
 
 			const handlePress = () => {
@@ -113,7 +133,7 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 				iconLeft = <FontAwesome6 name="phone" size={20} color={contrastColor} />;
 			} else if (finalHref?.startsWith('mailto:')) {
 				iconLeft = <MaterialCommunityIcons name="email" size={24} color={contrastColor} />;
-			} else if (href?.toLowerCase().startsWith('latlon:')) {
+			} else if (isLocationLink) {
 				iconLeft = <Ionicons name="navigate" size={24} color={contrastColor} />;
 			}
 

--- a/apps/frontend/app/components/RedirectButton/index.tsx
+++ b/apps/frontend/app/components/RedirectButton/index.tsx
@@ -1,7 +1,7 @@
 import { Dimensions, DimensionValue, Text, TouchableOpacity } from 'react-native';
 import React from 'react';
 import styles from './styles';
-import { FontAwesome6, MaterialCommunityIcons } from '@expo/vector-icons';
+import { FontAwesome6, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { RedirectButtonProps } from './types';
 import usePlatformHelper from '@/helper/platformHelper';
 import { myContrastColor } from '@/helper/ColorHelper';
@@ -43,7 +43,13 @@ const RedirectButton: React.FC<RedirectButtonProps> = ({ type, label, background
 			}}
 			onPress={onClick}
 		>
-			{type === 'email' ? <MaterialCommunityIcons name="email" size={24} color={color || contrastColor} /> : <FontAwesome6 name="arrow-up-right-from-square" size={20} color={color || contrastColor} />}
+			{type === 'email' ? (
+				<MaterialCommunityIcons name="email" size={24} color={color || contrastColor} />
+			) : type === 'location' ? (
+				<Ionicons name="navigate" size={24} color={color || contrastColor} />
+			) : (
+				<FontAwesome6 name="arrow-up-right-from-square" size={20} color={color || contrastColor} />
+			)}
 			<Text style={{ ...styles.label, color: color || contrastColor, fontSize }}>{label}</Text>
 		</TouchableOpacity>
 	);

--- a/apps/frontend/app/components/RedirectButton/types.ts
+++ b/apps/frontend/app/components/RedirectButton/types.ts
@@ -1,5 +1,5 @@
 export interface RedirectButtonProps {
-	type: 'email' | 'link';
+	type: 'email' | 'link' | 'location';
 	label: string;
 	backgroundColor?: string;
 	color?: string;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -369,6 +369,7 @@ export enum TranslationKeys {
 	markdown_example_line_breaks = 'markdown_example_line_breaks',
 	markdown_example_list = 'markdown_example_list',
 	markdown_example_links = 'markdown_example_links',
+	markdown_example_geo = 'markdown_example_geo',
 	tap_to_edit = 'tap_to_edit',
 	haptics_test = 'haptics_test',
 	haptics_test_description = 'haptics_test_description',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -6167,6 +6167,16 @@
     "tr": "Örnek: bağlantılar",
     "zh": "示例：链接"
   },
+  "markdown_example_geo": {
+    "de": "Beispiel: Standort (geo:)",
+    "en": "Example: location (geo:)",
+    "ar": "Example: location (geo:)",
+    "es": "Ejemplo: ubicación (geo:)",
+    "fr": "Exemple : localisation (geo:)",
+    "ru": "Пример: местоположение (geo:)",
+    "tr": "Örnek: konum (geo:)",
+    "zh": "示例：位置（geo:）"
+  },
   "tap_to_edit": {
     "de": "Tippen zum Bearbeiten",
     "en": "Tap to edit",


### PR DESCRIPTION
## Summary
The screenshot showed a building/campus detail screen where `[Route anzeigen](geo:52.27..., 8.04...)` rendered as literal markdown text instead of a button. Turned out there were **two** separate bugs, in two separate markdown renderers used by different parts of the app:

**1. `MyMarkdown.tsx`** (used by `/experimentell/markdown-test`, food items, chat details): per CommonMark, a link destination can't contain a raw unescaped space, so `[text](geo:52.27, 8.04)` (space after the comma) was never recognized as a link by `markdown-it` at all - it fell through as literal text.
- Strip whitespace from `geo:`/`maps:`/`latlon:` link destinations before handing content to `markdown-it`.
- Wire up the existing (previously unused) `resolveLocationHref`/`UriScheme` helpers so `geo:`/`maps:` links (not just the app's custom `latlon:` scheme) render as a button with a navigate icon and a working Google Maps URL.

**2. `CustomMarkdown.tsx`** (the renderer actually used by building/housing/campus/foodoffers detail descriptions - i.e. the screen in the screenshot): a completely separate, hand-rolled regex-based markdown implementation whose link pattern only matched `http(s)://` URLs, so `geo:` links were never recognized as links here either (its regex doesn't have CommonMark's space restriction, so no whitespace-stripping was needed for this one).
- Add a `location` content type/pattern matching `geo:`/`maps:` links, reusing the same `resolveLocationHref` helper.
- Add a `location` type to `RedirectButton` with a navigate icon.

Also added a `geo:` example to `/experimentell/markdown-test`, rendered through both `MyMarkdown` and `CustomMarkdown`, so both code paths are directly testable/visible going forward.

## Test plan
- [x] `yarn tsc --noEmit` - 92 baseline errors, no new errors introduced
- [x] Verified live via Puppeteer against `yarn expo start --web` on `/experimentell/markdown-test`: `[Route anzeigen](geo:52.27158519499881, 8.04527493587901)` renders as a "Route anzeigen" button with a navigate icon in both the `MyMarkdown` and `CustomMarkdown` examples, instead of literal markdown text
- [x] Verified the sanitize + resolve logic standalone: the geo link resolves to `https://www.google.com/maps/search/?api=1&query=52.27158519499881,8.04527493587901`