### PR TITLE
fix: food offer sorting is wrong and doesn't update live

### DIFF
--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -256,41 +256,36 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		[sortBy, language, ownFoodFeedbacksForSort, profile, foodCategories, foodOfferCategories]
 	);
 
-	useEffect(() => {
-		setDays(prev => {
-			const updated = prev.map(d => ({ ...d, offers: sortOffers(d.offers) }));
-			// Only update the cache if data has already been loaded for the current cacheKey.
-			// This prevents the sort effect from writing the previous canteen's data into the
-			// new canteen's cache key when the canteen changes (which would corrupt the cache
-			// before the fetch for the new canteen completes).
-			if (updated.length > 0 && daysCache[cacheKey] !== undefined) {
-				updateCache(updated);
-			}
-			return updated;
-		});
-	}, [sortOffers, updateCache, cacheKey]);
+	// Sorting is applied at render time (see `displayDays` below) instead of mutating
+	// `days`/`daysCache` here. Re-sorting used to run as an effect that raced with the
+	// focus-triggered `init()` (below), which reads `daysCache` synchronously and could
+	// overwrite the freshly sorted state with the stale, previously-cached order.
+	// Keeping `days`/`daysCache` sort-agnostic avoids that race entirely and makes the
+	// on-screen order update immediately whenever the sort option changes.
+	const displayDays = useMemo(
+		() => days.map(d => ({ ...d, offers: sortOffers(d.offers) })),
+		[days, sortOffers]
+	);
 
 	const loadDay = useCallback(
 		async (date: string): Promise<DayData> => {
 			const res = await fetchFoodOffersByCanteen(canteenId, date);
 			const offers = res?.data || [];
-			const sortedOffers = sortOffers(offers);
 			// Persist to AsyncStorage cache
 			await cacheFoodOffers(canteenId, date, offers);
-			return { date, offers: sortedOffers } as DayData;
+			return { date, offers } as DayData;
 		},
-		[canteenId, sortOffers]
+		[canteenId]
 	);
 
 	const loadCachedDay = useCallback(
 		async (date: string): Promise<DayData | null> => {
 			const cached = await getCachedFoodOffers(canteenId, date);
 			if (!cached || cached.offers.length === 0) return null;
-			const sortedOffers = sortOffers(cached.offers);
 			dayHashesRef.current[date] = cached.hash;
-			return { date, offers: sortedOffers };
+			return { date, offers: cached.offers };
 		},
-		[canteenId, sortOffers]
+		[canteenId]
 	);
 
 	const init = useCallback(
@@ -556,7 +551,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 			<FoodOffersLoadingBar color={foods_area_color} loading={serverLoading} isOffline={isOffline} textColor={theme.screen.text} />
 			<FlatList
 				ref={flatListRef}
-				data={days}
+				data={displayDays}
 				keyExtractor={item => item.date}
 				renderItem={renderDay}
 				onEndReached={onEndReached}

--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -201,9 +201,16 @@ export function sortByOwnFavorite(foodOffers: DatabaseTypes.Foodoffers[], ownFee
 }
 
 export function sortByPublicFavorite(foodOffers: DatabaseTypes.Foodoffers[]) {
+  const getEffectiveRating = (food: DatabaseTypes.Foods): number | null | undefined => {
+    return food?.rating_average ?? food?.rating_average_legacy;
+  };
+
   foodOffers.sort((a, b) => {
     const aFood = (typeof a.food === 'object' && a.food !== null ? a.food : {}) as DatabaseTypes.Foods;
     const bFood = (typeof b.food === 'object' && b.food !== null ? b.food : {}) as DatabaseTypes.Foods;
+    const aRating = getEffectiveRating(aFood);
+    const bRating = getEffectiveRating(bFood);
+
     const getRatingCategory = (rating: number | null | undefined) => {
       if (isRatingNegative(rating)) return 'negative';
       if (rating === null || rating === undefined) return 'null';
@@ -211,15 +218,20 @@ export function sortByPublicFavorite(foodOffers: DatabaseTypes.Foodoffers[]) {
       return 'unknown'; // Fallback for unexpected cases
     };
 
-    const aCategory = getRatingCategory(aFood?.rating_average);
-    const bCategory = getRatingCategory(bFood?.rating_average);
+    const aCategory = getRatingCategory(aRating);
+    const bCategory = getRatingCategory(bRating);
 
     const priorityOrder = ['positive', 'unknown', 'null', 'negative'];
 
     const aPriority = priorityOrder.indexOf(aCategory);
     const bPriority = priorityOrder.indexOf(bCategory);
 
-    return aPriority - bPriority;
+    if (aPriority !== bPriority) {
+      return aPriority - bPriority;
+    }
+
+    // Within the same category, rank by the actual rating value (highest first)
+    return (bRating ?? 0) - (aRating ?? 0);
   });
 
 

--- a/packages/common/src/__tests__/SortingHelper.test.ts
+++ b/packages/common/src/__tests__/SortingHelper.test.ts
@@ -33,6 +33,30 @@ describe('SortingHelper', () => {
     expect(sorted.map((o: any) => o.food.rating_average)).toEqual([4, null, 2]);
   });
 
+  test('sortByPublicFavorite ranks items within the same category by their actual rating, highest first', () => {
+    // Reproduces the bug where items with the same "positive" bucket kept their original,
+    // unsorted order instead of being ranked by their numeric rating (e.g. 4.4, 4.6, 3.9, 4.9, 4.2 shown unsorted).
+    const offers: any = [
+      { food: { rating_average: 4.4 } },
+      { food: { rating_average: 4.6 } },
+      { food: { rating_average: 3.9 } },
+      { food: { rating_average: 4.9 } },
+      { food: { rating_average: 4.2 } },
+    ];
+    const sorted = sortByPublicFavorite(offers);
+    expect(sorted.map((o: any) => o.food.rating_average)).toEqual([4.9, 4.6, 4.4, 4.2, 3.9]);
+  });
+
+  test('sortByPublicFavorite falls back to rating_average_legacy when rating_average is missing', () => {
+    const offers: any = [
+      { food: { rating_average: null, rating_average_legacy: 3.5 } },
+      { food: { rating_average: 4.8, rating_average_legacy: null } },
+      { food: { rating_average: null, rating_average_legacy: null } },
+    ];
+    const sorted = sortByPublicFavorite(offers);
+    expect(sorted.map((o: any) => o.food.rating_average ?? o.food.rating_average_legacy)).toEqual([4.8, 3.5, null]);
+  });
+
   test('sortByOwnFavorite orders by personal rating', () => {
     const offers: any = [{ food: { id: 'f1' } }, { food: { id: 'f2' } }, { food: { id: 'f3' } }];
     const feedbacks = [


### PR DESCRIPTION
## Summary

Two bugs in the "sort food offers" feature, both reported by the user with a real screenshot ("sort by public rating" showing 4.4, 4.6, 3.9, 4.9, 4.2 ★ in that exact, unsorted order):

**1. `sortByPublicFavorite` never ranked items by their actual rating (`packages/common/src/SortingHelper.ts`)**
It only bucketed offers into positive/null/negative groups and never sorted **within** a bucket by the real `rating_average`, so same-bucket items (e.g. all "positive") kept whatever arbitrary order the backend returned. It also ignored the `rating_average_legacy` fallback the food cards themselves use to display a rating, so foods with only a legacy rating were miscategorized as "unrated".
Fix: added a descending numeric tie-break within each bucket, and applied the same `rating_average ?? rating_average_legacy` fallback used by the UI.

**2. The list didn't update live when the sort type was changed (`apps/frontend/app/components/FoodOffersScrollList/index.tsx`)**
Even after fixing (1), switching the sort type in the running app didn't reliably reorder the on-screen list. Root cause: `loadDay`/`loadCachedDay` sorted offers before caching, and a `useEffect` re-sorted `days` on every `sortBy` change — both writing into the module-level `daysCache`. Since `sortBy` was in `loadDay`/`loadCachedDay`'s dependencies, changing it also changed `init`'s identity, which re-triggered `useFocusEffect` (the screen was already focused). `init()` synchronously read the stale `daysCache` *before* the sort effect's `setDays` updater had actually run, so its `setDays(daysCache[cacheKey])` call was queued after the sort effect's update and silently reverted the order.
Fix: moved sorting to a render-time `useMemo` (`displayDays`) so `days`/`daysCache` stay sort-agnostic. `loadDay`/`loadCachedDay`/`init` no longer depend on the sort function, so switching sort no longer retriggers `useFocusEffect`/`init` — the on-screen order now updates immediately.

## Other areas checked (per request)
- Every other `FoodSortOption` (alphabetical, food category, foodoffer category, price ascending/descending, own favorite, eating habits, intelligent) was audited with targeted unit tests using realistic data (German umlauts, missing categories, mixed markings, mixed price groups) — all correct.
- Campus (`app/(app)/campus/index.tsx`) and Apartments/Living (`app/(app)/housing/index.tsx`) sorting was reviewed too: both derive their sorted lists via a pure `useMemo` chain with no async re-fetch in between, so they already re-render live correctly — no equivalent bug found there.

## Verification
- Added unit tests reproducing the exact reported rating-sort scenario (`packages/common/src/__tests__/SortingHelper.test.ts`) — all passing.
- `tsc --noEmit` on the frontend app shows the same 92 pre-existing errors before and after this change (no new errors introduced).
- **Verified end-to-end with Playwright against the real running app** (static web export served locally, hitting the live `test.rocket-meals.de` backend as a guest user): opened the food offers screen for "Mensa Universitätsstraße", enabled "Durchschnittsbewertung auf Karte anzeigen", then switched through Rating → Alphabetical → Price ascending → Price descending via the sort modal, screenshotting immediately after each selection with no reload/renavigation:
  - Rating: 5.0 → 4.5 → 4.3 → 4.0 → 4.0 → 3.5 (descending) ✓
  - Alphabetical: Abwechslungsreiche → Fagottini → Grüner → Steckrüben → Verschiedene → Verschiedene ✓
  - Price ascending: 0,80€ → 0,80€ → 0,90€ → 1,00€ → 1,20€ → 1,50€ ✓
  - Price descending: 1,50€ → 1,20€ → 1,00€ → 0,90€ → 0,80€ → 0,80€ ✓
  
  Each switch produced a different, correctly-ordered list immediately, confirming the live-render fix works in the real app, not just in unit tests.

## Test plan
- [x] `yarn jest src/__tests__/SortingHelper.test.ts` in `packages/common` — all pass
- [x] Full `packages/common` test suite — all pass
- [x] `tsc --noEmit` on `apps/frontend/app` — no new errors vs. `master`
- [x] Playwright end-to-end verification against the real app for all sort types

🤖 Generated with [Claude Code](https://claude.com/claude-code)