### PR TITLE
test: Maestro e2e tests for food offer sorting with mocked Directus backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,13 @@ Diese Datei enthält Arbeitsregeln für KI-Agenten in diesem Repository.
 ## Wichtige Referenzen
 - Für visuelle Änderungen und Screenshots: `SCREENSHOTS_PLAYWRIGHT.md`
 
+## Maestro End-to-End-Tests
+
+- Tests liegen als TypeScript in `apps/frontend/maestro-tests/src/tests/` und werden mit `yarn maestro:generate` (aus `apps/frontend/app/`) zu YAML generiert.
+- `yarn maestro` führt die Tests gegen das echte Test-Backend aus; `yarn maestro:mock` startet zusätzlich den Directus-GET-Mock (`maestro-tests/src/mock-server/mockServer.ts`) und führt nur Tests mit dem Tag `mock-backend` aus.
+- Der Mock serviert die geteilten Fixtures aus `packages/common/src/testData/` — dieselben Daten, gegen die auch die Unit-Tests laufen. Neue deterministische E2E-Tests sollten diese Fixtures erweitern statt eigene Daten zu definieren.
+- Für Element-Targeting immer `nativeID={ComponentIds.XXX}` verwenden (siehe `apps/frontend/app/constants/ComponentIds.ts`).
+
 ## React-Dateien (verbindliche Konvention)
 Bei React-Dateien sollen **Styles, Export und Logik in derselben Datei** bleiben.
 

--- a/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
@@ -16,6 +16,7 @@ import { AppScreens, DatabaseTypes } from 'repo-depkit-common';
 import { CanteenHelper } from '@/redux/actions';
 import { BuildingsHelper } from '@/redux/actions/Buildings/Buildings';
 import { excerpt, getImageUrl } from '@/constants/HelperFunctions';
