### PR TITLE
fix(score-tracker): Freund-Änderungen ins Spiel synchronisieren + Sticky-Header im Avatar-Editor

### DIFF
--- a/apps/score-tracker/frontend/store/gameSlice.ts
+++ b/apps/score-tracker/frontend/store/gameSlice.ts
@@ -3,6 +3,7 @@ import type { AvatarConfig } from 'repo-depkit-common-ui';
 import type { Player, Round, GameState, GameStatus } from '../helpers/GameStorage';
 import { PLAYER_COLORS } from '../helpers/GameStorage';
 import type { Friend } from '../helpers/FriendsStorage';
+import { renameFriend, setFriendColor, setFriendAvatar } from './friendsSlice';
 export type { Player, Round, GameState, GameStatus };
 
 // ─── State type ───────────────────────────────────────────────────────────────
@@ -154,6 +155,33 @@ const gameSlice = createSlice({
 		resetAll() {
 			return { players: [], rounds: [], status: 'setup', currentRoundIndex: 0 };
 		},
+	},
+	// Players added from a friend are linked via friendId. When the friend is
+	// edited in the players screen, mirror the change onto the linked player(s)
+	// of the current game so both screens stay in sync.
+	extraReducers: (builder) => {
+		builder
+			.addCase(renameFriend, (state, action) => {
+				for (const player of state.players) {
+					if (player.friendId === action.payload.friendId) {
+						player.name = action.payload.name;
+					}
+				}
+			})
+			.addCase(setFriendColor, (state, action) => {
+				for (const player of state.players) {
+					if (player.friendId === action.payload.friendId) {
+						player.color = action.payload.color;
+					}
+				}
+			})
+			.addCase(setFriendAvatar, (state, action) => {
+				for (const player of state.players) {
+					if (player.friendId === action.payload.friendId) {
+						player.avatarConfig = action.payload.avatarConfig;
+					}
+				}
+			});
 	},
 });
 

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -70,6 +70,24 @@
  *   `Platform.OS === 'web'`.  This constrains the scroll view to the remaining
  *   height inside the sheet, restoring scroll on web for all modals.
  *
+ * ─── SCROLL FIX 6 (native: reset scroll offset when modal content changes) ───
+ *   Symptom: after picking a value in a category sub-modal (e.g. a hairstyle)
+ *   and returning to the editor, the sticky avatar header was not rendered
+ *   until the user scrolled slightly.
+ *   Root cause: the modal stack renders only the top-most item inside ONE
+ *   BaseBottomSheet, and every stack item is a MyScrollViewModal at the same
+ *   tree position — React therefore reuses the SAME component instance (and
+ *   the same native scroll view including its content offset) and only swaps
+ *   the children. The sticky header element inside the content, however, IS
+ *   remounted, and RN's ScrollViewStickyHeader positions itself from scroll
+ *   events only — until the first scroll event it assumes offset 0, so with
+ *   the carried-over offset it is translated off-screen.
+ *   Fix: `MyScrollViewModal` scrolls back to the top (native only) whenever
+ *   its children change, keeping native offset and sticky-header state
+ *   consistent. Side effect (intended): each modal content starts at the top
+ *   instead of inheriting the previous content's offset. A mount effect can
+ *   NOT work here because the component never remounts between contents.
+ *
  * ─── NESTED SCROLLVIEW (do NOT add) ──────────────────────────────────────────
  *   Do NOT add another ScrollView / FlatList inside AvatarEditorModalContent.
  *   All scrolling must be handled by MyScrollViewModal's BottomSheetScrollView

--- a/packages/common-ui/src/components/MyScrollViewModal/index.tsx
+++ b/packages/common-ui/src/components/MyScrollViewModal/index.tsx
@@ -44,6 +44,35 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 	React.useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
 	React.useEffect(() => () => { onCloseRef.current?.(); }, []);
 
