### PR TITLE
feat(feedback): send full redux state snapshot with app feedback

### DIFF
--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Dimensions, KeyboardTypeOptions, PixelRatio, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Dimensions, KeyboardTypeOptions, PixelRatio, Platform, ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
@@ -15,6 +15,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { DatabaseTypes, EmailHelper, StringHelper } from 'repo-depkit-common';
 import { useAppSelector } from '@/redux/hooks';
+import { configureStore } from '@/redux/store';
 import { myContrastColor } from '@/helper/ColorHelper';
 import SettingsList from '@/components/SettingsList';
 import SettingsListEditable from '@/components/SettingsListEditable';
@@ -39,6 +40,7 @@ const FeedbackScreen = () => {
 	}>({});
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [errorJson, setErrorJson] = useState<string | null>(null);
+	const [includeAppState, setIncludeAppState] = useState(true);
 	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
 	const { openTextInputModal } = useMyScrollviewTextInputModal();
 
@@ -200,6 +202,16 @@ const FeedbackScreen = () => {
 		[inputValues, openTextInputModal, translate]
 	);
 
+	const appendAppStateToContent = (sanitizedInput: { [key: string]: any }) => {
+		if (!includeAppState) return;
+		try {
+			const appStateJson = JSON.stringify(configureStore.getState());
+			sanitizedInput.content = `${sanitizedInput.content ?? ''}\n\n---APP_STATE_JSON---\n${appStateJson}`;
+		} catch (e) {
+			// ignore serialization errors, submit feedback without the app state snapshot
+		}
+	};
+
 	const handleCreateAppFeedback = async () => {
 		if (inputValues) {
 			setLoading(true);
@@ -216,6 +228,7 @@ const FeedbackScreen = () => {
 					return true;
 				})
 			);
+			appendAppStateToContent(sanitizedInput);
 			try {
 				console.log('Creating app feedback with input:');
 				await appFeedback.createAppFeedback(sanitizedInput);
@@ -259,6 +272,7 @@ const FeedbackScreen = () => {
 					return true;
 				})
 			);
+			appendAppStateToContent(sanitizedInput);
 			try {
 				await appFeedback.updateAppFeedback(String(app_feedbacks_id), sanitizedInput);
 				setLoading(false);
@@ -501,6 +515,17 @@ const FeedbackScreen = () => {
 								noIconIndent
 							/>
 						))}
+
+						<SettingsGroupTitle fontSize={14}>
+							{translate(TranslationKeys.feedback_include_app_state_description)}
+						</SettingsGroupTitle>
+						<SettingsList
+							iconBgColor={primaryColor}
+							leftIcon={<MaterialCommunityIcons name="bug-outline" size={24} color={theme.screen.icon} />}
+							label={translate(TranslationKeys.feedback_include_app_state_title)}
+							rightElement={<Switch value={includeAppState} onValueChange={setIncludeAppState} />}
+							groupPosition="single"
+						/>
 
 						{errorJson && <Text style={{ color: 'red', marginVertical: 10 }}>{errorJson}</Text>}
 						{errorMessage && <Text style={{ color: 'red', marginBottom: 10 }}>{errorMessage}</Text>}

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -750,4 +750,6 @@ export enum TranslationKeys {
 	further_settings = 'further_settings',
 	options_and_information = 'options_and_information',
 	show_average_rating_on_card = 'show_average_rating_on_card',
+	feedback_include_app_state_title = 'feedback_include_app_state_title',
+	feedback_include_app_state_description = 'feedback_include_app_state_description',
 }

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -6497,6 +6497,26 @@
     "tr": "Daha fazla iyileştirme veya istek fark ettiyseniz, lütfen bunları bizimle paylaşın.",
     "zh": "如果您发现了其他改进或愿望，请随时与我们分享。"
   },
+  "feedback_include_app_state_title": {
+    "de": "App-Zustand zur Fehlerbehebung mitsenden",
+    "en": "Include app state for troubleshooting",
+    "ar": "إرفاق حالة التطبيق لاستكشاف الأخطاء",
+    "es": "Incluir el estado de la app para la resolución de errores",
+    "fr": "Inclure l'état de l'application pour le dépannage",
+    "ru": "Прикрепить состояние приложения для устранения неполадок",
+    "tr": "Sorun giderme için uygulama durumunu ekle",
+    "zh": "附加应用状态以便排查问题"
+  },
+  "feedback_include_app_state_description": {
+    "de": "Sendet zusätzlich einen technischen Schnappschuss deiner App-Daten mit, damit wir deinen Fehler leichter nachvollziehen können. Du musst diese Daten nicht einsehen.",
+    "en": "Additionally sends a technical snapshot of your app data so we can more easily reproduce your issue. You don't need to review this data yourself.",
+    "ar": "يرسل أيضًا لقطة تقنية لبيانات التطبيق الخاصة بك حتى نتمكن من إعادة إنتاج مشكلتك بسهولة أكبر. لست بحاجة لمراجعة هذه البيانات بنفسك.",
+    "es": "Además, envía una instantánea técnica de los datos de tu app para que podamos reproducir tu problema más fácilmente. No es necesario que revises estos datos tú mismo.",
+    "fr": "Envoie également un instantané technique des données de votre application afin que nous puissions reproduire plus facilement votre problème. Vous n'avez pas besoin de consulter ces données vous-même.",
+    "ru": "Дополнительно отправляется техническая копия данных приложения, чтобы нам было проще воспроизвести вашу проблему. Просматривать эти данные самостоятельно не требуется.",
+    "tr": "Sorununuzu daha kolay tekrar oluşturabilmemiz için uygulama verilerinizin teknik bir anlık görüntüsünü de gönderir. Bu verileri kendiniz incelemeniz gerekmez.",
+    "zh": "还会发送应用数据的技术快照，以便我们更容易重现您的问题。您无需自行查看这些数据。"
+  },
   "public_links": {
     "de": "Öffentliche Links",
     "en": "Public Links",


### PR DESCRIPTION
## Summary
- Adds a toggle (default: on) to the App-Feedback screen that attaches a JSON snapshot of the entire Redux store to the feedback `content` on submit.
- The dump is only appended to the payload sent to the server — the user's own visible content text stays untouched, so they never need to see the technical data.
- Goal: reproduce user-reported bugs from their exact app state (settings, cached data, etc.) at the time of the report.
- New translation strings added for the toggle label/description in all supported locales (de, en, ar, es, fr, ru, tr, zh).

## Test plan
- [ ] Open Feedback & Support screen, confirm the new switch is on by default
- [ ] Submit feedback with the switch on, verify `content` in the created `app_feedbacks` record contains the appended `---APP_STATE_JSON---` block with the redux state
- [ ] Toggle switch off, submit again, verify no app-state block is appended
- [ ] Update an existing feedback entry and confirm the same behavior applies