### PR TITLE
ci: reliable app build detection (last-built tags + shared common build number)

### DIFF
--- a/.github/actions/check-build-number/action.yml
+++ b/.github/actions/check-build-number/action.yml
@@ -1,65 +1,90 @@
 name: Check Build Number
-description: Checks if the build number in config.ts changed compared to a previous state
+description: >
+  Determines whether an app needs a new store build. The effective build number
+  (<working-directory>/build-number.json + packages/common/build-number.json) is
+  compared against the last successfully built number, which is recorded as the
+  git tag last-built/<build-key>/<number> by the record-build-number action.
+  This is independent of git history, so it stays reliable across multi-commit
+  pushes, CI report commits and fork synchronization. Requires the repository to
+  be checked out with credentials (default actions/checkout) and the job to have
+  "contents: write" permission (a baseline tag is pushed on first run).
 
 inputs:
   working-directory:
+    required: true
+    description: 'App directory containing build-number.json (e.g. apps/frontend/app)'
+  build-key:
+    required: true
+    description: 'Unique key for this build target (e.g. frontend-ios). Used in the last-built/<build-key>/<number> tag.'
+  common-build-number-file:
     required: false
-    description: 'Directory containing the config.ts with getBuildNumber()'
-    default: apps/frontend/app
-  previous-commit-sha:
-    required: false
-    description: 'Commit SHA to compare against (e.g. pre-sync state in forks). If empty, uses HEAD^ from git history.'
-    default: ''
+    description: 'Path to the shared build number JSON that is added to every app build number'
+    default: packages/common/build-number.json
+
+outputs:
+  changed:
+    description: 'true if the effective build number is greater than the last successfully built number'
+    value: ${{ steps.check.outputs.changed }}
+  build-number:
+    description: 'The effective build number (app + common)'
+    value: ${{ steps.check.outputs.build-number }}
 
 runs:
   using: "composite"
   steps:
-    # Full history needed when comparing against an older commit SHA (fork sync scenario)
-    - name: 🔄 Checkout repository (full history)
-      if: ${{ inputs.previous-commit-sha != '' }}
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    # Only last 2 commits needed for HEAD^ comparison (normal push scenario)
-    - name: 🔄 Checkout repository (last 2 commits)
-      if: ${{ inputs.previous-commit-sha == '' }}
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-
-    - name: 🔍 Compare build number
+    - name: 🔍 Compare effective build number against last successful build
       id: check
+      shell: bash
       run: |
-        COMPARE_REF="${{ inputs.previous-commit-sha }}"
-        if [ -z "$COMPARE_REF" ]; then
-          COMPARE_REF="HEAD^"
-          echo "📦 Comparing against HEAD^ (git history)"
-        else
-          echo "📦 Comparing against commit $COMPARE_REF (sync-fork)"
-        fi
+        set -euo pipefail
 
-        old=$(git show ${COMPARE_REF}:${{ inputs.working-directory }}/config.ts | grep -A 5 'function getBuildNumber' | grep 'return' | grep -Eo '[0-9]+' | head -1 || echo "not-found")
-        new=$(cat ${{ inputs.working-directory }}/config.ts | grep -A 5 'function getBuildNumber' | grep 'return' | grep -Eo '[0-9]+' | head -1 || echo "not-found")
-        echo "📦 Old build number: $old"
-        echo "📦 New build number: $new"
+        APP_FILE="${{ inputs.working-directory }}/build-number.json"
+        COMMON_FILE="${{ inputs.common-build-number-file }}"
+        BUILD_KEY="${{ inputs.build-key }}"
+        TAG_PREFIX="last-built/${BUILD_KEY}/"
 
-        if [ "$old" = "not-found" ]; then
-          echo "⚠️ Old build number not found, skipping comparison"
-          echo "changed=skip" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+        for f in "$APP_FILE" "$COMMON_FILE"; do
+          if [ ! -f "$f" ]; then
+            echo "::error::Build number file not found: $f"
+            exit 1
+          fi
+        done
 