+	// SCROLL FIX 6 (native: reset scroll offset when the modal content changes)
+	// The modal stack renders only the top-most item inside ONE BaseBottomSheet
+	// (see ModalRenderer). All stack items render a MyScrollViewModal at the
+	// same tree position, so React does NOT remount it when the content is
+	// swapped (editor -> category picker -> back) — it re-renders the SAME
+	// instance (and the same native scroll view, which keeps its content
+	// offset) with the new children. The sticky header element inside the
+	// content however IS remounted, and React Native's ScrollViewStickyHeader
+	// only positions itself from scroll events: until the first scroll event
+	// it assumes offset 0. With the carried-over offset the header is
+	// therefore translated off-screen and stays invisible until the user
+	// scrolls. Fix: whenever the content (children) changes, scroll back to
+	// the top — this keeps native offset and sticky-header state consistent
+	// (both 0) and makes every modal content start at the top instead of
+	// inheriting the previous content's offset. A mount effect cannot work
+	// here because the component never remounts between contents. Web is
+	// untouched (no stickyHeaderIndices there, see SCROLL FIX 4).
+	const scrollableRef = React.useRef<any>(null);
+	React.useEffect(() => {
+		if (Platform.OS === 'web') return;
+		const node = scrollableRef.current;
+		if (!node) return;
+		if (typeof node.scrollTo === 'function') {
+			node.scrollTo({ x: 0, y: 0, animated: false });
+		} else if (typeof node.scrollToOffset === 'function') {
+			node.scrollToOffset({ offset: 0, animated: false });
+		}
+	}, [children]);
+
 	const titleElement = title ? (
 		<View
 			key="__title"
@@ -88,6 +117,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 		return (
 			<View style={[containerStyle, webFlex]}>
 				<BottomSheetFlatList
+					ref={scrollableRef}
 					style={webFlex}
 					data={data}
 					keyExtractor={keyExtractor}
@@ -137,6 +167,7 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 		<View style={[containerStyle, webFlex]}>
 			{renderStickyOutside && <View>{stickyHeaderComponent}</View>}
 			<BottomSheetScrollView
+				ref={scrollableRef}
 				style={webFlex}
 				contentContainerStyle={contentStyle}
 				showsVerticalScrollIndicator={showsVerticalScrollIndicator}


### PR DESCRIPTION
## Problem

1. **Spieler-Sync**: Wird ein Freund im Spieler-Screen bearbeitet (Name, Avatar, Farbe), wurde der verknüpfte Spieler im Game-Screen nicht aktualisiert. Spieler werden beim Hinzufügen als Snapshot des Freundes angelegt (`addFriendPlayer`, verknüpft über `friendId`) — spätere Änderungen am Freund kamen dort nie an.

2. **Sticky-Header-Bug (nativ)**: Wählt man im Avatar-Editor z. B. eine andere Frisur und kommt zurück zur Attribut-Übersicht, wurde der Sticky-Header (Avatar-Vorschau) nicht gerendert, bis man kurz scrollt.

## Ursache & Fix

### 1. Freund → Spieler Sync (`gameSlice.ts`)
`gameSlice` reagiert jetzt per `extraReducers` auf `renameFriend`, `setFriendColor` und `setFriendAvatar` und spiegelt die Änderung auf alle Spieler mit passender `friendId`. Gäste und nicht verknüpfte Spieler bleiben unberührt.

### 2. Sticky-Header (`MyScrollViewModal`, SCROLL FIX 6)
Der Modal-Stack rendert alle Inhalte über **eine** `MyScrollViewModal`-Instanz an derselben Baumposition — beim Wechsel Editor → Kategorie-Picker → zurück wird die Komponente (und die native ScrollView samt Scroll-Offset) wiederverwendet, nur die `children` werden getauscht. Der Sticky-Header im Inhalt wird dabei aber neu gemountet und positioniert sich ausschließlich über Scroll-Events — bis zum ersten Scroll geht er von Offset 0 aus und liegt daher außerhalb des Sichtbereichs.

Fix: `MyScrollViewModal` scrollt (nur nativ) bei jedem `children`-Wechsel an den Anfang. Damit sind nativer Offset und Sticky-Header-Zustand konsistent, und jedes Modal startet oben statt den Offset des vorherigen Inhalts zu erben. Die Fix-Historie ist gemäß Konvention im Header-Kommentar von `MyAvatarEditor` als SCROLL FIX 6 dokumentiert.

## Verifikation

- **iOS-Simulator (Expo Go, Maestro)**: Bug reproduziert (Editor → scrollen → Frisur wählen → zurück → Header fehlt bis zum Scrollen) und nach dem Fix erneut durchgespielt — Sticky-Header erscheint sofort, Auswahl (Frisur) wird übernommen.
- **Web (expo web)**: Freund angelegt, als Spieler ins Spiel geholt, dann im Spieler-Screen umbenannt („Oma Erna") und Avatar geändert — Name und Avatar des Spielers im Game-Screen aktualisieren sich sofort. Web-Sticky-Header (eigener Codepfad, SCROLL FIX 4) unverändert funktionsfähig.
- `tsc --noEmit`: keine neuen Fehler (13 vorbestehende Fehler identisch mit `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)