### PR TITLE
App download banner + SonarCloud fixes (security E→A, 11 bugs, 4 data clumps)

### DIFF
--- a/.github/workflows/frontend-maestro.yml
+++ b/.github/workflows/frontend-maestro.yml
@@ -41,13 +41,22 @@ jobs:
           done
 
       - name: "🌐 Install Chrome"
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2
         with:
           chrome-version: stable
 
       - name: "🎭 Install Maestro CLI"
         run: |
-          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          # Pinned Maestro release, downloaded over enforced HTTPS and verified
+          # against its published SHA-256 checksum before anything is executed.
+          MAESTRO_VERSION="cli-2.6.1"
+          MAESTRO_SHA256="3440825f514f537c6a96bcf5de995780c2a4a7f83a43208fdc95d4f1fecfad3b"
+          curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/maestro.zip "https://github.com/mobile-dev-inc/Maestro/releases/download/${MAESTRO_VERSION}/maestro.zip"
+          echo "${MAESTRO_SHA256}  /tmp/maestro.zip" | sha256sum --check --strict
+          unzip -q /tmp/maestro.zip -d "$HOME/.maestro-install"
+          mkdir -p "$HOME/.maestro"
+          cp -r "$HOME/.maestro-install/maestro/"* "$HOME/.maestro/"
+          chmod +x "$HOME/.maestro/bin/maestro"
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
       - name: "📝 Generate Maestro YAML from TypeScript tests"

--- a/.github/workflows/pr-expo-preview.yml
+++ b/.github/workflows/pr-expo-preview.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: "🔨 Build & Deploy Web Preview"
         run: |
-          npx expo export -p web
+          yarn expo export -p web
           yarn run copy-assets
           yarn gh-pages --nojekyll -d dist --dest "pr-${{ github.event.pull_request.number }}"
         working-directory: ./apps/frontend/app

--- a/.github/workflows/pr-expo-preview.yml
+++ b/.github/workflows/pr-expo-preview.yml
@@ -5,9 +5,15 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to redeploy just the web preview for (skips the EAS mobile update)"
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -198,21 +204,48 @@ jobs:
             }
 
   web-preview-deploy:
-    name: "🌐 Web Preview Deploy (PR #${{ github.event.pull_request.number }})"
+    name: "🌐 Web Preview Deploy (PR #${{ github.event.pull_request.number || inputs.pr_number }})"
     runs-on: ubuntu-latest
     needs: check-repository
     if: >-
-      github.event.action != 'closed'
-      && needs.check-repository.outputs.is-upstream == 'true'
-      && github.event.pull_request.head.repo.full_name == github.repository
+      needs.check-repository.outputs.is-upstream == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (
+          github.event.action != 'closed'
+          && github.event.pull_request.head.repo.full_name == github.repository
+        )
+      )
     permissions:
       contents: write
       pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:
+      # workflow_dispatch carries no pull_request context, so the fork check the
+      # pull_request trigger gets for free (head.repo.full_name == github.repository)
+      # has to be re-verified via the API before anything is checked out - this job
+      # runs with EXPO_TOKEN/GITHUB_TOKEN and deploys to public GitHub Pages, so a
+      # manually-dispatched run must never build a fork's code.
+      - name: "🔒 Verify PR head repository (manual dispatch only)"
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEAD_REPO=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
+          echo "PR #${PR_NUMBER} head repository: ${HEAD_REPO}"
+          if [ "$HEAD_REPO" != "${{ github.repository }}" ]; then
+            echo "::error::Refusing to build PR #${PR_NUMBER} - its head branch is on a fork (${HEAD_REPO}), not ${{ github.repository }}."
+            exit 1
+          fi
+
       - name: "🔄 Checkout PR Head"
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # workflow_dispatch has no pull_request.head.ref, but any PR's head
+          # commit can be checked out directly via the refs/pull/<n>/head ref
+          # (the step above already confirmed this PR's head lives in this repo).
+          ref: ${{ github.event.pull_request.head.ref || format('refs/pull/{0}/head', inputs.pr_number) }}
 
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
         uses: ./.github/actions/setup-and-install
@@ -245,19 +278,20 @@ jobs:
         run: |
           yarn expo export -p web
           yarn run copy-assets
-          yarn gh-pages --nojekyll -d dist --dest "pr-${{ github.event.pull_request.number }}"
+          yarn gh-pages --nojekyll -d dist --dest "pr-${PR_NUMBER}"
         working-directory: ./apps/frontend/app
         env:
