### PR TITLE
fix: Android NFC instruction modal loop + modal-stack close behavior

### DIFF
--- a/apps/frontend/app/app/(app)/account-balance/MyCardReaderInterface.ts
+++ b/apps/frontend/app/app/(app)/account-balance/MyCardReaderInterface.ts
@@ -10,4 +10,12 @@ export interface MyCardReaderInterface {
 	isNfcSupported: () => Promise<MyCardReaderResponseSupport>;
 	isNfcEnabled: () => Promise<MyCardReaderResponseSupport>;
 	readCard: (callBack: (answer: CardResponse | undefined) => Promise<void>, showInstruction: () => void, hideInstruction: () => void, nfcInstruction: string) => Promise<void>;
+	/**
+	 * Interrupts an in-flight readCard() call (e.g. user pressed "cancel reading"
+	 * on the instruction). Best-effort: the underlying NFC session is torn down,
+	 * which causes readCard()'s pending native calls to reject/resolve early, so
+	 * callBack() is never invoked with card data. Safe to call even when no read
+	 * is in progress.
+	 */
+	cancelRead: () => Promise<void>;
 }

--- a/apps/frontend/app/app/(app)/account-balance/MyNativeCardReader.ts
+++ b/apps/frontend/app/app/(app)/account-balance/MyNativeCardReader.ts
@@ -87,4 +87,19 @@ export default class MyNativeCardReader implements MyCardReaderInterface {
 			hideInstruction();
 		}
 	}
+
+	async cancelRead(): Promise<void> {
+		if (isExpoGo) return;
+		const nfc = await loadNfc();
+		if (!nfc?.NfcManager) return;
+		try {
+			// Tearing down the NFC session interrupts whatever native call
+			// readCard() is currently awaiting (requestTechnology/transceive),
+			// so its try/finally unwinds early instead of waiting for a card.
+			await nfc.NfcManager.cancelTechnologyRequest();
+		} catch (e) {
+			// Best-effort, same as MensaCardReaderHelper._cleanUp - nothing to
+			// recover from if there was no active request.
+		}
+	}
 }

--- a/apps/frontend/app/app/(app)/account-balance/MyUnsupportedCardReader.ts
+++ b/apps/frontend/app/app/(app)/account-balance/MyUnsupportedCardReader.ts
@@ -22,4 +22,8 @@ export default class MyUnsupportedCardReader implements MyCardReaderInterface {
 	async readCard(callBack: (answer: CardResponse | undefined) => Promise<void>, showInstruction: () => void, hideInstruction: () => void, nfcInstruction: string): Promise<void> {
 		throw new Error('NFC is not supported on this device');
 	}
+
+	async cancelRead(): Promise<void> {
+		// No-op: readCard() always throws here, so there is never a read to cancel.
+	}
 }

--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -34,7 +34,6 @@ import ProjectButton from '@/components/ProjectButton';
 import { myContrastColor } from '@/helper/ColorHelper';
 import useAppRatingScore from '@/hooks/useAppRatingScore';
 import useDebugMode from '@/hooks/useDebugMode';
