### PR TITLE
fix: account-balance modal closes itself immediately on open

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -276,6 +276,7 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
                         setIsActive(true);
                         return () => {
                                 setIsActive(false);
+                                closeInstructionRef.current();
 			};
 		}, [])
 	);
@@ -321,12 +322,6 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
                         animationRef?.current?.play(); // Reset animation to ensure it starts fresh
                 }
         }, [animationJson, autoPlay]);
-
-        useEffect(() => {
-                if (!isActive) {
-                        closeInstructionRef.current();
-                }
-        }, [isActive]);
 
 	const renderLottie = useMemo(() => {
 		if (animationJson) {


### PR DESCRIPTION
## Summary
- Opening the Account Balance modal from the foodoffers quick-access button (NFC card icon) closed the modal instantly, even though the NFC read was still starting.
- Root cause: `isActive` starts as `false` and only flips to `true` inside a `useFocusEffect`. A separate effect (`useEffect(() => { if (!isActive) closeInstructionRef.current(); }, [isActive])`) ran on the very first render, before that focus effect had updated `isActive`, and called the shared modal `close()`. As a standalone route the modal stack is empty so this was a harmless no-op — but when opened as the foodoffers quick-access modal, the stack has exactly one item (the balance modal itself), so `close()` popped it, closing the modal right after it opened.
- Fix: move the "close NFC instruction popup" call into the cleanup of the focus effect that manages `isActive`, so it only runs on actual blur/unmount, and remove the separate effect that misfired on mount.

## Test plan
- [ ] Open Foodoffers, tap the balance quick-access (credit-card) icon in the header — modal should stay open and show the NFC scan animation/instruction.
- [ ] Read a card via NFC — balance should update and remain visible in the modal (no auto-close).
- [ ] Navigate to `/account-balance` directly (not via modal) — behavior unchanged (read card, balance updates, no regressions).
- [ ] Leave the foodoffers screen while the balance modal/instruction is open — instruction popup still closes correctly on blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)