-          EXPO_PUBLIC_BASE_URL_SUFFIX: /pr-${{ github.event.pull_request.number }}
+          EXPO_PUBLIC_BASE_URL_SUFFIX: /pr-${{ env.PR_NUMBER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "💬 Comment on PR"
         uses: actions/github-script@v7
         env:
           WEB_BASE_PATH: ${{ env.WEB_BASE_PATH }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = Number(process.env.PR_NUMBER);
             const marker = '<!-- web-preview-comment -->';
             const baseUrlPath = process.env.WEB_BASE_PATH;
             const url = `https://rocket-meals.de/${baseUrlPath}/pr-${prNumber}/`;

--- a/apps/accessibilityTester/src/report.ts
+++ b/apps/accessibilityTester/src/report.ts
@@ -1,5 +1,29 @@
 import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
 import path from 'path';
+
+// Report output must stay inside the working tree: the repository root when the tool
+// runs inside a checkout (found by walking up to the nearest .git), otherwise the
+// current working directory. The reportDir CLI flag is untrusted input.
+function findAllowedBaseDir(): string {
+  let current = process.cwd();
+  while (true) {
+    if (existsSync(path.join(current, '.git'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return process.cwd();
+    current = parent;
+  }
+}
+
+const ALLOWED_BASE_DIR = findAllowedBaseDir();
+
+function resolveGuardedPath(...segments: string[]): string {
+  const resolved = path.resolve(...segments);
+  if (resolved !== ALLOWED_BASE_DIR && !resolved.startsWith(ALLOWED_BASE_DIR + path.sep)) {
+    throw new Error(`Refusing to write outside "${ALLOWED_BASE_DIR}": "${resolved}"`);
+  }
+  return resolved;
+}
 
 export type ImpactLevel = 'critical' | 'serious' | 'moderate' | 'minor';
 
@@ -57,12 +81,12 @@ export function countViolationsByImpact(screens: ScreenResult[]): Record<ImpactL
 }
 
 async function ensureDir(dirPath: string) {
-  await fs.mkdir(dirPath, { recursive: true });
+  await fs.mkdir(resolveGuardedPath(dirPath), { recursive: true });
 }
 
 export async function writeJsonReport(report: AccessibilityReport, reportDir: string) {
   await ensureDir(reportDir);
-  const filePath = path.join(reportDir, 'accessibility-report.json');
+  const filePath = resolveGuardedPath(reportDir, 'accessibility-report.json');
   await fs.writeFile(filePath, JSON.stringify(report, null, 2) + '\n', 'utf-8');
   console.log(`JSON report written: ${filePath}`);
 }
@@ -184,7 +208,7 @@ export function generateMarkdownReport(report: AccessibilityReport): string {
 
 export async function writeMarkdownReport(report: AccessibilityReport, reportDir: string) {
   await ensureDir(reportDir);
-  const filePath = path.join(reportDir, 'accessibility-report.md');
+  const filePath = resolveGuardedPath(reportDir, 'accessibility-report.md');
   await fs.writeFile(filePath, generateMarkdownReport(report), 'utf-8');
   console.log(`Markdown report written: ${filePath}`);
 }
@@ -223,9 +247,9 @@ export function generateBadgeSvg(report: AccessibilityReport): string {
 }
 
 export async function writeBadge(report: AccessibilityReport, reportDir: string) {
-  const badgeDir = path.join(reportDir, 'badges');
+  const badgeDir = resolveGuardedPath(reportDir, 'badges');
   await ensureDir(badgeDir);
-  const filePath = path.join(badgeDir, 'accessibility.svg');
+  const filePath = resolveGuardedPath(badgeDir, 'accessibility.svg');
   await fs.writeFile(filePath, generateBadgeSvg(report), 'utf-8');
   console.log(`Badge written: ${filePath}`);
 }

--- a/apps/backend-sync/src/DirectusDatabaseSync.ts
+++ b/apps/backend-sync/src/DirectusDatabaseSync.ts
@@ -253,13 +253,23 @@ export class DirectusDatabaseSync {
     console.log(' -  Enabled required settings');
   }
 
+  // Validates a CLI-controlled value against an anchored allowlist pattern before it is
+  // passed to an OS command, so faulty or malicious CLI arguments cannot smuggle in
+  // unexpected content (see SonarCloud S8705).
+  private static requireSafeCliValue(name: string, value: string, pattern: RegExp): string {
+    if (!pattern.test(value)) {
+      throw new Error(`Refusing to pass unsafe value for "${name}" to the directus-sync CLI`);
+    }
+    return value;
+  }
+
   private getDirectusSyncArgs(): string[] {
     const preserveIds = 'dashboards,operations,panels,policies,roles,translations';
     return [
-      '--directus-url', this.config.directusInstanceUrl,
-      '--directus-email', this.config.adminEmail,
-      '--directus-password', this.config.adminPassword,
-      '--dump-path', this.dumpPath,
+      '--directus-url', DirectusDatabaseSync.requireSafeCliValue('directus-url', this.config.directusInstanceUrl, /^https?:\/\/[\w.-]+(?::\d+)?(?:\/[\w./-]*)?$/),
+      '--directus-email', DirectusDatabaseSync.requireSafeCliValue('directus-email', this.config.adminEmail, /^[^\s@]+@[^\s@]+$/),
+      '--directus-password', DirectusDatabaseSync.requireSafeCliValue('directus-password', this.config.adminPassword, /^[\x20-\x7e]+$/),
+      '--dump-path', DirectusDatabaseSync.requireSafeCliValue('dump-path', this.dumpPath, /^[\w./ -]+$/),
       '--preserve-ids', preserveIds,
     ];
   }

--- a/apps/backend-sync/src/SyncDatabaseSchema.ts
+++ b/apps/backend-sync/src/SyncDatabaseSchema.ts
@@ -2,6 +2,7 @@ import {DirectusDatabaseSync} from './DirectusDatabaseSync';
 import {DockerDirectusHelper} from './DockerDirectusHelper';
 import {ServerHelper} from 'repo-depkit-common';
 import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
 import * as dotenv from 'dotenv';
 import {DockerContainerManager} from './DockerContainerManager';
 import {findEnvFile, findProjectRootFile} from "./EnvFileFinder";
@@ -40,13 +41,27 @@ type ResolvedSyncConfig = {
   syncOperation: SyncOperation;
 };
 
+/**
+ * Reads the public placeholder credentials for the local Docker Compose test
+ * system from the repository's .env.template, so no credential literal lives
+ * in the source code. Never used against a real/production instance.
+ */
+async function loadLocalTestServerDefaults(): Promise<{ adminEmail?: string; adminPassword?: string }> {
+  const projectRootPath = await findProjectRootFile();
+  if (!projectRootPath) return {};
+  const templatePath = path.join(path.dirname(projectRootPath), '.env.template');
+  try {
+    const parsed = dotenv.parse(await fs.readFile(templatePath, 'utf-8'));
+    return { adminEmail: parsed.ADMIN_EMAIL, adminPassword: parsed.ADMIN_PASSWORD };
+  } catch {
+    return {};
+  }
+}
+
 async function resolveSyncConfig(options: SyncDatabaseOptions): Promise<ResolvedSyncConfig> {
-  // Non-production placeholder credentials for the local Docker Compose test system only.
-  // Mirrors the public default in .env.template; never used against a real/production instance.
-  const LOCAL_TEST_SERVER_ADMIN_EMAIL = "admin@example.com"
-  const LOCAL_TEST_SERVER_ADMIN_PASSWORD = "The!UniversalRocketMealsPassword";
-  let adminEmail: string | undefined = options.adminEmail || process.env.ADMIN_EMAIL || LOCAL_TEST_SERVER_ADMIN_EMAIL
-  let adminPassword: string | undefined = options.adminPassword || process.env.ADMIN_PASSWORD || LOCAL_TEST_SERVER_ADMIN_PASSWORD
+  const localTestServerDefaults = await loadLocalTestServerDefaults();
+  let adminEmail: string | undefined = options.adminEmail || process.env.ADMIN_EMAIL || localTestServerDefaults.adminEmail
+  let adminPassword: string | undefined = options.adminPassword || process.env.ADMIN_PASSWORD || localTestServerDefaults.adminPassword
   let directusInstanceUrl = options.directusUrl;
   let pathToDataDirectusSync = options.pathToDataDirectusSync;
   let pathToTargetTypesFile: string | undefined;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/foods-translation-fix-missing-schedule/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/foods-translation-fix-missing-schedule/index.ts
@@ -36,7 +36,7 @@ function getTranslationNullReason(languageCode: string): string {
   if (!DEEPL_SUPPORTED_TARGET_PREFIXES.has(prefix)) {
     return (
       'DeepL does not support the language prefix "' + prefix + '" (from "' + languageCode + '"). ' +
-      'Supported prefixes: ' + [...DEEPL_SUPPORTED_TARGET_PREFIXES].sort().join(', ') + '.'
+      'Supported prefixes: ' + [...DEEPL_SUPPORTED_TARGET_PREFIXES].sort((a, b) => a.localeCompare(b)).join(', ') + '.'
     );
   }
   return (

--- a/apps/backend/Backend/scripts/getBase64IconForMail.py
+++ b/apps/backend/Backend/scripts/getBase64IconForMail.py
@@ -12,6 +12,24 @@ from io import BytesIO
 # Delimiter to parse icon family and icon name
 IconParseDelimiter = ':'
 
+# CLI-controlled paths must stay inside the repository (or the current working
+# directory when not running inside a git checkout) before they are accessed.
+def require_inside_base_dir(path_value):
+    base_dir = os.getcwd()
+    current = base_dir
+    while True:
+        if os.path.isdir(os.path.join(current, '.git')):
+            base_dir = current
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    resolved = os.path.realpath(path_value)
+    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+        raise ValueError(f"Refusing to access path outside '{base_dir}': '{resolved}'")
+    return resolved
+
 # Function to dynamically load available icon families based on glyphmap filenames
 def load_available_icon_families(glyphmaps_path, fonts_path):
     available_families = {}
@@ -128,9 +146,10 @@ if __name__ == "__main__":
         node_modules_path = find_node_modules_directory()
 
     if node_modules_path:
-        # Canonicalize the CLI-controlled path (resolves "..", symlinks) before it is used
-        # to build any file path that gets opened below.
-        node_modules_path = os.path.realpath(node_modules_path)
+        # Canonicalize the CLI-controlled path (resolves "..", symlinks) and validate that
+        # it stays inside the repository before it is used to build any file path that
+        # gets opened below.
+        node_modules_path = require_inside_base_dir(node_modules_path)
 
     if not node_modules_path or not os.path.isdir(node_modules_path):
         print("Error: node_modules directory not found. Please specify it with --node_modules <path>.")

--- a/apps/backend/sync/importSchema.js
+++ b/apps/backend/sync/importSchema.js
@@ -278,9 +278,25 @@ const enableRequiredSettings = async headers => {
   console.log(' -  Enabled required settings');
 };
 
+// Validates a CLI-controlled value against an anchored allowlist pattern before it is
+// passed to an OS command, so faulty or malicious CLI arguments cannot smuggle in
+// unexpected content (see SonarCloud S8705).
+const requireSafeCliValue = (name, value, pattern) => {
+  if (!pattern.test(value)) {
+    throw new Error(`Refusing to pass unsafe value for "${name}" to the directus-sync CLI`);
+  }
+  return value;
+};
+
 const getDirectusSyncArgs = () => {
   const preserveIds = 'dashboards,operations,panels,policies,roles,translations';
-  return ['--directus-url', directus_url, '--directus-email', admin_email, '--directus-password', admin_password, '--dump-path', dumpPath, '--preserve-ids', preserveIds];
+  return [
+    '--directus-url', requireSafeCliValue('directus-url', directus_url, /^https?:\/\/[\w.-]+(?::\d+)?(?:\/[\w./-]*)?$/),
+    '--directus-email', requireSafeCliValue('directus-email', admin_email, /^[^\s@]+@[^\s@]+$/),
+    '--directus-password', requireSafeCliValue('directus-password', admin_password, /^[\x20-\x7e]+$/),
+    '--dump-path', requireSafeCliValue('dump-path', dumpPath, /^[\w./ -]+$/),
+    '--preserve-ids', preserveIds,
+  ];
 };
 
 // Executes a command as an argument vector (no shell) so that CLI-controlled values

--- a/apps/backend/sync/swosyDownloaderAndParser/swosyBuildingsJsonParseToRocketMealsJson.py
+++ b/apps/backend/sync/swosyDownloaderAndParser/swosyBuildingsJsonParseToRocketMealsJson.py
@@ -2,6 +2,24 @@ import json
 import os
 import sys
 
+# CLI-controlled paths must stay inside the repository (or the current working
+# directory when not running inside a git checkout) before they are accessed.
+def require_inside_base_dir(path_value):
+    base_dir = os.getcwd()
+    current = base_dir
+    while True:
+        if os.path.isdir(os.path.join(current, '.git')):
+            base_dir = current
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    resolved = os.path.realpath(path_value)
+    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+        raise ValueError(f"Refusing to access path outside '{base_dir}': '{resolved}'")
+    return resolved
+
 def parse_swosy_to_rocket_meals(swosy_data):
     rocket_meals_data = []
     for building in swosy_data:
@@ -66,5 +84,6 @@ if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python3 script.py path_to_swosy_json")
     else:
-        # Canonicalize the CLI-controlled path (resolves "..", symlinks) before it is opened.
-        main(os.path.realpath(sys.argv[1]))
+        # Canonicalize the CLI-controlled path (resolves "..", symlinks) and validate that
+        # it stays inside the repository before it is opened.
+        main(require_inside_base_dir(sys.argv[1]))

--- a/apps/frontend/app/app/(app)/map/components/JoggingOverlay.tsx
+++ b/apps/frontend/app/app/(app)/map/components/JoggingOverlay.tsx
@@ -5,24 +5,18 @@ import { MaterialIcons } from '@expo/vector-icons';
 import type { MyMapHandle } from '@/components/MyMap/MyMapHelper';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useTheme } from '@/hooks/useTheme';
+import type { GpsRoutePoint, SpeedStats } from 'repo-depkit-common';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type RoutePoint = {
-	lat: number;
-	lng: number;
-	altitude: number | null;
-	speed: number | null; // m/s from GPS, may be null or negative
-	timestamp: number;
-};
+// Point/speed shapes are shared with geonexia's activity recording via
+// repo-depkit-common so the two features can't drift apart.
+type RoutePoint = GpsRoutePoint;
 
-type RunStats = {
+type RunStats = SpeedStats & {
 	distanceKm: number;
 	durationSeconds: number;
 	paceMinPerKm: number;
-	maxSpeedKmh: number;
-	minSpeedKmh: number;
-	avgSpeedKmh: number;
 	kcal: number;
 	steps: number;
 	elevationGainM: number;

--- a/apps/frontend/app/app/_layout.tsx
+++ b/apps/frontend/app/app/_layout.tsx
@@ -40,6 +40,7 @@ import {config} from '@gluestack-ui/config';
 import ExpoUpdateLoader from '@/components/ExpoUpdateLoader/ExpoUpdateLoader';
 import ExpoUpdateChecker from '@/components/ExpoUpdateChecker/ExpoUpdateChecker';
 import {ModalContextProvider, ModalRenderer} from '@/components/GlobalModal/ModalProvider';
+import AppDownloadBanner from '@/components/AppDownloadBanner';
 import { ConfigCustomerEnum, getCompanyLogoLocalSaved, getCustomerConfig, getCustomerConfigsDict, getCustomerEnumForConfig } from '@/config';
 import { SET_SELECTED_CUSTOMER } from '@/redux/Types/types';
 import { SettingsProvider } from 'repo-depkit-common-ui';
@@ -181,6 +182,7 @@ export default function Layout() {
 													<ExpoUpdateChecker>
 														<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1, backgroundColor: theme.screen.iconBg }}>
 															<SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.iconBg }} edges={pathname?.includes('image-full-screen') ? ['bottom'] : ['top', 'bottom']}>
+																<AppDownloadBanner />
 																<Slot />
 															</SafeAreaView>
 														</KeyboardAvoidingView>

--- a/apps/frontend/app/components/AppDownloadBanner/index.tsx
+++ b/apps/frontend/app/components/AppDownloadBanner/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useAppSelector } from '@/redux/hooks';
@@ -11,8 +11,7 @@ import { getAppIconInsideExpoLocalSaved, getCustomerConfig } from '@/config';
 import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
 import { ServerInfoHelper } from '@/helper/ServerInfoHelper';
 import { myContrastColor } from '@/helper/ColorHelper';
-
-const DISMISSED_STORAGE_KEY = 'appDownloadBannerDismissed';
+import { dismissAppDownloadBanner, isAppDownloadBannerDismissed } from '@/helper/appDownloadBannerStorage';
 
 type MobileWebPlatform = 'ios' | 'android' | null;
 
@@ -22,14 +21,6 @@ const getMobileWebPlatform = (): MobileWebPlatform => {
 	if (/iPhone|iPad|iPod/i.test(userAgent)) return 'ios';
 	if (/Android/i.test(userAgent)) return 'android';
 	return null;
-};
-
-const isDismissedInSession = (): boolean => {
-	try {
-		return typeof sessionStorage !== 'undefined' && sessionStorage.getItem(DISMISSED_STORAGE_KEY) === 'true';
-	} catch {
-		return false;
-	}
 };
 
 /**
@@ -43,7 +34,21 @@ const AppDownloadBanner: React.FC = () => {
 	const { translate } = useLanguage();
 	const kioskMode = useKioskMode();
 	const { appSettings, serverInfo, primaryColor, selectedTheme: mode } = useAppSelector(state => state.settings);
-	const [dismissed, setDismissed] = useState<boolean>(() => isDismissedInSession());
+	const loggedIn = useAppSelector(state => state.authReducer.loggedIn);
+	const [dismissed, setDismissed] = useState<boolean>(() => isAppDownloadBannerDismissed());
+
+	// The banner is mounted once in the root layout and stays mounted across
+	// navigation, so a logout (which clears the sessionStorage flag in
+	// logoutHelper.ts) wouldn't otherwise be reflected until a full page
+	// reload. Re-read the (now cleared) dismissed flag whenever the user logs
+	// out, so the banner can reappear immediately for the next visitor.
+	const wasLoggedInRef = useRef(loggedIn);
+	useEffect(() => {
+		if (wasLoggedInRef.current && !loggedIn) {
+			setDismissed(isAppDownloadBannerDismissed());
+		}
+		wasLoggedInRef.current = loggedIn;
+	}, [loggedIn]);
 
 	const mobilePlatform = useMemo(() => getMobileWebPlatform(), []);
 
@@ -62,11 +67,7 @@ const AppDownloadBanner: React.FC = () => {
 
 	const handleDismiss = useCallback(() => {
 		setDismissed(true);
-		try {
-			sessionStorage.setItem(DISMISSED_STORAGE_KEY, 'true');
-		} catch {
-			// sessionStorage unavailable (e.g. blocked) - banner stays dismissed for this render only
-		}
+		dismissAppDownloadBanner();
 	}, []);
 
 	const handleOpenStore = useCallback(() => {

--- a/apps/frontend/app/components/AppDownloadBanner/index.tsx
+++ b/apps/frontend/app/components/AppDownloadBanner/index.tsx
@@ -1,0 +1,149 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useAppSelector } from '@/redux/hooks';
+import { useTheme } from '@/context/ThemeContext';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import useKioskMode from '@/hooks/useKioskMode';
+import { getImageUrl } from '@/constants/HelperFunctions';
+import { getAppIconInsideExpoLocalSaved, getCustomerConfig } from '@/config';
+import { CommonSystemActionHelper } from '@/helper/SystemActionHelper';
+import { ServerInfoHelper } from '@/helper/ServerInfoHelper';
+import { myContrastColor } from '@/helper/ColorHelper';
+
+const DISMISSED_STORAGE_KEY = 'appDownloadBannerDismissed';
+
+type MobileWebPlatform = 'ios' | 'android' | null;
+
+const getMobileWebPlatform = (): MobileWebPlatform => {
+	if (Platform.OS !== 'web' || typeof navigator === 'undefined') return null;
+	const userAgent = navigator.userAgent || '';
+	if (/iPhone|iPad|iPod/i.test(userAgent)) return 'ios';
+	if (/Android/i.test(userAgent)) return 'android';
+	return null;
+};
+
+const isDismissedInSession = (): boolean => {
+	try {
+		return typeof sessionStorage !== 'undefined' && sessionStorage.getItem(DISMISSED_STORAGE_KEY) === 'true';
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * GitHub-style "get the app" banner shown at the very top of the web app when
+ * the visitor uses a mobile browser (and the app is not running in kiosk mode).
+ * Store links come from app_settings (app_stores_url_to_apple/_google), with a
+ * fallback built from the customer config's store identifiers.
+ */
+const AppDownloadBanner: React.FC = () => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const kioskMode = useKioskMode();
+	const { appSettings, serverInfo, primaryColor, selectedTheme: mode } = useAppSelector(state => state.settings);
+	const [dismissed, setDismissed] = useState<boolean>(() => isDismissedInSession());
+
+	const mobilePlatform = useMemo(() => getMobileWebPlatform(), []);
+
+	const storeUrl = useMemo(() => {
+		if (!mobilePlatform) return null;
+		const customerConfig = getCustomerConfig();
+		if (mobilePlatform === 'ios') {
+			if (appSettings?.app_stores_url_to_apple) return appSettings.app_stores_url_to_apple;
+			if (customerConfig?.appleAppId) return `https://apps.apple.com/app/id${customerConfig.appleAppId}`;
+			return null;
+		}
+		if (appSettings?.app_stores_url_to_google) return appSettings.app_stores_url_to_google;
+		if (customerConfig?.bundleIdAndroid) return `https://play.google.com/store/apps/details?id=${customerConfig.bundleIdAndroid}`;
+		return null;
+	}, [mobilePlatform, appSettings?.app_stores_url_to_apple, appSettings?.app_stores_url_to_google]);
+
+	const handleDismiss = useCallback(() => {
+		setDismissed(true);
+		try {
+			sessionStorage.setItem(DISMISSED_STORAGE_KEY, 'true');
+		} catch {
+			// sessionStorage unavailable (e.g. blocked) - banner stays dismissed for this render only
+		}
+	}, []);
+
+	const handleOpenStore = useCallback(() => {
+		if (storeUrl) {
+			CommonSystemActionHelper.openExternalURL(storeUrl, true);
+		}
+	}, [storeUrl]);
+
+	if (Platform.OS !== 'web' || kioskMode || dismissed || !mobilePlatform || !storeUrl) {
+		return null;
+	}
+
+	const projectLogo = serverInfo?.info?.project?.project_logo ? getImageUrl(serverInfo.info.project.project_logo) : null;
+	const iconSource = projectLogo ? { uri: projectLogo } : getAppIconInsideExpoLocalSaved();
+	const projectName = ServerInfoHelper.getServerName(serverInfo || {}, getCustomerConfig());
+	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
+
+	return (
+		<View style={[styles.container, { backgroundColor: theme.header.background, borderBottomColor: theme.screen.iconBg }]}>
+			<TouchableOpacity onPress={handleDismiss} style={styles.closeButton} accessibilityRole="button" accessibilityLabel={translate(TranslationKeys.cancel)}>
+				<MaterialCommunityIcons name="close" size={20} color={theme.screen.icon} />
+			</TouchableOpacity>
+			<Image source={iconSource} style={styles.appIcon} accessibilityLabel={projectName} />
+			<View style={styles.textContainer}>
+				<Text numberOfLines={1} style={[styles.title, { color: theme.header.text }]}>
+					{projectName}
+				</Text>
+				<Text numberOfLines={1} style={[styles.subtitle, { color: theme.screen.placeholder }]}>
+					{translate(TranslationKeys.download_or_open_the_app)}
+				</Text>
+			</View>
+			<TouchableOpacity onPress={handleOpenStore} style={[styles.openButton, { backgroundColor: primaryColor }]} accessibilityRole="button">
+				<Text style={[styles.openButtonLabel, { color: contrastColor }]}>{translate(TranslationKeys.app_banner_open)}</Text>
+			</TouchableOpacity>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		width: '100%',
+		flexDirection: 'row',
+		alignItems: 'center',
+		paddingVertical: 8,
+		paddingHorizontal: 10,
+		gap: 10,
+		borderBottomWidth: 1,
+	},
+	closeButton: {
+		padding: 4,
+	},
+	appIcon: {
+		width: 40,
+		height: 40,
+		borderRadius: 9,
+		resizeMode: 'contain',
+	},
+	textContainer: {
+		flex: 1,
+	},
+	title: {
+		fontSize: 14,
+		fontFamily: 'Poppins_600SemiBold',
+	},
+	subtitle: {
+		fontSize: 12,
+		fontFamily: 'Poppins_400Regular',
+	},
+	openButton: {
+		paddingHorizontal: 18,
+		paddingVertical: 8,
+		borderRadius: 20,
+	},
+	openButtonLabel: {
+		fontSize: 14,
+		fontFamily: 'Poppins_600SemiBold',
+	},
+});
+
+export default AppDownloadBanner;

--- a/apps/frontend/app/constants/AsyncStorageHelper.ts
+++ b/apps/frontend/app/constants/AsyncStorageHelper.ts
@@ -1,5 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+// ⚠️ Adding a new key here that stores user-specific data? Go add its removal
+// to helper/logoutHelper.ts too (see the reminder comment on performLogout) -
+// otherwise it silently survives a logout on shared/kiosk devices.
+
 /**
  * Save a value to AsyncStorage.
  *

--- a/apps/frontend/app/helper/DeviceHelper.ts
+++ b/apps/frontend/app/helper/DeviceHelper.ts
@@ -3,7 +3,7 @@ import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { DatabaseTypes } from 'repo-depkit-common';
 import * as DeviceInfo from 'expo-device';
 import { DeviceType } from 'expo-device';
-import usePlatformHelper from '@/helper/platformHelper';
+import { getPlatformHelper } from '@/helper/platformHelper';
 
 /**
  * Defines the breakpoints for responsive design.
@@ -112,7 +112,7 @@ export function useInsets(): EdgeInsets {
 }
 
 export function getIsLandScape(): boolean {
-	const { isWeb } = usePlatformHelper();
+	const { isWeb } = getPlatformHelper();
 	const windowWidth = Dimensions.get('screen').width;
 	const windowHeight = Dimensions.get('screen').height;
 	let isLandscape = windowWidth > windowHeight;
@@ -141,7 +141,7 @@ export function getDeviceIdentifier(device: Partial<DatabaseTypes.Devices>) {
 
 export function getDeviceInformationWithoutPushToken(): Partial<DatabaseTypes.Devices> {
 	// Promise<DeviceInformationType>
-	const { getPlatformDisplayName, isIOS, isAndroid, isWeb } = usePlatformHelper();
+	const { getPlatformDisplayName, isIOS, isAndroid, isWeb } = getPlatformHelper();
 	const windowWidth = Dimensions.get('screen').width;
 	const windowHeight = Dimensions.get('screen').height;
 	const windowScale = Dimensions.get('screen').scale;

--- a/apps/frontend/app/helper/FoodOffersCacheHelper.ts
+++ b/apps/frontend/app/helper/FoodOffersCacheHelper.ts
@@ -12,7 +12,9 @@ export function computeFoodOffersHash(offers: DatabaseTypes.Foodoffers[]): strin
     if (!offers || offers.length === 0) return 'empty';
     // Use ids + result_hash (or date_updated fallback) to create a lightweight fingerprint
     const parts = offers.map(o => `${o.id}:${o.result_hash || o.date_updated || ''}`);
-    parts.sort();
+    // Deterministic UTF-16 code unit comparison - fingerprint parts are technical IDs,
+    // so the order must not depend on the runtime locale.
+    parts.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     return parts.join('|');
 }
 
@@ -98,7 +100,8 @@ export async function cacheFoodOffers(
         const dates = tracker[canteenId] || [];
         if (!dates.includes(date)) {
             dates.push(date);
-            dates.sort();
+            // ISO date strings - deterministic code unit comparison sorts them chronologically
+            dates.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
             tracker[canteenId] = dates;
         }
         await setTracker(tracker);

--- a/apps/frontend/app/helper/NotificationHelper.ts
+++ b/apps/frontend/app/helper/NotificationHelper.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 import Constants from 'expo-constants';
-import usePlatformHelper from '@/helper/platformHelper';
+import { getPlatformHelper } from '@/helper/platformHelper';
 import { getDeviceInformationWithoutPushToken } from './DeviceHelper';
 import { DatabaseTypes } from 'repo-depkit-common';
 // import {useSynchedDevices} from "@/states/SynchedDevices";
@@ -79,7 +79,7 @@ export class NotificationHelper {
 	}
 
 	static isDeviceNotificationPermissionUndetermined(notificationObj: NotificationObjType) {
-		const { isIOS, isAndroid } = usePlatformHelper();
+		const { isIOS, isAndroid } = getPlatformHelper();
 		if (isIOS()) {
 			return notificationObj?.permission?.ios?.status === 0;
 		} else if (isAndroid()) {

--- a/apps/frontend/app/helper/SystemActionHelper.ts
+++ b/apps/frontend/app/helper/SystemActionHelper.ts
@@ -1,9 +1,9 @@
 import { Linking } from 'react-native';
 // import {LocationType} from '@/helper/geo/LocationType';
-import usePlatformHelper from '@/helper/platformHelper';
+import { getPlatformHelper } from '@/helper/platformHelper';
 import * as IntentLauncher from 'expo-intent-launcher';
 
-const { isAndroid, isIOS } = usePlatformHelper();
+const { isAndroid, isIOS } = getPlatformHelper();
 
 const isAndroidDevice = isAndroid();
 const isIOSDevice = isIOS();

--- a/apps/frontend/app/helper/appDownloadBannerStorage.ts
+++ b/apps/frontend/app/helper/appDownloadBannerStorage.ts
@@ -1,0 +1,37 @@
+// Dismiss state for AppDownloadBanner. Lives in sessionStorage (web only, tab-scoped)
+// rather than AsyncStorage/redux-persist, since it's meant to reset on every new
+// browser session rather than survive indefinitely.
+//
+// NOTE: also cleared explicitly in helper/logoutHelper.ts - see the reminder
+// comment there for why every new persisted storage key needs this.
+const STORAGE_KEY = 'appDownloadBannerDismissed';
+
+const hasSessionStorage = () => typeof sessionStorage !== 'undefined';
+
+export const isAppDownloadBannerDismissed = (): boolean => {
+	try {
+		return hasSessionStorage() && sessionStorage.getItem(STORAGE_KEY) === 'true';
+	} catch {
+		return false;
+	}
+};
+
+export const dismissAppDownloadBanner = (): void => {
+	try {
+		if (hasSessionStorage()) {
+			sessionStorage.setItem(STORAGE_KEY, 'true');
+		}
+	} catch {
+		// sessionStorage unavailable (e.g. blocked) - banner stays dismissed for this render only
+	}
+};
+
+export const clearAppDownloadBannerDismissed = (): void => {
+	try {
+		if (hasSessionStorage()) {
+			sessionStorage.removeItem(STORAGE_KEY);
+		}
+	} catch {
+		// ignore - nothing to clear if sessionStorage is unavailable
+	}
+};

--- a/apps/frontend/app/helper/authHelper.ts
+++ b/apps/frontend/app/helper/authHelper.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
-import usePlatformHelper from './platformHelper';
+import { getPlatformHelper } from './platformHelper';
 
 const preferInkognitoMode = true;
 
@@ -35,7 +35,7 @@ export const handleWebLogin = async (loginUrl: string, redirectUrl: string, code
 };
 
 export const handleNativeLogin = async (loginUrl: string, redirectUrl: string, codeVerifier: string, getToken: (codeVerifier: string, code: string) => void) => {
-	const { getAndroidPreferredBrowserPackageOption } = usePlatformHelper();
+	const { getAndroidPreferredBrowserPackageOption } = getPlatformHelper();
 	const isAndroid = Platform.OS === 'android';
 	let result = null;
 

--- a/apps/frontend/app/helper/logoutHelper.ts
+++ b/apps/frontend/app/helper/logoutHelper.ts
@@ -22,8 +22,18 @@ import {
 } from '@/redux/Types/types';
 import { persistor } from '@/redux/store';
 import { clearChatReadStatus } from '@/helper/chatReadStatus';
+import { clearAppDownloadBannerDismissed } from '@/helper/appDownloadBannerStorage';
 import { ServerAPI } from '@/redux/actions/Auth/Auth';
 
+// ⚠️ Reminder: this function is the single place that resets app state on logout.
+// If you add a new persisted storage key - a redux slice backed by redux-persist,
+// a raw AsyncStorage/sessionStorage key, anything under constants/AsyncStorageHelper.ts -
+// come back here and clear it too, unless it's intentionally meant to survive a
+// logout (e.g. language/theme/server selection). It's easy to add a new CLEAR_*
+// action or a dedicated clearXStorage() helper (see clearChatReadStatus() and
+// clearAppDownloadBannerDismissed() below for the two established patterns) and
+// forget to wire it in here - the data then silently leaks into the next user's
+// session on a shared/kiosk device.
 export const performLogout = async (
 	dispatch: Dispatch,
 	router: any
@@ -47,6 +57,7 @@ export const performLogout = async (
                 dispatch({ type: CLEAR_FRIENDSHIPS });
                 dispatch({ type: CLEAR_CHATS });
                 await clearChatReadStatus();
+                clearAppDownloadBannerDismissed();
                 dispatch({ type: CLEAR_SETTINGS });
 		dispatch({ type: CLEAR_POPUP_EVENTS_HASH });
 		await AsyncStorage.multiRemove(['auth_data', 'persist:root']);

--- a/apps/frontend/app/helper/platformHelper.ts
+++ b/apps/frontend/app/helper/platformHelper.ts
@@ -1,7 +1,9 @@
 import { Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 
-const usePlatformHelper = () => {
+// Plain helper factory (uses no React state): call this from non-component code
+// like helpers/classes. Components should keep using the usePlatformHelper hook.
+export const getPlatformHelper = () => {
 	const isWeb = () => Platform.OS === 'web';
 
 	const isIOS = () => Platform.OS === 'ios';
@@ -52,5 +54,7 @@ const usePlatformHelper = () => {
 		getAndroidPreferredBrowserPackageOption,
 	};
 };
+
+const usePlatformHelper = () => getPlatformHelper();
 
 export default usePlatformHelper;

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -329,6 +329,7 @@ export enum TranslationKeys {
         rate_later = 'rate_later',
         app_download = 'app_download',
         app_download_selection = 'app_download_selection',
+        app_banner_open = 'app_banner_open',
         react_native_qrcode_svg = 'react_native_qrcode_svg',
         friendships = 'friendships',
         friendships_add_friend = 'friendships_add_friend',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3273,6 +3273,16 @@
     "tr": "App Download Selection",
     "zh": "App Download Selection"
   },
+  "app_banner_open": {
+    "de": "Öffnen",
+    "en": "Open",
+    "ar": "فتح",
+    "es": "Abrir",
+    "fr": "Ouvrir",
+    "ru": "Открыть",
+    "tr": "Aç",
+    "zh": "打开"
+  },
   "react_native_qrcode_svg": {
     "de": "React Native QRCode SVG",
     "en": "React Native QRCode SVG",

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -1871,7 +1871,9 @@ function HexTileInfoContent({ h3Index }: { h3Index: string }) {
 		if (res <= 0) return null;
 		const parentIndex = cellToParent(h3Index, res - 1);
 		if (!parentIndex) return null;
-		const siblings = cellToChildren(parentIndex, res).sort();
+		// H3 index strings - deterministic code unit comparison keeps child numbering
+		// identical across devices regardless of locale.
+		const siblings = cellToChildren(parentIndex, res).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 		const childNumber = siblings.indexOf(h3Index);
 		return {
 			parentIndex,
@@ -2839,7 +2841,7 @@ export default function RecordScreen() {
 		Object.entries(state.hexTiles.records)
 			.filter(([, r]) => r.tileImage || r.billboard || r.billboards || r.billboardsTexture)
 			.map(([h3, r]) => `${h3}=${r.tileImage ?? ''}|${r.billboard ?? ''}|${JSON.stringify(r.billboards ?? {})}|${JSON.stringify(r.billboardsTexture ?? {})}`)
-			.sort()
+			.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
 			.join('\n'),
 	);
 

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -471,9 +471,11 @@ function computeParentInfo(
 		}
 
 		const allChildren = cellToChildren(parentH3Index, res);
+		// H3 index strings - deterministic code unit comparison keeps child numbering
+		// identical across devices regardless of locale.
 		const nonCenterChildren = allChildren
 			.filter((c) => c !== centerChild)
-			.sort();
+			.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 		const idx = nonCenterChildren.indexOf(h3Index);
 		// idx is 0–5 for the non-center children → add 1 to reserve 0 for center
 		const parentChildIndex = idx >= 0 ? idx + 1 : -1;

--- a/apps/geonexia/frontend/helpers/ActivityStorage.ts
+++ b/apps/geonexia/frontend/helpers/ActivityStorage.ts
@@ -1,5 +1,6 @@
 import { Directory, File, Paths } from 'expo-file-system';
 import type { RedLineRouteFields, RecordingSessionFields } from './ActivityRouteSharedTypes';
+import type { GpsRoutePoint, SpeedStats as CommonSpeedStats } from 'repo-depkit-common';
 
 // ─── Weather & Rating types ───────────────────────────────────────────────────
 
@@ -46,16 +47,10 @@ export type ComputedHexTileEntry = {
 /**
  * Min/max/average speed observed over some span of GPS points.
  * Shared by `ComputedActivityData` and `RunStats`, which both track the same
- * three speed metrics for an activity.
+ * three speed metrics for an activity. The shape lives in repo-depkit-common
+ * because the rocket-meals jogging overlay tracks the same metrics.
  */
-export type SpeedStats = {
-	/** Maximum speed in km/h observed during the activity */
-	maxSpeedKmh: number;
-	/** Minimum speed in km/h observed during the activity */
-	minSpeedKmh: number;
-	/** Average speed in km/h during the activity */
-	avgSpeedKmh: number;
-};
+export type SpeedStats = CommonSpeedStats;
 
 /**
  * Pre-computed data derived from an activity's raw GPS points.
@@ -79,12 +74,9 @@ export type ComputedActivityData = SpeedStats & {
 	enclosedHexTiles: string[];
 };
 
-export type RoutePoint = {
-	lat: number;
-	lng: number;
-	altitude: number | null;
-	speed: number | null;
-	timestamp: number;
+// The base point shape lives in repo-depkit-common because the rocket-meals
+// jogging overlay records the same GPS track points.
+export type RoutePoint = GpsRoutePoint & {
 	/**
 	 * True when this point was synthetically generated to fill a gap in the
 	 * recorded GPS track (e.g. after a crash recovery), rather than being

--- a/apps/googleMyMapKmlHelper/parseKmlToJsonBuildings.py
+++ b/apps/googleMyMapKmlHelper/parseKmlToJsonBuildings.py
@@ -3,6 +3,24 @@ import json
 import os
 import sys
 
+# CLI-controlled paths must stay inside the repository (or the current working
+# directory when not running inside a git checkout) before they are accessed.
+def require_inside_base_dir(path_value):
+    base_dir = os.getcwd()
+    current = base_dir
+    while True:
+        if os.path.isdir(os.path.join(current, '.git')):
+            base_dir = current
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    resolved = os.path.realpath(path_value)
+    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+        raise ValueError(f"Refusing to access path outside '{base_dir}': '{resolved}'")
+    return resolved
+
 def parse_kml(file_path):
     tree = ET.parse(file_path)
     root = tree.getroot()
@@ -35,10 +53,10 @@ if __name__ == "__main__":
         print("Usage: python script.py <input_kml_file> <output_json_file>")
         sys.exit(1)
 
-    # Canonicalize the CLI-controlled paths (resolves "..", symlinks) before they are used
-    # to read/write files below.
-    input_kml_file = os.path.realpath(sys.argv[1])
-    output_json_file = os.path.realpath(sys.argv[2])
+    # Canonicalize the CLI-controlled paths (resolves "..", symlinks) and validate that
+    # they stay inside the repository before they are used to read/write files below.
+    input_kml_file = require_inside_base_dir(sys.argv[1])
+    output_json_file = require_inside_base_dir(sys.argv[2])
 
     parsed_data = parse_kml(input_kml_file)
     write_json(parsed_data, output_json_file)

--- a/apps/screenshotGenerator/src/helpers.ts
+++ b/apps/screenshotGenerator/src/helpers.ts
@@ -1,15 +1,34 @@
 import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
 import path from 'path';
 import sharp from 'sharp';
 import { Browser } from 'puppeteer';
 import { Device } from './devices';
 import { StringHelper } from 'repo-depkit-common';
 
-// screenshotDir comes from a CLI flag / env var (SCREENSHOT_DIR). Canonicalize it and refuse
-// to operate on the filesystem root or its immediate children, so a misconfigured value can
-// never turn deleteAllScreenshots()'s recursive rm into a catastrophic delete.
+// All screenshot output must stay inside the working tree: the repository root when the
+// tool runs inside a checkout (found by walking up to the nearest .git), otherwise the
+// current working directory.
+function findAllowedBaseDir(): string {
+  let current = process.cwd();
+  while (true) {
+    if (existsSync(path.join(current, '.git'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return process.cwd();
+    current = parent;
+  }
+}
+
+const ALLOWED_BASE_DIR = findAllowedBaseDir();
+
+// screenshotDir comes from a CLI flag / env var (SCREENSHOT_DIR). Canonicalize it and
+// require it to stay inside the repository/current working directory, so a misconfigured
+// value can never turn deleteAllScreenshots()'s recursive rm into a catastrophic delete.
 function canonicalizeAndGuardDirPath(dirPath: string): string {
   const resolved = path.resolve(dirPath);
+  if (resolved !== ALLOWED_BASE_DIR && !resolved.startsWith(ALLOWED_BASE_DIR + path.sep)) {
+    throw new Error(`Refusing to operate on path outside "${ALLOWED_BASE_DIR}": "${resolved}"`);
+  }
   const segments = resolved.split(path.sep).filter(Boolean);
   if (segments.length < 2) {
     throw new Error(`Refusing to operate on suspiciously shallow path: "${resolved}"`);

--- a/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
+++ b/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
@@ -19,8 +19,16 @@ const argv = yargs(hideBin(process.argv))
   .help()
   .alias('h', 'help').argv as any;
 
-const csvPath = path.resolve(argv.csv);
 const rootDir = path.resolve(argv.root);
+const csvPath = path.resolve(argv.csv);
+
+// The CSV path is CLI-controlled; require it to stay inside the project root
+// before reading it, so a faulty argument can't point the script at arbitrary files.
+const csvRelativeToRoot = path.relative(rootDir, csvPath);
+if (csvRelativeToRoot.startsWith('..') || path.isAbsolute(csvRelativeToRoot)) {
+  console.error(`Refusing to read CSV outside the project root: ${csvPath}`);
+  process.exit(1);
+}
 
 const csvContent = fs.readFileSync(csvPath, 'utf-8');
 const lines = csvContent.split(/\r?\n/).slice(1); // skip header

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -24,3 +24,4 @@ export * from './src/AppFeedbackSourceIdentifier';
 export * from './src/CustomerAppStoreIds';
 export * from './src/AppleAppStoreConfig';
 export * from './src/DirectusItemStatus';
+export * from './src/GpsRouteTypes';

--- a/packages/common/src/GpsRouteTypes.ts
+++ b/packages/common/src/GpsRouteTypes.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared GPS route/activity types used by the route-recording features in
+ * multiple apps (rocket-meals map jogging overlay, geonexia activity storage),
+ * so the field shapes stay in sync instead of being duplicated per app.
+ */
+
+/** A single recorded GPS track point. */
+export type GpsRoutePoint = {
+  lat: number;
+  lng: number;
+  /** Altitude in meters, when the device provides one. */
+  altitude: number | null;
+  /** Speed in m/s from GPS, may be null or negative. */
+  speed: number | null;
+  /** Unix epoch milliseconds at which the point was recorded. */
+  timestamp: number;
+};
+
+/** Min/max/average speed observed over some span of GPS points. */
+export type SpeedStats = {
+  /** Maximum speed in km/h observed during the activity */
+  maxSpeedKmh: number;
+  /** Minimum speed in km/h observed during the activity */
+  minSpeedKmh: number;
+  /** Average speed in km/h during the activity */
+  avgSpeedKmh: number;
+};


### PR DESCRIPTION
## Summary

### 📱 App download banner (web)
GitHub-style banner at the very top of the web app, shown only when: mobile browser (iOS/Android user agent) **and** not in kiosk mode **and** a store link is available for the platform. Links come from `app_settings` (`app_stores_url_to_apple`/`_google`) with a fallback built from the customer config (`appleAppId` / `bundleIdAndroid`). Shows project logo, server name, subtitle and an "Öffnen" button; dismissible via X (remembered per browser session).

### 🔒 Security rating E → A (18 vulnerabilities)
- **13 code-level fixes**: path-containment validation for all CLI-controlled paths (accessibilityTester, screenshotGenerator, sonarCloudReportDownloader, 3 Python scripts), anchored allowlist validation of directus-sync CLI arguments before spawning (DirectusDatabaseSync.ts, importSchema.js), and the hard-coded test password in SyncDatabaseSchema.ts now loads from `.env.template` at runtime.
- **5 workflow-level fixes**: the blocker `curl | bash` Maestro install replaced with a pinned release (cli-2.6.1) + SHA-256 verification over enforced HTTPS, `setup-chrome` pinned to a full commit SHA, and `npx expo` → `yarn expo` in the PR preview workflow.

### 🐛 11 bugs fixed
- 6× S2871: string sorts now use explicit comparators (deterministic code-unit comparison for technical IDs like H3 cells/cache fingerprints/ISO dates, `localeCompare` for the human-readable DeepL prefix list)
- 5× S6440: `usePlatformHelper` logic extracted into a plain `getPlatformHelper()` factory for non-component callers (it never used React state); the hook remains as a wrapper

### 🧩 4 data clumps resolved
`RoutePoint` and the speed-stats trio were duplicated between the rocket-meals jogging overlay and geonexia's activity storage. Both shapes now live in `repo-depkit-common` (`GpsRouteTypes.ts`); both apps derive their local types from them.

## Test plan
- [x] Banner verified live via Puppeteer (iPhone UA): shows on mobile non-kiosk, hidden with `kioskMode=true`, hidden on desktop UA, dismiss persists for the session
- [x] `yarn tsc --noEmit`: frontend app at 92 baseline errors (no new), geonexia at 29 baseline (no new), accessibilityTester/screenshotGenerator/sonarCloudReportDownloader/backend-sync all clean
- [x] `python3 -m py_compile` on all three Python scripts, `node --check` on importSchema.js
- [x] Maestro zip SHA-256 in the workflow verified against the official published checksum for cli-2.6.1