-        if [ "$old" != "$new" ]; then
-          echo "✅ Build number changed"
+        APP_NUMBER=$(jq -er '.buildNumber' "$APP_FILE")
+        COMMON_NUMBER=$(jq -er '.buildNumber' "$COMMON_FILE")
+        case "${APP_NUMBER}${COMMON_NUMBER}" in
+          *[!0-9]*)
+            echo "::error::buildNumber values must be non-negative integers (app='$APP_NUMBER', common='$COMMON_NUMBER')"
+            exit 1
+            ;;
+        esac
+
+        EFFECTIVE=$((APP_NUMBER + COMMON_NUMBER))
+        echo "📦 App build number:       $APP_NUMBER ($APP_FILE)"
+        echo "📦 Common build number:    $COMMON_NUMBER ($COMMON_FILE)"
+        echo "📦 Effective build number: $EFFECTIVE"
+
+        # Last successfully built number = highest last-built/<build-key>/<n> tag on origin.
+        LAST=$(git ls-remote --tags origin "refs/tags/${TAG_PREFIX}*" \
+          | sed -n "s#.*refs/tags/${TAG_PREFIX}##p" \
+          | { grep -E '^[0-9]+$' || true; } \
+          | sort -n | tail -1) || LAST=""
+
+        if [ -z "$LAST" ]; then
+          # No record yet: assume the current number was already built before this
+          # mechanism existed and record it as baseline WITHOUT building. The next
+          # bump then triggers a build. For a brand-new app or fork that was never
+          # built, bump the build number (or run the first build manually via EAS).
+          echo "ℹ️ No last-built tag found for '${BUILD_KEY}'. Recording baseline ${TAG_PREFIX}${EFFECTIVE} without building."
+          git tag -f "${TAG_PREFIX}${EFFECTIVE}"
+          git push origin "refs/tags/${TAG_PREFIX}${EFFECTIVE}"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        elif [ "$EFFECTIVE" -gt "$LAST" ]; then
+          echo "✅ Build number increased ($LAST -> $EFFECTIVE): build required"
           echo "changed=true" >> "$GITHUB_OUTPUT"
         else
-          echo "🚫 Build number unchanged"
+          echo "🚫 Build number unchanged (last built: $LAST, current: $EFFECTIVE): no build required"
           echo "changed=false" >> "$GITHUB_OUTPUT"
         fi
-      shell: bash
 
-outputs:
-  changed:
-    description: 'true if the build number changed'
-    value: ${{ steps.check.outputs.changed }}
+        echo "build-number=$EFFECTIVE" >> "$GITHUB_OUTPUT"

--- a/.github/actions/record-build-number/action.yml
+++ b/.github/actions/record-build-number/action.yml
@@ -1,0 +1,48 @@
+name: Record Built Build Number
+description: >
+  Records a successful store build by pushing the git tag
+  last-built/<build-key>/<build-number>. The check-build-number action compares
+  against this tag, so it MUST only run after the build (and submit) succeeded.
+  Requires the repository to be checked out with credentials (default
+  actions/checkout) and the job to have "contents: write" permission.
+
+inputs:
+  build-key:
+    required: true
+    description: 'Unique key for this build target (e.g. frontend-ios). Must match the key used in check-build-number.'
+  build-number:
+    required: true
+    description: 'The effective build number that was just built (output build-number of check-build-number)'
+
+runs:
+  using: "composite"
+  steps:
+    - name: 💾 Record successful build as git tag
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        BUILD_KEY="${{ inputs.build-key }}"
+        BUILD_NUMBER="${{ inputs.build-number }}"
+        TAG_PREFIX="last-built/${BUILD_KEY}/"
+        TAG="${TAG_PREFIX}${BUILD_NUMBER}"
+
+        if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+          echo "ℹ️ Tag ${TAG} already exists on origin"
+        else
+          git tag -f "$TAG"
+          git push origin "refs/tags/${TAG}"
+          echo "✅ Recorded successful build: ${TAG}"
+        fi
+
+        # Best effort: prune older last-built tags of this build key to keep the
+        # tag list small. Failures here must not fail the build.
+        OLD_TAGS=$(git ls-remote --tags origin "refs/tags/${TAG_PREFIX}*" \
+          | sed -n "s#.*refs/tags/${TAG_PREFIX}##p" \
+          | { grep -E '^[0-9]+$' || true; }) || OLD_TAGS=""
+        for n in $OLD_TAGS; do
+          if [ "$n" -lt "$BUILD_NUMBER" ]; then
+            echo "🧹 Pruning outdated tag ${TAG_PREFIX}${n}"
+            git push origin ":refs/tags/${TAG_PREFIX}${n}" || true
+          fi
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       previous_commit_sha:
-        description: 'Commit SHA to compare build numbers against (from sync-fork: pre-sync state)'
+        description: 'DEPRECATED, no longer used. Build detection is based on last-built/* git tags. Kept so older sync-fork workflows can still trigger this workflow.'
         required: false
         default: ''
 
