### PR TITLE
fix: Android avatar clipping (DiceBear id collision) + avatar-editor debug screen

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/avatars/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/avatars/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
@@ -10,6 +10,7 @@ import {
 	MyAvatar,
 	AvatarStyle,
 	AvatarSize,
+	AvatarConfig,
 	SettingsList,
 	SettingsListGroupTitle,
 	SettingsListSelectOption,
@@ -17,21 +18,28 @@ import {
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useAvatarProfileEditor, AVATAR_BACKGROUND } from '@/hooks/useAvatarProfileEditor';
-import { UserHelper } from '@/helper/UserHelper';
 
 const ALL_AVATAR_STYLES = Object.values(AvatarStyle).map((style) => ({
 	id: style,
 	label: style,
 }));
 
+// Debug-only default config used for the size-comparison row below when the user has no avatar yet.
+const DEBUG_SIZE_PREVIEW_CONFIG: AvatarConfig = {
+	style: AvatarStyle.MICAH,
+	size: AvatarSize.LARGE,
+};
+
+// Different render sizes to compare on the same screen. Useful for spotting size-dependent
+// rendering bugs (e.g. clipping that only shows up at certain pixel sizes on some Android devices).
+const DEBUG_PREVIEW_SIZES = [24, AvatarSize.SMALL, AvatarSize.MEDIUM, AvatarSize.LARGE, AvatarSize.XLARGE];
+
 const AvatarsScreen = () => {
 	useSetPageTitle(TranslationKeys.avatars);
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const { primaryColor } = useAppSelector((state) => state.settings);
-	const { user } = useAppSelector((state) => state.authReducer);
 	const debugMode = useDebugMode();
-	const isRegisteredUser = UserHelper.isRegisteredUser(user);
 	const { show: showModal, close: closeModal } = useMyScrollViewModal();
 
 	const [selectedStyle, setSelectedStyle] = useState<AvatarStyle>(AvatarStyle.MICAH);
@@ -117,25 +125,54 @@ const AvatarsScreen = () => {
 					</>
 				)}
 
-				{isRegisteredUser && (
-					<>
-						<SettingsListGroupTitle title={translate(TranslationKeys.avatars)} />
-						<SettingsList
-							title={avatarConfig ? translate(TranslationKeys.edit) : translate(TranslationKeys.avatar_create_new)}
-							onPress={openActionsModal}
-							leftIcon={
-								avatarConfig ? (
-									<MaterialCommunityIcons name="pencil" size={20} />
-								) : (
-									<MaterialCommunityIcons name="plus-circle" size={20} />
-								)
-							}
-							iconBgColor={primaryColor}
-							groupPosition="single"
-							rightElement={<MaterialCommunityIcons name="chevron-right" size={20} color={theme.screen.icon} />}
-						/>
-					</>
-				)}
+				{/*
+					Always shown here (unlike the production Settings/Friends screens, where the
+					avatar editor entry point is currently commented out because of the Android
+					rendering bug), so the editor stays reachable for testing regardless of
+					registration status. Saving still no-ops without a logged-in profile.
+				*/}
+				<SettingsListGroupTitle title={translate(TranslationKeys.avatars)} />
+				<SettingsList
+					title={avatarConfig ? translate(TranslationKeys.edit) : translate(TranslationKeys.avatar_create_new)}
+					onPress={openActionsModal}
+					leftIcon={
+						avatarConfig ? (
+							<MaterialCommunityIcons name="pencil" size={20} />
+						) : (
+							<MaterialCommunityIcons name="plus-circle" size={20} />
+						)
+					}
+					iconBgColor={primaryColor}
+					groupPosition="single"
+					rightElement={<MaterialCommunityIcons name="chevron-right" size={20} color={theme.screen.icon} />}
+				/>
+
+				{/*
+					Debug row: the same avatar rendered at several sizes side by side. Added to help
+					diagnose a bug where avatars render partially cut off on some Android devices
+					(e.g. Galaxy S25) but not on web/iOS - useful for checking whether the clipping
+					is specific to certain render sizes.
+				*/}
+				<SettingsListGroupTitle title={`${translate(TranslationKeys.avatars)} - Size Debug`} />
+				<View style={styles.sizeDebugRow}>
+					{DEBUG_PREVIEW_SIZES.map((size) => {
+						// MyAvatar prioritizes `config.size` over the `size` prop, so pass style/options
+						// separately here instead of `config` to force each preview to its own size.
+						const previewConfig = avatarConfig ?? DEBUG_SIZE_PREVIEW_CONFIG;
+						return (
+							<View key={size} style={styles.sizeDebugItem}>
+								<MyAvatar
+									style={previewConfig.style}
+									options={previewConfig.options}
+									size={size}
+									rounded={true}
+									backgroundColor={AVATAR_BACKGROUND}
+								/>
+								<Text style={{ color: theme.screen.text }}>{size}px</Text>
+							</View>
+						);
+					})}
+				</View>
 			</View>
 		</ScrollView>
 	);