+import { ComponentIds } from '@/constants/ComponentIds';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import LottieView from 'lottie-react-native';
@@ -780,6 +781,7 @@ const OnboardingScreen = () => {
 					<TouchableOpacity
 						onPress={handleNext}
 						style={[styles.navButtonPrimary, styles.navButtonFullWidth, { backgroundColor: primaryColor }]}
+						nativeID={ComponentIds.ONBOARDING_NEXT_BUTTON}
 					>
 						<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>
 							{translate(TranslationKeys.onboarding_next)}
@@ -801,6 +803,7 @@ const OnboardingScreen = () => {
 							<TouchableOpacity
 								onPress={handleNext}
 								style={[styles.navButtonPrimary, { backgroundColor: primaryColor }]}
+								nativeID={ComponentIds.ONBOARDING_NEXT_BUTTON}
 							>
 								<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>
 									{translate(TranslationKeys.onboarding_next)}
@@ -812,6 +815,7 @@ const OnboardingScreen = () => {
 								onPress={handleStart}
 								style={[styles.navButtonPrimary, { backgroundColor: primaryColor }]}
 								activeOpacity={0.8}
+								nativeID={ComponentIds.ONBOARDING_START_BUTTON}
 							>
 								<MaterialCommunityIcons name="rocket-launch" size={24} color={contrastColor} />
 								<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>

--- a/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersHeader.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersHeader.tsx
@@ -92,7 +92,7 @@ const FoodOffersHeader: React.FC<FoodOffersHeaderProps> = ({
                     <CustomTooltip
                         placement="top"
                         trigger={triggerProps => (
-                            <IconButton {...triggerProps} onPress={openOptionsModal} style={iconPaddingStyle}>
+                            <IconButton {...triggerProps} onPress={openOptionsModal} style={iconPaddingStyle} nativeID={ComponentIds.FOODOFFERS_OPTIONS_BUTTON}>
                                 <Entypo name="dots-three-vertical" size={22} color={theme.header.text} />
                             </IconButton>
                         )}

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -9,6 +9,7 @@ import CanteenFeedbackLabels from '@/components/CanteenFeedbackLabels/CanteenFee
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { sortFoodOffers } from '@/helper/foodOfferSortHelper';
+import { ComponentIds } from '@/constants/ComponentIds';
 import styles from './styles';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import { useFocusEffect } from 'expo-router';
@@ -43,6 +44,8 @@ interface DayData {
 interface DayItem {
 	foodoffer: DatabaseTypes.Foodoffers | null;
 	foodofferInfoItem: DatabaseTypes.FoodoffersInfoItems | null;
+	/** 0-based position of the foodoffer within the day's (sorted) offers; null for info items. */
+	offerIndex: number | null;
 }
 
 const EMPTY_FEEDBACKS: any[] = [];
@@ -181,9 +184,9 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 		const startInfos = sortBySortField(infoItemsFiltered.filter(i => i.placement === 'start'));
 		const endInfos = sortBySortField(infoItemsFiltered.filter(i => i.placement === 'end'));
 
-		const startItems = startInfos.map(i => ({ foodoffer: null, foodofferInfoItem: i }));
-		const main = offers.map(o => ({ foodoffer: o, foodofferInfoItem: null }));
-		const endItems = endInfos.map(i => ({ foodoffer: null, foodofferInfoItem: i }));
+		const startItems = startInfos.map(i => ({ foodoffer: null, foodofferInfoItem: i, offerIndex: null }));
+		const main = offers.map((o, offerIndex) => ({ foodoffer: o, foodofferInfoItem: null, offerIndex }));
+		const endItems = endInfos.map(i => ({ foodoffer: null, foodofferInfoItem: i, offerIndex: null }));
 
 		return [...startItems, ...main, ...endItems] as DayItem[];
 	}, [foodOffersInfoItems, selectedCanteen, parseDateOnly]);
@@ -471,9 +474,12 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 				>
 					{dayItems.map((dayItem, index) => {
 						if (dayItem.foodoffer) {
+							const food = dayItem.foodoffer.food;
+							const foodId = typeof food === 'object' && food !== null ? food.id : food;
 							return (
 								<View
 									key={`offer-${dayItem.foodoffer.id}`}
+									nativeID={`${ComponentIds.FOODOFFER_POSITION_PREFIX}-${dayItem.offerIndex}-${foodId}`}
 									style={{
 										width: cardWidth || '100%',
 										marginHorizontal: itemGap,

--- a/apps/frontend/app/components/PriceGroupSettingsList/index.tsx
+++ b/apps/frontend/app/components/PriceGroupSettingsList/index.tsx
@@ -12,6 +12,7 @@ import { UserHelper } from '@/helper/UserHelper';
 import { UPDATE_PROFILE } from '@/redux/Types/types';
 import { DatabaseTypes } from 'repo-depkit-common';
 import SettingsList from '@/components/SettingsList';
+import { ComponentIds } from '@/constants/ComponentIds';
 
 interface PriceGroupSettingsListProps {
 	onSelect?: (priceGroup: string) => void;
@@ -103,6 +104,7 @@ const PriceGroupSettingsList = ({ onSelect }: PriceGroupSettingsListProps) => {
 							/>
 						}
 						handleFunction={() => handleSelect(option.id)}
+						nativeID={`${ComponentIds.PRICE_GROUP_SELECT_BUTTON}-${option.id}`}
 					/>
 				);
 			})}

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -126,11 +126,26 @@ export const studiFutterConfig: CustomerConfig = {
     foodoffers_show_separated_markings_breakdown: true
 };
 
+// EXPO_PUBLIC_SERVER_URL overrides the backend URL of every customer config.
+// It is inlined into the JS bundle by Metro at build time, exactly like
+// EXPO_PUBLIC_CUSTOMER. Used by the Maestro test runner (--mock) to point the
+// app at the local mock backend before the app is started. Never set in
+// production builds.
+export function getServerUrlOverride(): string | undefined {
+        return process.env.EXPO_PUBLIC_SERVER_URL || undefined;
+}
+
+function applyServerUrlOverride(config: CustomerConfig): CustomerConfig {
+        const override = getServerUrlOverride();
+        if (!override) return config;
+        return { ...config, server_url: override };
+}
+
 export function getCustomerConfigsDict(): Record<ConfigCustomerEnum, CustomerConfig> {
         return {
-                [ConfigCustomerEnum.TEST]: devConfig,
-                [ConfigCustomerEnum.SWOSY]: swosyConfig,
-                [ConfigCustomerEnum.STUDI_FUTTER]: studiFutterConfig,
+                [ConfigCustomerEnum.TEST]: applyServerUrlOverride(devConfig),
+                [ConfigCustomerEnum.SWOSY]: applyServerUrlOverride(swosyConfig),
+                [ConfigCustomerEnum.STUDI_FUTTER]: applyServerUrlOverride(studiFutterConfig),
         };
 }
 
@@ -180,7 +195,7 @@ export function getCustomerEnvVariable(): string | undefined {
 
 export function getCustomerConfig(): CustomerConfig {
 	const customer = getCustomerEnvVariable();
-	return getCustomerConfigsDict()[customer as ConfigCustomerEnum] || devConfig;
+	return getCustomerConfigsDict()[customer as ConfigCustomerEnum] || applyServerUrlOverride(devConfig);
 }
 
 export function getGeneratedAssetsPath(): string {

--- a/apps/frontend/app/constants/ComponentIds.ts
+++ b/apps/frontend/app/constants/ComponentIds.ts
@@ -48,6 +48,13 @@ export enum AppComponentIds {
 	CANTEEN_SELECTION_EMPTY = 'canteen-selection-empty',
 	CANTEEN_SELECT_BUTTON = 'canteen-select-button',
 
+	// Onboarding
+	ONBOARDING_NEXT_BUTTON = 'onboarding-next-button',
+	ONBOARDING_START_BUTTON = 'onboarding-start-button',
+	// Prefix for the price group options; the PriceGroupKey is appended,
+	// e.g. "price-group-select-button-student".
+	PRICE_GROUP_SELECT_BUTTON = 'price-group-select-button',
+
 	// Settings groups
 	SETTINGS_GROUP_APP_SETTINGS = 'settings-group-app-settings',
 	SETTINGS_GROUP_CANTEEN_USAGE = 'settings-group-canteen-usage',
@@ -81,6 +88,15 @@ export enum AppComponentIds {
 
 	// Food offers
 	FOODOFFERS_BALANCE_QUICK_ACCESS = 'foodoffers-balance-quick-access',
+	FOODOFFERS_OPTIONS_BUTTON = 'foodoffers-options-button',
+	FOODOFFERS_OPTION_SORT = 'foodoffers-option-sort',
+	// Prefix for the sort options in the sorting modal; the FoodSortOption value
+	// is appended, e.g. "sort-option-rating", "sort-option-alphabetical".
+	SORT_OPTION_PREFIX = 'sort-option',
+	// Prefix for a food card at a specific list position; the 0-based position
+	// and the food id are appended, e.g. "foodoffer-position-0-food-gnocchi".
+	// This encodes the rendered order so Maestro tests can assert sorting.
+	FOODOFFER_POSITION_PREFIX = 'foodoffer-position',
 
 	// Housing
 	HOUSING_SEARCH = 'housing-search',

--- a/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
+++ b/apps/frontend/app/hooks/useFoodofferSortingModal.tsx
@@ -20,6 +20,7 @@ import { useAppSelector } from '@/redux/hooks';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import SettingsListSelectOption from '@/components/SettingsListSelectOption/SettingsListSelectOption';
+import { ComponentIds } from '@/constants/ComponentIds';
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import { RootState } from '@/redux/reducer';
@@ -164,6 +165,7 @@ export const SortSheet: React.FC<SortSheetProps> = ({ closeSheet }) => {
                                         options={sortingOptions.map((option) => ({
                                                 ...option,
                                                 label: translate(option.label),
+                                                nativeID: `${ComponentIds.SORT_OPTION_PREFIX}-${option.id}`,
                                         }))}
                                         selectedOption={selectedOption}
                                         onSelect={updateSort}

--- a/apps/frontend/app/hooks/useMyScrollviewModalFoodOffersOptions.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewModalFoodOffersOptions.tsx
@@ -5,6 +5,7 @@ import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewMo
 import { useLanguage } from '@/hooks/useLanguage';
 import { TranslationKeys } from '@/locales/keys';
 import SettingsList from '@/components/SettingsList/SettingsList';
+import { ComponentIds } from '@/constants/ComponentIds';
 import { useAppSelector } from '@/redux/hooks';
 import { shallowEqual } from 'react-redux';
 import FoodoffersAverageRatingToggle from '@/components/FoodoffersAverageRatingToggle';
@@ -32,6 +33,7 @@ type NavigationOption = {
 	title: string;
 	icon: React.ReactNode;
 	onPress: () => void;
+	nativeID?: string;
 };
 
 type BooleanToggleOption = {
@@ -75,6 +77,7 @@ const FoodOffersOptionsContent: React.FC<FoodOffersOptionsContentProps> = ({
 			title: translate(TranslationKeys.sort),
 			icon: <MaterialIcons name="sort" size={20} />,
 			onPress: () => { onSort(); },
+			nativeID: ComponentIds.FOODOFFERS_OPTION_SORT,
 		},
 		{
 			key: 'priceGroup',
@@ -144,6 +147,7 @@ const FoodOffersOptionsContent: React.FC<FoodOffersOptionsContentProps> = ({
 						onPress={option.onPress}
 						groupPosition={groupPosition}
 						showSeparator={showSeparator}
+						nativeID={option.nativeID}
 					/>
 				);
 			})}

--- a/apps/frontend/app/package.json
+++ b/apps/frontend/app/package.json
@@ -21,7 +21,9 @@
     "export:web:dev": "expo export --platform web",
     "maestro:generate": "ts-node --project ../maestro-tests/tsconfig.json ../maestro-tests/src/framework/generate.ts",
     "maestro": "bash ../run-maestro-web-test.sh",
-    "maestro:runOnly": "bash ../run-maestro-web-test.sh --skip-generate"
+    "maestro:runOnly": "bash ../run-maestro-web-test.sh --skip-generate",
+    "maestro:mock": "bash ../run-maestro-web-test.sh --mock",
+    "maestro:mock-server": "ts-node --project ../maestro-tests/tsconfig.json ../maestro-tests/src/mock-server/mockServer.ts"
   },
   "jest": {
     "preset": "jest-expo"

--- a/apps/frontend/maestro-tests/src/framework/loginHelper.ts
+++ b/apps/frontend/maestro-tests/src/framework/loginHelper.ts
@@ -48,3 +48,28 @@ export function selectFirstCanteen(test: MaestroTestCase): MaestroTestCase {
 		.tapOnId(ComponentIds.CANTEEN_SELECT_BUTTON)
 		.waitForAnimationToEnd();
 }
+
+/**
+ * Complete the onboarding flow shown after a fresh anonymous login
+ * (welcome → canteen → price group → preferences → start).
+ *
+ * A fresh session is always routed to onboarding by (app)/index.tsx until a
+ * canteen AND a price group are set. Selecting a canteen or price group
+ * automatically advances to the next step.
+ */
+export function completeAnonymousOnboarding(test: MaestroTestCase): MaestroTestCase {
+	return test
+		// Welcome step
+		.assertVisibleId(ComponentIds.ONBOARDING_NEXT_BUTTON)
+		.tapOnId(ComponentIds.ONBOARDING_NEXT_BUTTON)
+		.waitForAnimationToEnd()
+		// Canteen step – selecting a canteen advances to the price group step
+		.tapOnId(ComponentIds.CANTEEN_SELECT_BUTTON)
+		.waitForAnimationToEnd()
+		// Price group step – selecting a price group advances to the preferences step
+		.tapOnId(`${ComponentIds.PRICE_GROUP_SELECT_BUTTON}-student`)
+		.waitForAnimationToEnd()
+		// Preferences step – start the app
+		.tapOnId(ComponentIds.ONBOARDING_START_BUTTON)
+		.waitForAnimationToEnd();
+}

--- a/apps/frontend/maestro-tests/src/mock-server/mockServer.ts
+++ b/apps/frontend/maestro-tests/src/mock-server/mockServer.ts
@@ -1,0 +1,196 @@
+/**
+ * mockServer.ts – Minimal Directus GET mock backend for Maestro end-to-end tests.
+ *
+ * Serves the shared fixtures from packages/common/src/testData/FoodOfferTestData.ts
+ * so that the app shows a deterministic canteen and deterministic food offers,
+ * matching exactly the data the unit tests run against.
+ *
+ * Scope (intentionally small, see repo discussion):
+ * - Only GET requests are mocked. Directus write operations are answered with
+ *   403 so the app degrades gracefully (anonymous mode does not need writes).
+ * - Collections without fixtures return an empty list, which the app treats
+ *   like an empty backend (screens render their empty states).
+ * - A future improvement is to run a real Directus + database for e2e tests;
+ *   until then this mock keeps the tests fast and deterministic.
+ *
+ * Usage (from apps/frontend/app):
+ *   yarn maestro:mock-server            # starts on port 4030
+ *   MOCK_SERVER_PORT=5000 yarn maestro:mock-server
+ */
+
+import * as http from 'http';
+import { URL } from 'url';
+
+import {
+	getTestFoodoffers,
+	TEST_APP_SETTINGS,
+	TEST_CANTEEN,
+} from '../../../../../packages/common/src/testData/FoodOfferTestData';
+
+const PORT = Number(process.env.MOCK_SERVER_PORT) || 4030;
+
+/** Returns today's date as YYYY-MM-DD in local time (same as the app requests). */
+function getLocalDateString(date: Date): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
+/**
+ * Extracts the requested date (YYYY-MM-DD) from the Directus filter query params.
+ * We only need any `date._gte` value to know which day is being requested.
+ *
+ * Two formats occur:
+ * - Directus SDK sends the filter as one JSON string:
+ *   `filter={"_and":[...{"date":{"_gte":"2026-07-14"}}...]}`
+ * - axios serializes nested objects with bracket notation:
+ *   `filter[_and][1][_or][0][_and][0][date][_gte]=2026-07-14`
+ */
+function extractRequestedDate(requestUrl: URL): string | null {
+	// Bracket notation (axios)
+	for (const [key, value] of requestUrl.searchParams.entries()) {
+		if (key.startsWith('filter') && key.endsWith('[date][_gte]')) {
+			return value;
+		}
+	}
+
+	// JSON string (Directus SDK)
+	const filterParam = requestUrl.searchParams.get('filter');
+	if (!filterParam) return null;
+	try {
+		const filter = JSON.parse(filterParam);
+		const found: string[] = [];
+		const walk = (node: any): void => {
+			if (!node || typeof node !== 'object') return;
+			if (node.date && typeof node.date._gte === 'string') found.push(node.date._gte);
+			for (const value of Object.values(node)) walk(value);
+		};
+		walk(filter);
+		return found[0] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function sendJson(res: http.ServerResponse, statusCode: number, body: unknown): void {
+	const payload = JSON.stringify(body);
+	res.writeHead(statusCode, {
+		'Content-Type': 'application/json',
+		'Content-Length': Buffer.byteLength(payload),
+	});
+	res.end(payload);
+}
+
+/** Handles GET /items/<collection>. Returns fixture data or an empty list. */
+function handleItemsRequest(collection: string, requestUrl: URL, res: http.ServerResponse): void {
+	switch (collection) {
+		case 'app_settings':
+			// Singleton collection: Directus returns an object, not an array.
+			sendJson(res, 200, { data: TEST_APP_SETTINGS });
+			return;
+		case 'canteens':
+			sendJson(res, 200, { data: [TEST_CANTEEN] });
+			return;
+		case 'foodoffers': {
+			const requestedDate = extractRequestedDate(requestUrl);
+			const today = getLocalDateString(new Date());
+			// Only "today" has offers; other days are empty. This keeps the
+			// element ids in the rendered list unique for Maestro assertions.
+			if (requestedDate === null || requestedDate === today) {
+				sendJson(res, 200, { data: getTestFoodoffers(requestedDate ?? today) });
+			} else {
+				sendJson(res, 200, { data: [] });
+			}
+			return;
+		}
+		default:
+			sendJson(res, 200, { data: [] });
+	}
+}
+
+const server = http.createServer((req, res) => {
+	const method = req.method ?? 'GET';
+	const requestUrl = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+	const pathname = requestUrl.pathname;
+
+	// CORS: the app runs on a different origin (Expo dev server).
+	res.setHeader('Access-Control-Allow-Origin', '*');
+	res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+
+	// eslint-disable-next-line no-console
+	console.log(`[mock-backend] ${method} ${pathname}${requestUrl.search}`);
+
+	if (method === 'OPTIONS') {
+		res.writeHead(204);
+		res.end();
+		return;
+	}
+
+	if (method !== 'GET') {
+		// Only GET requests are mocked (see file header).
+		sendJson(res, 403, { errors: [{ message: 'Mock backend only supports GET requests.' }] });
+		return;
+	}
+
+	if (pathname === '/server/info') {
+		sendJson(res, 200, {
+			data: {
+				project: {
+					project_name: 'Rocket Meals Mock',
+					project_descriptor: 'Maestro mock backend',
+					project_logo: null,
+					project_color: '#D14610',
+					public_foreground: null,
+					public_background: null,
+					public_note: null,
+					custom_css: null,
+				},
+			},
+		});
+		return;
+	}
+
+	if (pathname === '/server/health') {
+		sendJson(res, 200, { status: 'ok' });
+		return;
+	}
+
+	if (pathname === '/auth' || pathname.startsWith('/auth/')) {
+		// No SSO providers in the mock; the anonymous flow does not need them.
+		sendJson(res, 200, { data: [] });
+		return;
+	}
+
+	if (pathname === '/users/me') {
+		sendJson(res, 401, { errors: [{ message: 'Not authenticated (mock backend).' }] });
+		return;
+	}
+
+	if (pathname.startsWith('/assets/')) {
+		res.writeHead(404);
+		res.end();
+		return;
+	}
+
+	if (pathname.startsWith('/items/')) {
+		const collection = pathname.split('/')[2] ?? '';
+		handleItemsRequest(collection, requestUrl, res);
+		return;
+	}
+
+	if (pathname.startsWith('/fields/')) {
+		sendJson(res, 200, { data: [] });
+		return;
+	}
+
+	sendJson(res, 200, { data: [] });
+});
+
+server.listen(PORT, () => {
+	// eslint-disable-next-line no-console
+	console.log(`[mock-backend] Directus GET mock listening on http://localhost:${PORT}`);
+	// eslint-disable-next-line no-console
+	console.log(`[mock-backend] Foodoffers are served for today (${getLocalDateString(new Date())}) only.`);
+});

--- a/apps/frontend/maestro-tests/src/tests/food-offers-sorting-test.ts
+++ b/apps/frontend/maestro-tests/src/tests/food-offers-sorting-test.ts
@@ -1,0 +1,94 @@
+/**
+ * food-offers-sorting-test.ts – Verifies that sorting the food offers list works
+ * and that the rendered order updates immediately when the sort type changes.
+ *
+ * REQUIRES THE MOCK BACKEND: run via `yarn maestro:mock` (from apps/frontend/app),
+ * which starts the Directus GET mock server and the Expo dev server with
+ * EXPO_PUBLIC_SERVER_URL pointing at it. The mock serves the shared fixtures from
+ * packages/common/src/testData/FoodOfferTestData.ts, and this test asserts the
+ * exact same expected orders that the unit tests in
+ * packages/common/src/__tests__/SortingHelper.test.ts assert.
+ *
+ * Each food card wrapper carries the nativeID
+ *   `foodoffer-position-<position>-<foodId>`
+ * (see ComponentIds.FOODOFFER_POSITION_PREFIX), so asserting a specific id
+ * asserts that a specific food is rendered at a specific list position.
+ */
+
+import { MaestroTestCase } from '../framework/MaestroTestCase';
+import { ComponentIds } from '../../../app/constants/ComponentIds';
+import { completeAnonymousOnboarding, performAnonymousLogin } from '../framework/loginHelper';
+import { EXPECTED_FOOD_ID_ORDER } from '../../../../../packages/common/src/testData/FoodOfferTestData';
+import { FoodSortOption } from '../../../../../packages/common/src/SortingEnums';
+
+const test = new MaestroTestCase({
+	appId: 'com.rocketmeals.web',
+	tags: ['web', 'food-offers', 'sorting', 'mock-backend'],
+	outputFileName: 'food-offers-sorting-test',
+});
+
+/** Assert that every food is rendered at its expected list position. */
+function assertFoodOrder(sortOption: FoodSortOption): void {
+	const expectedFoodIds = EXPECTED_FOOD_ID_ORDER[sortOption];
+	if (!expectedFoodIds) {
+		throw new Error(`No expected order defined for sort option: ${sortOption}`);
+	}
+	for (let position = 0; position < expectedFoodIds.length; position++) {
+		test.assertVisibleId(`${ComponentIds.FOODOFFER_POSITION_PREFIX}-${position}-${expectedFoodIds[position]}`);
+	}
+}
+
+/** Open the sort modal via the header options menu and select a sort option. */
+function selectSortOption(sortOption: FoodSortOption): void {
+	test
+		.tapOnId(ComponentIds.FOODOFFERS_OPTIONS_BUTTON)
+		.waitForAnimationToEnd()
+		.tapOnId(ComponentIds.FOODOFFERS_OPTION_SORT)
+		.waitForAnimationToEnd()
+		.tapOnId(`${ComponentIds.SORT_OPTION_PREFIX}-${sortOption}`)
+		.waitForAnimationToEnd()
+		// Selecting a sort option closes only the sort modal (the topmost sheet);
+		// the options menu below it stays open by design – close it as a user would.
+		.tapOnId(ComponentIds.MODAL_CLOSE_BUTTON)
+		.waitForAnimationToEnd();
+}
+
+// Login anonymously and complete onboarding with the mocked canteen ("Mensa Testhausen").
+performAnonymousLogin(test);
+completeAnonymousOnboarding(test);
+
+test
+	// Dismiss any popup/event modal that may have appeared after canteen selection
+	.optionalTapOnId(ComponentIds.MODAL_CLOSE_BUTTON)
+	.waitForAnimationToEnd()
+
+	// Navigate to food offers via drawer (same as the existing food-offers test)
+	.tapOnId(ComponentIds.OPEN_DRAWER)
+	.waitForAnimationToEnd()
+	.tapOnId(ComponentIds.DRAWER_ITEM_FOOD_OFFERS)
+	.waitForAnimationToEnd()
+	.takeScreenshot('sorting-01-food-offers-loaded')
+	// The mocked offers must be visible (any position, food from the fixtures)
+	.assertVisibleId(`${ComponentIds.FOODOFFER_POSITION_PREFIX}-0-`);
+
+// Public rating: highest rating first, legacy-only rating treated as its value.
+selectSortOption(FoodSortOption.RATING);
+test.takeScreenshot('sorting-02-rating');
+assertFoodOrder(FoodSortOption.RATING);
+
+// Alphabetical: sorted by the displayed food name.
+selectSortOption(FoodSortOption.ALPHABETICAL);
+test.takeScreenshot('sorting-03-alphabetical');
+assertFoodOrder(FoodSortOption.ALPHABETICAL);
+
+// Price ascending (anonymous profile → student prices).
+selectSortOption(FoodSortOption.PRICE_ASCENDING);
+test.takeScreenshot('sorting-04-price-ascending');
+assertFoodOrder(FoodSortOption.PRICE_ASCENDING);
+
+// Price descending.
+selectSortOption(FoodSortOption.PRICE_DESCENDING);
+test.takeScreenshot('sorting-05-price-descending');
+assertFoodOrder(FoodSortOption.PRICE_DESCENDING);
+
+export default test;

--- a/apps/frontend/maestro-tests/src/tests/food-offers-test.ts
+++ b/apps/frontend/maestro-tests/src/tests/food-offers-test.ts
@@ -9,7 +9,7 @@
 
 import { MaestroTestCase } from '../framework/MaestroTestCase';
 import { ComponentIds } from '../../../app/constants/ComponentIds';
-import { performAnonymousLogin, selectFirstCanteen } from '../framework/loginHelper';
+import { completeAnonymousOnboarding, performAnonymousLogin } from '../framework/loginHelper';
 
 const test = new MaestroTestCase({
 	appId: 'com.rocketmeals.web',
@@ -17,9 +17,10 @@ const test = new MaestroTestCase({
 	outputFileName: 'food-offers-test',
 });
 
-// Login and select a canteen
+// Login and complete onboarding (fresh sessions are always routed to onboarding
+// by (app)/index.tsx until a canteen and a price group are set)
 performAnonymousLogin(test);
-selectFirstCanteen(test);
+completeAnonymousOnboarding(test);
 
 test
 	.takeScreenshot('food-offers-after-canteen-selected')

--- a/apps/frontend/run-maestro-web-test.sh
+++ b/apps/frontend/run-maestro-web-test.sh
@@ -5,13 +5,22 @@
 # Usage:
 #   yarn maestro              (from apps/frontend/app/)  – generates + runs tests
 #   yarn maestro:runOnly      (from apps/frontend/app/)  – runs tests without regenerating
-#   ./run-maestro-web-test.sh [--skip-generate]  (from apps/frontend/)
+#   yarn maestro:mock         (from apps/frontend/app/)  – runs the mock-backend tests
+#   ./run-maestro-web-test.sh [--skip-generate] [--mock]  (from apps/frontend/)
 #
 # Flags:
 #   --skip-generate   Skip step 5 (YAML generation from TypeScript).
 #                     Use when the generated files are already up-to-date.
+#   --mock            Start the Directus GET mock backend
+#                     (maestro-tests/src/mock-server/mockServer.ts) and start the
+#                     Expo dev server with EXPO_PUBLIC_SERVER_URL pointing at it,
+#                     so all app requests are answered with the shared fixtures
+#                     from packages/common/src/testData. Only tests tagged
+#                     "mock-backend" run in this mode; without --mock those
+#                     tests are excluded (they would fail on real data).
 #
 # The script:
+#   0. (--mock only) Starts the Directus GET mock backend
 #   1. Starts the Expo web dev server in the background (output suppressed)
 #   2. Waits until the server is reachable
 #   3. Installs Maestro CLI if not already present
@@ -19,7 +28,7 @@
 #   5. Generates YAML test files from TypeScript  (skipped with --skip-generate)
 #   6. Runs all Maestro tests
 #   7. Lists failed tests and screenshot paths (on failure)
-#   8. Stops the dev server on exit (success or failure)
+#   8. Stops the dev server (and mock backend) on exit (success or failure)
 # =============================================================================
 
 set -e
@@ -28,10 +37,14 @@ set -e
 # Parse flags
 # ---------------------------------------------------------------------------
 SKIP_GENERATE=false
+MOCK_MODE=false
 for arg in "$@"; do
     case "$arg" in
         --skip-generate)
             SKIP_GENERATE=true
+            ;;
+        --mock)
+            MOCK_MODE=true
             ;;
     esac
 done
@@ -39,10 +52,36 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GENERATED_DIR="$SCRIPT_DIR/maestro-tests/generated"
 DEV_URL="http://localhost:8081/"
+MOCK_SERVER_PORT="${MOCK_SERVER_PORT:-4030}"
+MOCK_SERVER_URL="http://localhost:$MOCK_SERVER_PORT"
+MOCK_BACKEND_TAG="mock-backend"
 export PATH="$HOME/.maestro/bin:$PATH"
 
 echo "=== Maestro Web Smoke Test ==="
 echo ""
+
+# ---------------------------------------------------------------------------
+# 0. (--mock only) Start the Directus GET mock backend
+# ---------------------------------------------------------------------------
+MOCK_PID=""
+if [ "$MOCK_MODE" = true ]; then
+    echo "Starting Directus GET mock backend on $MOCK_SERVER_URL ..."
+    (cd "$SCRIPT_DIR/app" && MOCK_SERVER_PORT="$MOCK_SERVER_PORT" yarn maestro:mock-server) > /dev/null 2>&1 &
+    MOCK_PID=$!
+
+    for i in $(seq 1 30); do
+        if curl -sf "$MOCK_SERVER_URL/server/health" > /dev/null 2>&1; then
+            echo "Mock backend is ready."
+            break
+        fi
+        if [ "$i" -eq 30 ]; then
+            echo "ERROR: Mock backend did not start within 30s."
+            exit 1
+        fi
+        sleep 1
+    done
+    echo ""
+fi
 
 # ---------------------------------------------------------------------------
 # 1. Start Expo web dev server in the background (output suppressed)
@@ -50,16 +89,28 @@ echo ""
 echo "Starting Expo web dev server..."
 # Use the pinned "expo" dependency already installed in node_modules, instead of "npx expo"
 # which can fetch and run an on-demand, unpinned package version.
-(cd "$SCRIPT_DIR/app" && BROWSER=none yarn expo start --web --non-interactive) > /dev/null 2>&1 &
+# With --mock, EXPO_PUBLIC_SERVER_URL is inlined into the bundle by Metro and
+# overrides the backend URL of every customer config (see app/config.ts).
+if [ "$MOCK_MODE" = true ]; then
+    (cd "$SCRIPT_DIR/app" && BROWSER=none EXPO_PUBLIC_SERVER_URL="$MOCK_SERVER_URL" yarn expo start --web --non-interactive) > /dev/null 2>&1 &
+else
+    (cd "$SCRIPT_DIR/app" && BROWSER=none yarn expo start --web --non-interactive) > /dev/null 2>&1 &
+fi
 WEB_PID=$!
 
-# Stop the dev server (and any child processes) when the script exits
+# Stop the dev server, the mock backend and any child processes on exit
 cleanup() {
     echo ""
     echo "Stopping Expo web dev server (PID $WEB_PID)..."
     kill "$WEB_PID" 2>/dev/null || true
     pkill -P "$WEB_PID" 2>/dev/null || true
     wait "$WEB_PID" 2>/dev/null || true
+    if [ -n "$MOCK_PID" ]; then
+        echo "Stopping mock backend (PID $MOCK_PID)..."
+        kill "$MOCK_PID" 2>/dev/null || true
+        pkill -P "$MOCK_PID" 2>/dev/null || true
+        wait "$MOCK_PID" 2>/dev/null || true
+    fi
 }
 trap cleanup EXIT
 
@@ -133,7 +184,13 @@ mkdir -p "$MAESTRO_DEBUG_DIR"
 echo "Running Maestro tests..."
 echo ""
 set +e
-maestro test "$GENERATED_DIR" --platform web --debug-output "$MAESTRO_DEBUG_DIR"
+if [ "$MOCK_MODE" = true ]; then
+    # Only run tests that are designed for the deterministic mock backend.
+    maestro test "$GENERATED_DIR" --platform web --include-tags "$MOCK_BACKEND_TAG" --debug-output "$MAESTRO_DEBUG_DIR"
+else
+    # Exclude mock-backend tests: they assert fixture data that the real backend does not serve.
+    maestro test "$GENERATED_DIR" --platform web --exclude-tags "$MOCK_BACKEND_TAG" --debug-output "$MAESTRO_DEBUG_DIR"
+fi
 MAESTRO_EXIT_CODE=$?
 set -e
 

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -8,6 +8,7 @@ export * from './src/GlobalParams';
 export * from './src/DistanceHelper';
 export * from './src/SortingHelper';
 export * from './src/SortingEnums';
+export * from './src/testData/FoodOfferTestData';
 export * from './src/ServerHelper';
 export * from './src/FormCommonHelper';
 export * from './src/ChatConversationState';

--- a/packages/common/src/__tests__/SortingHelper.test.ts
+++ b/packages/common/src/__tests__/SortingHelper.test.ts
@@ -1,4 +1,4 @@
-import { sortByEatingHabits, sortByFoodCategoryOnly, sortByFoodName, sortByFoodOfferCategoryOnly, sortByOwnFavorite, sortByPublicFavorite, sortBySortField } from 'repo-depkit-common';
+import { EXPECTED_FOOD_ID_ORDER, FoodSortOption, getTestFoodoffers, sortByEatingHabits, sortByFoodCategoryOnly, sortByFoodName, sortByFoodOfferCategoryOnly, sortByOwnFavorite, sortByPrice, sortByPublicFavorite, sortBySortField } from 'repo-depkit-common';
 
 describe('SortingHelper', () => {
   test('sortByFoodName sorts alphabetically', () => {
@@ -99,5 +99,40 @@ describe('SortingHelper', () => {
     const items = [{ id: 'a', sort: 3 }, { id: 'b', sort: 1 }, { id: 'c' }];
     const sorted = sortBySortField(items);
     expect(sorted.map(i => i.id)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+/**
+ * These tests run against the shared fixtures in src/testData/FoodOfferTestData.ts,
+ * which are also served by the Maestro mock backend. The expected orders asserted
+ * here are the same ones the Maestro end-to-end test asserts in the UI, so a
+ * mismatch between unit- and e2e-level expectations is impossible.
+ */
+describe('SortingHelper with shared FoodOfferTestData fixtures', () => {
+  const getFoodIds = (offers: any[]) => offers.map((o: any) => o.food.id);
+
+  test('public rating sort matches the shared expected order', () => {
+    const sorted = sortByPublicFavorite(getTestFoodoffers('2026-01-01'));
+    expect(getFoodIds(sorted)).toEqual(EXPECTED_FOOD_ID_ORDER[FoodSortOption.RATING]);
+  });
+
+  test('alphabetical sort matches the shared expected order', () => {
+    const sorted = sortByFoodName(getTestFoodoffers('2026-01-01'), 'de');
+    expect(getFoodIds(sorted)).toEqual(EXPECTED_FOOD_ID_ORDER[FoodSortOption.ALPHABETICAL]);
+  });
+
+  test('alphabetical sort matches the shared expected order in English too', () => {
+    const sorted = sortByFoodName(getTestFoodoffers('2026-01-01'), 'en');
+    expect(getFoodIds(sorted)).toEqual(EXPECTED_FOOD_ID_ORDER[FoodSortOption.ALPHABETICAL]);
+  });
+
+  test('price ascending sort matches the shared expected order', () => {
+    const sorted = sortByPrice(getTestFoodoffers('2026-01-01'), undefined, false);
+    expect(getFoodIds(sorted)).toEqual(EXPECTED_FOOD_ID_ORDER[FoodSortOption.PRICE_ASCENDING]);
+  });
+
+  test('price descending sort matches the shared expected order', () => {
+    const sorted = sortByPrice(getTestFoodoffers('2026-01-01'), undefined, true);
+    expect(getFoodIds(sorted)).toEqual(EXPECTED_FOOD_ID_ORDER[FoodSortOption.PRICE_DESCENDING]);
   });
 });

--- a/packages/common/src/testData/FoodOfferTestData.ts
+++ b/packages/common/src/testData/FoodOfferTestData.ts
@@ -1,0 +1,123 @@
+import * as DatabaseTypes from '../databaseTypes/types';
+import { FoodSortOption } from '../SortingEnums';
+
+/**
+ * Shared food offer test data used by:
+ * - Unit tests (packages/common/src/__tests__/SortingHelper.test.ts)
+ * - The Maestro mock backend (apps/frontend/maestro-tests/src/mock-server)
+ *
+ * Keeping the fixtures and the expected sort orders in one place guarantees
+ * that the unit tests and the end-to-end tests verify the same behavior on
+ * the same data. The ratings intentionally reproduce the originally reported
+ * sorting bug (4.4, 4.6, 3.9, 4.9, 4.2 shown unsorted).
+ */
+
+export const TEST_CANTEEN_ID = 'canteen-test-1';
+export const TEST_CANTEEN_ALIAS = 'Mensa Testhausen';
+
+export const TEST_CANTEEN: DatabaseTypes.Canteens = {
+	id: TEST_CANTEEN_ID,
+	alias: TEST_CANTEEN_ALIAS,
+	status: 'published',
+	sort: 1,
+} as DatabaseTypes.Canteens;
+
+export interface TestFoodSpec {
+	/** Stable id used in fixtures and in Maestro element ids. */
+	id: string;
+	/** Displayed (German) dish name; also used for alphabetical sorting. */
+	name: string;
+	ratingAverage: number | null;
+	ratingAverageLegacy: number | null;
+	priceStudent: number;
+	priceEmployee: number;
+	priceGuest: number;
+}
+
+/**
+ * The array order is the "backend order" (the order the server would return
+ * without any client-side sorting) and intentionally does NOT match any of
+ * the expected sort results.
+ */
+export const TEST_FOOD_SPECS: TestFoodSpec[] = [
+	{ id: 'food-gnocchi', name: 'Gebratene Gnocchi, Ratatouille', ratingAverage: 4.4, ratingAverageLegacy: null, priceStudent: 2.4, priceEmployee: 3.6, priceGuest: 4.8 },
+	{ id: 'food-blattsalat', name: 'Gemischter Blattsalat, Kräuter-Joghurt', ratingAverage: 4.6, ratingAverageLegacy: null, priceStudent: 0.6, priceEmployee: 0.9, priceGuest: 1.2 },
+	{ id: 'food-bohnen', name: 'Grüne Bohnen', ratingAverage: 3.9, ratingAverageLegacy: null, priceStudent: 0.6, priceEmployee: 0.9, priceGuest: 1.2 },
+	{ id: 'food-roestinchen', name: 'Mini-Röstinchen', ratingAverage: 4.9, ratingAverageLegacy: null, priceStudent: 1.0, priceEmployee: 1.5, priceGuest: 2.0 },
+	// Only a legacy rating: must be treated like a 3.5 rating (fallback), not like "unrated".
+	{ id: 'food-schnitzel', name: 'Paniertes Schnitzel', ratingAverage: null, ratingAverageLegacy: 3.5, priceStudent: 3.2, priceEmployee: 4.4, priceGuest: 5.6 },
+	{ id: 'food-nudelsalat', name: 'Nudelsalat', ratingAverage: 4.2, ratingAverageLegacy: null, priceStudent: 1.8, priceEmployee: 2.6, priceGuest: 3.4 },
+];
+
+function buildTestFood(spec: TestFoodSpec): DatabaseTypes.Foods {
+	return {
+		id: spec.id,
+		alias: spec.name,
+		status: 'published',
+		rating_average: spec.ratingAverage,
+		rating_average_legacy: spec.ratingAverageLegacy,
+		rating_amount: spec.ratingAverage === null ? null : 12,
+		translations: [
+			{ id: 1, languages_code: 'de-DE', name: spec.name },
+			// Same name for English so tests behave identically in every app language.
+			{ id: 2, languages_code: 'en-US', name: spec.name },
+		],
+		markings: [],
+		attribute_values: [],
+		feedbacks: [],
+	} as unknown as DatabaseTypes.Foods;
+}
+
+export const TEST_FOODS: DatabaseTypes.Foods[] = TEST_FOOD_SPECS.map(buildTestFood);
+
+/**
+ * Builds the foodoffers for a given date (YYYY-MM-DD) in backend order.
+ * The nested food objects match what the app requests via `fields=food.*,food.translations.*`.
+ */
+export function getTestFoodoffers(date: string): DatabaseTypes.Foodoffers[] {
+	return TEST_FOOD_SPECS.map((spec, index) => {
+		return {
+			id: `foodoffer-${spec.id}`,
+			alias: spec.name,
+			canteen: TEST_CANTEEN_ID,
+			date,
+			food: buildTestFood(spec),
+			price_student: spec.priceStudent,
+			price_employee: spec.priceEmployee,
+			price_guest: spec.priceGuest,
+			sort: index + 1,
+			status: 'published',
+			markings: [],
+			attribute_values: [],
+			foodoffer_components: [],
+		} as unknown as DatabaseTypes.Foodoffers;
+	});
+}
+
+/**
+ * Expected food id orders per sort option for the fixtures above.
+ * Ties (equal prices) keep the backend order because Array.prototype.sort is stable.
+ */
+export const EXPECTED_FOOD_ID_ORDER: Partial<Record<FoodSortOption, string[]>> = {
+	[FoodSortOption.RATING]: ['food-roestinchen', 'food-blattsalat', 'food-gnocchi', 'food-nudelsalat', 'food-bohnen', 'food-schnitzel'],
+	[FoodSortOption.ALPHABETICAL]: ['food-gnocchi', 'food-blattsalat', 'food-bohnen', 'food-roestinchen', 'food-nudelsalat', 'food-schnitzel'],
+	[FoodSortOption.PRICE_ASCENDING]: ['food-blattsalat', 'food-bohnen', 'food-roestinchen', 'food-nudelsalat', 'food-gnocchi', 'food-schnitzel'],
+	[FoodSortOption.PRICE_DESCENDING]: ['food-schnitzel', 'food-gnocchi', 'food-nudelsalat', 'food-roestinchen', 'food-blattsalat', 'food-bohnen'],
+};
+
+/**
+ * Minimal app_settings singleton so the food area is enabled and the average
+ * rating is displayed on the food cards (needed to visually verify rating sort).
+ */
+export const TEST_APP_SETTINGS: Partial<DatabaseTypes.AppSettings> = {
+	foods_enabled: true,
+	foods_ratings_average_display: true,
+	foods_ratings_average_display_on_card: true,
+	foods_ratings_amount_display: true,
+	campus_enabled: true,
+	housing_enabled: true,
+	news_enabled: false,
+	map_enabled: false,
+	balance_enabled: false,
+	course_timetable_enabled: false,
+};


### PR DESCRIPTION
## Summary

Follow-up to #3772: adds a deterministic Maestro end-to-end test that verifies food offer sorting (public rating, alphabetical, price ascending/descending) in the real running app — driven by a **mocked Directus backend** so the data is fully controlled before the app starts.

### Shared test data (single source of truth)
- New `packages/common/src/testData/FoodOfferTestData.ts`: canteen "Mensa Testhausen", six foods with the exact ratings from the originally reported sorting bug (4.4/4.6/3.9/4.9/4.2 + one legacy-only 3.5 rating), prices per price group, and the **expected order per sort option**.
- The unit tests (`SortingHelper.test.ts`, 5 new tests) and the Maestro test assert the *same* expected orders from this file — unit- and e2e-level expectations cannot drift apart.

### Mock backend (GET only, as discussed)
- `apps/frontend/maestro-tests/src/mock-server/mockServer.ts`: dependency-free Node HTTP server answering Directus GET requests with the shared fixtures — `/server/info`, `/items/app_settings` (singleton), `/items/canteens`, `/items/foodoffers` (date-filter aware, supports both the Directus-SDK JSON filter format and axios bracket notation). All other collections return empty lists; writes return 403.
- Setting up a real Directus + database for e2e tests remains a sensible future step; this mock keeps tests fast and deterministic until then.

### Wiring
- `EXPO_PUBLIC_SERVER_URL` (inlined by Metro at bundle time, like `EXPO_PUBLIC_CUSTOMER`) now overrides every customer config's `server_url` (`app/config.ts`). Never set in production builds.
- `run-maestro-web-test.sh --mock` / `yarn maestro:mock`: starts the mock backend, starts Expo with the override, and runs only tests tagged `mock-backend`. Normal runs (`yarn maestro`) exclude that tag, so existing behavior is unchanged.

### Element targeting (nativeIDs per repo convention)
- New `ComponentIds`: foodoffers options button (⋮), "Sortieren" row, each sort option (`sort-option-<id>`), onboarding next/start buttons, price group options.
- Every food card wrapper gets a **position-encoding id** `foodoffer-position-<n>-<foodId>`, so Maestro can assert the rendered order directly (`assertVisibleId("foodoffer-position-0-food-roestinchen")` = "highest-rated dish is first").

### Flow fix
- The existing `food-offers-test.ts` (and the new test) now go through the onboarding flow (welcome → canteen → price group → start), matching current app behavior — fresh sessions are always routed to onboarding by `(app)/index.tsx` until canteen + price group are set. The previous flow expected a canteen-selection screen that no longer follows login directly.

## Verification
- `packages/common` jest suite: **31 tests pass**, including the new shared-fixture order tests.
- **Real Maestro run passes end-to-end** (`maestro test food-offers-sorting-test.yaml --platform web`, exit 0): anonymous login → onboarding with mocked canteen → food offers show the six mocked dishes → all four sort switches assert all six positions each (24 position assertions), confirming both correct sorting and immediate re-rendering.
- Updated `food-offers-test.yaml` also passes (exit 0).
- Mock endpoints verified with curl (today → 6 offers in backend order, other days → empty, POST → 403).
- Maestro screenshot shows "Mensa Testhausen" with cards in correct rating order 4.9 → 4.6 → 4.4 → 4.2 → 3.9 → 3.5 (legacy fallback included).

## Test plan
- [x] `yarn jest` in `packages/common`
- [x] `yarn maestro:generate` produces valid YAML
- [x] `maestro test food-offers-sorting-test.yaml --platform web` → exit 0
- [x] `maestro test food-offers-test.yaml --platform web` → exit 0
- [x] Playwright cross-check of the identical flow (all 4 sort orders correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)