@@ -28,20 +28,10 @@ jobs:
         id: check
         uses: ./.github/actions/check-repository
 
-  check-build:
-    name: "🔍 Check Build Number"
-    runs-on: ubuntu-latest
-    needs: check-repository
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
-    steps:
-      - name: "🔄 Checkout Repository"
-        uses: actions/checkout@v4
-      - name: "🔍 Compare Build Number"
-        id: check
-        uses: ./.github/actions/check-build-number
-        with:
-          previous-commit-sha: ${{ github.event.inputs.previous_commit_sha }}
+  # Build detection: each build job checks its effective build number
+  # (apps/<app>/build-number.json + packages/common/build-number.json) against the
+  # last successfully built number, recorded as git tag last-built/<build-key>/<n>.
+  # See .github/actions/check-build-number and .github/actions/record-build-number.
 
 #  lint:
 #    name: "🎨 Prettier & ESLint"
@@ -244,7 +234,7 @@ jobs:
     name: "🔨 Directus Backend Build"
     runs-on: ubuntu-latest
 #    needs: sonarcloud-report
-    needs: [check-build, check-repository]
+    needs: [check-repository]
     steps:
       - name: "🏗 Setup repo"
         if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
@@ -262,7 +252,7 @@ jobs:
     name: "🏗 EAS Update Production"
     runs-on: ubuntu-latest
     #    needs: sonarcloud-report
-    needs: [check-build, check-repository]
+    needs: [check-repository]
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
@@ -281,103 +271,145 @@ jobs:
   build-android:
     name: "📦 Build & 🚀 Submit Android App"
     runs-on: ubuntu-latest
-#    needs: [sonarcloud-report, check-build]
-    needs: [check-build, check-repository]
-    if: needs.check-build.outputs.changed == 'true'
+    needs: [check-repository]
+    permissions:
+      contents: write
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: master
+      - name: "🔍 Check Build Number"
+        id: check
+        uses: ./.github/actions/check-build-number
+        with:
+          working-directory: apps/frontend/app
+          build-key: frontend-android
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        if: steps.check.outputs.changed == 'true'
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       - name: "🛠️ Build and Submit Android App"
+        if: steps.check.outputs.changed == 'true'
         run: eas build --platform android --non-interactive --profile production --auto-submit
         working-directory: ./apps/frontend/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: "💾 Record Built Build Number"
+        if: steps.check.outputs.changed == 'true'
+        uses: ./.github/actions/record-build-number
+        with:
+          build-key: frontend-android
+          build-number: ${{ steps.check.outputs.build-number }}
 
   build-android-preview:
     name: "🧪 Build Android Preview APK"
     runs-on: ubuntu-latest
