### PR TITLE
feat(avatar): add custom micah hairstyles (CUSTOM_xxx)

### DIFF
--- a/packages/common-ui/index.ts
+++ b/packages/common-ui/index.ts
@@ -102,6 +102,10 @@ export type { SettingsListMyMapThemeSelectionProps } from './src/components/Sett
 export { default as MyAvatar, STYLE_MAP } from './src/components/MyAvatar';
 export { AvatarStyle, AvatarSize } from './src/components/MyAvatar';
 export type { MyAvatarProps, AvatarConfig, AvatarAppearanceProps } from './src/components/MyAvatar';
+export { MicahCustomHair, MICAH_CUSTOM_HAIR_KEYS } from './src/components/MyAvatar/micahExtended';
+
+export { default as MicahHairGallery } from './src/components/MicahHairGallery';
+export type { MicahHairGalleryProps } from './src/components/MicahHairGallery';
 
 export { useAvatarEditorModal, AvatarPropKey, MICAH_PRESETS, presetToConfig, generateRandomAvatarConfig } from './src/components/MyAvatarEditor';
 export type { UseAvatarEditorModalOptions, OpenAvatarEditorProps, AvatarPreset } from './src/components/MyAvatarEditor';

--- a/packages/common-ui/src/components/MicahHairGallery/index.tsx
+++ b/packages/common-ui/src/components/MicahHairGallery/index.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { Style } from '@dicebear/core';
+import MyAvatar, { AvatarSize, AvatarStyle, STYLE_MAP } from '../MyAvatar';
+import { MICAH_CUSTOM_HAIR_KEYS } from '../MyAvatar/micahExtended';
+import { useTheme } from '../../context/ThemeContext';
+
+export type MicahHairGalleryProps = {
+	/** Fixed hair color (hex, without '#') applied to every preview. Defaults to the style's own schema default. */
+	hairColor?: string;
+	/** Fixed skin color (hex, without '#') applied to every preview. Defaults to the style's own schema default. */
+	baseColor?: string;
+	/** Size of each avatar preview. Defaults to `AvatarSize.MEDIUM`. */
+	previewSize?: AvatarSize | number;
+};
+
+const CUSTOM_HAIR_KEY_SET = new Set<string>(MICAH_CUSTOM_HAIR_KEYS);
+
+/**
+ * Dev/design tool: renders every hair option available for the `micah` avatar
+ * style - both `@dicebear/micah`'s built-in hairstyles and the custom ones
+ * added in `MyAvatar/micahExtended.ts` - as a grid of live previews, each
+ * labelled with its option key ("custom" ones are flagged).
+ *
+ * Reads the option list straight from `STYLE_MAP[AvatarStyle.MICAH].schema`,
+ * so it always reflects exactly what's selectable in the avatar editor - use
+ * it to see what already exists before adding a new hairstyle, and to sanity
+ * check a new SVG (fit, color, clipping) once it's wired into
+ * `micahCustomHair.ts` without having to open the full avatar editor.
+ */
+const MicahHairGallery: React.FC<MicahHairGalleryProps> = ({ hairColor, baseColor, previewSize = AvatarSize.MEDIUM }) => {
+	const { theme } = useTheme();
+	const micahStyle = STYLE_MAP[AvatarStyle.MICAH] as Style<object> & { schema: { properties: Record<string, any> } };
+	const hairKeys: string[] = micahStyle.schema.properties.hair.items.enum;
+
+	const fixedOptions: Record<string, string[]> = {};
+	if (hairColor) fixedOptions.hairColor = [hairColor];
+	if (baseColor) fixedOptions.baseColor = [baseColor];
+
+	return (
+		<ScrollView
+			style={[styles.container, { backgroundColor: theme.screen.background }]}
+			contentContainerStyle={styles.grid}
+		>
+			{hairKeys.map((key) => {
+				const isCustom = CUSTOM_HAIR_KEY_SET.has(key);
+				return (
+					<View key={key} style={styles.cell}>
+						<MyAvatar
+							style={AvatarStyle.MICAH}
+							size={previewSize}
+							rounded
+							backgroundColor="#ffffff"
+							options={{ ...fixedOptions, hair: [key] }}
+						/>
+						<Text style={[styles.label, { color: theme.screen.text }]} numberOfLines={1}>
+							{key}
+						</Text>
+						{isCustom && (
+							<Text style={[styles.badge, { color: theme.screen.placeholder ?? theme.screen.text }]}>custom</Text>
+						)}
+					</View>
+				);
+			})}
+		</ScrollView>
+	);
+};
+
+export default MicahHairGallery;
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	grid: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		padding: 12,
+		gap: 12,
+	},
+	cell: {
+		alignItems: 'center',
+		width: 96,
+	},
+	label: {
+		marginTop: 4,
+		fontSize: 12,
+		textAlign: 'center',
+	},
+	badge: {
+		fontSize: 10,
+		fontStyle: 'italic',
+	},
+});