-import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 
 enum BalanceStateLowerBound {
 	CONFIDENT = 10,
@@ -60,7 +59,6 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
 	const { translate } = useLanguage();
 	const dispatch = useDispatch();
 	const debugMode = useDebugMode();
-	const { show: showInstructionModal, close: closeInstructionModal } = useMyScrollViewModal();
 	const { profile, isDevMode } = useAppSelector((state) => state.authReducer);
 	const { appSettings, language, primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
 	const balance_area_color = appSettings?.balance_area_color ? appSettings?.balance_area_color : primaryColor;
@@ -72,17 +70,16 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
         const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
         const [animationJson, setAmimationJson] = useState<any>(null);
         const [debugErrors, setDebugErrors] = useState<Array<{ timestamp: Date; error: string; source: string }>>([]);
-        // The NFC "hold your card" instruction opens as its own instance on the
-        // global modal stack (like the account-required modal inside the foodoffers
-        // details modal): close() only pops the top stack item, so an underlying
-        // balance modal stays open. isInstructionModalOpenRef guards hideInstruction
-        // so it only ever closes the instruction's own instance - readCard calls
-        // hideInstruction even when no instruction was shown (iOS system NFC sheet,
-        // cancelled reads), and without the guard that close() would pop - and thus
-        // close - the balance modal instead. The ref is reset via the modal's
-        // onClose (fired on content unmount), which also covers the user dismissing
-        // the instruction manually (pan-down/close button) while a read is running.
-        const isInstructionModalOpenRef = useRef(false);
+        // The NFC "hold your card" instruction (Android only - iOS has its own
+        // system sheet, see MyNativeCardReader) used to be pushed as its own item
+        // on the global modal stack on top of this screen's modal. That made the
+        // modal-stack renderer (which only mounts the top-most stack item) unmount
+        // this whole component whenever the instruction opened or closed, wiping
+        // all local state and re-triggering autoStartNfc in a loop every time the
+        // instruction closed. Rendering the instruction as local state instead
+        // keeps this component mounted the entire time (works the same whether
+        // opened as a modal from foodoffers or navigated to as a plain screen).
+        const [showingInstruction, setShowingInstruction] = useState(false);
         const { addPointsForBalanceRead } = useAppRatingScore();
 
         const debugLogMessages = useMemo(
@@ -203,16 +200,14 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
 	};
 
         const hideInstruction = useCallback(() => {
-                if (!isInstructionModalOpenRef.current) return;
-                isInstructionModalOpenRef.current = false;
-                closeInstructionModal();
-        }, [closeInstructionModal]);
+                setShowingInstruction(false);
+        }, []);
 
         // Debug-only: pretend the NFC module returned a card with the given balance,
         // running the exact same callback as a real read (redux update + persist),
         // then dismissing the instruction like a completed read would. Lets us verify
