### PR TITLE
Automated accessibility audits with reports (axe-core)

### DIFF
--- a/apps/accessibilityTester/README.md
+++ b/apps/accessibilityTester/README.md
@@ -1,0 +1,35 @@
+# Accessibility Tester
+
+Automated accessibility (a11y) audits for all app screens using [axe-core](https://github.com/dequelabs/axe-core) via Puppeteer.
+
+The screen list comes from `APP_ROUTES` (`repo-depkit-common`), the same canonical list the screenshot generator uses - new screens added to the `AppScreens` enum are picked up automatically. Every screen is opened with `kioskMode=true` (demo login) and audited against the WCAG 2.1 A/AA + best-practice rule sets.
+
+## Reports
+
+Three files are written to `reports/accessibility/`:
+
+- `accessibility-report.json` - full machine-readable results (all violations with element selectors, HTML snippets and failure summaries)
+- `accessibility-report.md` - human-readable summary: per-screen violation table, most common rule violations across the app, and per-screen details with docs links
+- `badges/accessibility.svg` - badge showing the total violation count (color-coded by the worst impact level found)
+
+## Usage
+
+Against a locally running dev server (`yarn expo start --web` in `apps/frontend/app`):
+
+```bash
+yarn workspace accessibilitytester start --baseUrl http://localhost:8081
+```
+
+Options (also settable via env vars `BASE_URL`, `REPORT_DIR`, `BROWSER_LANG`, `AXE_TAGS`, `FAIL_ON_VIOLATIONS`):
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--baseUrl` | `http://localhost:8081` | Base URL of the running web app |
+| `--reportDir` | `<repo>/reports/accessibility` | Output directory for the reports |
+| `--browserLang` | `de` | Browser language |
+| `--tags` | `wcag2a,wcag2aa,wcag21a,wcag21aa,best-practice` | axe-core rule tags to run |
+| `--failOnViolations` | `false` | Exit with code 1 if critical/serious violations are found (for use as a CI gate) |
+
+## CI
+
+The `♿ Accessibility Audit` workflow (`.github/workflows/frontend-accessibility.yml`) runs weekly and on manual dispatch: it exports the web app, serves it locally, runs the audit and commits the updated reports (same pattern as the data-clumps and sonarCloud reports).

--- a/apps/accessibilityTester/package.json
+++ b/apps/accessibilityTester/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "accessibilitytester",
+  "version": "1.0.0",
+  "description": "Automated accessibility (a11y) audits for all app screens using axe-core, generating reports into the repository reports folder",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "local": "yarn run start -- --baseUrl http://localhost:8081"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.5.4"
+  },
+  "dependencies": {
+    "@axe-core/puppeteer": "^4.10.1",
+    "axe-core": "^4.10.2",
+    "puppeteer": "^23.1.1",
+    "repo-depkit-common": "workspace:*",
+    "yargs": "^17.7.2"
+  }
+}