@@ -162,6 +199,18 @@ const styles = StyleSheet.create({
 	},
 	modalContent: {
 		paddingVertical: 8,
+	},
+	sizeDebugRow: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		alignItems: 'flex-end',
+		justifyContent: 'center',
+		gap: 16,
+		paddingVertical: 16,
+	},
+	sizeDebugItem: {
+		alignItems: 'center',
+		gap: 4,
 	},
 });
 

--- a/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
@@ -659,8 +659,7 @@ const OnboardingScreen = () => {
 						</Text>
 					</View>
 				</View>
-				{/* Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed. */}
-				{/* {renderAvatarCarousel()} */}
+				{renderAvatarCarousel()}
 			</View>
 		</View>
 	);

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -55,10 +55,10 @@ import useCanteenVisitsVisibilityModal from '@/hooks/useCanteenVisitsVisibilityM
 import useAppRatingScore from '@/hooks/useAppRatingScore';
 import { useMyScrollviewModalPriceGroupSettings } from '@/hooks/useMyScrollviewModalPriceGroupSettings';
 import { ApartmentSortOption, CampusSortOption, FoodSortOption } from 'repo-depkit-common';
-import { MapStyleKey, SettingsListMyMapThemeSelection /*, MyAvatar */ } from 'repo-depkit-common-ui';
+import { MapStyleKey, SettingsListMyMapThemeSelection, MyAvatar } from 'repo-depkit-common-ui';
 import { FriendsContent } from '@/components/FriendsContent';
 import { ComponentIds } from '@/constants/ComponentIds';