-        // on-device that a read finishing while the instruction modal is stacked on
-        // top of the balance modal closes only the instruction and updates the UI.
+        // that a read finishing while the instruction is shown hides it again and
+        // updates the UI.
         const simulateNfcRead = async (amount: number) => {
                 const mock: CardResponse = {
                         currentBalance: amount.toFixed(2),
@@ -235,76 +230,17 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
 
         const showInstruction = useCallback(() => {
                 if (!isActive) return;
-                if (isInstructionModalOpenRef.current) return;
-                isInstructionModalOpenRef.current = true;
-                showInstructionModal({
-                        title: 'NFC',
-                        onClose: () => {
-                                isInstructionModalOpenRef.current = false;
-                        },
-                        children: (
-                                <View style={styles.sheetView}>
-                                        {/* Previous balance (snapshot from before this read), so the user
-                                            still sees their old value while scanning - especially when the
-                                            foodoffers quick-access opens balance with auto-started NFC and
-                                            Android jumps straight to this instruction. Only shown when a
-                                            previous balance actually exists. */}
-                                        {profile?.credit_balance !== null && profile?.credit_balance !== undefined && (
-                                                <Text style={{ ...styles.nfcInstructionRead, color: theme.screen.text, marginBottom: 8 }}>
-                                                        {`${translate(TranslationKeys.nfcInstructionOldBalance)}: ${showFormatedPrice(formatPrice(profile.credit_balance))}`}
-                                                </Text>
-                                        )}
-                                        <Text
-                                                style={{
-                                                        ...styles.nfcInstructionRead,
-                                                        color: theme.screen.text,
-                                                }}
-                                        >
-                                                {translate(TranslationKeys.nfcInstructionRead)}
-                                        </Text>
-                                        <View style={styles.nfcAnimationContainer}>
-                                                <LottieView
-                                                        source={require('@/assets/gifs/nfc.json')}
-                                                        resizeMode="contain"
-                                                        style={styles.nfcAnimation}
-                                                        autoPlay
-                                                        loop
-                                                />
-                                        </View>
-                                        <Text
-                                                style={{
-                                                        ...styles.nfcInstructionChipPosition,
-                                                        color: theme.screen.text,
-                                                }}
-                                        >
-                                                {translate(TranslationKeys.nfcInstructionChipPosition)}
-                                        </Text>
-                                        {debugMode && (
-                                                <View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 4 }}>
-                                                        {[1, 5, 10].map(amount => (
-                                                                <TouchableOpacity
-                                                                        key={`instruction-simulate-${amount}`}
-                                                                        style={{
-                                                                                paddingVertical: 8,
-                                                                                paddingHorizontal: 14,
-                                                                                borderRadius: 8,
-                                                                                borderWidth: 1,
-                                                                                borderColor: theme.screen.iconBg,
-                                                                                marginHorizontal: 6,
-                                                                                marginTop: 8,
-                                                                        }}
-                                                                        onPress={() => void simulateNfcRead(amount)}
-                                                                >
-                                                                        <Text style={{ color: theme.screen.text }}>{`Simulate ${amount}€`}</Text>
-                                                                </TouchableOpacity>
-                                                        ))}
-                                                </View>
-                                        )}
-                                </View>
-                        ),
-                });
-                // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [isActive, showInstructionModal, debugMode, profile?.credit_balance, theme.screen.text, theme.screen.iconBg, translate]);
+                setShowingInstruction(true);
+        }, [isActive]);
+
+        // Cancel button on the instruction: tears down the in-flight NFC session
+        // (best-effort, safe even if the native call has already finished) and
+        // immediately shows the normal balance content again, instead of waiting
+        // for readCard()'s own cleanup to unwind.
+        const handleCancelRead = useCallback(() => {
+                setShowingInstruction(false);
+                myCardReader.cancelRead().catch((e: any) => addDebugError(e, 'Cancel NFC Read'));
+        }, [myCardReader, addDebugError]);
 
 	const onReadNfcPress = async () => {
 		await myCardReader.readCard(callBack, showInstruction, hideInstruction, translate(TranslationKeys.nfcInstructionRead));
@@ -325,7 +261,10 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
 	// screen is active and NFC is confirmed supported+enabled - used when this
 	// screen is opened from the foodoffers quick-access button. Guarded to fire
 	// only once per mount so it doesn't re-trigger after the read completes and
-	// the focus/NFC-status effects above re-run.
+	// the focus/NFC-status effects above re-run. Safe to keep as a plain local
+	// ref: the instruction is now local state (see showingInstruction above)
+	// instead of a second modal-stack item, so this component no longer
+	// unmounts/remounts while the instruction is shown or dismissed.
 	const hasAutoStartedNfcRef = useRef(false);
 	useEffect(() => {
 		if (!autoStartNfc || hasAutoStartedNfcRef.current) return;
@@ -410,6 +349,55 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
 			return <LottieView ref={animationRef} source={animationJson ? animationJson : {}} resizeMode="contain" style={{ width: '100%', height: '100%' }} autoPlay={!!autoPlay} loop={false} />;
 		}
 	}, [autoPlay, animationJson]);
