### PR TITLE
fix: Android keyboard covers SettingsList modals (nickname etc.)

### DIFF
--- a/packages/common-ui/src/components/BaseBottomSheet/index.tsx
+++ b/packages/common-ui/src/components/BaseBottomSheet/index.tsx
@@ -90,8 +90,17 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 	const webAccessibilityOverrides = Platform.OS === 'web' ? { accessibilityRole: null as any, accessibilityLabel: null as any } : {};
 	const renderBackground = useCallback((backgroundProps: BottomSheetBackgroundProps) => <View pointerEvents={backgroundProps.pointerEvents} style={[backgroundStyles.background, backgroundProps.style]} />, []);
 
+	// Android now enforces edge-to-edge (Expo SDK 54 / targetSdk 35+), so the
+	// window never actually resizes when the keyboard opens regardless of the
+	// declared windowSoftInputMode. Telling @gorhom/bottom-sheet
+	// android_keyboardInputMode="adjustResize" makes it assume the OS already
+	// shrank the container and skip its own keyboard-avoidance math entirely
+	// (it force-sets heightWithinContainer to 0 - see their BottomSheet.tsx),
+	// so the sheet no longer lifts above the keyboard on Android. Declaring
+	// "adjustPan" matches what actually happens under edge-to-edge and lets
+	// the library shift the sheet up by the tracked keyboard height itself.
 	return (
-		<BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundComponent={Platform.OS === 'web' ? renderBackground : undefined} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} keyboardBehavior="interactive" keyboardBlurBehavior="restore" android_keyboardInputMode="adjustResize" topInset={topInset} {...webAccessibilityOverrides} {...props}>
+		<BottomSheet ref={ref} snapPoints={snapPoints} backdropComponent={renderBackdrop} backgroundComponent={Platform.OS === 'web' ? renderBackground : undefined} backgroundStyle={effectiveBackgroundStyle} handleComponent={null} onChange={handleChange} keyboardBehavior="interactive" keyboardBlurBehavior="restore" android_keyboardInputMode="adjustPan" topInset={topInset} {...webAccessibilityOverrides} {...props}>
 			<View style={styles.header}>
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />


### PR DESCRIPTION
## Summary
- Auf Android schiebt sich die Tastatur seit Kurzem über die SettingsList-Modals (z. B. `SettingsListNickname` und alle anderen text-/datumsbasierten SettingsList-Sheets), während iOS korrekt funktioniert.
- Ursache: Android erzwingt inzwischen zwingend Edge-to-Edge (Expo SDK 54 / targetSdk 35+). Dadurch resized sich das native Fenster beim Öffnen der Tastatur nicht mehr, unabhängig vom deklarierten `windowSoftInputMode`.
- `@gorhom/bottom-sheet` erhält in `BaseBottomSheet` `android_keyboardInputMode="adjustResize"` und geht deshalb davon aus, dass Android den Container bereits verkleinert hat — es überspringt seine eigene Keyboard-Avoidance-Logik komplett auf Android (`heightWithinContainer` wird hart auf `0` gesetzt, siehe `@gorhom/bottom-sheet`'s `BottomSheet.tsx`). Das Sheet bewegt sich also gar nicht mehr nach oben.
- Fix: `android_keyboardInputMode` auf `"adjustPan"` ändern, was der tatsächlichen Realität unter Edge-to-Edge entspricht und die Bibliothek dazu bringt, das Sheet selbst um die getrackte Tastaturhöhe nach oben zu verschieben (wie auf iOS).
- Zentrale Stelle in `packages/common-ui`, betrifft daher alle Apps (frontend, geonexia, score-tracker), die `BaseBottomSheet` nutzen.

## Test plan
- [x] Root-Cause per Quellcode-Analyse von `@gorhom/bottom-sheet@5.2.9` verifiziert (`BottomSheet.tsx` Zeilen ~843-861 und ~1678-1698: `heightWithinContainer` wird bei `android_keyboardInputMode === 'adjustResize'` auf Android hart auf 0 gesetzt).
- [x] `tsc --noEmit` für `apps/frontend/app` zeigt keine neuen Fehler (einziger verbleibender Fehler in derselben Datei existiert bereits unverändert auf `master`).
- [ ] Manuelles Testen auf einem echten Android-Gerät/Emulator konnte in dieser Session nicht abgeschlossen werden (Touch-Injection im verwendeten Android-Emulator war in der Sandbox defekt - Taps kamen im RN-Fabric-Surface nicht an, obwohl native Apps wie Chrome reagierten). Bitte vor dem Merge kurz auf einem Android-Gerät die SettingsList-Nickname-Eingabe (`/experimentell/settings-list-components`) verifizieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)