--- a/apps/accessibilityTester/src/index.ts
+++ b/apps/accessibilityTester/src/index.ts
@@ -1,0 +1,152 @@
+import path from 'path';
+import puppeteer, { Browser } from 'puppeteer';
+import { AxePuppeteer } from '@axe-core/puppeteer';
+import { source as axeSource, version as axeCoreVersion } from 'axe-core';
+import { APP_ROUTES, AppLinks, GlobalParams } from 'repo-depkit-common';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { AccessibilityReport, countViolationsByImpact, ImpactLevel, ScreenResult, ViolationSummary, writeBadge, writeJsonReport, writeMarkdownReport } from './report';
+
+const argv = yargs(hideBin(process.argv))
+  .option('baseUrl', {
+    alias: 'u',
+    description: 'Base URL of the running web app (e.g. http://localhost:8081 or http://localhost:8081/rocket-meals)',
+    type: 'string',
+    demandOption: false,
+  })
+  .option('reportDir', {
+    alias: 'd',
+    description: 'Directory to write the accessibility reports into',
+    type: 'string',
+    demandOption: false,
+  })
+  .option('browserLang', {
+    alias: 'b',
+    description: 'Language for the browser',
+    type: 'string',
+    demandOption: false,
+  })
+  .option('tags', {
+    alias: 't',
+    description: 'Comma separated axe-core rule tags to run',
+    type: 'string',
+    demandOption: false,
+  })
+  .option('failOnViolations', {
+    alias: 'f',
+    description: 'Exit with code 1 if critical or serious violations are found',
+    type: 'boolean',
+    demandOption: false,
+  })
+  .help()
+  .alias('help', 'h').argv as any;
+
+const baseUrl: string = (argv.baseUrl || process.env.BASE_URL || 'http://localhost:8081').replace(/\/$/, '');
+// Default assumes the script is started from apps/accessibilityTester (yarn workspace / yarn start)
+const reportDir: string = path.resolve(argv.reportDir || process.env.REPORT_DIR || path.join(process.cwd(), '../../reports/accessibility'));
+const browserLang: string = argv.browserLang || process.env.BROWSER_LANG || 'de';
+const tags: string[] = (argv.tags || process.env.AXE_TAGS || 'wcag2a,wcag2aa,wcag21a,wcag21aa,best-practice').split(',').map((tag: string) => tag.trim());
+const failOnViolations: boolean = Boolean(argv.failOnViolations || process.env.FAIL_ON_VIOLATIONS);
+
+const VIEWPORT = { width: 1280, height: 900 };
+const PAGE_SETTLE_MS = 3000;
+const PAGE_TIMEOUT_MS = 60000;
+
+function buildScreenUrl(screen: string): string {
+  const relativeUrl = AppLinks.build(screen, [{ key: GlobalParams.kioskMode, value: true }]);
+  return `${baseUrl}/${relativeUrl}`;
+}
+
+function summarizeViolations(violations: any[]): ViolationSummary[] {
+  return violations.map(violation => ({
+    id: violation.id,
+    // axe reports impact per node; the rule-level impact can be null in edge cases
+    impact: (violation.impact ?? 'minor') as ImpactLevel,
+    description: violation.description,
+    help: violation.help,
+    helpUrl: violation.helpUrl,
+    wcagTags: (violation.tags ?? []).filter((tag: string) => tag.startsWith('wcag')),
+    nodeCount: violation.nodes.length,
+    nodes: violation.nodes.map((node: any) => ({
+      target: Array.isArray(node.target) ? node.target.join(' ') : String(node.target),
+      html: String(node.html ?? '').slice(0, 300),
+      failureSummary: node.failureSummary,
+    })),
+  }));
+}
+
+async function analyzeScreen(browser: Browser, screen: string): Promise<ScreenResult> {
+  const url = buildScreenUrl(screen);
+  const page = await browser.newPage();
+  try {
+    await page.setViewport(VIEWPORT);
+    await page.goto(url, { waitUntil: 'networkidle2', timeout: PAGE_TIMEOUT_MS });
+    // Give the app time to finish booting/animations after network idle
+    await new Promise(resolve => setTimeout(resolve, PAGE_SETTLE_MS));
+
+    const results = await new AxePuppeteer(page, axeSource).withTags(tags).analyze();
+
+    return {
+      screen,
+      url,
+      violations: summarizeViolations(results.violations),
+      passCount: results.passes.length,
+      incompleteCount: results.incomplete.length,
+    };
+  } catch (error: any) {
+    console.error(`Error analyzing ${screen}: ${error.message}`);
+    return { screen, url, error: error.message, violations: [], passCount: 0, incompleteCount: 0 };
+  } finally {
+    await page.close().catch(() => undefined);
+  }
+}
+
+(async () => {
+  console.log(`Running accessibility audit against ${baseUrl}`);
+  console.log(`Rule tags: ${tags.join(', ')}`);
+  console.log(`Report directory: ${reportDir}`);
+  console.log(`Screens to analyze: ${APP_ROUTES.length}`);
+
+  const browser = await puppeteer.launch({
+    args: [`--lang=${browserLang}`, '--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  const screens: ScreenResult[] = [];
+  let current = 0;
+  for (const screen of APP_ROUTES) {
+    current++;
+    console.log(`[${current}/${APP_ROUTES.length}] Analyzing ${screen} ...`);
+    const result = await analyzeScreen(browser, screen);
+    const violationElementCount = result.violations.reduce((sum, violation) => sum + violation.nodeCount, 0);
+    console.log(result.error ? `  ⚠️ error: ${result.error}` : `  ${violationElementCount} violation element(s), ${result.passCount} passed rules`);
+    screens.push(result);
+  }
+
+  await browser.close();
+
+  const report: AccessibilityReport = {
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    axeCoreVersion,
+    tags,
+    viewport: VIEWPORT,
+    totals: countViolationsByImpact(screens),
+    screens,
+  };
+
+  await writeJsonReport(report, reportDir);
+  await writeMarkdownReport(report, reportDir);
+  await writeBadge(report, reportDir);
+
+  console.log('---');
+  console.log(`Total violations (affected elements): ${report.totals.violations}`);
+  console.log(`  critical: ${report.totals.critical}, serious: ${report.totals.serious}, moderate: ${report.totals.moderate}, minor: ${report.totals.minor}`);
+  if (report.totals.screensWithErrors > 0) {
+    console.log(`  screens with load errors: ${report.totals.screensWithErrors}`);
+  }
+
+  if (failOnViolations && report.totals.critical + report.totals.serious > 0) {
+    console.error('Failing because critical/serious violations were found (--failOnViolations).');
+    process.exit(1);
+  }
+})();

--- a/apps/accessibilityTester/src/report.ts
+++ b/apps/accessibilityTester/src/report.ts
@@ -1,0 +1,231 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export type ImpactLevel = 'critical' | 'serious' | 'moderate' | 'minor';
+
+export const IMPACT_LEVELS: ImpactLevel[] = ['critical', 'serious', 'moderate', 'minor'];
+
+export interface ViolationNodeSummary {
+  target: string;
+  html: string;
+  failureSummary?: string;
+}
+
+export interface ViolationSummary {
+  id: string;
+  impact: ImpactLevel;
+  description: string;
+  help: string;
+  helpUrl: string;
+  wcagTags: string[];
+  nodeCount: number;
+  nodes: ViolationNodeSummary[];
+}
+
+export interface ScreenResult {
+  screen: string;
+  url: string;
+  error?: string;
+  violations: ViolationSummary[];
+  passCount: number;
+  incompleteCount: number;
+}
+
+export interface AccessibilityReport {
+  generatedAt: string;
+  baseUrl: string;
+  axeCoreVersion: string;
+  tags: string[];
+  viewport: { width: number; height: number };
+  totals: Record<ImpactLevel, number> & { violations: number; screensWithErrors: number };
+  screens: ScreenResult[];
+}
+
+export function countViolationsByImpact(screens: ScreenResult[]): Record<ImpactLevel, number> & { violations: number; screensWithErrors: number } {
+  const totals = { critical: 0, serious: 0, moderate: 0, minor: 0, violations: 0, screensWithErrors: 0 };
+  for (const screen of screens) {
+    if (screen.error) {
+      totals.screensWithErrors++;
+      continue;
+    }
+    for (const violation of screen.violations) {
+      totals[violation.impact] += violation.nodeCount;
+      totals.violations += violation.nodeCount;
+    }
+  }
+  return totals;
+}
+
+async function ensureDir(dirPath: string) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+export async function writeJsonReport(report: AccessibilityReport, reportDir: string) {
+  await ensureDir(reportDir);
+  const filePath = path.join(reportDir, 'accessibility-report.json');
+  await fs.writeFile(filePath, JSON.stringify(report, null, 2) + '\n', 'utf-8');
+  console.log(`JSON report written: ${filePath}`);
+}
+
+function impactEmoji(impact: ImpactLevel): string {
+  switch (impact) {
+    case 'critical':
+      return '🟥';
+    case 'serious':
+      return '🟧';
+    case 'moderate':
+      return '🟨';
+    case 'minor':
+      return '🟦';
+  }
+}
+
+function escapeMarkdownTableCell(text: string): string {
+  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+export function generateMarkdownReport(report: AccessibilityReport): string {
+  const lines: string[] = [];
+  lines.push('# Accessibility Report');
+  lines.push('');
+  lines.push(`> Generated: ${report.generatedAt} | axe-core ${report.axeCoreVersion} | Rules: ${report.tags.join(', ')} | Viewport: ${report.viewport.width}x${report.viewport.height}`);
+  lines.push(`> Base URL: ${report.baseUrl}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`Total violations (affected elements): **${report.totals.violations}** — 🟥 Critical: ${report.totals.critical}, 🟧 Serious: ${report.totals.serious}, 🟨 Moderate: ${report.totals.moderate}, 🟦 Minor: ${report.totals.minor}`);
+  if (report.totals.screensWithErrors > 0) {
+    lines.push('');
+    lines.push(`⚠️ ${report.totals.screensWithErrors} screen(s) could not be analyzed (load error) — see details below.`);
+  }
+  lines.push('');
+  lines.push('| Screen | 🟥 Critical | 🟧 Serious | 🟨 Moderate | 🟦 Minor | Total | Passes |');
+  lines.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: |');
+
+  const sortedScreens = [...report.screens].sort((a, b) => {
+    const countTotal = (s: ScreenResult) => s.violations.reduce((sum, v) => sum + v.nodeCount, 0);
+    return countTotal(b) - countTotal(a);
+  });
+
+  for (const screen of sortedScreens) {
+    if (screen.error) {
+      lines.push(`| ${escapeMarkdownTableCell(screen.screen)} | - | - | - | - | ⚠️ error | - |`);
+      continue;
+    }
+    const byImpact = { critical: 0, serious: 0, moderate: 0, minor: 0 };
+    for (const violation of screen.violations) {
+      byImpact[violation.impact] += violation.nodeCount;
+    }
+    const total = byImpact.critical + byImpact.serious + byImpact.moderate + byImpact.minor;
+    lines.push(`| ${escapeMarkdownTableCell(screen.screen)} | ${byImpact.critical} | ${byImpact.serious} | ${byImpact.moderate} | ${byImpact.minor} | ${total} | ${screen.passCount} |`);
+  }
+
+  lines.push('');
+  lines.push('## Most common rule violations');
+  lines.push('');
+  const ruleCounts = new Map<string, { impact: ImpactLevel; help: string; helpUrl: string; nodeCount: number; screenCount: number }>();
+  for (const screen of report.screens) {
+    for (const violation of screen.violations) {
+      const existing = ruleCounts.get(violation.id);
+      if (existing) {
+        existing.nodeCount += violation.nodeCount;
+        existing.screenCount += 1;
+      } else {
+        ruleCounts.set(violation.id, { impact: violation.impact, help: violation.help, helpUrl: violation.helpUrl, nodeCount: violation.nodeCount, screenCount: 1 });
+      }
+    }
+  }
+  const sortedRules = [...ruleCounts.entries()].sort((a, b) => b[1].nodeCount - a[1].nodeCount);
+  if (sortedRules.length === 0) {
+    lines.push('No violations found. 🎉');
+  } else {
+    lines.push('| Rule | Impact | Elements | Screens | Help |');
+    lines.push('| --- | --- | ---: | ---: | --- |');
+    for (const [ruleId, info] of sortedRules) {
+      lines.push(`| \`${ruleId}\` | ${impactEmoji(info.impact)} ${info.impact} | ${info.nodeCount} | ${info.screenCount} | [${escapeMarkdownTableCell(info.help)}](${info.helpUrl}) |`);
+    }
+  }
+
+  lines.push('');
+  lines.push('## Details per screen');
+  for (const screen of sortedScreens) {
+    lines.push('');
+    lines.push(`### ${screen.screen}`);
+    lines.push('');
+    lines.push(`URL: \`${screen.url}\``);
+    if (screen.error) {
+      lines.push('');
+      lines.push(`⚠️ Could not analyze this screen: ${screen.error}`);
+      continue;
+    }
+    if (screen.violations.length === 0) {
+      lines.push('');
+      lines.push('No violations found. 🎉');
+      continue;
+    }
+    for (const impact of IMPACT_LEVELS) {
+      const violationsForImpact = screen.violations.filter(v => v.impact === impact);
+      for (const violation of violationsForImpact) {
+        lines.push('');
+        lines.push(`- ${impactEmoji(impact)} **${violation.id}** (${impact}) — ${violation.nodeCount} element(s)`);
+        lines.push(`  - ${violation.help} ([docs](${violation.helpUrl}))`);
+        for (const node of violation.nodes.slice(0, 3)) {
+          lines.push(`  - \`${escapeMarkdownTableCell(node.target)}\``);
+        }
+        if (violation.nodeCount > 3) {
+          lines.push(`  - … and ${violation.nodeCount - 3} more (see JSON report)`);
+        }
+      }
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+export async function writeMarkdownReport(report: AccessibilityReport, reportDir: string) {
+  await ensureDir(reportDir);
+  const filePath = path.join(reportDir, 'accessibility-report.md');
+  await fs.writeFile(filePath, generateMarkdownReport(report), 'utf-8');
+  console.log(`Markdown report written: ${filePath}`);
+}
+
+function badgeColor(totals: AccessibilityReport['totals']): string {
+  if (totals.critical > 0) return '#e05d44';
+  if (totals.serious > 0) return '#fe7d37';
+  if (totals.moderate > 0) return '#dfb317';
+  if (totals.minor > 0) return '#a4a61d';
+  return '#4c1';
+}
+
+export function generateBadgeSvg(report: AccessibilityReport): string {
+  const label = 'accessibility';
+  const value = `${report.totals.violations} violations`;
+  const color = badgeColor(report.totals);
+  // Approximate text widths (Verdana 11px averages ~6.5px per character) - the
+  // same flat badge style shields.io uses, kept dependency-free on purpose.
+  const labelWidth = Math.round(label.length * 6.5) + 12;
+  const valueWidth = Math.round(value.length * 6.5) + 12;
+  const totalWidth = labelWidth + valueWidth;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="20" role="img" aria-label="${label}: ${value}">
+  <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+  <clipPath id="r"><rect width="${totalWidth}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${color}"/>
+    <rect width="${totalWidth}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="14">${label}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14">${value}</text>
+  </g>
+</svg>
+`;
+}
+
+export async function writeBadge(report: AccessibilityReport, reportDir: string) {
+  const badgeDir = path.join(reportDir, 'badges');
+  await ensureDir(badgeDir);
+  const filePath = path.join(badgeDir, 'accessibility.svg');
+  await fs.writeFile(filePath, generateBadgeSvg(report), 'utf-8');
+  console.log(`Badge written: ${filePath}`);
+}

--- a/apps/accessibilityTester/tsconfig.json
+++ b/apps/accessibilityTester/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -131,6 +131,7 @@ const Index = () => {
 							currentValue = StringHelper.replaceAllWithOptions({ str: text, find: '[^0-9]', replace: '' });
 						}}
 						keyboardType="number-pad"
+						accessibilityLabel={intervalLabel}
 					/>
 					<View
 						style={[
@@ -285,6 +286,7 @@ const Index = () => {
 												onChangeText={text => handleSortChange(attribute.id, text)}
 												keyboardType="numeric"
 												maxLength={2}
+												accessibilityLabel={`${translate(TranslationKeys.sort)}: ${attribute?.alias ?? ''}`}
 												style={{
 													...styles.sortField,
 													color: theme.screen.text,

--- a/apps/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
@@ -90,6 +90,7 @@ const Index = () => {
 								false: theme.screen.icon,
 								true: foods_area_color,
 							}}
+							accessibilityLabel="Allergene Anzeigen"
 						/>
 					</View>
 				</View>

--- a/apps/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
@@ -79,7 +79,7 @@ const Index = () => {
 					}}
 				>
 					<View style={styles.col1}>
-						<Text style={{ ...styles.label, color: theme.screen.text }}>Allergene Anzeigen</Text>
+						<Text style={{ ...styles.label, color: theme.screen.text }}>{translate(TranslationKeys.show_allergens)}</Text>
 					</View>
 					<View style={styles.col2}>
 						<Switch
@@ -90,7 +90,7 @@ const Index = () => {
 								false: theme.screen.icon,
 								true: foods_area_color,
 							}}
-							accessibilityLabel="Allergene Anzeigen"
+							accessibilityLabel={translate(TranslationKeys.show_allergens)}
 						/>
 					</View>
 				</View>

--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -94,6 +94,23 @@ export default function Layout() {
 		Poppins_900Black_Italic,
 	});
 
+        // On iOS Safari the browser chrome (address bar / bottom toolbar) takes its
+        // color from the theme-color meta tag; without it those areas stay white and
+        // the page looks less like an app. Keep the tag and the document background
+        // in sync with the active app theme.
+        useEffect(() => {
+                if (Platform.OS !== 'web' || typeof document === 'undefined') return;
+                let meta = document.querySelector('meta[name="theme-color"]:not([media])') as HTMLMetaElement | null;
+                if (!meta) {
+                        meta = document.createElement('meta');
+                        meta.setAttribute('name', 'theme-color');
+                        document.head.appendChild(meta);
+                }
+                meta.setAttribute('content', theme.header.background);
+                document.documentElement.style.backgroundColor = theme.screen.background;
+                document.body.style.backgroundColor = theme.screen.background;
+        }, [theme]);
+
         useEffect(() => {
                 const setServerUrl = async () => {
                         const customerConfigs = getCustomerConfigsDict();

--- a/apps/frontend/app/components/AutoImageScroller/index.tsx
+++ b/apps/frontend/app/components/AutoImageScroller/index.tsx
@@ -3,8 +3,14 @@ import { Dimensions, FlatList, View } from 'react-native';
 import { Image } from 'expo-image';
 import styles from './styles';
 
+export interface AutoScrollerImage {
+	uri: string;
+	/** Accessible description of the image (e.g. the food name), used as alt text on web. */
+	alt: string;
+}
+
 interface AutoImageScrollerProps {
-	images: string[];
+	images: AutoScrollerImage[];
 	numColumns: number;
 	size: number;
 	speedPercent: number; // percent of screen height per second
@@ -12,7 +18,7 @@ interface AutoImageScrollerProps {
 }
 
 const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({ images, numColumns, size, speedPercent, loadMore }) => {
-	const flatListRef = useRef<FlatList<string>>(null);
+	const flatListRef = useRef<FlatList<AutoScrollerImage>>(null);
 	const scrollOffset = useRef(0);
 	const screenHeight = Dimensions.get('window').height;
 	const frameRef = useRef<number | null>(null);
@@ -62,13 +68,13 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({ images, numColumn
 		};
 	}, [images, numColumns, size, speedPercent, screenHeight]);
 
-	const renderItem = ({ item, index }: { item: string; index: number }) => {
+	const renderItem = ({ item, index }: { item: AutoScrollerImage; index: number }) => {
 		const columnIndex = index % numColumns;
 		const offset = (columnIndex % 3) * (size / 3);
 		return (
 			<View style={{ transform: [{ translateY: offset }] }}>
 				{/* expo-image only maps accessibilityLabel (not alt) to the img alt attribute on web */}
-				<Image source={{ uri: item }} style={[styles.image, { width: size, height: size }]} contentFit="cover" alt="" accessibilityLabel="" />
+				<Image source={{ uri: item.uri }} style={[styles.image, { width: size, height: size }]} contentFit="cover" alt={item.alt} accessibilityLabel={item.alt} />
 			</View>
 		);
 	};

--- a/apps/frontend/app/components/AutoImageScroller/index.tsx
+++ b/apps/frontend/app/components/AutoImageScroller/index.tsx
@@ -67,7 +67,8 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({ images, numColumn
 		const offset = (columnIndex % 3) * (size / 3);
 		return (
 			<View style={{ transform: [{ translateY: offset }] }}>
-				<Image source={{ uri: item }} style={[styles.image, { width: size, height: size }]} contentFit="cover" />
+				{/* expo-image only maps accessibilityLabel (not alt) to the img alt attribute on web */}
+				<Image source={{ uri: item }} style={[styles.image, { width: size, height: size }]} contentFit="cover" alt="" accessibilityLabel="" />
 			</View>
 		);
 	};

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -119,6 +119,7 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 			aspectRatio={false}
 			onPress={() => handleNavigation(campus?.id)}
 			imageSource={imageSource}
+			imageAccessibilityLabel={campus?.alias ?? undefined}
 			containerStyle={{
 				width: '100%',
 				backgroundColor: theme.card.background,

--- a/apps/frontend/app/components/CardWithText/CardWithText.tsx
+++ b/apps/frontend/app/components/CardWithText/CardWithText.tsx
@@ -3,13 +3,14 @@ import { ImageSourcePropType, ImageStyle, StyleProp } from 'react-native';
 import { CardWithText as BaseCardWithText, CardWithTextProps } from 'repo-depkit-common-ui';
 import MyImage from '@/components/MyImage';
 
-function defaultRenderImage(source: ImageSourcePropType, style: StyleProp<ImageStyle>): React.ReactNode {
+function defaultRenderImage(source: ImageSourcePropType, style: StyleProp<ImageStyle>, imageAccessibilityLabel?: string): React.ReactNode {
 	if (typeof source === 'object' && source !== null && !Array.isArray(source) && 'uri' in source) {
 		return (
 			<MyImage
 				remote_image_url={(source as { uri?: string }).uri}
 				style={style}
 				contentFit="cover"
+				accessibilityLabel={imageAccessibilityLabel}
 			/>
 		);
 	}
@@ -18,6 +19,7 @@ function defaultRenderImage(source: ImageSourcePropType, style: StyleProp<ImageS
 			defaultImage={source}
 			style={style}
 			contentFit="cover"
+			accessibilityLabel={imageAccessibilityLabel}
 		/>
 	);
 }

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -325,6 +325,7 @@ export const FoodItemBase: React.FC<FoodItemProps> = memo(
               imageSource={{
                 uri: imageUri as string,
               }}
+              imageAccessibilityLabel={foodName}
               containerStyle={[
                 containerStyle,
                 cardWidth ? { width: '100%' } : { flex: 1 },

--- a/apps/frontend/app/components/Login/AttentionSheet.tsx
+++ b/apps/frontend/app/components/Login/AttentionSheet.tsx
@@ -40,7 +40,7 @@ const AttentionSheet: React.FC<AttentionSheetProps> = ({ closeSheet, handleLogin
 					<LottieView ref={animationRef} source={updatedAnimationJson} resizeMode="contain" style={{ width: '100%', height: '100%' }} autoPlay={false} loop={false} />
 				</View>
 				<Text style={{ ...styles.attentionSheetHeading, color: theme.sheet.text }} nativeID={ComponentIds.LOGIN_ATTENTION_TITLE}>{translate(TranslationKeys.attention)}</Text>
-				<View style={{ ...styles.attentionContent, width: isWeb ? '80%' : '100%' }}>
+				<View style={{ ...styles.attentionContent, width: '100%' }}>
 					<Text style={{ ...styles.attentionBody, color: theme.sheet.text }}>{translate(TranslationKeys.without_account_limitations)}</Text>
 					<View style={{ ...styles.attentionActions, width: isWeb ? '60%' : '100%' }}>
 						<TouchableOpacity

--- a/apps/frontend/app/components/Login/Form.tsx
+++ b/apps/frontend/app/components/Login/Form.tsx
@@ -125,7 +125,7 @@ const LoginForm: React.FC<FormProps> = ({ openSheet, onSuccess, openAttentionShe
 						style={styles.checkbox}
 						name={isChecked ? 'checkbox-marked' : 'checkbox-blank-outline'}
 						size={30}
-						color={isChecked ? '#000000' : theme.login.text}
+						color={theme.login.text}
 					/>
 					<Text
 						style={{

--- a/apps/frontend/app/components/Login/Form.tsx
+++ b/apps/frontend/app/components/Login/Form.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import Checkbox from 'expo-checkbox';
 import { useTheme } from '@/hooks/useTheme';
 import { UrlHelper } from '@/constants/UrlHelper';
 import { styles } from './styles';
@@ -111,15 +110,22 @@ const LoginForm: React.FC<FormProps> = ({ openSheet, onSuccess, openAttentionShe
 					}}
 					style={styles.section}
 					nativeID={ComponentIds.LOGIN_ACCEPT_PRIVACY}
+					accessibilityRole="checkbox"
+					accessibilityState={{ checked: isChecked }}
+					// react-native-web does not reliably map accessibilityState.checked to
+					// aria-checked here, but role="checkbox" requires it (axe aria-required-attr)
+					aria-checked={isChecked}
+					accessibilityLabel={translate(TranslationKeys.i_accept_privacy_policy_and_terms_of_service)}
 				>
-					<Checkbox
+					{/* Icon-based checkbox instead of expo-checkbox: its web implementation
+					    renders a native <input> that can't receive an accessible label
+					    (critical axe-core "label" violation). The TouchableOpacity above
+					    carries the checkbox role/state/label instead. */}
+					<MaterialCommunityIcons
 						style={styles.checkbox}
-						value={isChecked}
-						onValueChange={(val) => {
-							setChecked(val);
-							if (val) setAgbError(false);
-						}}
-						color={isChecked ? '#000000' : undefined}
+						name={isChecked ? 'checkbox-marked' : 'checkbox-blank-outline'}
+						size={30}
+						color={isChecked ? '#000000' : theme.login.text}
 					/>
 					<Text
 						style={{

--- a/apps/frontend/app/components/Login/styles.ts
+++ b/apps/frontend/app/components/Login/styles.ts
@@ -200,7 +200,7 @@ export const styles = StyleSheet.create({
 	attentionBody: {
 		fontSize: 16,
 		fontFamily: 'Poppins_400Regular',
-		marginVertical: 20,
+		marginVertical: 8,
 		textAlign: 'center',
 	},
 	attentionActions: {
@@ -252,7 +252,7 @@ export const styles = StyleSheet.create({
 	attentionSheetHeading: {
 		fontSize: 32,
 		fontFamily: 'Poppins_700Bold',
-		marginTop: 20,
+		marginTop: 4,
 	},
 	sheetSubHeading: {
 		fontSize: 16,

--- a/apps/frontend/app/components/MyImage/index.tsx
+++ b/apps/frontend/app/components/MyImage/index.tsx
@@ -97,7 +97,7 @@ const MyImage: React.FC<MyImageProps> = ({
         }
 
         // Map resizeMode to contentFit if present in props (compatibility)
-        const { resizeMode, ...rest } = props as any;
+        const { resizeMode, alt, accessibilityLabel, ...rest } = props as any;
         let contentFit = props.contentFit;
         if (resizeMode && !contentFit) {
              if (resizeMode === 'cover') contentFit = 'cover';
@@ -106,7 +106,14 @@ const MyImage: React.FC<MyImageProps> = ({
              else if (resizeMode === 'center') contentFit = 'none';
         }
 
-        return <Image source={source} contentFit={contentFit} {...rest} />;
+        // Images without a provided description get an empty alt, which marks them
+        // as decorative for assistive technology instead of leaving the alt missing
+        // entirely (a critical axe-core "image-alt" violation on web). Note that
+        // expo-image's web renderer only turns accessibilityLabel (not the alt
+        // prop) into the img alt attribute, so the label must always be a string.
+        const resolvedAlt = accessibilityLabel ?? alt ?? '';
+
+        return <Image source={source} contentFit={contentFit} alt={resolvedAlt} accessibilityLabel={resolvedAlt} {...rest} />;
 };
 
 export default React.memo(MyImage);

--- a/apps/frontend/app/components/StatisticsCard/StatisticsCard.tsx
+++ b/apps/frontend/app/components/StatisticsCard/StatisticsCard.tsx
@@ -45,6 +45,7 @@ const StatisticsCard: React.FC<StatisticsCardProps> = ({ food, handleImageSheet,
 					remote_image_url={food?.image_remote_url}
 					directus_asset_id={food?.image}
 					defaultImageUrl={defaultImage}
+					accessibilityLabel={food?.alias ?? ''}
 				/>
 				<TouchableOpacity
 					style={styles.uploadImage}

--- a/apps/frontend/app/components/VerticalImageScroll/index.tsx
+++ b/apps/frontend/app/components/VerticalImageScroll/index.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useAppSelector } from '@/redux/hooks';
 import { RootState } from '@/redux/reducer';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
-import AutoImageScroller from '@/components/AutoImageScroller';
+import AutoImageScroller, { AutoScrollerImage } from '@/components/AutoImageScroller';
 import styles from './styles';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { loadBestRatedFoodsWithImage } from '@/helper/FoodHelper';
@@ -29,15 +29,17 @@ const VerticalImageScroll: React.FC = () => {
 
 	const size = amountColumnsForcard === 0 ? CardDimensionHelper.getCardDimension(screenWidth) : CardDimensionHelper.getCardWidth(screenWidth, numColumns);
 
-	const [images, setImages] = useState<string[]>([]);
+	const [images, setImages] = useState<AutoScrollerImage[]>([]);
 	const offset = useRef(0);
 
 	const fetchImages = async () => {
 		if (offset.current >= MAX_ITEMS) return;
 		const result = await loadBestRatedFoodsWithImage(Math.min(PAGE_SIZE, MAX_ITEMS - offset.current), offset.current);
-		const urls = (result ?? []).map((food: any) => getImageUrl(String((food as any).image))).filter(Boolean) as string[];
-		setImages(prev => [...prev, ...urls]);
-		offset.current += urls.length;
+		const items = (result ?? [])
+			.map((food: any) => ({ uri: getImageUrl(String(food.image)), alt: String(food.alias ?? '') }))
+			.filter((item): item is AutoScrollerImage => Boolean(item.uri));
+		setImages(prev => [...prev, ...items]);
+		offset.current += items.length;
 	};
 
 	useEffect(() => {

--- a/apps/frontend/app/components/VerticalScrollTopFood/index.tsx
+++ b/apps/frontend/app/components/VerticalScrollTopFood/index.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useAppSelector } from '@/redux/hooks';
 import { RootState } from '@/redux/reducer';
 import CardDimensionHelper from '@/helper/CardDimensionHelper';
-import AutoImageScroller from '@/components/AutoImageScroller';
+import AutoImageScroller, { AutoScrollerImage } from '@/components/AutoImageScroller';
 import styles from './styles';
 import { getImageUrl } from '@/constants/HelperFunctions';
 import { loadMostLikedOrDislikedFoods } from '@/helper/FoodHelper';
@@ -29,15 +29,17 @@ const VerticalScrollTopFood: React.FC = () => {
 
 	const size = amountColumnsForcard === 0 ? CardDimensionHelper.getCardDimension(screenWidth) : CardDimensionHelper.getCardWidth(screenWidth, numColumns);
 
-	const [images, setImages] = useState<string[]>([]);
+	const [images, setImages] = useState<AutoScrollerImage[]>([]);
 	const offset = useRef(0);
 
 	const fetchImages = async () => {
 		if (offset.current >= MAX_ITEMS) return;
 		const result = await loadMostLikedOrDislikedFoods(Math.min(PAGE_SIZE, MAX_ITEMS - offset.current), offset.current, undefined, true);
-		const urls = (result ?? []).map((food: any) => getImageUrl(String((food as any).image))).filter(Boolean) as string[];
-		setImages(prev => [...prev, ...urls]);
-		offset.current += urls.length;
+		const items = (result ?? [])
+			.map((food: any) => ({ uri: getImageUrl(String(food.image)), alt: String(food.alias ?? '') }))
+			.filter((item): item is AutoScrollerImage => Boolean(item.uri));
+		setImages(prev => [...prev, ...items]);
+		offset.current += items.length;
 	};
 
 	useEffect(() => {

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -155,6 +155,7 @@ export enum TranslationKeys {
 	unknown = 'unknown',
 	animation = 'animation',
 	allergene = 'allergene',
+	show_allergens = 'show_allergens',
 	clear_markings_selection = 'clear_markings_selection',
 	foodoffers_show_separated_markings_breakdown = 'foodoffers_show_separated_markings_breakdown',
 	foodoffers_show_separated_markings_breakdown_option_enabled = 'foodoffers_show_separated_markings_breakdown_option_enabled',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1589,6 +1589,16 @@
     "tr": "Alerjenler",
     "zh": "过敏原"
   },
+  "show_allergens": {
+    "de": "Allergene anzeigen",
+    "en": "Show allergens",
+    "ar": "إظهار مسببات الحساسية",
+    "es": "Mostrar alérgenos",
+    "fr": "Afficher les allergènes",
+    "ru": "Показать аллергены",
+    "tr": "Alerjenleri göster",
+    "zh": "显示过敏原"
+  },
   "clear_markings_selection": {
     "de": "Allergen-Auswahl zurücksetzen",
     "en": "Clear allergen selection",

--- a/packages/common-ui/src/components/BaseBottomSheet/index.tsx
+++ b/packages/common-ui/src/components/BaseBottomSheet/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useCallback, useMemo, useState } from 'react';
-import { Pressable, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, TouchableOpacity, View } from 'react-native';
 import Animated, { Extrapolation, interpolate, runOnJS, useAnimatedReaction, useAnimatedStyle } from 'react-native-reanimated';
-import BottomSheet, { type BottomSheetBackdropProps, type BottomSheetProps } from '@gorhom/bottom-sheet';
+import BottomSheet, { type BottomSheetBackdropProps, type BottomSheetBackgroundProps, type BottomSheetProps } from '@gorhom/bottom-sheet';
 import { AntDesign } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../context/ThemeContext';
@@ -44,6 +44,15 @@ const backdropStyles = StyleSheet.create({
 	},
 });
 
+// Mirrors @gorhom/bottom-sheet's default background style, minus its hardcoded
+// (and on web invalid) accessibilityRole="adjustable".
+const backgroundStyles = StyleSheet.create({
+	background: {
+		backgroundColor: 'white',
+		borderRadius: 15,
+	},
+});
+
 export interface BaseBottomSheetProps extends Omit<BottomSheetProps, 'backdropComponent'> {
 	onClose?: () => void;
 	headerBackgroundColor?: string;
@@ -70,8 +79,19 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 		[onClose, onChange],
 	);
 
+	// On web, @gorhom/bottom-sheet defaults to accessibilityRole "adjustable",
+	// which becomes role="slider" without the required aria-valuenow (a critical
+	// axe-core violation). The sheet isn't slider-adjustable here anyway (the
+	// drag handle is hidden), so drop the role/label on web. Passing null (not
+	// undefined) prevents the library's defaults from kicking back in. The
+	// library's default background component hardcodes the same broken role, so
+	// it's replaced with a plain view (same default style: rounded corners, the
+	// backgroundStyle prop still applies on top).
+	const webAccessibilityOverrides = Platform.OS === 'web' ? { accessibilityRole: null as any, accessibilityLabel: null as any } : {};
+	const renderBackground = useCallback((backgroundProps: BottomSheetBackgroundProps) => <View pointerEvents={backgroundProps.pointerEvents} style={[backgroundStyles.background, backgroundProps.style]} />, []);
+
 	return (
-		<BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} keyboardBehavior="interactive" keyboardBlurBehavior="restore" android_keyboardInputMode="adjustResize" topInset={topInset} {...props}>
+		<BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundComponent={Platform.OS === 'web' ? renderBackground : undefined} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} keyboardBehavior="interactive" keyboardBlurBehavior="restore" android_keyboardInputMode="adjustResize" topInset={topInset} {...webAccessibilityOverrides} {...props}>
 			<View style={styles.header}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />

--- a/packages/common-ui/src/components/CardWithText/index.tsx
+++ b/packages/common-ui/src/components/CardWithText/index.tsx
@@ -50,11 +50,17 @@ export interface CardWithTextProps extends TouchableOpacityProps {
 	 */
 	aspectRatio?: number | boolean;
 	/**
-	 * Optional custom image renderer. Receives the image source and computed style.
+	 * Optional custom image renderer. Receives the image source, computed style
+	 * and the accessibility label for the image (if provided).
 	 * Use this to render with a caching image component (e.g. expo-image).
 	 * When omitted, the default React Native Image is used.
 	 */
-	renderImage?: (source: ImageSourcePropType, style: StyleProp<ImageStyle>) => React.ReactNode;
+	renderImage?: (source: ImageSourcePropType, style: StyleProp<ImageStyle>, imageAccessibilityLabel?: string) => React.ReactNode;
+	/**
+	 * Accessible description of the card image (e.g. the food or building name).
+	 * Forwarded to the image so screen readers get an alt text on web.
+	 */
+	imageAccessibilityLabel?: string;
 }
 
 const CardWithText: React.FC<CardWithTextProps> = ({
@@ -71,6 +77,7 @@ const CardWithText: React.FC<CardWithTextProps> = ({
 	knownCardWidth,
 	aspectRatio = 1,
 	renderImage,
+	imageAccessibilityLabel,
 	...rest
 }) => {
 	const [measuredWidth, setMeasuredWidth] = useState<number | null>(null);
@@ -115,8 +122,8 @@ const CardWithText: React.FC<CardWithTextProps> = ({
 				<View style={[{ borderTopLeftRadius: topRadius, borderTopRightRadius: topRadius }, ...resolvedImageContainerStyle]}>
 					{imageSource ? (
 						renderImage
-							? renderImage(imageSource, [styles.image, imageStyle])
-							: <Image source={imageSource} style={[styles.image, imageStyle]} resizeMode="cover" />
+							? renderImage(imageSource, [styles.image, imageStyle], imageAccessibilityLabel)
+							: <Image source={imageSource} style={[styles.image, imageStyle]} resizeMode="cover" accessible={!!imageAccessibilityLabel} accessibilityLabel={imageAccessibilityLabel} />
 					) : null}
 					{imageChildren}
 				</View>

--- a/packages/common-ui/src/components/SettingsListBoolean/SettingsListBoolean.tsx
+++ b/packages/common-ui/src/components/SettingsListBoolean/SettingsListBoolean.tsx
@@ -51,6 +51,7 @@ const SettingsListBoolean: React.FC<SettingsListBooleanProps> = ({
 					thumbColor={theme.screen.icon}
 					ios_backgroundColor={theme.screen.iconBg}
 					disabled={isDisabled}
+					accessibilityLabel={props.title ?? props.label}
 				/>
 			}
 			handleFunction={isDisabled ? undefined : onToggle}

--- a/reports/accessibility/accessibility-report.json
+++ b/reports/accessibility/accessibility-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-09T21:56:16.259Z",
+  "generatedAt": "2026-07-10T05:56:39.610Z",
   "baseUrl": "http://localhost:8081",
   "axeCoreVersion": "4.12.1",
   "tags": [
@@ -14,11 +14,11 @@
     "height": 900
   },
   "totals": {
-    "critical": 114,
-    "serious": 14,
+    "critical": 0,
+    "serious": 10,
     "moderate": 71,
     "minor": 0,
-    "violations": 199,
+    "violations": 81,
     "screensWithErrors": 0
   },
   "screens": [
@@ -26,44 +26,6 @@
       "screen": "login",
       "url": "http://localhost:8081/login?kioskMode=true",
       "violations": [
-        {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
-          "id": "label",
-          "impact": "critical",
-          "description": "Ensure every form element has a label",
-          "help": "Form elements must have labels",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "input",
-              "html": "<input aria-checked=\"false\" class=\"r-WebkitAppearance-n1uzsy r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "landmark-one-main",
           "impact": "moderate",
@@ -113,132 +75,13 @@
           ]
         }
       ],
-      "passCount": 21,
+      "passCount": 24,
       "incompleteCount": 1
     },
     {
       "screen": "foodoffers",
       "url": "http://localhost:8081/foodoffers?kioskMode=true",
       "violations": [
-        {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 21,
-          "nodes": [
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .r-gap-580adz.r-left-1n430bm.r-justifyContent-1h0z5md > .r-transitionProperty-1i6wzkk.r-cursor-1loqt21.r-touchAction-1otgn73 > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://www.studente...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(5) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(6) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .r-gap-580adz.r-left-1n430bm.r-justifyContent-1h0z5md > .r-transitionProperty-1i6wzkk.r-cursor-1loqt21.r-touchAction-1otgn73 > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://www.studente...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(5) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(6) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .r-gap-580adz.r-left-1n430bm.r-justifyContent-1h0z5md > .r-transitionProperty-1i6wzkk.r-cursor-1loqt21.r-touchAction-1otgn73 > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://www.studente...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(5) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(6) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "region",
           "impact": "moderate",
@@ -269,30 +112,6 @@
       "url": "http://localhost:8081/eating-habits?kioskMode=true",
       "violations": [
         {
-          "id": "aria-required-attr",
-          "impact": "critical",
-          "description": "Ensure elements with ARIA roles have all required ARIA attributes",
-          "help": "Required ARIA attributes must be provided",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 2,
-          "nodes": [
-            {
-              "target": ".r-borderRadius-1ylenci",
-              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx r-borderRadius-1ylenci r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-pointerEvents-633pao\" style=\"background-color: rgb(26, 26, 26);\"></div>",
-              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
-            },
-            {
-              "target": "#\\32 ",
-              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx\" id=\"2\" style=\"overflow: hidden; user-select: none; touch-action: none; padding-bottom: 110.68px; height: 782.68px;\">",
-              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -314,7 +133,7 @@
           ]
         }
       ],
-      "passCount": 26,
+      "passCount": 17,
       "incompleteCount": 2
     },
     {
@@ -351,164 +170,6 @@
       "url": "http://localhost:8081/campus?kioskMode=true",
       "violations": [
         {
-          "id": "aria-required-attr",
-          "impact": "critical",
-          "description": "Ensure elements with ARIA roles have all required ARIA attributes",
-          "help": "Required ARIA attributes must be provided",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 2,
-          "nodes": [
-            {
-              "target": ".r-borderRadius-1ylenci",
-              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx r-borderRadius-1ylenci r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-pointerEvents-633pao\" style=\"background-color: rgb(26, 26, 26);\"></div>",
-              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
-            },
-            {
-              "target": "#\\32 ",
-              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx\" id=\"2\" style=\"overflow: hidden; user-select: none; touch-action: none;\">",
-              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
-            }
-          ]
-        },
-        {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 24,
-          "nodes": [
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(5) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(6) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(7) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(8) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(9) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(10) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(11) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://swosy.rocket...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(12) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(13) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(14) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(15) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(16) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(17) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(18) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(19) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(20) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(21) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(22) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(23) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(24) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -530,7 +191,7 @@
           ]
         }
       ],
-      "passCount": 29,
+      "passCount": 21,
       "incompleteCount": 2
     },
     {
@@ -552,7 +213,7 @@
             {
               "target": ".r-textAlign-q4m81j",
               "html": "<div dir=\"auto\" class=\"css-text-146c3p1 r-textAlign-q4m81j\" style=\"font-size: 16px; color: rgb(255, 255, 255);\">Failed to load apartments</div>",
-              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.69 (foreground color: #d5d5d5, background color: #d50909, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1"
+              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.63 (foreground color: #ffffff, background color: #ff3333, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1"
             }
           ]
         },
@@ -644,44 +305,6 @@
       "url": "http://localhost:8081/settings?kioskMode=true",
       "violations": [
         {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
-          "id": "label",
-          "impact": "critical",
-          "description": "Ensure every form element has a label",
-          "help": "Form elements must have labels",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -703,37 +326,13 @@
           ]
         }
       ],
-      "passCount": 23,
+      "passCount": 29,
       "incompleteCount": 2
     },
     {
       "screen": "price-group",
       "url": "http://localhost:8081/price-group?kioskMode=true",
       "violations": [
-        {
-          "id": "color-contrast",
-          "impact": "serious",
-          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
-          "help": "Elements must meet minimum color contrast ratio thresholds",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2aa",
-            "wcag143"
-          ],
-          "nodeCount": 2,
-          "nodes": [
-            {
-              "target": ".css-text-146c3p1[dir=\"auto\"]:nth-child(1)",
-              "html": "<div dir=\"auto\" class=\"css-text-146c3p1\">This screen doesn't exist.</div>",
-              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
-            },
-            {
-              "target": "span",
-              "html": "<span class=\"css-textHasAncestor-1jxf684\">Go to home screen!</span>",
-              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
-            }
-          ]
-        },
         {
           "id": "document-title",
           "impact": "serious",
@@ -802,7 +401,7 @@
           ]
         }
       ],
-      "passCount": 12,
+      "passCount": 13,
       "incompleteCount": 1
     },
     {
@@ -926,80 +525,6 @@
       "url": "http://localhost:8081/statistics?kioskMode=true",
       "violations": [
         {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 12,
-          "nodes": [
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(5) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(6) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(5) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(6) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -1016,56 +541,13 @@
           ]
         }
       ],
-      "passCount": 15,
+      "passCount": 16,
       "incompleteCount": 1
     },
     {
       "screen": "labels",
       "url": "http://localhost:8081/labels?kioskMode=true",
       "violations": [
-        {
-          "id": "aria-required-attr",
-          "impact": "critical",
-          "description": "Ensure elements with ARIA roles have all required ARIA attributes",
-          "help": "Required ARIA attributes must be provided",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 2,
-          "nodes": [
-            {
-              "target": ".r-borderRadius-1ylenci",
-              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx r-borderRadius-1ylenci r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-pointerEvents-633pao\" style=\"background-color: rgb(26, 26, 26);\"></div>",
-              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
-            },
-            {
-              "target": "#\\32 ",
-              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx\" id=\"2\" style=\"overflow: hidden; user-select: none; touch-action: none; padding-bottom: 112.361px; height: 832.361px;\">",
-              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
-            }
-          ]
-        },
-        {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"/assets/?unstable_pa...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "region",
           "impact": "moderate",
@@ -1083,7 +565,7 @@
           ]
         }
       ],
-      "passCount": 24,
+      "passCount": 14,
       "incompleteCount": 1
     },
     {
@@ -1313,25 +795,6 @@
       "url": "http://localhost:8081/form-categories?kioskMode=true",
       "violations": [
         {
-          "id": "label",
-          "impact": "critical",
-          "description": "Ensure every form element has a label",
-          "help": "Form elements must have labels",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -1353,7 +816,7 @@
           ]
         }
       ],
-      "passCount": 23,
+      "passCount": 29,
       "incompleteCount": 2
     },
     {
@@ -1462,30 +925,6 @@
       "url": "http://localhost:8081/leaflet-map?kioskMode=true",
       "violations": [
         {
-          "id": "color-contrast",
-          "impact": "serious",
-          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
-          "help": "Elements must meet minimum color contrast ratio thresholds",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2aa",
-            "wcag143"
-          ],
-          "nodeCount": 2,
-          "nodes": [
-            {
-              "target": ".css-text-146c3p1[dir=\"auto\"]:nth-child(1)",
-              "html": "<div dir=\"auto\" class=\"css-text-146c3p1\">This screen doesn't exist.</div>",
-              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
-            },
-            {
-              "target": "span",
-              "html": "<span class=\"css-textHasAncestor-1jxf684\">Go to home screen!</span>",
-              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
-            }
-          ]
-        },
-        {
           "id": "document-title",
           "impact": "serious",
           "description": "Ensure each HTML document contains a non-empty <title> element",
@@ -1553,7 +992,7 @@
           ]
         }
       ],
-      "passCount": 12,
+      "passCount": 13,
       "incompleteCount": 1
     },
     {
@@ -1638,150 +1077,6 @@
       "url": "http://localhost:8081/vertical-image-scroll?kioskMode=true",
       "violations": [
         {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 26,
-          "nodes": [
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(7) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".css-view-g5y9jx:nth-child(7) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -1803,7 +1098,7 @@
           ]
         }
       ],
-      "passCount": 18,
+      "passCount": 17,
       "incompleteCount": 2
     },
     {
@@ -1854,25 +1149,6 @@
       "url": "http://localhost:8081/bigScreen?kioskMode=true",
       "violations": [
         {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"/assets/?unstable_pa...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
-        {
           "id": "region",
           "impact": "moderate",
           "description": "Ensure all page content is contained by landmarks",
@@ -1903,53 +1179,19 @@
           "nodes": [
             {
               "target": ".r-WebkitOverflowScrolling-150rngu",
-              "html": "<div class=\"css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx\" style=\"flex: 1 1 0%; background-color: rgb(26, 26, 26);\">",
+              "html": "<div class=\"css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx\" style=\"flex: 1 1 0%; background-color: rgb(255, 255, 255);\">",
               "failureSummary": "Fix any of the following:\n  Element should have focusable content\n  Element should be focusable"
             }
           ]
         }
       ],
-      "passCount": 15,
+      "passCount": 14,
       "incompleteCount": 0
     },
     {
       "screen": "foodPlanDay",
       "url": "http://localhost:8081/foodPlanDay?kioskMode=true",
       "violations": [
-        {
-          "id": "label",
-          "impact": "critical",
-          "description": "Ensure every form element has a label",
-          "help": "Form elements must have labels",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 4,
-          "nodes": [
-            {
-              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(5) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(7) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(13) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(17) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "region",
           "impact": "moderate",
@@ -1967,87 +1209,13 @@
           ]
         }
       ],
-      "passCount": 19,
+      "passCount": 25,
       "incompleteCount": 1
     },
     {
       "screen": "foodPlanList",
       "url": "http://localhost:8081/foodPlanList?kioskMode=true",
       "violations": [
-        {
-          "id": "label",
-          "impact": "critical",
-          "description": "Ensure every form element has a label",
-          "help": "Form elements must have labels",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 12,
-          "nodes": [
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(1) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(2) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(3) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(4) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(5) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(6) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(7) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(8) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(9) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(10) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(11) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            },
-            {
-              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(12) > input",
-              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "region",
           "impact": "moderate",
@@ -2065,32 +1233,13 @@
           ]
         }
       ],
-      "passCount": 21,
+      "passCount": 22,
       "incompleteCount": 1
     },
     {
       "screen": "foodPlanWeek",
       "url": "http://localhost:8081/foodPlanWeek?kioskMode=true",
       "violations": [
-        {
-          "id": "label",
-          "impact": "critical",
-          "description": "Ensure every form element has a label",
-          "help": "Form elements must have labels",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag412"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "input",
-              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "region",
           "impact": "moderate",
@@ -2108,32 +1257,13 @@
           ]
         }
       ],
-      "passCount": 24,
+      "passCount": 25,
       "incompleteCount": 1
     },
     {
       "screen": "list-day-screen",
       "url": "http://localhost:8081/list-day-screen?kioskMode=true",
       "violations": [
-        {
-          "id": "image-alt",
-          "impact": "critical",
-          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
-          "help": "Images must have alternative text",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
-          "wcagTags": [
-            "wcag2a",
-            "wcag111"
-          ],
-          "nodeCount": 1,
-          "nodes": [
-            {
-              "target": "img[fetchpriority=\"auto\"]",
-              "html": "<img fetchpriority=\"auto\" src=\"/assets/?unstable_pa...\" style=\"object-position: lef...\">",
-              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
-            }
-          ]
-        },
         {
           "id": "region",
           "impact": "moderate",
@@ -2151,7 +1281,7 @@
           ]
         }
       ],
-      "passCount": 15,
+      "passCount": 14,
       "incompleteCount": 1
     },
     {

--- a/reports/accessibility/accessibility-report.json
+++ b/reports/accessibility/accessibility-report.json
@@ -1,0 +1,2249 @@
+{
+  "generatedAt": "2026-07-09T21:56:16.259Z",
+  "baseUrl": "http://localhost:8081",
+  "axeCoreVersion": "4.12.1",
+  "tags": [
+    "wcag2a",
+    "wcag2aa",
+    "wcag21a",
+    "wcag21aa",
+    "best-practice"
+  ],
+  "viewport": {
+    "width": 1280,
+    "height": 900
+  },
+  "totals": {
+    "critical": 114,
+    "serious": 14,
+    "moderate": 71,
+    "minor": 0,
+    "violations": 199,
+    "screensWithErrors": 0
+  },
+  "screens": [
+    {
+      "screen": "login",
+      "url": "http://localhost:8081/login?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "input",
+              "html": "<input aria-checked=\"false\" class=\"r-WebkitAppearance-n1uzsy r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "landmark-one-main",
+          "impact": "moderate",
+          "description": "Ensure the document has a main landmark",
+          "help": "Document should have one main landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix all of the following:\n  Document does not have a main landmark"
+            }
+          ]
+        },
+        {
+          "id": "page-has-heading-one",
+          "impact": "moderate",
+          "description": "Ensure that the page, or at least one of its frames contains a level-one heading",
+          "help": "Page should contain a level-one heading",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix all of the following:\n  Page must have a level-one heading"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "#root",
+              "html": "<div id=\"root\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 21,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "foodoffers",
+      "url": "http://localhost:8081/foodoffers?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 21,
+          "nodes": [
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .r-gap-580adz.r-left-1n430bm.r-justifyContent-1h0z5md > .r-transitionProperty-1i6wzkk.r-cursor-1loqt21.r-touchAction-1otgn73 > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://www.studente...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(5) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(6) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .r-gap-580adz.r-left-1n430bm.r-justifyContent-1h0z5md > .r-transitionProperty-1i6wzkk.r-cursor-1loqt21.r-touchAction-1otgn73 > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://www.studente...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(5) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(6) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(4) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .r-gap-580adz.r-left-1n430bm.r-justifyContent-1h0z5md > .r-transitionProperty-1i6wzkk.r-cursor-1loqt21.r-touchAction-1otgn73 > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://www.studente...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(5) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(6) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 27,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "eating-habits",
+      "url": "http://localhost:8081/eating-habits?kioskMode=true",
+      "violations": [
+        {
+          "id": "aria-required-attr",
+          "impact": "critical",
+          "description": "Ensure elements with ARIA roles have all required ARIA attributes",
+          "help": "Required ARIA attributes must be provided",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-borderRadius-1ylenci",
+              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx r-borderRadius-1ylenci r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-pointerEvents-633pao\" style=\"background-color: rgb(26, 26, 26);\"></div>",
+              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
+            },
+            {
+              "target": "#\\32 ",
+              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx\" id=\"2\" style=\"overflow: hidden; user-select: none; touch-action: none; padding-bottom: 110.68px; height: 782.68px;\">",
+              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "account-balance",
+      "url": "http://localhost:8081/account-balance?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "campus",
+      "url": "http://localhost:8081/campus?kioskMode=true",
+      "violations": [
+        {
+          "id": "aria-required-attr",
+          "impact": "critical",
+          "description": "Ensure elements with ARIA roles have all required ARIA attributes",
+          "help": "Required ARIA attributes must be provided",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-borderRadius-1ylenci",
+              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx r-borderRadius-1ylenci r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-pointerEvents-633pao\" style=\"background-color: rgb(26, 26, 26);\"></div>",
+              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
+            },
+            {
+              "target": "#\\32 ",
+              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx\" id=\"2\" style=\"overflow: hidden; user-select: none; touch-action: none;\">",
+              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
+            }
+          ]
+        },
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 24,
+          "nodes": [
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(5) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(6) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(7) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(8) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(9) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(10) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(11) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://swosy.rocket...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(12) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(13) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(14) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(15) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(16) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(17) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(18) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(19) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(20) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(21) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(22) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(23) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(24) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 29,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "housing",
+      "url": "http://localhost:8081/housing?kioskMode=true",
+      "violations": [
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2aa",
+            "wcag143"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-textAlign-q4m81j",
+              "html": "<div dir=\"auto\" class=\"css-text-146c3p1 r-textAlign-q4m81j\" style=\"font-size: 16px; color: rgb(255, 255, 255);\">Failed to load apartments</div>",
+              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.69 (foreground color: #d5d5d5, background color: #d50909, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 24,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "news",
+      "url": "http://localhost:8081/news?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "course-timetable",
+      "url": "http://localhost:8081/course-timetable?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "settings",
+      "url": "http://localhost:8081/settings?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 23,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "price-group",
+      "url": "http://localhost:8081/price-group?kioskMode=true",
+      "violations": [
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2aa",
+            "wcag143"
+          ],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".css-text-146c3p1[dir=\"auto\"]:nth-child(1)",
+              "html": "<div dir=\"auto\" class=\"css-text-146c3p1\">This screen doesn't exist.</div>",
+              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
+            },
+            {
+              "target": "span",
+              "html": "<span class=\"css-textHasAncestor-1jxf684\">Go to home screen!</span>",
+              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
+            }
+          ]
+        },
+        {
+          "id": "document-title",
+          "impact": "serious",
+          "description": "Ensure each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag242"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix any of the following:\n  Document does not have a non-empty <title> element"
+            }
+          ]
+        },
+        {
+          "id": "landmark-one-main",
+          "impact": "moderate",
+          "description": "Ensure the document has a main landmark",
+          "help": "Document should have one main landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix all of the following:\n  Document does not have a main landmark"
+            }
+          ]
+        },
+        {
+          "id": "page-has-heading-one",
+          "impact": "moderate",
+          "description": "Ensure that the page, or at least one of its frames contains a level-one heading",
+          "help": "Page should contain a level-one heading",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix all of the following:\n  Page must have a level-one heading"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "#root",
+              "html": "<div id=\"root\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 12,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "data-access",
+      "url": "http://localhost:8081/data-access?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "support-FAQ",
+      "url": "http://localhost:8081/support-FAQ?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "licenseInformation",
+      "url": "http://localhost:8081/licenseInformation?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "management",
+      "url": "http://localhost:8081/management?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "statistics",
+      "url": "http://localhost:8081/statistics?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 12,
+          "nodes": [
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(5) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(6) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(5) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-width-a1w0r5.css-view-g5y9jx:nth-child(2) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(6) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-bottom-1p0dtai",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 15,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "labels",
+      "url": "http://localhost:8081/labels?kioskMode=true",
+      "violations": [
+        {
+          "id": "aria-required-attr",
+          "impact": "critical",
+          "description": "Ensure elements with ARIA roles have all required ARIA attributes",
+          "help": "Required ARIA attributes must be provided",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-borderRadius-1ylenci",
+              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx r-borderRadius-1ylenci r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-pointerEvents-633pao\" style=\"background-color: rgb(26, 26, 26);\"></div>",
+              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
+            },
+            {
+              "target": "#\\32 ",
+              "html": "<div aria-label=\"Bottom Sheet\" role=\"slider\" class=\"css-view-g5y9jx\" id=\"2\" style=\"overflow: hidden; user-select: none; touch-action: none; padding-bottom: 112.361px; height: 832.361px;\">",
+              "failureSummary": "Fix any of the following:\n  Required ARIA attribute not present: aria-valuenow"
+            }
+          ]
+        },
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"/assets/?unstable_pa...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.r-bottom-1p0dtai.r-top-ipm5af",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 24,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "events",
+      "url": "http://localhost:8081/events?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "experimentell",
+      "url": "http://localhost:8081/experimentell?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "faq-food",
+      "url": "http://localhost:8081/faq-food?kioskMode=true",
+      "violations": [
+        {
+          "id": "document-title",
+          "impact": "serious",
+          "description": "Ensure each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag242"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix any of the following:\n  Document does not have a non-empty <title> element"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 3,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-pointerEvents-12vffkv.r-justifyContent-1777fci.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-justifyContent-1777fci r-pointerEvents-12vffkv\" style=\"max-width: 1212px; margin-left: 4px;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-pointerEvents-105ug2t.r-overflow-1udh08x.r-left-1d2f490 > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\"><div class=\"css-view-g5y9jx\"><div dir=\"auto\" class=\"css-text-146c3p1\">index</div></div></div>",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 28,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "faq-living",
+      "url": "http://localhost:8081/faq-living?kioskMode=true",
+      "violations": [
+        {
+          "id": "document-title",
+          "impact": "serious",
+          "description": "Ensure each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag242"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix any of the following:\n  Document does not have a non-empty <title> element"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 3,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-pointerEvents-12vffkv.r-justifyContent-1777fci.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-justifyContent-1777fci r-pointerEvents-12vffkv\" style=\"max-width: 1212px; margin-left: 4px;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-pointerEvents-105ug2t.r-overflow-1udh08x.r-left-1d2f490 > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\"><div class=\"css-view-g5y9jx\"><div dir=\"auto\" class=\"css-text-146c3p1\">index</div></div></div>",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 28,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "feedback-support",
+      "url": "http://localhost:8081/feedback-support?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 22,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "forms",
+      "url": "http://localhost:8081/forms?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "form-categories",
+      "url": "http://localhost:8081/form-categories?kioskMode=true",
+      "violations": [
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 23,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "form-submissions",
+      "url": "http://localhost:8081/form-submissions?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 21,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "form-submission",
+      "url": "http://localhost:8081/form-submission?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "delete-user",
+      "url": "http://localhost:8081/delete-user?kioskMode=true",
+      "violations": [
+        {
+          "id": "document-title",
+          "impact": "serious",
+          "description": "Ensure each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag242"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix any of the following:\n  Document does not have a non-empty <title> element"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-bottom-1p0dtai",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 11,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "leaflet-map",
+      "url": "http://localhost:8081/leaflet-map?kioskMode=true",
+      "violations": [
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2aa",
+            "wcag143"
+          ],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".css-text-146c3p1[dir=\"auto\"]:nth-child(1)",
+              "html": "<div dir=\"auto\" class=\"css-text-146c3p1\">This screen doesn't exist.</div>",
+              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
+            },
+            {
+              "target": "span",
+              "html": "<span class=\"css-textHasAncestor-1jxf684\">Go to home screen!</span>",
+              "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 1.54 (foreground color: #000000, background color: #2e2e2e, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1"
+            }
+          ]
+        },
+        {
+          "id": "document-title",
+          "impact": "serious",
+          "description": "Ensure each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag242"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix any of the following:\n  Document does not have a non-empty <title> element"
+            }
+          ]
+        },
+        {
+          "id": "landmark-one-main",
+          "impact": "moderate",
+          "description": "Ensure the document has a main landmark",
+          "help": "Document should have one main landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix all of the following:\n  Document does not have a main landmark"
+            }
+          ]
+        },
+        {
+          "id": "page-has-heading-one",
+          "impact": "moderate",
+          "description": "Ensure that the page, or at least one of its frames contains a level-one heading",
+          "help": "Page should contain a level-one heading",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix all of the following:\n  Page must have a level-one heading"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "#root",
+              "html": "<div id=\"root\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 12,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "notification",
+      "url": "http://localhost:8081/notification?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 17,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "support-ticket",
+      "url": "http://localhost:8081/support-ticket?kioskMode=true",
+      "violations": [
+        {
+          "id": "aria-progressbar-name",
+          "impact": "serious",
+          "description": "Ensure every ARIA progressbar node has an accessible name",
+          "help": "ARIA progressbar nodes must have an accessible name",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "div[role=\"progressbar\"]",
+              "html": "<div role=\"progressbar\" aria-valuemax=\"1\" aria-valuemin=\"0\" class=\"css-view-g5y9jx r-alignItems-1awozwy r-justifyContent-1777fci\">",
+              "failureSummary": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "vertical-image-scroll",
+      "url": "http://localhost:8081/vertical-image-scroll?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 26,
+          "nodes": [
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(2) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(3) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(4) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(5) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(6) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(4) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(7) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".css-view-g5y9jx:nth-child(7) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage=\"true\"] > div > img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"https://test.rocket-...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 2,
+          "nodes": [
+            {
+              "target": ".r-maxWidth-dnmrzs",
+              "html": "<div class=\"css-view-g5y9jx r-bo...\" style=\"position: absolute; ...\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            },
+            {
+              "target": ".r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 18,
+      "incompleteCount": 2
+    },
+    {
+      "screen": "wikis",
+      "url": "http://localhost:8081/wikis?kioskMode=true",
+      "violations": [
+        {
+          "id": "aria-progressbar-name",
+          "impact": "serious",
+          "description": "Ensure every ARIA progressbar node has an accessible name",
+          "help": "ARIA progressbar nodes must have an accessible name",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-justifyContent-1777fci",
+              "html": "<div role=\"progressbar\" aria-valuemax=\"1\" aria-valuemin=\"0\" class=\"css-view-g5y9jx r-alignItems-1awozwy r-justifyContent-1777fci\">",
+              "failureSummary": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-bottom-1p0dtai",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 21,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "bigScreen",
+      "url": "http://localhost:8081/bigScreen?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"/assets/?unstable_pa...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        },
+        {
+          "id": "scrollable-region-focusable",
+          "impact": "serious",
+          "description": "Ensure elements that have scrollable content are accessible by keyboard in Safari",
+          "help": "Scrollable region must have keyboard access",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag211",
+            "wcag213"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-WebkitOverflowScrolling-150rngu",
+              "html": "<div class=\"css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx\" style=\"flex: 1 1 0%; background-color: rgb(26, 26, 26);\">",
+              "failureSummary": "Fix any of the following:\n  Element should have focusable content\n  Element should be focusable"
+            }
+          ]
+        }
+      ],
+      "passCount": 15,
+      "incompleteCount": 0
+    },
+    {
+      "screen": "foodPlanDay",
+      "url": "http://localhost:8081/foodPlanDay?kioskMode=true",
+      "violations": [
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 4,
+          "nodes": [
+            {
+              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(5) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(7) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(13) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(17) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 19,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "foodPlanList",
+      "url": "http://localhost:8081/foodPlanList?kioskMode=true",
+      "violations": [
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 12,
+          "nodes": [
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(1) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(2) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(3) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(4) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(5) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(6) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(7) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(8) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(9) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(10) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(11) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            },
+            {
+              "target": ".r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(12) > input",
+              "html": "<input maxlength=\"2\" autocapitalize=\"sentences\" autocomplete=\"on\" autocorrect=\"on\" dir=\"auto\" inputmode=\"numeric\" rows=\"1\" spellcheck=\"true\" virtualkeyboardpolic...=\"auto\" class=\"css-textinput-11aywt...\" value=\"\" style=\"width: 50px; height:...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-bottom-1p0dtai",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 21,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "foodPlanWeek",
+      "url": "http://localhost:8081/foodPlanWeek?kioskMode=true",
+      "violations": [
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "input",
+              "html": "<input role=\"switch\" class=\"r-appearance-30o5oe r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-margin-crgep1 r-padding-t60dpp r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-cursor-1ei5mc7\" type=\"checkbox\" checked=\"\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an implicit (wrapped) <label>\n  Element does not have an explicit <label>\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element has no placeholder attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 24,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "list-day-screen",
+      "url": "http://localhost:8081/list-day-screen?kioskMode=true",
+      "violations": [
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "description": "Ensure <img> elements have alternative text or a role of none or presentation",
+          "help": "Images must have alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag111"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "img[fetchpriority=\"auto\"]",
+              "html": "<img fetchpriority=\"auto\" src=\"/assets/?unstable_pa...\" style=\"object-position: lef...\">",
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element's default semantics were not overridden with role=\"none\" or role=\"presentation\""
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.r-bottom-1p0dtai.r-left-1d2f490",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 15,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "list-week-screen",
+      "url": "http://localhost:8081/list-week-screen?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "#root > .r-flex-13awgt0.css-view-g5y9jx > .css-view-g5y9jx > .css-view-g5y9jx > .css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 13,
+      "incompleteCount": 1
+    },
+    {
+      "screen": "rss-feed",
+      "url": "http://localhost:8081/rss-feed?kioskMode=true",
+      "violations": [
+        {
+          "id": "document-title",
+          "impact": "serious",
+          "description": "Ensure each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer",
+          "wcagTags": [
+            "wcag2a",
+            "wcag242"
+          ],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": "html",
+              "html": "<html lang=\"en\" class=\"gs gs-light\">",
+              "failureSummary": "Fix any of the following:\n  Document does not have a non-empty <title> element"
+            }
+          ]
+        },
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 21,
+      "incompleteCount": 0
+    },
+    {
+      "screen": "rss-feed-config",
+      "url": "http://localhost:8081/rss-feed-config?kioskMode=true",
+      "violations": [
+        {
+          "id": "region",
+          "impact": "moderate",
+          "description": "Ensure all page content is contained by landmarks",
+          "help": "All page content should be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer",
+          "wcagTags": [],
+          "nodeCount": 1,
+          "nodes": [
+            {
+              "target": ".r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d",
+              "html": "<div class=\"css-view-g5y9jx r-flex-13awgt0 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af\" style=\"background-color: rgb(242, 242, 242); display: flex;\">",
+              "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks"
+            }
+          ]
+        }
+      ],
+      "passCount": 27,
+      "incompleteCount": 0
+    }
+  ]
+}

--- a/reports/accessibility/accessibility-report.md
+++ b/reports/accessibility/accessibility-report.md
@@ -1,35 +1,28 @@
 # Accessibility Report
 
-> Generated: 2026-07-09T21:56:16.259Z | axe-core 4.12.1 | Rules: wcag2a, wcag2aa, wcag21a, wcag21aa, best-practice | Viewport: 1280x900
+> Generated: 2026-07-10T05:56:39.610Z | axe-core 4.12.1 | Rules: wcag2a, wcag2aa, wcag21a, wcag21aa, best-practice | Viewport: 1280x900
 > Base URL: http://localhost:8081
 
 ## Summary
 
-Total violations (affected elements): **199** — 🟥 Critical: 114, 🟧 Serious: 14, 🟨 Moderate: 71, 🟦 Minor: 0
+Total violations (affected elements): **81** — 🟥 Critical: 0, 🟧 Serious: 10, 🟨 Moderate: 71, 🟦 Minor: 0
 
 | Screen | 🟥 Critical | 🟧 Serious | 🟨 Moderate | 🟦 Minor | Total | Passes |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| campus | 26 | 0 | 2 | 0 | 28 | 29 |
-| vertical-image-scroll | 26 | 0 | 2 | 0 | 28 | 18 |
-| foodoffers | 21 | 0 | 2 | 0 | 23 | 27 |
-| statistics | 12 | 0 | 1 | 0 | 13 | 15 |
-| foodPlanList | 12 | 0 | 1 | 0 | 13 | 21 |
-| price-group | 0 | 3 | 3 | 0 | 6 | 12 |
-| leaflet-map | 0 | 3 | 3 | 0 | 6 | 12 |
-| login | 2 | 0 | 3 | 0 | 5 | 21 |
-| foodPlanDay | 4 | 0 | 1 | 0 | 5 | 19 |
-| eating-habits | 2 | 0 | 2 | 0 | 4 | 26 |
-| settings | 2 | 0 | 2 | 0 | 4 | 23 |
-| labels | 3 | 0 | 1 | 0 | 4 | 24 |
+| price-group | 0 | 1 | 3 | 0 | 4 | 13 |
 | faq-food | 0 | 1 | 3 | 0 | 4 | 28 |
 | faq-living | 0 | 1 | 3 | 0 | 4 | 28 |
+| leaflet-map | 0 | 1 | 3 | 0 | 4 | 13 |
+| login | 0 | 0 | 3 | 0 | 3 | 24 |
 | housing | 0 | 1 | 2 | 0 | 3 | 24 |
-| form-categories | 1 | 0 | 2 | 0 | 3 | 23 |
 | support-ticket | 0 | 1 | 2 | 0 | 3 | 26 |
-| bigScreen | 1 | 1 | 1 | 0 | 3 | 15 |
+| foodoffers | 0 | 0 | 2 | 0 | 2 | 27 |
+| eating-habits | 0 | 0 | 2 | 0 | 2 | 17 |
 | account-balance | 0 | 0 | 2 | 0 | 2 | 17 |
+| campus | 0 | 0 | 2 | 0 | 2 | 21 |
 | news | 0 | 0 | 2 | 0 | 2 | 17 |
 | course-timetable | 0 | 0 | 2 | 0 | 2 | 17 |
+| settings | 0 | 0 | 2 | 0 | 2 | 29 |
 | data-access | 0 | 0 | 2 | 0 | 2 | 17 |
 | support-FAQ | 0 | 0 | 2 | 0 | 2 | 17 |
 | licenseInformation | 0 | 0 | 2 | 0 | 2 | 17 |
@@ -38,14 +31,21 @@ Total violations (affected elements): **199** — 🟥 Critical: 114, 🟧 Serio
 | experimentell | 0 | 0 | 2 | 0 | 2 | 17 |
 | feedback-support | 0 | 0 | 2 | 0 | 2 | 22 |
 | forms | 0 | 0 | 2 | 0 | 2 | 17 |
+| form-categories | 0 | 0 | 2 | 0 | 2 | 29 |
 | form-submissions | 0 | 0 | 2 | 0 | 2 | 21 |
 | form-submission | 0 | 0 | 2 | 0 | 2 | 17 |
 | delete-user | 0 | 1 | 1 | 0 | 2 | 11 |
 | notification | 0 | 0 | 2 | 0 | 2 | 17 |
+| vertical-image-scroll | 0 | 0 | 2 | 0 | 2 | 17 |
 | wikis | 0 | 1 | 1 | 0 | 2 | 21 |
-| foodPlanWeek | 1 | 0 | 1 | 0 | 2 | 24 |
-| list-day-screen | 1 | 0 | 1 | 0 | 2 | 15 |
+| bigScreen | 0 | 1 | 1 | 0 | 2 | 14 |
 | rss-feed | 0 | 1 | 1 | 0 | 2 | 21 |
+| statistics | 0 | 0 | 1 | 0 | 1 | 16 |
+| labels | 0 | 0 | 1 | 0 | 1 | 14 |
+| foodPlanDay | 0 | 0 | 1 | 0 | 1 | 25 |
+| foodPlanList | 0 | 0 | 1 | 0 | 1 | 22 |
+| foodPlanWeek | 0 | 0 | 1 | 0 | 1 | 25 |
+| list-day-screen | 0 | 0 | 1 | 0 | 1 | 14 |
 | list-week-screen | 0 | 0 | 1 | 0 | 1 | 13 |
 | rss-feed-config | 0 | 0 | 1 | 0 | 1 | 27 |
 
@@ -53,111 +53,20 @@ Total violations (affected elements): **199** — 🟥 Critical: 114, 🟧 Serio
 
 | Rule | Impact | Elements | Screens | Help |
 | --- | --- | ---: | ---: | --- |
-| `image-alt` | 🟥 critical | 88 | 9 | [Images must have alternative text](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer) |
 | `region` | 🟨 moderate | 65 | 39 | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer) |
-| `label` | 🟥 critical | 20 | 6 | [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer) |
-| `aria-required-attr` | 🟥 critical | 6 | 3 | [Required ARIA attributes must be provided](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer) |
 | `document-title` | 🟧 serious | 6 | 6 | [Documents must have <title> element to aid in navigation](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer) |
-| `color-contrast` | 🟧 serious | 5 | 3 | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer) |
 | `landmark-one-main` | 🟨 moderate | 3 | 3 | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer) |
 | `page-has-heading-one` | 🟨 moderate | 3 | 3 | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer) |
 | `aria-progressbar-name` | 🟧 serious | 2 | 2 | [ARIA progressbar nodes must have an accessible name](https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name?application=axe-puppeteer) |
+| `color-contrast` | 🟧 serious | 1 | 1 | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer) |
 | `scrollable-region-focusable` | 🟧 serious | 1 | 1 | [Scrollable region must have keyboard access](https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=axe-puppeteer) |
 
 ## Details per screen
-
-### campus
-
-URL: `http://localhost:8081/campus?kioskMode=true`
-
-- 🟥 **aria-required-attr** (critical) — 2 element(s)
-  - Required ARIA attributes must be provided ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer))
-  - `.r-borderRadius-1ylenci`
-  - `#\32 `
-
-- 🟥 **image-alt** (critical) — 24 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `.css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - `.css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - `.css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - … and 21 more (see JSON report)
-
-- 🟨 **region** (moderate) — 2 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-maxWidth-dnmrzs`
-  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
-
-### vertical-image-scroll
-
-URL: `http://localhost:8081/vertical-image-scroll?kioskMode=true`
-
-- 🟥 **image-alt** (critical) — 26 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `.css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - `.css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - `.css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - … and 23 more (see JSON report)
-
-- 🟨 **region** (moderate) — 2 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-maxWidth-dnmrzs`
-  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
-
-### foodoffers
-
-URL: `http://localhost:8081/foodoffers?kioskMode=true`
-
-- 🟥 **image-alt** (critical) — 21 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `.css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - `.css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - `.css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
-  - … and 18 more (see JSON report)
-
-- 🟨 **region** (moderate) — 2 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af`
-  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
-
-### statistics
-
-URL: `http://localhost:8081/statistics?kioskMode=true`
-
-- 🟥 **image-alt** (critical) — 12 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `.r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img`
-  - `.r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img`
-  - `.r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img`
-  - … and 9 more (see JSON report)
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-bottom-1p0dtai`
-
-### foodPlanList
-
-URL: `http://localhost:8081/foodPlanList?kioskMode=true`
-
-- 🟥 **label** (critical) — 12 element(s)
-  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
-  - `.r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(1) > input`
-  - `.r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(2) > input`
-  - `.r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(3) > input`
-  - … and 9 more (see JSON report)
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-bottom-1p0dtai`
 
 ### price-group
 
 URL: `http://localhost:8081/price-group?kioskMode=true`
 
-- 🟧 **color-contrast** (serious) — 2 element(s)
-  - Elements must meet minimum color contrast ratio thresholds ([docs](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer))
-  - `.css-text-146c3p1[dir="auto"]:nth-child(1)`
-  - `span`
-
 - 🟧 **document-title** (serious) — 1 element(s)
   - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
   - `html`
@@ -173,118 +82,6 @@ URL: `http://localhost:8081/price-group?kioskMode=true`
 - 🟨 **region** (moderate) — 1 element(s)
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
   - `#root`
-
-### leaflet-map
-
-URL: `http://localhost:8081/leaflet-map?kioskMode=true`
-
-- 🟧 **color-contrast** (serious) — 2 element(s)
-  - Elements must meet minimum color contrast ratio thresholds ([docs](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer))
-  - `.css-text-146c3p1[dir="auto"]:nth-child(1)`
-  - `span`
-
-- 🟧 **document-title** (serious) — 1 element(s)
-  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
-  - `html`
-
-- 🟨 **landmark-one-main** (moderate) — 1 element(s)
-  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
-  - `html`
-
-- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
-  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
-  - `html`
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `#root`
-
-### login
-
-URL: `http://localhost:8081/login?kioskMode=true`
-
-- 🟥 **image-alt** (critical) — 1 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `img[fetchpriority="auto"]`
-
-- 🟥 **label** (critical) — 1 element(s)
-  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
-  - `input`
-
-- 🟨 **landmark-one-main** (moderate) — 1 element(s)
-  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
-  - `html`
-
-- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
-  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
-  - `html`
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `#root`
-
-### foodPlanDay
-
-URL: `http://localhost:8081/foodPlanDay?kioskMode=true`
-
-- 🟥 **label** (critical) — 4 element(s)
-  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
-  - `.r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(5) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input`
-  - `.r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(7) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input`
-  - `.r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(13) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input`
-  - … and 1 more (see JSON report)
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
-
-### eating-habits
-
-URL: `http://localhost:8081/eating-habits?kioskMode=true`
-
-- 🟥 **aria-required-attr** (critical) — 2 element(s)
-  - Required ARIA attributes must be provided ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer))
-  - `.r-borderRadius-1ylenci`
-  - `#\32 `
-
-- 🟨 **region** (moderate) — 2 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-maxWidth-dnmrzs`
-  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
-
-### settings
-
-URL: `http://localhost:8081/settings?kioskMode=true`
-
-- 🟥 **image-alt** (critical) — 1 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `img[fetchpriority="auto"]`
-
-- 🟥 **label** (critical) — 1 element(s)
-  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
-  - `input`
-
-- 🟨 **region** (moderate) — 2 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-maxWidth-dnmrzs`
-  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
-
-### labels
-
-URL: `http://localhost:8081/labels?kioskMode=true`
-
-- 🟥 **aria-required-attr** (critical) — 2 element(s)
-  - Required ARIA attributes must be provided ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer))
-  - `.r-borderRadius-1ylenci`
-  - `#\32 `
-
-- 🟥 **image-alt** (critical) — 1 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `img[fetchpriority="auto"]`
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-flex-13awgt0.r-bottom-1p0dtai.r-top-ipm5af`
 
 ### faq-food
 
@@ -314,6 +111,42 @@ URL: `http://localhost:8081/faq-living?kioskMode=true`
   - `.r-pointerEvents-12vffkv.r-justifyContent-1777fci.css-view-g5y9jx`
   - `.r-pointerEvents-105ug2t.r-overflow-1udh08x.r-left-1d2f490 > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
+### leaflet-map
+
+URL: `http://localhost:8081/leaflet-map?kioskMode=true`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **landmark-one-main** (moderate) — 1 element(s)
+  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
+  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `#root`
+
+### login
+
+URL: `http://localhost:8081/login?kioskMode=true`
+
+- 🟨 **landmark-one-main** (moderate) — 1 element(s)
+  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
+  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `#root`
+
 ### housing
 
 URL: `http://localhost:8081/housing?kioskMode=true`