+
+	if (showingInstruction) {
+		return (
+			<ScrollView style={{ ...styles.container, backgroundColor: theme.screen.background }} contentContainerStyle={{ alignItems: 'center' }}>
+				<View style={styles.sheetView}>
+					{/* Previous balance (snapshot from before this read), so the user
+					    still sees their old value while scanning - especially when the
+					    foodoffers quick-access opens balance with auto-started NFC and
+					    Android jumps straight to this instruction. Only shown when a
+					    previous balance actually exists. */}
+					{profile?.credit_balance !== null && profile?.credit_balance !== undefined && (
+						<Text style={{ ...styles.nfcInstructionRead, color: theme.screen.text, marginBottom: 8 }}>
+							{`${translate(TranslationKeys.nfcInstructionOldBalance)}: ${showFormatedPrice(formatPrice(profile.credit_balance))}`}
+						</Text>
+					)}
+					<Text style={{ ...styles.nfcInstructionRead, color: theme.screen.text }}>{translate(TranslationKeys.nfcInstructionRead)}</Text>
+					<View style={styles.nfcAnimationContainer}>
+						<LottieView source={require('@/assets/gifs/nfc.json')} resizeMode="contain" style={styles.nfcAnimation} autoPlay loop />
+					</View>
+					<Text style={{ ...styles.nfcInstructionChipPosition, color: theme.screen.text }}>{translate(TranslationKeys.nfcInstructionChipPosition)}</Text>
+					<TouchableOpacity style={{ ...styles.nfcButton, borderColor: theme.screen.iconBg, marginTop: 16 }} onPress={handleCancelRead}>
+						<MaterialCommunityIcons name="close-circle-outline" size={24} color={theme.screen.icon} />
+						<Text style={{ ...styles.nfcLabel, color: theme.screen.text }}>{translate(TranslationKeys.nfcCancelRead)}</Text>
+					</TouchableOpacity>
+					{debugMode && (
+						<View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 4 }}>
+							{[1, 5, 10].map(amount => (
+								<TouchableOpacity
+									key={`instruction-simulate-${amount}`}
+									style={{
+										paddingVertical: 8,
+										paddingHorizontal: 14,
+										borderRadius: 8,
+										borderWidth: 1,
+										borderColor: theme.screen.iconBg,
+										marginHorizontal: 6,
+										marginTop: 8,
+									}}
+									onPress={() => void simulateNfcRead(amount)}
+								>
+									<Text style={{ color: theme.screen.text }}>{`Simulate ${amount}€`}</Text>
+								</TouchableOpacity>
+							))}
+						</View>
+					)}
+				</View>
+			</ScrollView>
+		);
+	}
 
 	return (
 		<ScrollView style={{ ...styles.container, backgroundColor: theme.screen.background }} contentContainerStyle={{ alignItems: 'center' }}>

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -119,6 +119,7 @@ export enum TranslationKeys {
         nfcInstructionChipPosition = 'nfcInstructionChipPosition',
         nfcInstructionOldBalance = 'nfcInstructionOldBalance',
         showNfcInstruction = 'showNfcInstruction',
+        nfcCancelRead = 'nfcCancelRead',
         new = 'new',
 	attention = 'attention',
 	without_account_limitations = 'without_account_limitations',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1219,6 +1219,16 @@
     "tr": "NFC talimatını göster",
     "zh": "显示 NFC 指南"
   },
+  "nfcCancelRead": {
+    "de": "Auslesen abbrechen",
+    "en": "Cancel reading",
+    "ar": "إلغاء القراءة",
+    "es": "Cancelar lectura",
+    "fr": "Annuler la lecture",
+    "ru": "Отменить чтение",
+    "tr": "Okumayı iptal et",
+    "zh": "取消读取"
+  },
   "new": {
     "de": "Neu",
     "en": "New",

--- a/packages/common-ui/src/components/BaseBottomSheet/index.tsx
+++ b/packages/common-ui/src/components/BaseBottomSheet/index.tsx
@@ -54,12 +54,35 @@ const backgroundStyles = StyleSheet.create({
 });
 
 export interface BaseBottomSheetProps extends Omit<BottomSheetProps, 'backdropComponent'> {
+	/**
+	 * Header close/back button only. Steps back one level of the modal stack
+	 * (see ModalProvider's `close()`) - does NOT touch the sheet's open/closed
+	 * state unless the stack is down to its last item. Rendered as a chevron
+	 * ("back") instead of an X when `showBackChevron` is set, so the user
+	 * understands this only steps back rather than dismissing everything.
+	 */
 	onClose?: () => void;
+	/**
+	 * Backdrop tap and swipe-down-to-close. Both are a "get me out of here"
+	 * gesture from the user's perspective, independent of how many modals are
+	 * stacked - so both dismiss the entire stack at once (ModalProvider's
+	 * `closeAll()`) rather than stepping back one level like the header
+	 * button does. Falls back to `onClose` when not provided, so standalone
+	 * consumers of this component (outside the global modal stack, e.g.
+	 * BaseBottomModal/MarkingBottomSheet - a single sheet with no "stack" to
+	 * distinguish) keep their previous behaviour of a single close handler
+	 * for the button, backdrop, and swipe alike.
+	 */
+	onDismissAll?: () => void;
 	headerBackgroundColor?: string;
+	/** Shows a "back" chevron instead of an X in the header button - set when more than one modal is stacked, since the button only steps back one level. */
+	showBackChevron?: boolean;
 }
 
-const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose, children, backgroundStyle, onChange, headerBackgroundColor, ...props }, ref) => {
-	const renderBackdrop = useCallback((backdropProps: BottomSheetBackdropProps) => <CustomBackdrop {...backdropProps} onPress={onClose} />, [onClose]);
+const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose, onDismissAll, children, backgroundStyle, onChange, headerBackgroundColor, showBackChevron, ...props }, ref) => {
+	// See onDismissAll doc: falls back to onClose for standalone (non-stacked) consumers.
+	const dismissAll = onDismissAll ?? onClose;
+	const renderBackdrop = useCallback((backdropProps: BottomSheetBackdropProps) => <CustomBackdrop {...backdropProps} onPress={dismissAll} />, [dismissAll]);
 	const { theme } = useTheme();
 	const { top: topInset } = useSafeAreaInsets();
 	const snapPoints = useMemo(() => ['80%'], []);
@@ -69,14 +92,17 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 
 	const handleColor = theme.sheet.closeBg;
 
+	// Swipe-down-to-close animates the sheet to index -1 - same "dismiss
+	// everything" intent as a backdrop tap (see onDismissAll doc above), so it
+	// goes through the same handler rather than the header button's onClose.
 	const handleChange = useCallback(
 		(index: number) => {
 			if (index === -1) {
-				onClose?.();
+				dismissAll?.();
 			}
 			(onChange as any)?.(index);
 		},
-		[onClose, onChange],
+		[dismissAll, onChange],
 	);
 
 	// On web, @gorhom/bottom-sheet defaults to accessibilityRole "adjustable",
@@ -105,7 +131,7 @@ const BaseBottomSheet = forwardRef<BottomSheet, BaseBottomSheetProps>(({ onClose
 				<View style={styles.placeholder} />
 				<View style={[styles.handle, { backgroundColor: handleColor }]} />
 				<TouchableOpacity style={[styles.closeButton, { backgroundColor: theme.sheet.closeBg }]} onPress={onClose} nativeID={CommonUiComponentIds.MODAL_CLOSE_BUTTON}>
-					<AntDesign name="close" size={24} color={theme.sheet.closeIcon} />
+					<AntDesign name={showBackChevron ? 'left' : 'close'} size={24} color={theme.sheet.closeIcon} />
 				</TouchableOpacity>
 			</View>
 			{children}

--- a/packages/common-ui/src/components/GlobalModal/ModalProvider.tsx
+++ b/packages/common-ui/src/components/GlobalModal/ModalProvider.tsx
@@ -37,6 +37,8 @@ type ModalContextType = {
 	_handleSheetChange: (index: number) => void;
 	/** @internal used by ModalRenderer */
 	_screenBackgroundColor: string;
+	/** @internal used by ModalRenderer - how many modals are stacked, to decide whether the header button shows a back-chevron (stack) or an X (single modal) */
+	_stackDepth: number;
 };
 
 const ModalContext = createContext<ModalContextType | null>(null);
@@ -178,6 +180,17 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 		}));
 	};
 
