### PR TITLE
fix(security): resolve 3 remaining SonarCloud security findings

### DIFF
--- a/apps/backend/Backend/scripts/getBase64IconForMail.py
+++ b/apps/backend/Backend/scripts/getBase64IconForMail.py
@@ -61,6 +61,10 @@ def find_node_modules_directory(max_levels_up=10):
 
 # Function to load the glyph map from the JSON file
 def load_glyph_map(glyph_map_path):
+    # Re-validate immediately before the file is opened: glyph_map_path is derived
+    # from CLI-controlled input (--node_modules, icon family), so canonicalize and
+    # confirm it still resolves inside the repository right at this access point.
+    glyph_map_path = require_inside_base_dir(glyph_map_path)
     with open(glyph_map_path, "r") as file:
         glyph_map = json.load(file)
     return glyph_map

--- a/apps/backend/sync/importSchema.js
+++ b/apps/backend/sync/importSchema.js
@@ -304,6 +304,18 @@ const getDirectusSyncArgs = () => {
 const execWithOutput = async (cmd, args) => {
   console.log(' -  Pushing schema changes');
 
+  // Re-validate immediately before the OS command runs: cmd/args are built from
+  // CLI-controlled values several calls away (getDirectusSyncArgs), so guard the
+  // exact values reaching spawn() here too, right at the sink.
+  if (!/^[\w.-]+$/.test(cmd)) {
+    throw new Error(`Refusing to run unsafe command: "${cmd}"`);
+  }
+  for (const arg of args) {
+    if (typeof arg !== 'string' || /[\r\n\0]/.test(arg)) {
+      throw new Error('Refusing to pass unsafe argument to child process');
+    }
+  }
+
   const child = spawn(cmd, args, {
     env: { NODE_TLS_REJECT_UNAUTHORIZED: '0', ...process.env },
     stdio: ['inherit', 'pipe', 'pipe'],

--- a/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
+++ b/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
@@ -19,11 +19,17 @@ const argv = yargs(hideBin(process.argv))
   .help()
   .alias('h', 'help').argv as any;
 
-const rootDir = path.resolve(argv.root);
-const csvPath = path.resolve(argv.csv);
+const rootDir = fs.realpathSync(path.resolve(argv.root));
 
-// The CSV path is CLI-controlled; require it to stay inside the project root
-// before reading it, so a faulty argument can't point the script at arbitrary files.
+const resolvedCsvPath = path.resolve(argv.csv);
+if (!fs.existsSync(resolvedCsvPath)) {
+  console.error(`CSV file not found: ${resolvedCsvPath}`);
+  process.exit(1);
+}
+// The CSV path is CLI-controlled; canonicalize it (resolving symlinks, "..", etc.)
+// and require it to stay inside the project root before reading it, so a faulty
+// argument can't point the script at arbitrary files.
+const csvPath = fs.realpathSync(resolvedCsvPath);
 const csvRelativeToRoot = path.relative(rootDir, csvPath);
 if (csvRelativeToRoot.startsWith('..') || path.isAbsolute(csvRelativeToRoot)) {
   console.error(`Refusing to read CSV outside the project root: ${csvPath}`);
@@ -44,18 +50,19 @@ for (const line of lines) {
   const componentPath = match[1];
   const lineNumber = Number.parseInt(match[2], 10);
   const fileRelPath = componentPath.split(':')[1];
-  const filePath = path.resolve(rootDir, fileRelPath);
+  const resolvedFilePath = path.resolve(rootDir, fileRelPath);
 
-  // The CSV report is external, downloaded input; validate the path it points at stays
-  // inside rootDir before this script reads/overwrites it.
-  const relativeToRoot = path.relative(rootDir, filePath);
-  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
-    console.warn(`Skipping path outside root directory: ${filePath}`);
+  if (!fs.existsSync(resolvedFilePath)) {
+    console.warn(`File not found: ${resolvedFilePath}`);
     continue;
   }
 
-  if (!fs.existsSync(filePath)) {
-    console.warn(`File not found: ${filePath}`);
+  // The CSV report is external, downloaded input; canonicalize the path it points at
+  // and validate it stays inside rootDir before this script reads/overwrites it.
+  const filePath = fs.realpathSync(resolvedFilePath);
+  const relativeToRoot = path.relative(rootDir, filePath);
+  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+    console.warn(`Skipping path outside root directory: ${filePath}`);
     continue;
   }
 


### PR DESCRIPTION
## Summary

A prior commit (`caa8fa4b9`, merged to `master` on 2026-07-10) added path/argument validation to bring the SonarCloud security rating from E to A. The rescanned report (`reports/sonarCloud/report_security.csv`, updated after that commit) still flags the same 3 lines — the sanitizers existed, but weren't recognized by SonarCloud's dataflow analysis because they were too far from the actual sink or used a technique it doesn't treat as canonicalization.

- **`apps/backend/Backend/scripts/getBase64IconForMail.py:64`** — `require_inside_base_dir` was only applied to `node_modules_path` upstream; `load_glyph_map` now re-validates the exact `glyph_map_path` immediately before `open()`.
- **`apps/backend/sync/importSchema.js:307`** — CLI-derived values were validated in `getDirectusSyncArgs()`, several function calls and an array spread away from `spawn()`. `execWithOutput` now re-validates `cmd` and every element of `args` immediately before the `spawn()` call.
- **`apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts:33`** — `path.resolve()` doesn't resolve symlinks, so it isn't true canonicalization. Both the CSV path and the per-issue file path now go through `fs.realpathSync()` before the root-directory check and file read/write.

## Verification

- `python3 -m py_compile` clean on the `.py` file.
- `node --check` clean on the `.js` file.
- `npx tsc --noEmit` clean on the `sonarCloudReportDownloader` package.
- Behavior is unchanged for valid inputs; only the sanitizer placement/technique changed.

## Test plan

- [ ] Merge and confirm the next SonarCloud scan drops the security finding count from 3 to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)