@@ -321,19 +154,6 @@ URL: `http://localhost:8081/housing?kioskMode=true`
 - 🟧 **color-contrast** (serious) — 1 element(s)
   - Elements must meet minimum color contrast ratio thresholds ([docs](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer))
   - `.r-textAlign-q4m81j`
-
-- 🟨 **region** (moderate) — 2 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-maxWidth-dnmrzs`
-  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
-
-### form-categories
-
-URL: `http://localhost:8081/form-categories?kioskMode=true`
-
-- 🟥 **label** (critical) — 1 element(s)
-  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
-  - `input`
 
 - 🟨 **region** (moderate) — 2 element(s)
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
@@ -353,21 +173,23 @@ URL: `http://localhost:8081/support-ticket?kioskMode=true`
   - `.r-maxWidth-dnmrzs`
   - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
-### bigScreen
+### foodoffers
 
-URL: `http://localhost:8081/bigScreen?kioskMode=true`
+URL: `http://localhost:8081/foodoffers?kioskMode=true`
 
-- 🟥 **image-alt** (critical) — 1 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `img[fetchpriority="auto"]`
-
-- 🟧 **scrollable-region-focusable** (serious) — 1 element(s)
-  - Scrollable region must have keyboard access ([docs](https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=axe-puppeteer))
-  - `.r-WebkitOverflowScrolling-150rngu`
-
-- 🟨 **region** (moderate) — 1 element(s)
+- 🟨 **region** (moderate) — 2 element(s)
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+  - `.r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### eating-habits
+
+URL: `http://localhost:8081/eating-habits?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
 ### account-balance
 