-import { useAvatarProfileEditor, /* AVATAR_BACKGROUND, */ AVATAR_SETTINGS_ROW_SIZE } from '@/hooks/useAvatarProfileEditor';
+import { useAvatarProfileEditor, AVATAR_BACKGROUND, AVATAR_SETTINGS_ROW_SIZE } from '@/hooks/useAvatarProfileEditor';
 import FoodoffersAverageRatingToggle from '@/components/FoodoffersAverageRatingToggle';
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
@@ -504,19 +504,18 @@ const Settings = () => {
 					<View style={groupStyle}>
 						<SettingsList
 							leftIconComponent={
-								// Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
-								// settingsAvatarConfig ? (
-								// 	<MyAvatar
-								// 		config={settingsAvatarConfig}
-								// 		size={AVATAR_SETTINGS_ROW_SIZE / 2}
-								// 		rounded={true}
-								// 		backgroundColor={AVATAR_BACKGROUND}
-								// 	/>
-								// ) : (
+								settingsAvatarConfig ? (
+									<MyAvatar
+										config={settingsAvatarConfig}
+										size={AVATAR_SETTINGS_ROW_SIZE / 2}
+										rounded={true}
+										backgroundColor={AVATAR_BACKGROUND}
+									/>
+								) : (
 									<View style={{ width: AVATAR_SETTINGS_ROW_SIZE / 2, height: AVATAR_SETTINGS_ROW_SIZE / 2, borderRadius: AVATAR_SETTINGS_ROW_SIZE / 4, backgroundColor: primaryColor + '22', alignItems: 'center', justifyContent: 'center' }}>
 										<MaterialCommunityIcons name="account-outline" size={20} color={theme.screen.icon} />
 									</View>
-								// )
+								)
 							}
 							value={translate(TranslationKeys.avatar_appearance)}
 							rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -502,21 +502,21 @@ const Settings = () => {
 				<View style={sectionStyle}>
 					<SettingsGroupTitle>{translate(TranslationKeys.group_personalization)}</SettingsGroupTitle>
 					<View style={groupStyle}>
-						{/* Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
 						<SettingsList
 							leftIconComponent={
-								settingsAvatarConfig ? (
-									<MyAvatar
-										config={settingsAvatarConfig}
-										size={AVATAR_SETTINGS_ROW_SIZE / 2}
-										rounded={true}
-										backgroundColor={AVATAR_BACKGROUND}
-									/>
-								) : (
+								// Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
+								// settingsAvatarConfig ? (
+								// 	<MyAvatar
+								// 		config={settingsAvatarConfig}
+								// 		size={AVATAR_SETTINGS_ROW_SIZE / 2}
+								// 		rounded={true}
+								// 		backgroundColor={AVATAR_BACKGROUND}
+								// 	/>
+								// ) : (
 									<View style={{ width: AVATAR_SETTINGS_ROW_SIZE / 2, height: AVATAR_SETTINGS_ROW_SIZE / 2, borderRadius: AVATAR_SETTINGS_ROW_SIZE / 4, backgroundColor: primaryColor + '22', alignItems: 'center', justifyContent: 'center' }}>
 										<MaterialCommunityIcons name="account-outline" size={20} color={theme.screen.icon} />
 									</View>
-								)
+								// )
 							}
 							value={translate(TranslationKeys.avatar_appearance)}
 							rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}
@@ -525,14 +525,13 @@ const Settings = () => {
 							onAccountRequired={openAccountRequiredModal}
 							groupPosition="top"
 						/>
-						*/}
 						<SettingsListEditable
 							iconBgColor={primaryColor}
 							leftIcon={<MaterialCommunityIcons name="account" size={24} color={theme.screen.icon} />}
 							label={translate(TranslationKeys.nickname)}
 							value={profile?.id ? profile?.nickname ?? undefined : nickNameLocal}
 							handleFunction={openNicknameSheet}
-							groupPosition="top"
+							groupPosition="middle"
 						/>
 						{showFriendsInSettings && (
 							<SettingsList

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -20,8 +20,8 @@ import ProjectButton from '@/components/ProjectButton';
 import DebugView from '@/components/DebugView';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import * as Clipboard from 'expo-clipboard';
-// import { MyAvatar, AvatarSize } from 'repo-depkit-common-ui';
-import { useAvatarProfileEditor, /* AVATAR_BACKGROUND, */ AVATAR_SETTINGS_ROW_SIZE, parseProfileAvatar } from '@/hooks/useAvatarProfileEditor';
+import { MyAvatar, AvatarSize } from 'repo-depkit-common-ui';
+import { useAvatarProfileEditor, AVATAR_BACKGROUND, AVATAR_SETTINGS_ROW_SIZE, parseProfileAvatar } from '@/hooks/useAvatarProfileEditor';
 import { UserHelper } from '@/helper/UserHelper';
 import useAccountRequiredModal from '@/hooks/useAccountRequiredModal';
 
@@ -611,7 +611,6 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 			title: translate(TranslationKeys.friendships_details),
 			children: (
 				<View style={{ gap: 16 }}>
-					{/* Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
 					{otherAvatar && (
 						<View style={{ alignItems: 'center', paddingVertical: 8 }}>
 							<MyAvatar
@@ -622,7 +621,6 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 							/>
 						</View>
 					)}
-					*/}
 					<View>
 						<SettingsList
 							label={translate(TranslationKeys.friendships_friend_profile_id)}
@@ -691,24 +689,21 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 			return (
 				<SettingsList
 					key={friendship.id}
-					// Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
-					// iconBgColor={otherAvatar ? undefined : statusColor}
-					iconBgColor={statusColor}
+					iconBgColor={otherAvatar ? undefined : statusColor}
 					leftIconComponent={
-						// otherAvatar ? (
-						// 	<MyAvatar
-						// 		config={otherAvatar}
-						// 		size={AvatarSize.SMALL}
-						// 		rounded={true}
-						// 		backgroundColor={AVATAR_BACKGROUND}
-						// 	/>
-						// ) : undefined
-						undefined
+						otherAvatar ? (
+							<MyAvatar
+								config={otherAvatar}
+								size={AvatarSize.SMALL}
+								rounded={true}
+								backgroundColor={AVATAR_BACKGROUND}
+							/>
+						) : undefined
 					}
 					leftIcon={
-						// otherAvatar ? undefined : (
+						otherAvatar ? undefined : (
 							<MaterialCommunityIcons name="account-group" size={24} color="white" />
-						// )
+						)
 					}
 					label={showStatus ? translateFriendshipStatus(friendship.friendship_status) : undefined}
 					value={displayLabel}
@@ -736,19 +731,18 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 				{/* Profile Info */}
 				<SettingsList
 					leftIconComponent={
-						// Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
-						// ownAvatarConfig ? (
-						// 	<MyAvatar
-						// 		config={ownAvatarConfig}
-						// 		size={AVATAR_SETTINGS_ROW_SIZE / 2}
-						// 		rounded={true}
-						// 		backgroundColor={AVATAR_BACKGROUND}
-						// 	/>
-						// ) : (
+						ownAvatarConfig ? (
+							<MyAvatar
+								config={ownAvatarConfig}
+								size={AVATAR_SETTINGS_ROW_SIZE / 2}
+								rounded={true}
+								backgroundColor={AVATAR_BACKGROUND}
+							/>
+						) : (
 							<View style={{ width: AVATAR_SETTINGS_ROW_SIZE / 2, height: AVATAR_SETTINGS_ROW_SIZE / 2, borderRadius: AVATAR_SETTINGS_ROW_SIZE / 4, backgroundColor: primaryColor + '22', alignItems: 'center', justifyContent: 'center' }}>
 								<MaterialCommunityIcons name="account-outline" size={20} color={theme.screen.icon} />
 							</View>
-						// )
+						)
 					}
 					value={translate(TranslationKeys.avatar_appearance)}
 					rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -734,21 +734,21 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 				)}
 
 				{/* Profile Info */}
-				{/* Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
 				<SettingsList
 					leftIconComponent={
-						ownAvatarConfig ? (
-							<MyAvatar
-								config={ownAvatarConfig}
-								size={AVATAR_SETTINGS_ROW_SIZE / 2}
-								rounded={true}
-								backgroundColor={AVATAR_BACKGROUND}
-							/>
-						) : (
+						// Temporarily disabled: MyAvatar renders incorrectly on Android. Restore once fixed.
+						// ownAvatarConfig ? (
+						// 	<MyAvatar
+						// 		config={ownAvatarConfig}
+						// 		size={AVATAR_SETTINGS_ROW_SIZE / 2}
+						// 		rounded={true}
+						// 		backgroundColor={AVATAR_BACKGROUND}
+						// 	/>
+						// ) : (
 							<View style={{ width: AVATAR_SETTINGS_ROW_SIZE / 2, height: AVATAR_SETTINGS_ROW_SIZE / 2, borderRadius: AVATAR_SETTINGS_ROW_SIZE / 4, backgroundColor: primaryColor + '22', alignItems: 'center', justifyContent: 'center' }}>
 								<MaterialCommunityIcons name="account-outline" size={20} color={theme.screen.icon} />
 							</View>
-						)
+						// )
 					}
 					value={translate(TranslationKeys.avatar_appearance)}
 					rightIcon={<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />}
@@ -757,13 +757,12 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 					onAccountRequired={openAccountRequiredModal}
 					groupPosition="top"
 				/>
-				*/}
 				<SettingsList
 					iconBgColor={primaryColor}
 					leftIcon={<MaterialCommunityIcons name="identifier" size={24} color={theme.screen.icon} />}
 					label={translate(TranslationKeys.friendships_profile_id)}
 					value={profile?.id ?? '-'}
-					groupPosition="top"
+					groupPosition="middle"
 				/>
 				<SettingsListNickname
 					groupPosition="bottom"

--- a/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
+++ b/apps/frontend/app/hooks/useAppForegroundUpdateCheckModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { ActivityIndicator, AppState, AppStateStatus, Text, TouchableOpacity, View } from 'react-native';
 import * as Updates from 'expo-updates';
-import useDebugMode from '@/hooks/useDebugMode';
 
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import usePlatformHelper from '@/helper/platformHelper';
@@ -13,7 +12,6 @@ import { SET_SIMULATE_EXPO_UPDATE_AVAILABLE } from '@/redux/Types/types';
 
 const useAppForegroundUpdateCheckModal = () => {
         const appState = useRef<AppStateStatus>(AppState.currentState);
-        const debugMode = useDebugMode();
         const { isSmartPhone } = usePlatformHelper();
         const { show, close } = useMyScrollViewModal();
         const { theme } = useTheme();
@@ -31,7 +29,12 @@ const useAppForegroundUpdateCheckModal = () => {
                         },
                         { force }: { force?: boolean } = {}
                 ) => {
-                        if (!debugMode && !force) return;
+                        // Only show the intermediate check/status modal (searching, blocked, no update
+                        // found, ...) when the user has explicitly turned on "simulate update available"
+                        // in debug settings. It used to be gated on debug mode itself, which meant it
+                        // popped up on every single app foreground while debug mode was on. Forced
+                        // modals (e.g. a real update being found) always show regardless.
+                        if (!simulateExpoUpdateAvailable && !force) return;
 
                         const { title, message, loading, primaryAction, allowClose } = options;
 
@@ -81,7 +84,7 @@ const useAppForegroundUpdateCheckModal = () => {
                                 ),
                         });
                 },
-                [close, debugMode, show, theme.screen.background, theme.screen.text, theme.sheet.text]
+                [close, simulateExpoUpdateAvailable, show, theme.screen.background, theme.screen.text, theme.sheet.text]
         );
 
         const handleDownloadUpdate = useCallback(async () => {

--- a/packages/common-ui/src/components/MyAvatar/index.tsx
+++ b/packages/common-ui/src/components/MyAvatar/index.tsx
@@ -130,6 +130,25 @@ export function getStyleProbabilityKeys(style: AvatarStyle): Record<string, stri
 	return result;
 }
 
+// Every DiceBear-generated avatar (all styles) wraps its artwork in a <mask> that's a no-op:
+// `<mask id="viewboxMask"><rect x="0" y="0" width="W" height="H" rx="0" ry="0" fill="#fff" /></mask>`
+// where W/H exactly match the SVG's own viewBox. That rect covers the full viewport, so it clips
+// nothing beyond what the SVG's own viewBox/viewport already clips - it's a redundant safety net.
+// react-native-svg's Android renderer has long-standing bugs with <mask> (content inside a masked
+// <g> frequently renders partially or not at all - see e.g. software-mansion/react-native-svg
+// issues #2202, #1097, #1953), which is what caused avatars to render with pieces (typically the
+// top portion, e.g. hair) missing/cut off on Android while rendering fine on web/iOS. Stripping
+// this specific no-op mask removes that Android rendering bug without any visual change on
+// platforms where <mask> works, since the SVG viewport clips the same area anyway. Only matches
+// the exact no-op pattern above, so any *other*, visually meaningful <mask> a style might use for
+// real shading/shaping (e.g. bottts, notionists, personas) is left untouched.
+function stripRedundantViewboxMask(svg: string): string {
+	return svg.replace(
+		/<mask id="([^"]+)"><rect width="[\d.]+" height="[\d.]+" rx="0" ry="0" x="0" y="0" fill="#fff" \/><\/mask><g mask="url\(#\1\)">/,
+		'<g>'
+	);
+}
+
 const MyAvatar: React.FC<MyAvatarProps> = ({
 	config,
 	style: styleProp = AvatarStyle.LORELEI,
@@ -185,21 +204,17 @@ const MyAvatar: React.FC<MyAvatarProps> = ({
 				renderOptions[probKey] = ['0'];
 			}
 		}
-		return createAvatar(avatarStyle, {
+		const rawSvg = createAvatar(avatarStyle, {
 			size,
-			// DiceBear reuses the same static id (e.g. "viewboxMask") for the <mask>/<clipPath> that
-			// clips every avatar to its canvas. On web this collision is harmless because duplicate
-			// ids always point at geometrically identical defs, and each SvgXml on iOS resolves
-			// `url(#...)` against its own instance. react-native-svg's Android renderer keeps a
-			// shared defs/mask registry across all mounted <Svg> instances though, so when multiple
-			// MyAvatar components are on screen at once (chat/friends lists, settings + editor
-			// previews, onboarding carousel, ...) the ids collide there and avatars end up partially
-			// clipped/cut off. `randomizeIds` makes every rendered SVG's internal ids unique, which
-			// avoids the collision. See https://github.com/software-mansion/react-native-svg issues
-			// about mask/clipPath id collisions across multiple Svg instances on Android.
+			// A handful of styles (bottts, notionists, personas, ...) embed extra gradient/mask
+			// defs whose ids are otherwise identical across every avatar of that style+options.
+			// Randomizing them avoids collisions when multiple MyAvatar instances are mounted at
+			// once (chat/friends lists, settings + editor previews, onboarding carousel, ...).
 			randomizeIds: true,
 			...renderOptions,
 		}).toString();
+
+		return stripRedundantViewboxMask(rawSvg);
 	}, [style, size, options]);
 
 	return (

--- a/packages/common-ui/src/components/MyAvatar/index.tsx
+++ b/packages/common-ui/src/components/MyAvatar/index.tsx
@@ -187,6 +187,17 @@ const MyAvatar: React.FC<MyAvatarProps> = ({
 		}
 		return createAvatar(avatarStyle, {
 			size,
+			// DiceBear reuses the same static id (e.g. "viewboxMask") for the <mask>/<clipPath> that
+			// clips every avatar to its canvas. On web this collision is harmless because duplicate
+			// ids always point at geometrically identical defs, and each SvgXml on iOS resolves
+			// `url(#...)` against its own instance. react-native-svg's Android renderer keeps a
+			// shared defs/mask registry across all mounted <Svg> instances though, so when multiple
+			// MyAvatar components are on screen at once (chat/friends lists, settings + editor
+			// previews, onboarding carousel, ...) the ids collide there and avatars end up partially
+			// clipped/cut off. `randomizeIds` makes every rendered SVG's internal ids unique, which
+			// avoids the collision. See https://github.com/software-mansion/react-native-svg issues
+			// about mask/clipPath id collisions across multiple Svg instances on Android.
+			randomizeIds: true,
 			...renderOptions,
 		}).toString();
 	}, [style, size, options]);


### PR DESCRIPTION
## Summary

- **Root cause found and fixed** for avatars rendering partially clipped/cut off on some Android devices (confirmed via a real Galaxy S25 test) while rendering fine on web and iOS.
- Every DiceBear-generated avatar (all 30 styles) wraps its artwork in a `<mask>` that's a **no-op**: `<mask id="viewboxMask"><rect x="0" y="0" width="W" height="H" rx="0" ry="0" fill="#fff" /></mask>`, where `W`/`H` exactly equal the SVG's own `viewBox` — i.e. the mask rect covers the entire viewport and clips nothing beyond what the SVG's own viewport already clips on its own. `react-native-svg` has multiple long-standing, unresolved Android-specific bugs with `<mask>` (content inside a masked `<g>` frequently renders partially or not at all — see [software-mansion/react-native-svg#2202](https://github.com/software-mansion/react-native-svg/issues/2202), [#1097](https://github.com/react-native-community/react-native-svg/issues/1097), [#1953](https://github.com/software-mansion/react-native-svg/issues/1953)), which matches exactly what was observed on-device: content (typically the top portion, e.g. hair) cut off on Android, fine on web/iOS.
- Fix (`packages/common-ui/src/components/MyAvatar/index.tsx`): strip this specific no-op mask (verified byte-for-byte identical in shape across all 30 DiceBear styles by generating SVGs locally) instead of rendering it, so `SvgXml` never has to render a `<mask>` for the outer safety-clip at all. Any *other*, visually-meaningful `<mask>` a style actually needs for shading/shaping (e.g. `bottts`, `notionists`, `personas`) doesn't match this exact no-op pattern and is left untouched. Also keeps `randomizeIds: true`, since a few styles still embed extra gradient/mask ids that could otherwise collide when multiple avatars are mounted simultaneously (chat/friends lists, settings + editor previews, onboarding carousel, ...).
  - Note: an earlier commit on this PR shipped `randomizeIds: true` alone as a first (incorrect/insufficient) hypothesis, before the on-device screenshot showed the real symptom (content missing even for a single avatar, unrelated to id collisions). That's now superseded by this mask-stripping fix, which directly matches the observed bug.
- **Avatar UI fully restored** ✅: after the fix was confirmed working on the Galaxy S25, the two workaround commits that had hidden `MyAvatar` (`874305868` "temporarily hide MyAvatar rendering" and `4b508f92a` "hide avatar settings row") are now reverted on this branch — the avatar row in Settings, the avatars in the friends modal (`FriendsContent`, 3 spots incl. group avatars), and the onboarding avatar carousel are all active again.
- Made the experimental avatars screen (`/experimentell/avatars`) always show the avatar-editor entry point (previously gated behind `isRegisteredUser`) so the editor stays testable regardless of registration status.
- Added a debug row to that screen rendering the same avatar at 5 different sizes (24, 48, 96, 128, 192px) side by side — this is what surfaced the real bug on the Galaxy S25.
- **Extra:** the Expo update-check status modal (searching / blocked / no update found) used to be gated on debug mode, so it popped up on every single app foreground while debug mode was enabled. It's now gated on the existing "Expo-Update verfügbar simulieren" debug setting instead, so it only appears when explicitly requested via that toggle. Modals for an actually found update (real or simulated) are unaffected since they're always shown regardless of this gate.

## Test plan

- [x] Open `/experimentell/avatars` on the Galaxy S25 and confirm avatars render fully (no clipped/missing pieces) — **confirmed by on-device test**.
- [ ] Quick regression check of the restored spots on Android: avatar row in Settings, avatars in the friends modal, onboarding avatar carousel (`/experimentell/onboarding`).
- [ ] Try a few different styles/options in the editor on Android, especially `bottts`, `notionists`, and `personas` (styles with additional legitimate internal masks not touched by this fix).
- [ ] Confirm avatars still render correctly on web and iOS (regression check).
- [ ] With debug mode enabled and "Expo-Update verfügbar simulieren" off, foreground the app and confirm no update-check modal pops up. Turn the simulate toggle on and confirm the "Update gefunden" modal appears as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)