+	// Desired dismiss behaviour (see BaseBottomSheetProps for the matching
+	// prop docs): a backdrop tap or a swipe-down-to-close gesture is a "get me
+	// out of here" gesture from the user, independent of how many modals are
+	// stacked - both dismiss the ENTIRE stack via onDismissAll/closeAll. Only
+	// the header close/back button steps back one level via onClose/close().
+	// Because BaseBottomSheet already calls onDismissAll (closeAll) before
+	// invoking this onChange handler for index === -1, modalStackRef is
+	// already empty by the time we get here - so there is nothing left to
+	// re-expand for a partial pop anymore (that used to be a real case when
+	// swipe-down only popped one level; kept as a no-op guard in case a
+	// future caller reaches index === -1 with stack items still present).
 	const handleSheetChange = useCallback((index: number) => {
 		if (index >= 0) {
 			clearCloseTimeout();
@@ -243,6 +256,7 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 			_sheetRef: sheetRef,
 			_handleSheetChange: handleSheetChange,
 			_screenBackgroundColor: screenBackgroundColor,
+			_stackDepth: modalStack.length,
 		}}>
 			{children}
 		</ModalContext.Provider>
@@ -250,7 +264,15 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 };
 
 export const ModalRenderer: React.FC<{ children: ReactNode }> = ({ children }) => {
-	const { _currentItem: currentItem, _sheetRef: sheetRef, _handleSheetChange: handleSheetChange, _screenBackgroundColor: screenBackgroundColor, close } = useModalContext();
+	const {
+		_currentItem: currentItem,
+		_sheetRef: sheetRef,
+		_handleSheetChange: handleSheetChange,
+		_screenBackgroundColor: screenBackgroundColor,
+		_stackDepth: stackDepth,
+		close,
+		closeAll,
+	} = useModalContext();
 
 	return (
 		<>
@@ -265,6 +287,8 @@ export const ModalRenderer: React.FC<{ children: ReactNode }> = ({ children }) =
 						ref={sheetRef}
 						enablePanDownToClose
 						onClose={close}
+						onDismissAll={closeAll}
+						showBackChevron={stackDepth > 1}
 						onChange={handleSheetChange}
 						headerBackgroundColor={screenBackgroundColor}
 						backgroundStyle={currentItem.backgroundStyle}


### PR DESCRIPTION
## Summary
- Fixes an Android-only bug where pressing the NFC "read card" button on the foodoffers quick-access balance modal could loop forever between the balance content and the NFC instruction: the instruction was pushed as a second item on the global modal stack, which unmounted `AccountBalanceScreen` (only the top-most stack item is rendered), wiping the guard that stops `autoStartNfc` from re-triggering the read on every remount.
- Root fix: the instruction is now local state inside `AccountBalanceScreen` (hides the normal content, shows the instruction) instead of a second modal-stack item - identical behavior whether opened as a modal (foodoffers quick access) or navigated to as a plain screen. Only applies on Android; iOS keeps using its own system NFC sheet, Web is unsupported.
- Adds a "cancel reading" button on the instruction that calls a new `MyCardReaderInterface.cancelRead()` (`NfcManager.cancelTechnologyRequest()`) to actually interrupt the in-flight NFC session, not just hide the UI.
- Modal-stack close behavior: backdrop tap and swipe-down-to-close now dismiss the **entire** modal stack (`closeAll`), while the header button only steps back **one level** (`close`, previous behavior) - and shows a back-chevron instead of an X whenever more than one modal is stacked, so the icon communicates what the button will actually do.
- Standalone `BaseBottomSheet` consumers outside the global modal stack (`BaseBottomModal`, `MarkingBottomSheet`) are unaffected: `onDismissAll` falls back to `onClose` when not provided, preserving their single-close-handler behavior.

## Test plan
- [ ] On Android: open foodoffers, tap the balance quick-access button, let the NFC instruction show, dismiss it (X / backdrop / swipe) and confirm it does **not** reopen on its own.
- [ ] On Android: start a read, tap "cancel reading" on the instruction, confirm it returns to the balance content and no stale read completes afterwards.
- [ ] On Android: same flow via direct navigation to the account-balance screen (not through the foodoffers modal).
- [ ] On iOS: confirm the balance read flow still works via the system NFC sheet (no regression).
- [ ] Any modal with more than one stacked item (e.g. Avatar Editor: editor -> category picker): header button now shows a back-chevron and only steps back; backdrop tap / swipe now closes everything.
- [ ] `BaseBottomModal` / `MarkingBottomSheet` (marking details): backdrop tap and swipe-down-to-close still dismiss as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)