@@ -377,6 +199,15 @@ URL: `http://localhost:8081/account-balance?kioskMode=true`
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
   - `.r-maxWidth-dnmrzs`
   - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### campus
+
+URL: `http://localhost:8081/campus?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
 ### news
 
@@ -395,6 +226,15 @@ URL: `http://localhost:8081/course-timetable?kioskMode=true`
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
   - `.r-maxWidth-dnmrzs`
   - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### settings
+
+URL: `http://localhost:8081/settings?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
 ### data-access
 
@@ -468,6 +308,15 @@ URL: `http://localhost:8081/forms?kioskMode=true`
   - `.r-maxWidth-dnmrzs`
   - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
+### form-categories
+
+URL: `http://localhost:8081/form-categories?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
 ### form-submissions
 
 URL: `http://localhost:8081/form-submissions?kioskMode=true`
@@ -507,6 +356,15 @@ URL: `http://localhost:8081/notification?kioskMode=true`
   - `.r-maxWidth-dnmrzs`
   - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
 
+### vertical-image-scroll
+
+URL: `http://localhost:8081/vertical-image-scroll?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
 ### wikis
 
 URL: `http://localhost:8081/wikis?kioskMode=true`
@@ -519,29 +377,17 @@ URL: `http://localhost:8081/wikis?kioskMode=true`
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
   - `.r-bottom-1p0dtai`
 
