### PR TITLE
fix: avoid closing account-balance modal after NFC read

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -276,7 +276,6 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
                         setIsActive(true);
                         return () => {
                                 setIsActive(false);
-                                closeInstructionRef.current();
 			};
 		}, [])
 	);
@@ -322,6 +321,22 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
                         animationRef?.current?.play(); // Reset animation to ensure it starts fresh
                 }
         }, [animationJson, autoPlay]);
+
+        // Closes a lingering NFC instruction popup when the screen genuinely
+        // loses focus (isActive flips to false while still mounted). Skips the
+        // very first run: isActive starts as false before the focus effect above
+        // sets it to true, so without this guard the popup-close would fire
+        // (and close the whole modal) on initial mount instead of on real blur.
+        const skipInitialInactiveCloseRef = useRef(true);
+        useEffect(() => {
+                if (skipInitialInactiveCloseRef.current) {
+                        skipInitialInactiveCloseRef.current = false;
+                        return;
+                }
+                if (!isActive) {
+                        closeInstructionRef.current();
+                }
+        }, [isActive]);
 
 	const renderLottie = useMemo(() => {
 		if (animationJson) {


### PR DESCRIPTION
## Summary
Follow-up to #3748, which already got merged with only the first half of the fix (see below).

- #3748's fix moved the "close the NFC instruction popup" call into the cleanup of the `isActive` focus effect. That cleanup, however, also fires whenever the NFC instruction popup itself is shown — it's pushed onto the *same* global modal stack as the account-balance screen, which replaces (and thus unmounts) the account-balance screen while the popup is up. That unintentionally closed the whole modal right after a card was read.
- Fix: revert that cleanup change and instead watch `isActive` directly via its own effect, skipping the effect's first (mount-time) invocation with a ref guard. This only reacts to a genuine loss of focus while the screen stays mounted, not to the screen being unmounted because a nested modal (the NFC popup) replaced it.

## Test plan
- [ ] Open Foodoffers, tap the balance quick-access (credit-card) icon — modal opens and stays open (no more immediate self-close, confirmed by #3748).
- [ ] Read a card via NFC — the "hold card" popup shows, then closes, and the modal **stays open** showing the updated balance (this is the regression this PR fixes).
- [ ] Leave the foodoffers screen while the balance modal/instruction is open — instruction popup still closes correctly on real blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)