### PR TITLE
fix(security): re-anchor path/CLI sanitizers for 2 remaining SonarCloud findings

### DIFF
--- a/apps/backend/sync/importSchema.js
+++ b/apps/backend/sync/importSchema.js
@@ -301,22 +301,30 @@ const getDirectusSyncArgs = () => {
 
 // Executes a command as an argument vector (no shell) so that CLI-controlled values
 // (URL, email, password, paths) can never be interpreted as shell syntax.
+const ALLOWED_COMMANDS = new Set(['npx']);
+// Printable ASCII only: matches the broadest upstream field pattern (the password
+// pattern above), so every value that passes its own field validation still passes
+// here, while all control characters, newlines, NUL bytes, and non-ASCII bytes are
+// rejected right at the sink.
+const SAFE_ARG_PATTERN = /^[\x20-\x7e]+$/;
+
 const execWithOutput = async (cmd, args) => {
   console.log(' -  Pushing schema changes');
 
-  // Re-validate immediately before the OS command runs: cmd/args are built from
-  // CLI-controlled values several calls away (getDirectusSyncArgs), so guard the
-  // exact values reaching spawn() here too, right at the sink.
-  if (!/^[\w.-]+$/.test(cmd)) {
+  // Re-validate immediately before the OS command runs, right at the sink: only a
+  // fixed allowlisted executable and strictly allowlisted argument characters may
+  // reach spawn(), no matter how cmd/args were validated upstream.
+  if (!ALLOWED_COMMANDS.has(cmd)) {
     throw new Error(`Refusing to run unsafe command: "${cmd}"`);
   }
   for (const arg of args) {
-    if (typeof arg !== 'string' || /[\r\n\0]/.test(arg)) {
+    if (typeof arg !== 'string' || !SAFE_ARG_PATTERN.test(arg)) {
       throw new Error('Refusing to pass unsafe argument to child process');
     }
   }
 
   const child = spawn(cmd, args, {
+    shell: false,
     env: { NODE_TLS_REJECT_UNAUTHORIZED: '0', ...process.env },
     stdio: ['inherit', 'pipe', 'pipe'],
   });
@@ -347,7 +355,9 @@ const execWithOutput = async (cmd, args) => {
 };
 
 const execDirectusSync = async args => {
-  const output = await execWithOutput('npx', ['directus-sync@' + DirectusSyncVersion, ...args]);
+  const packageSpec =
+    'directus-sync@' + requireSafeCliValue('directus-sync-version', DirectusSyncVersion, /^[\w.^~-]+$/);
+  const output = await execWithOutput('npx', [packageSpec, ...args]);
   const lines = output.split('\n');
   for (const line of lines) {
     if (line.includes('✅  Done!')) {

--- a/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
+++ b/apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts
@@ -20,19 +20,32 @@ const argv = yargs(hideBin(process.argv))
   .alias('h', 'help').argv as any;
 
 const rootDir = fs.realpathSync(path.resolve(argv.root));
+const rootDirWithSep = rootDir.endsWith(path.sep) ? rootDir : rootDir + path.sep;
+
+// Canonicalizes `candidate` (resolving symlinks, "..", etc.) and returns the
+// canonical path only if it stays inside rootDir, otherwise null. Must be called
+// immediately before every filesystem access on a CLI- or CSV-derived path, since
+// a faulty argument or a symlink in the report could otherwise point outside the
+// project.
+const canonicalizeInsideRoot = (candidate: string): string | null => {
+  const canonical = fs.realpathSync(candidate);
+  if (canonical !== rootDir && !canonical.startsWith(rootDirWithSep)) {
+    return null;
+  }
+  return canonical;
+};
 
 const resolvedCsvPath = path.resolve(argv.csv);
 if (!fs.existsSync(resolvedCsvPath)) {
   console.error(`CSV file not found: ${resolvedCsvPath}`);
   process.exit(1);
 }
-// The CSV path is CLI-controlled; canonicalize it (resolving symlinks, "..", etc.)
-// and require it to stay inside the project root before reading it, so a faulty
-// argument can't point the script at arbitrary files.
-const csvPath = fs.realpathSync(resolvedCsvPath);
-const csvRelativeToRoot = path.relative(rootDir, csvPath);
-if (csvRelativeToRoot.startsWith('..') || path.isAbsolute(csvRelativeToRoot)) {
-  console.error(`Refusing to read CSV outside the project root: ${csvPath}`);
+// The CSV path is CLI-controlled; canonicalize it and require it to stay inside
+// the project root before reading it, so a faulty argument can't point the
+// script at arbitrary files.
+const csvPath = canonicalizeInsideRoot(resolvedCsvPath);
+if (!csvPath) {
+  console.error(`Refusing to read CSV outside the project root: ${resolvedCsvPath}`);
   process.exit(1);
 }
 
@@ -59,10 +72,9 @@ for (const line of lines) {
 
   // The CSV report is external, downloaded input; canonicalize the path it points at
   // and validate it stays inside rootDir before this script reads/overwrites it.
-  const filePath = fs.realpathSync(resolvedFilePath);
-  const relativeToRoot = path.relative(rootDir, filePath);
-  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
-    console.warn(`Skipping path outside root directory: ${filePath}`);
+  const filePath = canonicalizeInsideRoot(resolvedFilePath);
+  if (!filePath) {
+    console.warn(`Skipping path outside root directory: ${resolvedFilePath}`);
     continue;
   }
 


### PR DESCRIPTION
## Summary

The 2026-07-11 fix (#3764) re-validated at the sink, but the rescanned report (`reports/sonarCloud/report_security.csv` / `issue.md` on master) still flags the same two lines — the sanitizer patterns weren't recognized as sufficient by SonarCloud's dataflow analysis:

- **`apps/sonarCloudReportDownloader/src/fixStaticReadonly.ts`** (CSV path and per-issue file path) — switched the containment check from `path.relative(root, x).startsWith('..')` to a canonicalized prefix-boundary check (`fs.realpathSync()` then `startsWith(rootDir + path.sep)`), applied immediately before every filesystem access via a shared `canonicalizeInsideRoot()` helper.
- **`apps/backend/sync/importSchema.js`** (`spawn()` call in `execWithOutput`) — replaced the loose per-argument blocklist (only rejected `\r\n\0`) with a printable-ASCII allowlist (matches the broadest existing field pattern, the password one, so no legitimate value is newly rejected) plus an exact-match allowlist for the executable name (`npx` only). Also validates `DirectusSyncVersion` before it's concatenated into the package spec, and passes `shell: false` explicitly to `spawn()`.

## Verification

- `node --check apps/backend/sync/importSchema.js` clean.
- `npx tsc --noEmit` clean in `apps/sonarCloudReportDownloader`.
- Behavior unchanged for valid inputs; only sanitizer technique/placement changed.

## Test plan

- [ ] Rerun the SonarCloud scan and confirm the security count in `reports/sonarCloud/report_security.csv` drops to 0.
- [ ] Run `apps/sonarCloudReportDownloader` against a sample CSV to confirm readonly-fixing still works.
- [ ] Exercise `apps/backend/sync/importSchema.js` schema push against a dev Directus instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)