-### foodPlanWeek
+### bigScreen
 
-URL: `http://localhost:8081/foodPlanWeek?kioskMode=true`
+URL: `http://localhost:8081/bigScreen?kioskMode=true`
 
-- 🟥 **label** (critical) — 1 element(s)
-  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
-  - `input`
+- 🟧 **scrollable-region-focusable** (serious) — 1 element(s)
+  - Scrollable region must have keyboard access ([docs](https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=axe-puppeteer))
+  - `.r-WebkitOverflowScrolling-150rngu`
 
 - 🟨 **region** (moderate) — 1 element(s)
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
   - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
-
-### list-day-screen
-
-URL: `http://localhost:8081/list-day-screen?kioskMode=true`
-
-- 🟥 **image-alt** (critical) — 1 element(s)
-  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
-  - `img[fetchpriority="auto"]`
-
-- 🟨 **region** (moderate) — 1 element(s)
-  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
-  - `.r-flex-13awgt0.r-bottom-1p0dtai.r-left-1d2f490`
 
 ### rss-feed
 
@@ -554,6 +400,54 @@ URL: `http://localhost:8081/rss-feed?kioskMode=true`
 - 🟨 **region** (moderate) — 1 element(s)
   - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
   - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### statistics
+
+URL: `http://localhost:8081/statistics?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-bottom-1p0dtai`
+
+### labels
+
+URL: `http://localhost:8081/labels?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.r-bottom-1p0dtai.r-top-ipm5af`
+
+### foodPlanDay
+
+URL: `http://localhost:8081/foodPlanDay?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### foodPlanList
+
+URL: `http://localhost:8081/foodPlanList?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-bottom-1p0dtai`
+
+### foodPlanWeek
+
+URL: `http://localhost:8081/foodPlanWeek?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### list-day-screen
+
+URL: `http://localhost:8081/list-day-screen?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.r-bottom-1p0dtai.r-left-1d2f490`
 
 ### list-week-screen
 