--- a/packages/common-ui/src/components/MyAvatar/index.tsx
+++ b/packages/common-ui/src/components/MyAvatar/index.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 import { createAvatar, Style } from '@dicebear/core';
 import * as collection from '@dicebear/collection';
+import { micahExtended } from './micahExtended';
 
 export enum AvatarStyle {
 	ADVENTURER = 'adventurer',
@@ -95,7 +96,7 @@ export const STYLE_MAP: Record<AvatarStyle, Style<object>> = {
 	[AvatarStyle.INITIALS]: collection.initials,
 	[AvatarStyle.LORELEI]: collection.lorelei,
 	[AvatarStyle.LORELEI_NEUTRAL]: collection.loreleiNeutral,
-	[AvatarStyle.MICAH]: collection.micah,
+	[AvatarStyle.MICAH]: micahExtended,
 	[AvatarStyle.MINIAVS]: collection.miniavs,
 	[AvatarStyle.NOTIONISTS]: collection.notionists,
 	[AvatarStyle.NOTIONISTS_NEUTRAL]: collection.notionistsNeutral,

--- a/packages/common-ui/src/components/MyAvatar/micahCustomHair.ts
+++ b/packages/common-ui/src/components/MyAvatar/micahCustomHair.ts
@@ -1,0 +1,69 @@
+/**
+ * Custom hairstyles for the `micah` avatar style, layered on top of the DiceBear
+ * `@dicebear/micah` package's built-in hair options (see `micahExtended.ts`).
+ *
+ * DiceBear's collection packages ship as prebuilt npm modules with no plugin
+ * hook for adding new components, so a new hairstyle can't be registered
+ * "inside" `@dicebear/micah` itself. Instead, each entry here is a self-contained
+ * SVG fragment using the *same coordinate space* micah's own hair components
+ * use: it gets rendered inside `<g transform="translate(49 11)">...</g>`, i.e.
+ * the same group micah's built-in hair (fonze, pixie, turban, ...) renders into.
+ *
+ * To add a new hairstyle:
+ * 1. Add a `CUSTOM_xxx` member to `MicahCustomHair` below. The `CUSTOM_` prefix
+ *    is what lets these be told apart from DiceBear's own built-in hair keys at
+ *    a glance - both in code and in the avatar editor's option picker, which
+ *    shows the raw value as the label for every style (see `MyAvatarEditor`).
+ * 2. Add the matching `[MicahCustomHair.CUSTOM_xxx]: (hairColor) => svgFragment`
+ *    entry to `micahCustomHair`.
+ * 3. Use `fill="${hairColor}" stroke="#000" stroke-width="4"` to match micah's
+ *    flat line-art look (see the originals in `@dicebear/micah/lib/components/hair.js`
+ *    for reference proportions).
+ * 4. Render `<MicahHairGallery />` (packages/common-ui/src/components/MicahHairGallery)
+ *    to see every hairstyle - built-in and custom - side by side and check the fit.
+ */
+
+/** Custom `micah` hairstyles, on top of `@dicebear/micah`'s built-in ones. */
+export enum MicahCustomHair {
+	CUSTOM_SHORT_CROP = 'CUSTOM_SHORT_CROP',
+	CUSTOM_QUIFF_SWOOP = 'CUSTOM_QUIFF_SWOOP',
+	CUSTOM_AFRO_PUFF = 'CUSTOM_AFRO_PUFF',
+	CUSTOM_TOP_BUN = 'CUSTOM_TOP_BUN',
+	CUSTOM_SPACE_BUNS = 'CUSTOM_SPACE_BUNS',
+	CUSTOM_SIDE_PONYTAIL = 'CUSTOM_SIDE_PONYTAIL',
+}
+
+export type MicahHairRenderer = (hairColor: string) => string;
+
+/** Rounded cap hugging the skull, apex above the head - used by voluminous styles. */
+const DOME_CAP_PATH =
+	'M26 84C26 22 67 -8 121 -8C175 -8 216 22 216 84C216 100 201 104 121 96C41 104 26 100 26 84Z';
+
+/** Flatter cap sitting closer to the skull - used by styles where hair is pulled back. */
+const FLAT_CAP_PATH =
+	'M30 88C30 40 66 4 121 4C176 4 212 40 212 88C212 98 196 100 121 98C46 100 30 98 30 88Z';
+
+export const micahCustomHair: Record<MicahCustomHair, MicahHairRenderer> = {
+	[MicahCustomHair.CUSTOM_SHORT_CROP]: (hairColor) =>
+		`<path d="${DOME_CAP_PATH}" fill="${hairColor}" stroke="#000" stroke-width="4"/>`,
+
+	[MicahCustomHair.CUSTOM_QUIFF_SWOOP]: (hairColor) =>
+		`<path d="${DOME_CAP_PATH}" fill="${hairColor}" stroke="#000" stroke-width="4"/>` +
+		`<path d="M60 108C55 73 70 28 105 -7C120 -22 145 -17 150 3C153 18 130 28 118 48C108 66 108 88 118 103C108 110 78 113 60 108Z" fill="${hairColor}" stroke="#000" stroke-width="4"/>`,
+
+	[MicahCustomHair.CUSTOM_AFRO_PUFF]: (hairColor) =>
+		`<path d="M36 88A28 28 0 0 1 61 23A28 28 0 0 1 121 -12A28 28 0 0 1 181 23A28 28 0 0 1 206 88C206 88 165 113 121 108C77 113 36 88 36 88Z" fill="${hairColor}" stroke="#000" stroke-width="4"/>`,
+
+	[MicahCustomHair.CUSTOM_TOP_BUN]: (hairColor) =>
+		`<path d="${FLAT_CAP_PATH}" fill="${hairColor}" stroke="#000" stroke-width="4"/>` +
+		`<circle cx="121" cy="18" r="26" fill="${hairColor}" stroke="#000" stroke-width="4"/>`,
+
+	[MicahCustomHair.CUSTOM_SPACE_BUNS]: (hairColor) =>
+		`<path d="${FLAT_CAP_PATH}" fill="${hairColor}" stroke="#000" stroke-width="4"/>` +
+		`<circle cx="66" cy="14" r="22" fill="${hairColor}" stroke="#000" stroke-width="4"/>` +
+		`<circle cx="176" cy="14" r="22" fill="${hairColor}" stroke="#000" stroke-width="4"/>`,
+
+	[MicahCustomHair.CUSTOM_SIDE_PONYTAIL]: (hairColor) =>
+		`<path d="${FLAT_CAP_PATH}" fill="${hairColor}" stroke="#000" stroke-width="4"/>` +
+		`<path d="M195 55C215 50 230 65 235 95C240 130 225 165 205 185C198 192 188 190 190 178C200 155 205 125 198 95C193 75 185 62 195 55Z" fill="${hairColor}" stroke="#000" stroke-width="4"/>`,
+};

--- a/packages/common-ui/src/components/MyAvatar/micahExtended.ts
+++ b/packages/common-ui/src/components/MyAvatar/micahExtended.ts
@@ -1,0 +1,86 @@
+import type { Style, StyleCreateProps, StyleCreateResult } from '@dicebear/core';
+import * as collection from '@dicebear/collection';
+import { MicahCustomHair, micahCustomHair } from './micahCustomHair';
+
+export { MicahCustomHair } from './micahCustomHair';
+
+type MicahStyle = Style<object> & { schema: { properties: Record<string, any> } };
+
+const baseMicah = collection.micah as unknown as MicahStyle;
+
+const HAIR_GROUP_OPEN = '<g transform="translate(49 11)">';
+const EMPTY_HAIR_GROUP = `${HAIR_GROUP_OPEN}</g>`;
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+/** Every custom hair option key added on top of `@dicebear/micah`'s built-in hairstyles. */
+export const MICAH_CUSTOM_HAIR_KEYS: MicahCustomHair[] = Object.values(MicahCustomHair);
+
+function sanitizeHairColor(value: unknown): string {
+	if (typeof value === 'string' && (value === 'transparent' || HEX_COLOR_PATTERN.test(value))) {
+		return value;
+	}
+	return '#000000';
+}
+
+function firstValue(value: unknown): unknown {
+	return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * `micah` avatar style extended with additional hairstyles that don't exist in
+ * `@dicebear/micah` itself (see `micahCustomHair.ts`).
+ *
+ * `@dicebear/micah` is a plain npm package with no extension point for adding
+ * components, so this wraps it instead of forking it:
+ * - `schema` is the original schema with the custom hair keys appended to the
+ *   `hair` enum, so every schema-driven UI (`MyAvatarEditor`'s option pickers,
+ *   `MicahHairGallery`) picks the new options up automatically.
+ * - `create` renders the avatar exactly as `@dicebear/micah` normally would,
+ *   then - only when the requested `hair` value is one of ours - splices the
+ *   custom SVG into micah's own (empty, since it doesn't recognise the key)
+ *   hair group. This keeps every other component (base, eyes, colors, ...)
+ *   byte-for-byte identical to the original style.
+ */
+export const micahExtended: Style<object> = {
+	...baseMicah,
+	schema: {
+		...baseMicah.schema,
+		properties: {
+			...baseMicah.schema.properties,
+			hair: {
+				...baseMicah.schema.properties.hair,
+				items: {
+					...baseMicah.schema.properties.hair.items,
+					enum: [...baseMicah.schema.properties.hair.items.enum, ...MICAH_CUSTOM_HAIR_KEYS],
+				},
+				default: [...baseMicah.schema.properties.hair.default, ...MICAH_CUSTOM_HAIR_KEYS],
+			},
+		},
+	},
+	create: (props: StyleCreateProps<object>): StyleCreateResult => {
+		const result = baseMicah.create(props);
+
+		const options = props.options as Record<string, unknown>;
+		const hairOption = options.hair;
+		const requestedHair = Array.isArray(hairOption)
+			? hairOption.find((key): key is MicahCustomHair => typeof key === 'string' && key in micahCustomHair)
+			: undefined;
+
+		// `hairProbability` is 0/100 in practice (MyAvatar derives it from whether `hair`
+		// is set at all), so reading it directly here is safe and avoids consuming an
+		// extra `prng` draw, which would desync the background color/type picked
+		// afterwards by `createAvatar` for the same seed.
+		const hairProbability = Number(firstValue(options.hairProbability) ?? 100);
+		if (!requestedHair || hairProbability === 0) return result;
+
+		const extra = result.extra?.() ?? {};
+		const hairColor = sanitizeHairColor(extra.hairColor);
+		const hairSvg = micahCustomHair[requestedHair](hairColor);
+
+		return {
+			...result,
+			body: result.body.replace(EMPTY_HAIR_GROUP, `${HAIR_GROUP_OPEN}${hairSvg}</g>`),
+			extra: () => ({ ...extra, hair: requestedHair }),
+		};
+	},
+};


### PR DESCRIPTION
## Summary
- `@dicebear/micah` ships as a prebuilt npm package with no plugin hook for adding hair options, so `micahExtended.ts` wraps its `Style` object instead of forking it: the schema's `hair` enum is extended with our own `MicahCustomHair` keys, and `create()` splices a custom SVG into micah's own (otherwise empty) hair group when one is selected. Every other component (face, eyes, colors, ...) stays byte-for-byte identical to the original style.
- Adds 6 new hairstyles as a `MicahCustomHair` enum, prefixed `CUSTOM_` so they're clearly distinguishable from DiceBear's own built-in keys both in code and in the avatar editor's option picker (which shows the raw value as the label): `CUSTOM_SHORT_CROP`, `CUSTOM_QUIFF_SWOOP`, `CUSTOM_AFRO_PUFF`, `CUSTOM_TOP_BUN`, `CUSTOM_SPACE_BUNS`, `CUSTOM_SIDE_PONYTAIL`.
- `STYLE_MAP[AvatarStyle.MICAH]` now points at `micahExtended` - since `MyAvatarEditor`'s option pickers/previews/defaults are all schema-driven, they picked up the new hairstyles automatically, no further UI changes needed.
- Adds `MicahHairGallery`, a dev/design component that lists every `micah` hair option (built-in + custom) as a live-preview grid with a "custom" badge - useful for checking fit/color before/after adding a new hairstyle.

## Test plan
- [x] Rendered each new hairstyle via `createAvatar(micahExtended, ...)` and visually inspected (rsvg-convert → PNG) - fixed a viewBox-clipping bug on the first pass where buns/quiff peak were cut off at the top edge.
- [x] Verified the full `MyAvatar` render pipeline (flip, randomizeIds, viewbox-mask stripping) with a custom hairstyle end-to-end.
- [x] Verified native (built-in) `micah` hairstyles still render unaffected.
- [x] `tsc --noEmit` on the frontend app: no new type errors introduced by these files.
- [ ] Manual QA in the running app: open the avatar editor for a `micah` avatar and confirm the new `CUSTOM_xxx` hairstyles appear in the Hair picker with working previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)