-#    needs: [sonarcloud-report, check-build]
-    needs: [check-build, check-repository]
-    if: needs.check-build.outputs.changed == 'true'
+    needs: [check-repository]
+    permissions:
+      contents: write
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: "🔍 Check Build Number"
+        id: check
+        uses: ./.github/actions/check-build-number
+        with:
+          working-directory: apps/frontend/app
+          build-key: frontend-android-preview
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        if: steps.check.outputs.changed == 'true'
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       - name: "🧪 Build with previewApk profile"
+        if: steps.check.outputs.changed == 'true'
         run: eas build --platform android --non-interactive --profile previewApk
         working-directory: ./apps/frontend/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: "💾 Record Built Build Number"
+        if: steps.check.outputs.changed == 'true'
+        uses: ./.github/actions/record-build-number
+        with:
+          build-key: frontend-android-preview
+          build-number: ${{ steps.check.outputs.build-number }}
 
   build-ios:
     name: "📦 Build & 🚀 Submit iOS App"
     runs-on: ubuntu-latest
-#    needs: [sonarcloud-report, check-build]
-    needs: [check-build, check-repository]
-    if: needs.check-build.outputs.changed == 'true'
+    needs: [check-repository]
+    permissions:
+      contents: write
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: master
+      - name: "🔍 Check Build Number"
+        id: check
+        uses: ./.github/actions/check-build-number
+        with:
+          working-directory: apps/frontend/app
+          build-key: frontend-ios
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        if: steps.check.outputs.changed == 'true'
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
       - name: "🛠️ Build and Submit iOS App"
+        if: steps.check.outputs.changed == 'true'
         run: eas build --platform ios --non-interactive --auto-submit
         working-directory: ./apps/frontend/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-
-  geonexia-check-build:
-    name: "🔍 Geonexia Check Build Number"
-    runs-on: ubuntu-latest
-    needs: check-repository
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
-    steps:
-      - name: "🔄 Checkout Repository"
-        uses: actions/checkout@v4
-      - name: "🔍 Compare Geonexia Build Number"
-        id: check
-        uses: ./.github/actions/check-build-number
+      - name: "💾 Record Built Build Number"
+        if: steps.check.outputs.changed == 'true'
+        uses: ./.github/actions/record-build-number
         with:
-          working-directory: apps/geonexia/frontend
-          previous-commit-sha: ${{ github.event.inputs.previous_commit_sha }}
+          build-key: frontend-ios
+          build-number: ${{ steps.check.outputs.build-number }}
 
   geonexia-build-ios:
     name: "📦 Geonexia Build & 🚀 Submit iOS App"
     runs-on: ubuntu-latest
-    needs: [geonexia-check-build, check-repository]
-    if: needs.geonexia-check-build.outputs.changed == 'true' && needs.check-repository.outputs.is-upstream == 'true'
+    needs: [check-repository]
+    if: needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: master
+      - name: "🔍 Check Build Number"
+        id: check
+        uses: ./.github/actions/check-build-number
+        with:
+          working-directory: apps/geonexia/frontend
+          build-key: geonexia-ios
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        if: steps.check.outputs.changed == 'true'
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
       - name: "🛠️ Build and Submit Geonexia iOS App"
+        if: steps.check.outputs.changed == 'true'
         run: eas build --platform ios --non-interactive --auto-submit
         working-directory: ./apps/geonexia/frontend
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: "💾 Record Built Build Number"
+        if: steps.check.outputs.changed == 'true'
+        uses: ./.github/actions/record-build-number
+        with:
+          build-key: geonexia-ios
+          build-number: ${{ steps.check.outputs.build-number }}
 
   geonexia-expo-update:
     name: "🌍 Geonexia EAS Update (OTA)"
@@ -398,42 +430,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ref_name: ${{ github.ref_name }}
 
-  score-tracker-check-build:
-    name: "🔍 Score Tracker Check Build Number"
-    runs-on: ubuntu-latest
-    needs: check-repository
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
-    steps:
-      - name: "🔄 Checkout Repository"
-        uses: actions/checkout@v4
-      - name: "🔍 Compare Score Tracker Build Number"
-        id: check
-        uses: ./.github/actions/check-build-number
-        with:
-          working-directory: apps/score-tracker/frontend
-          previous-commit-sha: ${{ github.event.inputs.previous_commit_sha }}
-
   score-tracker-build-ios:
     name: "📦 Score Tracker Build & 🚀 Submit iOS App"
     runs-on: ubuntu-latest
