### PR TITLE
Quick balance-read button on the foodoffers screen

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -42,7 +42,17 @@ enum BalanceStateLowerBound {
 	CONFUSED = -0.01,
 }
 
-const AccountBalanceScreen = () => {
+export interface AccountBalanceScreenProps {
+	/**
+	 * When true, automatically triggers the NFC read (as if the user pressed
+	 * the "read card" button) as soon as the screen is focused/active and NFC
+	 * is supported+enabled. Used by the foodoffers quick-access button, which
+	 * opens this screen in a modal and wants the scan to start immediately.
+	 */
+	autoStartNfc?: boolean;
+}
+
+const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNfc = false }) => {
 	useSetPageTitle(TranslationKeys.accountbalance);
 	const toast = useToast();
 	const { theme } = useTheme();
@@ -225,6 +235,30 @@ const AccountBalanceScreen = () => {
 		await myCardReader.readCard(callBack, showInstruction, hideInstruction, translate(TranslationKeys.nfcInstructionRead));
 	};
 
+	const handleReadNfcPress = useCallback(async () => {
+		try {
+			await onReadNfcPress();
+		} catch (e: any) {
+			toast(`${JSON.stringify(e)}`, 'error');
+			console.error('Error', JSON.stringify(e));
+			addDebugError(e, 'NFC Card Read');
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [myCardReader, callBack, showInstruction, hideInstruction, translate, toast, addDebugError]);
+
+	// Auto-start the NFC scan (as if the read-card button was pressed) once the
+	// screen is active and NFC is confirmed supported+enabled - used when this
+	// screen is opened from the foodoffers quick-access button. Guarded to fire
+	// only once per mount so it doesn't re-trigger after the read completes and
+	// the focus/NFC-status effects above re-run.
+	const hasAutoStartedNfcRef = useRef(false);
+	useEffect(() => {
+		if (!autoStartNfc || hasAutoStartedNfcRef.current) return;
+		if (isWeb || !isActive || !isNfcSupported || !isNfcEnabled) return;
+		hasAutoStartedNfcRef.current = true;
+		handleReadNfcPress();
+	}, [autoStartNfc, isActive, isNfcSupported, isNfcEnabled, handleReadNfcPress]);
+
 	useEffect(() => {
 		const onChange = ({ window }: { window: any }) => {
 			setWindowWidth(window.width);
@@ -312,15 +346,7 @@ const AccountBalanceScreen = () => {
 			{!isWeb && isNfcEnabled && isNfcSupported && (
 				<ProjectButton
 					style={{ width: '80%' }}
-					onPress={async () => {
-						try {
-							await onReadNfcPress();
-						} catch (e: any) {
-							toast(`${JSON.stringify(e)}`, 'error');
-							console.error('Error', JSON.stringify(e));
-							addDebugError(e, 'NFC Card Read');
-						}
-					}}
+					onPress={handleReadNfcPress}
 					text={translate(TranslationKeys.nfcReadCard)}
 					iconLeft={<MaterialCommunityIcons name="credit-card-wireless-outline" size={24} color={contrastColor} />}
 				/>

--- a/apps/frontend/app/app/(app)/foodoffers/components/BalanceQuickAccessButton.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/BalanceQuickAccessButton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { CustomTooltip, TooltipContent, TooltipText } from '@/components/CustomTooltip';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useAppSelector } from '@/redux/hooks';
+import { isWeb } from '@/constants/Constants';
+import { AppComponentIds } from '@/constants/ComponentIds';
+import { TranslationKeys } from '@/locales/keys';
+import IconButton from '@/components/UI/IconButton';
+import useAccountBalanceModal from '@/hooks/useAccountBalanceModal';
+
+interface BalanceQuickAccessButtonProps {
+	style?: any;
+}
+
+/**
+ * Quick-access button for the foodoffers header: opens the account-balance
+ * screen in a modal with the NFC scan already running. Only makes sense on
+ * native (NFC isn't available on web) and only when the balance feature is
+ * enabled for this server, so both checks live here and the component simply
+ * renders nothing otherwise - callers don't need to duplicate the condition.
+ */
+const BalanceQuickAccessButton: React.FC<BalanceQuickAccessButtonProps> = ({ style }) => {
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+	const { appSettings } = useAppSelector(state => state.settings);
+	const { openAccountBalanceModal } = useAccountBalanceModal();
+
+	if (isWeb || !appSettings?.balance_enabled) {
+		return null;
+	}
+
+	return (
+		<CustomTooltip
+			placement="top"
+			trigger={triggerProps => (
+				<IconButton
+					{...triggerProps}
+					onPress={() => openAccountBalanceModal(true)}
+					style={style}
+					nativeID={AppComponentIds.FOODOFFERS_BALANCE_QUICK_ACCESS}
+				>
+					<MaterialCommunityIcons name="credit-card-wireless-outline" size={24} color={theme.header.text} />
+				</IconButton>
+			)}
+		>
+			<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
+				<TooltipText fontSize="$sm" color={theme.tooltip.text}>
+					{translate(TranslationKeys.accountbalance)}
+				</TooltipText>
+			</TooltipContent>
+		</CustomTooltip>
+	);
+};
+
+export default BalanceQuickAccessButton;

--- a/apps/frontend/app/app/(app)/foodoffers/components/BalanceQuickAccessButton.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/BalanceQuickAccessButton.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import React, { useCallback, useState } from 'react';
+import { Octicons } from '@expo/vector-icons';
+import { useFocusEffect } from 'expo-router';
 import { CustomTooltip, TooltipContent, TooltipText } from '@/components/CustomTooltip';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -9,6 +10,7 @@ import { AppComponentIds } from '@/constants/ComponentIds';
 import { TranslationKeys } from '@/locales/keys';
 import IconButton from '@/components/UI/IconButton';
 import useAccountBalanceModal from '@/hooks/useAccountBalanceModal';
+import useMyCardReader from '@/app/(app)/account-balance/MyCardReader';
 
 interface BalanceQuickAccessButtonProps {
 	style?: any;
@@ -17,17 +19,54 @@ interface BalanceQuickAccessButtonProps {
 /**
  * Quick-access button for the foodoffers header: opens the account-balance
  * screen in a modal with the NFC scan already running. Only makes sense on
- * native (NFC isn't available on web) and only when the balance feature is
- * enabled for this server, so both checks live here and the component simply
- * renders nothing otherwise - callers don't need to duplicate the condition.
+ * native (NFC isn't available on web), only when the balance feature is
+ * enabled for this server, and only when a card can actually be read (same
+ * isNfcSupported/isNfcEnabled check the account-balance screen itself uses to
+ * decide whether to show its "read card" button) - all three checks live here
+ * so the component simply renders nothing otherwise and callers don't need to
+ * duplicate any of this.
  */
 const BalanceQuickAccessButton: React.FC<BalanceQuickAccessButtonProps> = ({ style }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { appSettings } = useAppSelector(state => state.settings);
 	const { openAccountBalanceModal } = useAccountBalanceModal();
+	const myCardReader = useMyCardReader();
+	const [isNfcSupported, setIsNfcSupported] = useState(false);
+	const [isNfcEnabled, setIsNfcEnabled] = useState(false);
 
-	if (isWeb || !appSettings?.balance_enabled) {
+	const balanceFeatureActive = !isWeb && !!appSettings?.balance_enabled;
+
+	useFocusEffect(
+		useCallback(() => {
+			if (!balanceFeatureActive) return;
+
+			let isCurrent = true;
+			const checkNfcStatus = async () => {
+				try {
+					const nfcAvailable = await myCardReader.isNfcSupported();
+					if (isCurrent) setIsNfcSupported(nfcAvailable.result);
+
+					const nfcEnabled = await myCardReader.isNfcEnabled();
+					if (isCurrent) setIsNfcEnabled(nfcEnabled.result);
+				} catch (error) {
+					console.error('Error checking NFC status:', error);
+				}
+			};
+
+			checkNfcStatus();
+			return () => {
+				isCurrent = false;
+			};
+			// myCardReader is intentionally omitted: useMyCardReader() returns a new
+			// instance every render (same as account-balance/index.tsx), so including
+			// it here would re-trigger this effect (and the NFC check) on every
+			// render once setIsNfcSupported/setIsNfcEnabled cause a re-render.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [balanceFeatureActive])
+	);
+
+	if (!balanceFeatureActive || !isNfcSupported || !isNfcEnabled) {
 		return null;
 	}
 
@@ -41,7 +80,7 @@ const BalanceQuickAccessButton: React.FC<BalanceQuickAccessButtonProps> = ({ sty
 					style={style}
 					nativeID={AppComponentIds.FOODOFFERS_BALANCE_QUICK_ACCESS}
 				>
-					<MaterialCommunityIcons name="credit-card-wireless-outline" size={24} color={theme.header.text} />
+					<Octicons name="credit-card" size={24} color={theme.header.text} />
 				</IconButton>
 			)}
 		>

--- a/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersHeader.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersHeader.tsx
@@ -13,6 +13,7 @@ import { isWeb } from '@/constants/Constants';
 import styles from '../styles';
 import { RootDrawerParamList } from '../types';
 import { DatabaseTypes } from 'repo-depkit-common';
+import BalanceQuickAccessButton from './BalanceQuickAccessButton';
 
 interface FoodOffersHeaderProps {
     drawerPosition: 'left' | 'right';
@@ -86,6 +87,8 @@ const FoodOffersHeader: React.FC<FoodOffersHeaderProps> = ({
                 </View>
 
                 <View style={[styles.col2, drawerPosition === 'right' && styles.rowReverse]}>
+                    <BalanceQuickAccessButton style={iconPaddingStyle} />
+
                     <CustomTooltip
                         placement="top"
                         trigger={triggerProps => (

--- a/apps/frontend/app/constants/ComponentIds.ts
+++ b/apps/frontend/app/constants/ComponentIds.ts
@@ -79,6 +79,9 @@ export enum AppComponentIds {
 	EATING_HABITS_MARKINGS = 'eating-habits-markings',
 	EATING_HABITS_ALLERGENE = 'eating-habits-allergene',
 
+	// Food offers
+	FOODOFFERS_BALANCE_QUICK_ACCESS = 'foodoffers-balance-quick-access',
+
 	// Housing
 	HOUSING_SEARCH = 'housing-search',
 

--- a/apps/frontend/app/hooks/useAccountBalanceModal.tsx
+++ b/apps/frontend/app/hooks/useAccountBalanceModal.tsx
@@ -1,0 +1,25 @@
+import React, { useCallback } from 'react';
+import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
+import AccountBalanceScreen from '@/app/(app)/account-balance';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+
+const useAccountBalanceModal = () => {
+	const { show, close } = useMyScrollViewModal();
+	const { translate } = useLanguage();
+
+	const openAccountBalanceModal = useCallback(
+		(autoStartNfc: boolean = false) => {
+			show({
+				title: translate(TranslationKeys.accountbalance),
+				children: <AccountBalanceScreen autoStartNfc={autoStartNfc} />,
+				disableHorizontalPadding: true,
+			});
+		},
+		[show, translate]
+	);
+
+	return { openAccountBalanceModal, closeAccountBalanceModal: close };
+};
+
+export default useAccountBalanceModal;


### PR DESCRIPTION
## Summary
New NFC quick-access button in the foodoffers header (next to the ⋮ options button) that opens the account-balance screen in a modal with the NFC scan started automatically - no need to navigate to the balance screen and press "read card" separately.

- `BalanceQuickAccessButton` (`apps/frontend/app/app/(app)/foodoffers/components/`) does the native-check (`isWeb`) and the `app_settings.balance_enabled` check internally and returns `null` otherwise, so `FoodOffersHeader` can render it unconditionally without any caller-side branching.
- `useAccountBalanceModal` opens the existing `AccountBalanceScreen` as modal content via `useMyScrollViewModal()`, the same pattern already used by `useBuildingDetailsModal`/`useMyScrollviewModalDistanceInformation` - it's a real screen component rendered inside a modal, not a separate stripped-down UI.
- `AccountBalanceScreen` gained an `autoStartNfc` prop. The existing NFC-read handler (previously inlined in the button's `onPress`) is extracted into `handleReadNfcPress`, reused by both the manual button and a new effect that calls it once (guarded by a ref) as soon as the screen is active and NFC is confirmed supported+enabled - functionally identical to a real button press, just triggered automatically.

## Test plan
- [x] `yarn tsc --noEmit`: 92 baseline errors, no new ones
- [x] Verified live on the web dev server (`kioskMode=true`, where `app_settings.balance_enabled` is confirmed `true` on the test server): the button correctly renders nothing on web (`isWeb` gate), no console errors from the new files, rest of the foodoffers header unaffected
- [ ] NFC itself and the auto-triggered scan can only be exercised on a real iOS/Android device or simulator - not available in this environment, so the native path (button visible → modal opens → scan auto-starts) could not be visually verified end-to-end. The gating logic and modal-reuse pattern were verified by code review against the existing, working NFC flow on the account-balance screen.