### PR TITLE
feat: NFC chip position hint in card-read instruction modal

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -448,6 +448,14 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
                                                                         loop
                                                                 />
                                                         </View>
+                                                        <Text
+                                                                style={{
+                                                                        ...styles.nfcInstructionChipPosition,
+                                                                        color: theme.screen.text,
+                                                                }}
+                                                        >
+                                                                {translate(TranslationKeys.nfcInstructionChipPosition)}
+                                                        </Text>
                                                 </View>
                                         </View>
                                 </View>

--- a/apps/frontend/app/app/(app)/account-balance/styles.ts
+++ b/apps/frontend/app/app/(app)/account-balance/styles.ts
@@ -105,6 +105,13 @@ export default StyleSheet.create({
 		fontSize: 16,
 		fontFamily: 'Poppins_400Regular',
 	},
+	nfcInstructionChipPosition: {
+		fontSize: 13,
+		fontFamily: 'Poppins_400Regular',
+		textAlign: 'center',
+		paddingHorizontal: 24,
+		opacity: 0.8,
+	},
 	sheetView: {
 		width: '100%',
 		alignItems: 'center',

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -116,6 +116,7 @@ export enum TranslationKeys {
         nfcNotEnabled = 'nfcNotEnabled',
         pleaseEnableNFC = 'pleaseEnableNFC',
         nfcInstructionRead = 'nfcInstructionRead',
+        nfcInstructionChipPosition = 'nfcInstructionChipPosition',
         showNfcInstruction = 'showNfcInstruction',
         new = 'new',
 	attention = 'attention',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1189,6 +1189,16 @@
     "tr": "Kartı okumak için cihazınızı karta tutun.",
     "zh": "将设备靠近卡片以读取。"
   },
+  "nfcInstructionChipPosition": {
+    "de": "Falls die Karte nicht sofort erkannt wird, probiere verschiedene Stellen an deinem Gerät aus – der NFC-Chip sitzt bei jedem Gerät an einer anderen Position. Bei den meisten Android-Geräten befindet sich die NFC-Antenne auf der Rückseite im oberen Bereich, meist in der Nähe der Kamera.",
+    "en": "If the card isn't recognized right away, try holding it against different spots on your device – the NFC chip is positioned differently on every device. On most Android phones, the NFC antenna is on the back, usually near the top around the camera.",
+    "ar": "إذا لم تتم قراءة البطاقة على الفور، جرّب تقريبها من أماكن مختلفة من جهازك - يقع شريحة NFC في مكان مختلف في كل جهاز. في معظم هواتف أندرويد، توجد هوائي NFC في الجزء الخلفي، عادةً بالقرب من الكاميرا.",
+    "es": "Si la tarjeta no se reconoce de inmediato, prueba a colocarla en distintos puntos del dispositivo: el chip NFC está ubicado en un lugar diferente en cada dispositivo. En la mayoría de los teléfonos Android, la antena NFC se encuentra en la parte trasera, normalmente cerca de la cámara.",
+    "fr": "Si la carte n'est pas reconnue immédiatement, essayez de la placer à différents endroits de votre appareil : la puce NFC est positionnée différemment selon les appareils. Sur la plupart des téléphones Android, l'antenne NFC se trouve au dos, généralement près de l'appareil photo.",
+    "ru": "Если карта не считывается сразу, попробуйте приложить её к разным местам устройства — NFC-чип расположен по-разному на каждом устройстве. На большинстве Android-телефонов NFC-антенна находится на задней панели, обычно рядом с камерой.",
+    "tr": "Kart hemen okunmazsa cihazınızın farklı bölgelerine tutmayı deneyin – NFC çipi her cihazda farklı bir yerde bulunur. Çoğu Android telefonda NFC anteni arka yüzde, genellikle kamera çevresinde bulunur.",
+    "zh": "如果没有立即读取到卡片,请尝试将卡片贴近设备的不同位置——不同设备的 NFC 芯片位置各不相同。大多数安卓手机的 NFC 天线位于背面,通常靠近摄像头附近。"
+  },
   "showNfcInstruction": {
     "de": "NFC-Anleitung anzeigen",
     "en": "Show NFC instruction",


### PR DESCRIPTION
## Summary

- Adds a secondary hint line to the NFC card-read instruction modal (shown on Android while scanning, below the animation): if the card isn't recognized right away, try holding it against different spots on the device, since the NFC chip is positioned differently on every device — on most Android phones the antenna is on the back near the top, around the camera.
- New translation key `nfcInstructionChipPosition`, translated into all 8 app languages (de/en/ar/es/fr/ru/tr/zh). German: *"Falls die Karte nicht sofort erkannt wird, probiere verschiedene Stellen an deinem Gerät aus – der NFC-Chip sitzt bei jedem Gerät an einer anderen Position. Bei den meisten Android-Geräten befindet sich die NFC-Antenne auf der Rückseite im oberen Bereich, meist in der Nähe der Kamera."*
- Styled slightly smaller and dimmed (13px, 80% opacity, centered) below the existing instruction + animation so the primary "hold your device to the card" message stays dominant.
- iOS is untouched: it uses the system NFC sheet, so the custom instruction modal (and this hint) only ever appears on Android — which is also the platform where antenna position varies the most.

## Test plan

- [ ] On an Android device, open account balance and start an NFC read — confirm the instruction modal shows the new hint below the animation.
- [ ] Switch app language (e.g. English) and confirm the translated hint appears.
- [ ] Confirm iOS still shows only the system NFC sheet (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)