-    needs: [score-tracker-check-build, check-repository]
-    if: needs.score-tracker-check-build.outputs.changed == 'true' && needs.check-repository.outputs.is-upstream == 'true'
+    needs: [check-repository]
+    if: needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: master
+      - name: "🔍 Check Build Number"
+        id: check
+        uses: ./.github/actions/check-build-number
+        with:
+          working-directory: apps/score-tracker/frontend
+          build-key: score-tracker-ios
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        if: steps.check.outputs.changed == 'true'
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
       - name: "🛠️ Build and Submit Score Tracker iOS App"
+        if: steps.check.outputs.changed == 'true'
         run: eas build --platform ios --non-interactive --auto-submit
         working-directory: ./apps/score-tracker/frontend
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: "💾 Record Built Build Number"
+        if: steps.check.outputs.changed == 'true'
+        uses: ./.github/actions/record-build-number
+        with:
+          build-key: score-tracker-ios
+          build-number: ${{ steps.check.outputs.build-number }}
 
   score-tracker-expo-update:
     name: "🎯 Score Tracker EAS Update (OTA)"
@@ -458,7 +490,7 @@ jobs:
     name: "🌍 Deploy to GitHub Pages"
     runs-on: ubuntu-latest
 #    needs: sonarcloud-report
-    needs: [check-build, check-repository]
+    needs: [check-repository]
     if: github.ref_name == 'master'
     steps:
       - name: "🔄 Checkout Repository"

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -78,10 +78,11 @@ jobs:
           GH_TOKEN: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
         run: |
           echo "🚀 Triggering Combined CI workflow after successful sync..."
+          # No previous_commit_sha needed anymore: build detection in ci.yml is
+          # based on last-built/* git tags and independent of git history.
           gh workflow run ci.yml \
             --repo "${{ steps.check-repo.outputs.repository-name }}" \
-            --ref master \
-            -f previous_commit_sha="${{ steps.check-updates.outputs.local-commit }}"
+            --ref master
           echo "✅ Combined CI workflow triggered!"
 
       - name: ⏭️ Skip Fork Sync - No Updates

--- a/apps/frontend/app/app.config.ts
+++ b/apps/frontend/app/app.config.ts
@@ -7,6 +7,7 @@ require('ts-node').register({
 	compilerOptions: {
 		module: 'Node16',
 		moduleResolution: 'node16',
+		resolveJsonModule: true,
 	},
 });
 

--- a/apps/frontend/app/build-number.json
+++ b/apps/frontend/app/build-number.json
@@ -1,0 +1,4 @@
+{
+	"_readme": "App-specific build number. The effective build number is this value + packages/common/build-number.json. Bump it to trigger a new app-store build of this app only. Never decrease it.",
+	"buildNumber": 199
+}

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -1,6 +1,8 @@
 // This file can not have any imports. See app.config.ts as it will transpile this file to  JavaScript
 import { ServerHelper } from 'repo-depkit-common';
 import {ImageSourcePropType} from "react-native";
+import appBuildNumberJson from './build-number.json';
+import commonBuildNumberJson from 'repo-depkit-common/build-number.json';
 
 export { EXPO_ASC_KEY_ID, EXPO_ASC_ISSUER_ID, EXPO_APPLE_TEAM_ID, EXPO_APPLE_TEAM_TYPE } from 'repo-depkit-common';
 
@@ -30,12 +32,15 @@ export enum ConfigCustomerEnum {
         STUDI_FUTTER = 'studi-futter'
 }
 