--- a/reports/accessibility/accessibility-report.md
+++ b/reports/accessibility/accessibility-report.md
@@ -1,0 +1,572 @@
+# Accessibility Report
+
+> Generated: 2026-07-09T21:56:16.259Z | axe-core 4.12.1 | Rules: wcag2a, wcag2aa, wcag21a, wcag21aa, best-practice | Viewport: 1280x900
+> Base URL: http://localhost:8081
+
+## Summary
+
+Total violations (affected elements): **199** — 🟥 Critical: 114, 🟧 Serious: 14, 🟨 Moderate: 71, 🟦 Minor: 0
+
+| Screen | 🟥 Critical | 🟧 Serious | 🟨 Moderate | 🟦 Minor | Total | Passes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| campus | 26 | 0 | 2 | 0 | 28 | 29 |
+| vertical-image-scroll | 26 | 0 | 2 | 0 | 28 | 18 |
+| foodoffers | 21 | 0 | 2 | 0 | 23 | 27 |
+| statistics | 12 | 0 | 1 | 0 | 13 | 15 |
+| foodPlanList | 12 | 0 | 1 | 0 | 13 | 21 |
+| price-group | 0 | 3 | 3 | 0 | 6 | 12 |
+| leaflet-map | 0 | 3 | 3 | 0 | 6 | 12 |
+| login | 2 | 0 | 3 | 0 | 5 | 21 |
+| foodPlanDay | 4 | 0 | 1 | 0 | 5 | 19 |
+| eating-habits | 2 | 0 | 2 | 0 | 4 | 26 |
+| settings | 2 | 0 | 2 | 0 | 4 | 23 |
+| labels | 3 | 0 | 1 | 0 | 4 | 24 |
+| faq-food | 0 | 1 | 3 | 0 | 4 | 28 |
+| faq-living | 0 | 1 | 3 | 0 | 4 | 28 |
+| housing | 0 | 1 | 2 | 0 | 3 | 24 |
+| form-categories | 1 | 0 | 2 | 0 | 3 | 23 |
+| support-ticket | 0 | 1 | 2 | 0 | 3 | 26 |
+| bigScreen | 1 | 1 | 1 | 0 | 3 | 15 |
+| account-balance | 0 | 0 | 2 | 0 | 2 | 17 |
+| news | 0 | 0 | 2 | 0 | 2 | 17 |
+| course-timetable | 0 | 0 | 2 | 0 | 2 | 17 |
+| data-access | 0 | 0 | 2 | 0 | 2 | 17 |
+| support-FAQ | 0 | 0 | 2 | 0 | 2 | 17 |
+| licenseInformation | 0 | 0 | 2 | 0 | 2 | 17 |
+| management | 0 | 0 | 2 | 0 | 2 | 17 |
+| events | 0 | 0 | 2 | 0 | 2 | 17 |
+| experimentell | 0 | 0 | 2 | 0 | 2 | 17 |
+| feedback-support | 0 | 0 | 2 | 0 | 2 | 22 |
+| forms | 0 | 0 | 2 | 0 | 2 | 17 |
+| form-submissions | 0 | 0 | 2 | 0 | 2 | 21 |
+| form-submission | 0 | 0 | 2 | 0 | 2 | 17 |
+| delete-user | 0 | 1 | 1 | 0 | 2 | 11 |
+| notification | 0 | 0 | 2 | 0 | 2 | 17 |
+| wikis | 0 | 1 | 1 | 0 | 2 | 21 |
+| foodPlanWeek | 1 | 0 | 1 | 0 | 2 | 24 |
+| list-day-screen | 1 | 0 | 1 | 0 | 2 | 15 |
+| rss-feed | 0 | 1 | 1 | 0 | 2 | 21 |
+| list-week-screen | 0 | 0 | 1 | 0 | 1 | 13 |
+| rss-feed-config | 0 | 0 | 1 | 0 | 1 | 27 |
+
+## Most common rule violations
+
+| Rule | Impact | Elements | Screens | Help |
+| --- | --- | ---: | ---: | --- |
+| `image-alt` | 🟥 critical | 88 | 9 | [Images must have alternative text](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer) |
+| `region` | 🟨 moderate | 65 | 39 | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer) |
+| `label` | 🟥 critical | 20 | 6 | [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer) |
+| `aria-required-attr` | 🟥 critical | 6 | 3 | [Required ARIA attributes must be provided](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer) |
+| `document-title` | 🟧 serious | 6 | 6 | [Documents must have <title> element to aid in navigation](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer) |
+| `color-contrast` | 🟧 serious | 5 | 3 | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer) |
+| `landmark-one-main` | 🟨 moderate | 3 | 3 | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer) |
+| `page-has-heading-one` | 🟨 moderate | 3 | 3 | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer) |
+| `aria-progressbar-name` | 🟧 serious | 2 | 2 | [ARIA progressbar nodes must have an accessible name](https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name?application=axe-puppeteer) |
+| `scrollable-region-focusable` | 🟧 serious | 1 | 1 | [Scrollable region must have keyboard access](https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=axe-puppeteer) |
+
+## Details per screen
+
+### campus
+
+URL: `http://localhost:8081/campus?kioskMode=true`
+
+- 🟥 **aria-required-attr** (critical) — 2 element(s)
+  - Required ARIA attributes must be provided ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer))
+  - `.r-borderRadius-1ylenci`
+  - `#\32 `
+
+- 🟥 **image-alt** (critical) — 24 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `.css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - `.css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - `.css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .r-position-bnwqim.r-overflow-1udh08x.r-width-13qz1uu > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - … and 21 more (see JSON report)
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### vertical-image-scroll
+
+URL: `http://localhost:8081/vertical-image-scroll?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 26 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `.css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - `.css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - `.css-view-g5y9jx:nth-child(1) > .r-flexDirection-18u37iz.css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - … and 23 more (see JSON report)
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### foodoffers
+
+URL: `http://localhost:8081/foodoffers?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 21 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `.css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(1) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - `.css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(2) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - `.css-view-g5y9jx:nth-child(1) > .r-paddingInline-1e084wi.r-paddingBlock-ytbthy.css-view-g5y9jx > .r-alignItems-1oszu61.r-marginTop-1s2bzr4.r-flexWrap-1w6e6rj > .css-view-g5y9jx:nth-child(3) > .r-borderRadius-1q9bdsx.r-overflow-1udh08x.r-transitionProperty-1i6wzkk > .r-position-bnwqim.r-width-13qz1uu.r-overflow-1udh08x > .r-position-bnwqim.r-overflow-1udh08x.css-view-g5y9jx > .css-view-g5y9jx[data-expoimage="true"] > div > img[fetchpriority="auto"]`
+  - … and 18 more (see JSON report)
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### statistics
+
+URL: `http://localhost:8081/statistics?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 12 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `.r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img`
+  - `.r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(2) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img`
+  - `.r-width-a1w0r5.css-view-g5y9jx:nth-child(1) > .r-WebkitOverflowScrolling-150rngu.r-flexDirection-eqz5dr.r-flexGrow-16y2uox > .css-view-g5y9jx > .css-view-g5y9jx:nth-child(3) > .css-view-g5y9jx:nth-child(1) > .css-view-g5y9jx[data-expoimage="true"] > div > img`
+  - … and 9 more (see JSON report)
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-bottom-1p0dtai`
+
+### foodPlanList
+
+URL: `http://localhost:8081/foodPlanList?kioskMode=true`
+
+- 🟥 **label** (critical) — 12 element(s)
+  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
+  - `.r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(1) > input`
+  - `.r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(2) > input`
+  - `.r-paddingInline-1ubuhtd.r-width-13qz1uu.r-gap-uaa2di:nth-child(3) > input`
+  - … and 9 more (see JSON report)
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-bottom-1p0dtai`
+
+### price-group
+
+URL: `http://localhost:8081/price-group?kioskMode=true`
+
+- 🟧 **color-contrast** (serious) — 2 element(s)
+  - Elements must meet minimum color contrast ratio thresholds ([docs](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer))
+  - `.css-text-146c3p1[dir="auto"]:nth-child(1)`
+  - `span`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **landmark-one-main** (moderate) — 1 element(s)
+  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
+  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `#root`
+
+### leaflet-map
+
+URL: `http://localhost:8081/leaflet-map?kioskMode=true`
+
+- 🟧 **color-contrast** (serious) — 2 element(s)
+  - Elements must meet minimum color contrast ratio thresholds ([docs](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer))
+  - `.css-text-146c3p1[dir="auto"]:nth-child(1)`
+  - `span`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **landmark-one-main** (moderate) — 1 element(s)
+  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
+  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `#root`
+
+### login
+
+URL: `http://localhost:8081/login?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 1 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `img[fetchpriority="auto"]`
+
+- 🟥 **label** (critical) — 1 element(s)
+  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
+  - `input`
+
+- 🟨 **landmark-one-main** (moderate) — 1 element(s)
+  - Document should have one main landmark ([docs](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **page-has-heading-one** (moderate) — 1 element(s)
+  - Page should contain a level-one heading ([docs](https://dequeuniversity.com/rules/axe/4.12/page-has-heading-one?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `#root`
+
+### foodPlanDay
+
+URL: `http://localhost:8081/foodPlanDay?kioskMode=true`
+
+- 🟥 **label** (critical) — 4 element(s)
+  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
+  - `.r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(5) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input`
+  - `.r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(7) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input`
+  - `.r-transitionProperty-1i6wzkk.r-touchAction-1otgn73.r-paddingBlock-ytbthy:nth-child(13) > .r-marginInlineStart-wizibn.r-minHeight-1ii58gl.r-minWidth-25kp3t > .r-cursor-1loqt21.r-userSelect-lrvibr.css-view-g5y9jx > input`
+  - … and 1 more (see JSON report)
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### eating-habits
+
+URL: `http://localhost:8081/eating-habits?kioskMode=true`
+
+- 🟥 **aria-required-attr** (critical) — 2 element(s)
+  - Required ARIA attributes must be provided ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer))
+  - `.r-borderRadius-1ylenci`
+  - `#\32 `
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### settings
+
+URL: `http://localhost:8081/settings?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 1 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `img[fetchpriority="auto"]`
+
+- 🟥 **label** (critical) — 1 element(s)
+  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
+  - `input`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### labels
+
+URL: `http://localhost:8081/labels?kioskMode=true`
+
+- 🟥 **aria-required-attr** (critical) — 2 element(s)
+  - Required ARIA attributes must be provided ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-required-attr?application=axe-puppeteer))
+  - `.r-borderRadius-1ylenci`
+  - `#\32 `
+
+- 🟥 **image-alt** (critical) — 1 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `img[fetchpriority="auto"]`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.r-bottom-1p0dtai.r-top-ipm5af`
+
+### faq-food
+
+URL: `http://localhost:8081/faq-food?kioskMode=true`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 3 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af`
+  - `.r-pointerEvents-12vffkv.r-justifyContent-1777fci.css-view-g5y9jx`
+  - `.r-pointerEvents-105ug2t.r-overflow-1udh08x.r-left-1d2f490 > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### faq-living
+
+URL: `http://localhost:8081/faq-living?kioskMode=true`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 3 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs.r-bottom-1p0dtai.r-top-ipm5af`
+  - `.r-pointerEvents-12vffkv.r-justifyContent-1777fci.css-view-g5y9jx`
+  - `.r-pointerEvents-105ug2t.r-overflow-1udh08x.r-left-1d2f490 > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### housing
+
+URL: `http://localhost:8081/housing?kioskMode=true`
+
+- 🟧 **color-contrast** (serious) — 1 element(s)
+  - Elements must meet minimum color contrast ratio thresholds ([docs](https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=axe-puppeteer))
+  - `.r-textAlign-q4m81j`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### form-categories
+
+URL: `http://localhost:8081/form-categories?kioskMode=true`
+
+- 🟥 **label** (critical) — 1 element(s)
+  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
+  - `input`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### support-ticket
+
+URL: `http://localhost:8081/support-ticket?kioskMode=true`
+
+- 🟧 **aria-progressbar-name** (serious) — 1 element(s)
+  - ARIA progressbar nodes must have an accessible name ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name?application=axe-puppeteer))
+  - `div[role="progressbar"]`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### bigScreen
+
+URL: `http://localhost:8081/bigScreen?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 1 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `img[fetchpriority="auto"]`
+
+- 🟧 **scrollable-region-focusable** (serious) — 1 element(s)
+  - Scrollable region must have keyboard access ([docs](https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=axe-puppeteer))
+  - `.r-WebkitOverflowScrolling-150rngu`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### account-balance
+
+URL: `http://localhost:8081/account-balance?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### news
+
+URL: `http://localhost:8081/news?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### course-timetable
+
+URL: `http://localhost:8081/course-timetable?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### data-access
+
+URL: `http://localhost:8081/data-access?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### support-FAQ
+
+URL: `http://localhost:8081/support-FAQ?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### licenseInformation
+
+URL: `http://localhost:8081/licenseInformation?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### management
+
+URL: `http://localhost:8081/management?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### events
+
+URL: `http://localhost:8081/events?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### experimentell
+
+URL: `http://localhost:8081/experimentell?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### feedback-support
+
+URL: `http://localhost:8081/feedback-support?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flex-13awgt0.r-flexDirection-18u37iz.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### forms
+
+URL: `http://localhost:8081/forms?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### form-submissions
+
+URL: `http://localhost:8081/form-submissions?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### form-submission
+
+URL: `http://localhost:8081/form-submission?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### delete-user
+
+URL: `http://localhost:8081/delete-user?kioskMode=true`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-bottom-1p0dtai`
+
+### notification
+
+URL: `http://localhost:8081/notification?kioskMode=true`
+
+- 🟨 **region** (moderate) — 2 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-maxWidth-dnmrzs`
+  - `.r-flexDirection-18u37iz.r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx`
+
+### wikis
+
+URL: `http://localhost:8081/wikis?kioskMode=true`
+
+- 🟧 **aria-progressbar-name** (serious) — 1 element(s)
+  - ARIA progressbar nodes must have an accessible name ([docs](https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name?application=axe-puppeteer))
+  - `.r-justifyContent-1777fci`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-bottom-1p0dtai`
+
+### foodPlanWeek
+
+URL: `http://localhost:8081/foodPlanWeek?kioskMode=true`
+
+- 🟥 **label** (critical) — 1 element(s)
+  - Form elements must have labels ([docs](https://dequeuniversity.com/rules/axe/4.12/label?application=axe-puppeteer))
+  - `input`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### list-day-screen
+
+URL: `http://localhost:8081/list-day-screen?kioskMode=true`
+
+- 🟥 **image-alt** (critical) — 1 element(s)
+  - Images must have alternative text ([docs](https://dequeuniversity.com/rules/axe/4.12/image-alt?application=axe-puppeteer))
+  - `img[fetchpriority="auto"]`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.r-bottom-1p0dtai.r-left-1d2f490`
+
+### rss-feed
+
+URL: `http://localhost:8081/rss-feed?kioskMode=true`
+
+- 🟧 **document-title** (serious) — 1 element(s)
+  - Documents must have <title> element to aid in navigation ([docs](https://dequeuniversity.com/rules/axe/4.12/document-title?application=axe-puppeteer))
+  - `html`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### list-week-screen
+
+URL: `http://localhost:8081/list-week-screen?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `#root > .r-flex-13awgt0.css-view-g5y9jx > .css-view-g5y9jx > .css-view-g5y9jx > .css-view-g5y9jx > .r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`
+
+### rss-feed-config
+
+URL: `http://localhost:8081/rss-feed-config?kioskMode=true`
+
+- 🟨 **region** (moderate) — 1 element(s)
+  - All page content should be contained by landmarks ([docs](https://dequeuniversity.com/rules/axe/4.12/region?application=axe-puppeteer))
+  - `.r-flex-13awgt0.css-view-g5y9jx > .r-bottom-1p0dtai.r-left-1d2f490.r-position-u8s1d`

--- a/reports/accessibility/badges/accessibility.svg
+++ b/reports/accessibility/badges/accessibility.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20" role="img" aria-label="accessibility: 199 violations">
+  <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+  <clipPath id="r"><rect width="200" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="97" height="20" fill="#555"/>
+    <rect x="97" width="103" height="20" fill="#e05d44"/>
+    <rect width="200" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="48.5" y="14">accessibility</text>
+    <text x="148.5" y="14">199 violations</text>
+  </g>
+</svg>

--- a/reports/accessibility/badges/accessibility.svg
+++ b/reports/accessibility/badges/accessibility.svg
@@ -1,13 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20" role="img" aria-label="accessibility: 199 violations">
+<svg xmlns="http://www.w3.org/2000/svg" width="194" height="20" role="img" aria-label="accessibility: 81 violations">
   <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
-  <clipPath id="r"><rect width="200" height="20" rx="3" fill="#fff"/></clipPath>
+  <clipPath id="r"><rect width="194" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
     <rect width="97" height="20" fill="#555"/>
-    <rect x="97" width="103" height="20" fill="#e05d44"/>
-    <rect width="200" height="20" fill="url(#s)"/>
+    <rect x="97" width="97" height="20" fill="#fe7d37"/>
+    <rect width="194" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="48.5" y="14">accessibility</text>
-    <text x="148.5" y="14">199 violations</text>
+    <text x="145.5" y="14">81 violations</text>
   </g>
 </svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,6 +751,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@axe-core/puppeteer@npm:^4.10.1":
+  version: 4.12.1
+  resolution: "@axe-core/puppeteer@npm:4.12.1"
+  dependencies:
+    axe-core: "npm:~4.12.1"
+  peerDependencies:
+    puppeteer: ">=1.10.0"
+  checksum: 10c0/27ef967658c45fc5cb2ed396d3cf5d12e1303fb96e946ce683d4bfd7552108ed07b1da54f29ea678fda5aa503a02456a81e2306eaae3967c97c887ea8b9bc750
+  languageName: node
+  linkType: hard
+
 "@azure-rest/core-client@npm:^2.3.3":
   version: 2.5.1
   resolution: "@azure-rest/core-client@npm:2.5.1"
@@ -11231,6 +11242,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accessibilitytester@workspace:apps/accessibilityTester":
+  version: 0.0.0-use.local
+  resolution: "accessibilitytester@workspace:apps/accessibilityTester"
+  dependencies:
+    "@axe-core/puppeteer": "npm:^4.10.1"
+    "@types/node": "npm:^22.5.0"
+    axe-core: "npm:^4.10.2"
+    puppeteer: "npm:^23.1.1"
+    repo-depkit-common: "workspace:*"
+    tsx: "npm:^4.7.0"
+    typescript: "npm:^5.5.4"
+    yargs: "npm:^17.7.2"
+  languageName: unknown
+  linkType: soft
+
 "acorn-globals@npm:^7.0.0":
   version: 7.0.1
   resolution: "acorn-globals@npm:7.0.1"
@@ -11796,6 +11822,13 @@ __metadata:
   version: 1.1.2
   resolution: "aws-ssl-profiles@npm:1.1.2"
   checksum: 10c0/e5f59a4146fe3b88ad2a84f814886c788557b80b744c8cbcb1cbf8cf5ba19cc006a7a12e88819adc614ecda9233993f8f1d1f3b612cbc2f297196df9e8f4f66e
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:^4.10.2, axe-core@npm:~4.12.1":
+  version: 4.12.1
+  resolution: "axe-core@npm:4.12.1"
+  checksum: 10c0/03438bd98cef38ad57554feea0d8de21705001db2655c27e0c33ff55e16dd7d6f49c28fb420dc93f7532e68ff363c0953056a5836e6f47068f193eb1765c7db7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
New workspace app `apps/accessibilityTester` that runs automated accessibility audits (axe-core, WCAG 2.1 A/AA + best-practice rules) via Puppeteer against **every screen** in `APP_ROUTES` - the same canonical screen list the screenshot generator uses, so newly added screens are audited automatically. Screens are opened with `kioskMode=true` for a demo login session.

Three reports are written to `reports/accessibility/` (following the existing sonarCloud/data-clumps report conventions):
- `accessibility-report.json` - full machine-readable results (all violations with element selectors, HTML snippets, failure summaries)
- `accessibility-report.md` - per-screen violation table, most common rule violations across the app, per-screen details with docs links
- `badges/accessibility.svg` - violation-count badge, color-coded by the worst impact level found

Usage: `yarn workspace accessibilitytester start --baseUrl http://localhost:8081` (options: `--reportDir`, `--tags`, `--browserLang`, `--failOnViolations` as an optional CI gate).

### Initial audit results (committed)
199 violation elements across 39 screens: 🟥 114 critical, 🟧 14 serious, 🟨 71 moderate. Top issues: `image-alt` (88 elements - images without alt text), `region` (65 - content outside landmarks), `label` (20 - unlabeled form elements).

### CI workflow (separate commit, needs `workflow`-scoped token)
A workflow `frontend-accessibility.yml` (weekly + manual dispatch) that exports the web app, serves it locally, runs the audit, uploads reports as artifact and commits them back (data-clumps pattern) is committed **locally on this branch but not yet pushed**: both the git PAT and the gh CLI token lack the `workflow` scope, so pushing it was rejected by GitHub. After refreshing the token (`gh auth refresh -h github.com -s workflow`) a plain `git push` will add it to this PR.

## Test plan
- [x] Full local run against `yarn expo start --web` dev server: all 39 screens analyzed, no load errors, all three reports generated
- [x] `tsc --noEmit` clean for the new app
- [x] Report content spot-checked: violation counts, rule aggregation, docs links and badge render correctly