-// DO NOT CHANGE THE NAME OF THIS FUNCTION: getBuildNumber
-// The workflow action check-build-number will use this function to determine the build number
-// and will fail if the function is not present or does not return a number.
-// The build number is used to determine if a new build is required.
+// The effective build number is the sum of:
+// - ./build-number.json (bump for app-specific changes that need a new store build)
+// - packages/common/build-number.json (bump to trigger a new store build of ALL apps,
+//   e.g. after changing a native dependency in a shared package)
+// The CI action .github/actions/check-build-number reads the same JSON files and
+// triggers a store build when this sum is higher than the last successfully built
+// number (recorded as git tag last-built/<build-key>/<number>).
 export function getBuildNumber() {
-	return 199;
+	return appBuildNumberJson.buildNumber + commonBuildNumberJson.buildNumber;
 }
 
 export function getMajorVersion() {

--- a/apps/geonexia/frontend/app.config.ts
+++ b/apps/geonexia/frontend/app.config.ts
@@ -7,6 +7,7 @@ require('ts-node').register({
 	compilerOptions: {
 		module: 'Node16',
 		moduleResolution: 'node16',
+		resolveJsonModule: true,
 	},
 });
 

--- a/apps/geonexia/frontend/build-number.json
+++ b/apps/geonexia/frontend/build-number.json
@@ -1,0 +1,4 @@
+{
+	"_readme": "App-specific build number. The effective build number is this value + packages/common/build-number.json. Bump it to trigger a new app-store build of this app only. Never decrease it.",
+	"buildNumber": 17
+}

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -1,4 +1,6 @@
 import { ImageSourcePropType } from 'react-native';
+import appBuildNumberJson from './build-number.json';
+import commonBuildNumberJson from 'repo-depkit-common/build-number.json';
 
 export type CustomerConfig = {
 	projectName: string;
@@ -7,12 +9,15 @@ export type CustomerConfig = {
 	};
 };
 
-// DO NOT CHANGE THE NAME OF THIS FUNCTION: getBuildNumber
-// The workflow action check-build-number will use this function to determine the build number
-// and will fail if the function is not present or does not return a number.
-// The build number is used to determine if a new build is required.
+// The effective build number is the sum of:
+// - ./build-number.json (bump for app-specific changes that need a new store build)
+// - packages/common/build-number.json (bump to trigger a new store build of ALL apps,
+//   e.g. after changing a native dependency in a shared package)
+// The CI action .github/actions/check-build-number reads the same JSON files and
+// triggers a store build when this sum is higher than the last successfully built
+// number (recorded as git tag last-built/<build-key>/<number>).
 export function getBuildNumber() {
-	return 17;
+	return appBuildNumberJson.buildNumber + commonBuildNumberJson.buildNumber;
 }
 
 export const geonexiaConfig: CustomerConfig = {

--- a/apps/score-tracker/frontend/app.config.ts
+++ b/apps/score-tracker/frontend/app.config.ts
@@ -7,6 +7,7 @@ require('ts-node').register({
 	compilerOptions: {
 		module: 'Node16',
 		moduleResolution: 'node16',
+		resolveJsonModule: true,
 	},
 });
 

--- a/apps/score-tracker/frontend/build-number.json
+++ b/apps/score-tracker/frontend/build-number.json
@@ -1,0 +1,4 @@
+{
+	"_readme": "App-specific build number. The effective build number is this value + packages/common/build-number.json. Bump it to trigger a new app-store build of this app only. Never decrease it.",
+	"buildNumber": 10
+}

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -1,4 +1,6 @@
 import { ImageSourcePropType } from 'react-native';
+import appBuildNumberJson from './build-number.json';
+import commonBuildNumberJson from 'repo-depkit-common/build-number.json';
 
 export type CustomerConfig = {
 	projectName: string;
@@ -7,12 +9,15 @@ export type CustomerConfig = {
 	};
 };
 
-// DO NOT CHANGE THE NAME OF THIS FUNCTION: getBuildNumber
-// The workflow action check-build-number will use this function to determine the build number
-// and will fail if the function is not present or does not return a number.
-// The build number is used to determine if a new build is required.
+// The effective build number is the sum of:
+// - ./build-number.json (bump for app-specific changes that need a new store build)
+// - packages/common/build-number.json (bump to trigger a new store build of ALL apps,
+//   e.g. after changing a native dependency in a shared package)
+// The CI action .github/actions/check-build-number reads the same JSON files and
+// triggers a store build when this sum is higher than the last successfully built
+// number (recorded as git tag last-built/<build-key>/<number>).
 export function getBuildNumber() {
-	return 10;
+	return appBuildNumberJson.buildNumber + commonBuildNumberJson.buildNumber;
 }
 
 export const scoreTrackerConfig: CustomerConfig = {

--- a/docs/BUILD_NUMBERS.md
+++ b/docs/BUILD_NUMBERS.md
@@ -1,0 +1,73 @@
+# Build Numbers & App Store Builds
+
+This repo decides automatically in CI whether a new app-store build (EAS build +
+submit) is required. This document describes how that works and how to trigger
+a build.
+
+## How to trigger a new store build
+
+- **One app only** (e.g. frontend): bump `buildNumber` in the app's
+  `build-number.json`:
+  - `apps/frontend/app/build-number.json`
+  - `apps/geonexia/frontend/build-number.json`
+  - `apps/score-tracker/frontend/build-number.json`
+- **ALL apps at once** (e.g. after changing a native dependency in a shared
+  package like `packages/common` or `packages/common-ui`): bump `buildNumber`
+  in `packages/common/build-number.json`.
+
+The **effective build number** of an app is always:
+
+```
+effective = <app>/build-number.json + packages/common/build-number.json
+```
+
+Both values must only ever increase (Android `versionCode` and iOS
+`buildNumber` must be monotonic). The apps read the same JSON files at runtime
+via `getBuildNumber()` in their `config.ts`, so app version, `versionCode` and
+iOS build number are always in sync with what CI checks.
+
+## How CI decides whether to build
+
+The old approach compared the build number between `HEAD^` and `HEAD`, which
+silently missed builds whenever the bump was not the most recent commit
+(multi-commit pushes, `[skip ci]` report commits, fork syncs, failed runs).
+
+The new approach compares against the **last successfully built** number
+instead of git history:
+
+1. Each build job in `.github/workflows/ci.yml` runs
+   `.github/actions/check-build-number` with a unique `build-key`
+   (e.g. `frontend-ios`, `frontend-android`, `geonexia-ios`).
+2. The action computes the effective build number from the JSON files and reads
+   the git tag `last-built/<build-key>/<number>` from `origin`.
+3. If the effective number is **greater** than the tagged number, the job
+   builds and submits via EAS.
+4. After a successful build, `.github/actions/record-build-number` pushes the
+   new `last-built/<build-key>/<number>` tag (and prunes older ones).
+
+Properties:
+
+- **History-independent**: it does not matter how many commits were pushed at
+  once or whether the bump was the last commit.
+- **Self-healing**: if a build fails, the tag is not moved, so the next CI run
+  retries automatically.
+- **Per platform**: iOS and Android are tracked separately; if only one of them
+  fails, only that one is retried.
+- **Fork-friendly**: tags live per repository, so every fork tracks its own
+  last-built state. `gh repo sync` only syncs the branch, not tags.
+
+## First run / new forks
+
+If no `last-built/<build-key>/*` tag exists yet, the check assumes the current
+number was already built, records it as a baseline tag and does **not** build.
+This avoids a redundant build+submit when the mechanism is introduced or a new
+fork is set up. For a brand-new app or fork that was never built: bump the
+app's build number (or run the first `eas build` manually).
+
+## Notes
+
+- The tags are pushed with the default `GITHUB_TOKEN`; the build jobs therefore
+  declare `permissions: contents: write`.
+- The `previous_commit_sha` input of `ci.yml` is deprecated and ignored; it is
+  kept so older `sync-fork.yml` versions in forks can still trigger the
+  workflow during their first sync.

--- a/packages/common/build-number.json
+++ b/packages/common/build-number.json
@@ -1,0 +1,4 @@
+{
+	"_readme": "Shared build number for ALL apps. Bump this to trigger a new app-store build of every app, e.g. after changing a native dependency in a shared package (packages/common, packages/common-ui). Each app's effective build number is: <app>/build-number.json + this value. Never decrease it.",
+	"buildNumber": 0
+}


### PR DESCRIPTION
## Problem

Ob ein App-Store-Build nötig ist, wurde bisher per Diff der Build-Nummer in `config.ts` zwischen `HEAD^` (bzw. Pre-Sync-SHA bei Fork-Sync) und `HEAD` entschieden. Das verliert Builds, sobald der Bump nicht der letzte Commit ist:

- Pushes mit mehreren Commits
- CI-Report-Commits (`chore: update ... [skip ci]`) direkt nach dem Bump
- fehlgeschlagene/abgebrochene CI-Runs (Baseline wandert weiter, Build ist verloren)
- Fork-Sync-Sonderfälle

## Lösung: Vergleich gegen den letzten *erfolgreich gebauten* Stand statt gegen Git-History

**Build-Nummern als JSON, mit gemeinsamem Anteil in `packages/common`:**

```
effective = apps/<app>/build-number.json + packages/common/build-number.json
```

- `packages/common/build-number.json` bumpen ⇒ **alle** Apps bauen neu (z. B. nach Änderung einer nativen Dependency in einem Shared Package wie expo-sqlite in common/common-ui)
- `apps/<app>/build-number.json` bumpen ⇒ nur diese App baut neu
- Die Apps importieren dieselben JSON-Dateien zur Laufzeit (`getBuildNumber()` in `config.ts`), CI liest sie per `jq` — kein `grep` auf `config.ts` mehr, keine Drift möglich

**Tag-basierte Erkennung (`.github/actions/check-build-number`, neu: `record-build-number`):**

- Nach erfolgreichem `eas build --auto-submit` wird der Tag `last-built/<build-key>/<nummer>` gepusht (pro App **und Plattform**: `frontend-ios`, `frontend-android`, `frontend-android-preview`, `geonexia-ios`, `score-tracker-ios`)
- Der Check vergleicht die effektive Nummer gegen den höchsten Tag (via `git ls-remote`, historieunabhängig)
- **Selbstheilend:** schlägt ein Build fehl, bleibt der Tag stehen ⇒ nächster CI-Run versucht es erneut; iOS/Android unabhängig voneinander
- **Fork-sicher:** Tags sind pro Repository; `gh repo sync` synct nur den Branch. Jeder Fork trackt seinen eigenen Stand — `previous_commit_sha` wird nicht mehr gebraucht (Input bleibt als deprecated erhalten, damit alte `sync-fork.yml`-Versionen in Forks den Workflow beim ersten Sync noch triggern können)
- **Kein Doppel-Build bei Einführung:** existiert noch kein Tag, wird der aktuelle Stand als Baseline getaggt, ohne zu bauen

Details: `docs/BUILD_NUMBERS.md`

## Verifiziert

- Shell-Logik beider Actions lokal gegen ein Fake-Origin getestet (10 Szenarien: Baseline, unverändert, App-Bump, Fehlschlag+Retry, Record+Prune, Common-Bump, Idempotenz, invalide Werte, fehlende Datei) — alle grün
- `npx expo config` für alle drei Apps evaluiert: frontend `21.199.0`/`versionCode 199`, score-tracker `1.0.10`/`10`, geonexia `17` — identisch zu vorher; Common-Bump 0→1 ergibt korrekt `21.200.0`/`200`
- YAML-Syntax aller geänderten Workflow-/Action-Dateien validiert

## Hinweise

- Die Build-Jobs haben jetzt `permissions: contents: write` (Tag-Push mit `GITHUB_TOKEN`)
- expo-sqlite selbst habe ich bewusst **nicht** in `packages/common` verschoben (parallele sqlite-Arbeit in anderen Branches); wenn das passiert, ist der Rebuild-Trigger dafür jetzt genau ein Bump von `packages/common/build-number.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)