### PR TITLE
Fix account-required modal closing the whole stack instead of stepping back

### DIFF
--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -40,7 +40,16 @@ const MyScrollViewModal: React.FC<MyScrollViewModalProps> = ({
 
   const resolvedBackgroundColor = backgroundColor ?? theme.screen.background;
 
-  React.useEffect(() => () => onClose?.(), [onClose]);
+  // onClose must only fire when this component truly unmounts. The global modal
+  // stack renders every stack item's MyScrollViewModal at the same tree position
+  // (see ModalRenderer), so popping back to the previous modal re-renders the SAME
+  // instance with the previous modal's props. With onClose in the effect deps, that
+  // prop swap ran the cleanup with the just-popped modal's onClose (usually the
+  // stack's close()) and closed the remaining modal too - e.g. the account-required
+  // modal took the modal beneath it down with it despite showing the back chevron.
+  const onCloseRef = React.useRef(onClose);
+  React.useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+  React.useEffect(() => () => { onCloseRef.current?.(); }, []);
 
   const headerComponent = (
     <>

--- a/apps/frontend/app/hooks/useAccountRequiredModal.tsx
+++ b/apps/frontend/app/hooks/useAccountRequiredModal.tsx
@@ -22,9 +22,12 @@ const useAccountRequiredModal = () => {
 			void performLogout(dispatch, router);
 		};
 
+		// No onClose here: MyScrollViewModal fires onClose on unmount, and this modal
+		// also unmounts when the back chevron pops it while another modal is still on
+		// the stack (the stack renders only the top-most item). Passing close would
+		// close that remaining modal too instead of returning to it.
 		show({
 			title: translate(TranslationKeys.access_limited),
-			onClose: close,
 			children: (
 				<View style={{ gap: 12 }}>
 					<Text style={{ color: theme.sheet.text }}>
@@ -41,7 +44,7 @@ const useAccountRequiredModal = () => {
 				</View>
 			),
 		});
-	}, [close, closeAll, dispatch, router, show, theme.sheet.text, translate]);
+	}, [closeAll, dispatch, router, show, theme.sheet.text, translate]);
 
 	return { openAccountRequiredModal, closeAccountRequiredModal: close };
 };


### PR DESCRIPTION
## Problem

When the account-required modal ("Zugriff eingeschränkt") is opened on top of another modal, the back chevron is shown correctly — but pressing it closed **every** stacked modal instead of returning to the modal beneath.

## Cause

The global modal stack renders only the top-most item inside a single bottom sheet, all at the same tree position. Two things went wrong when the stack popped back:

1. **`apps/frontend/.../MyScrollViewModal.tsx`** ran its `onClose` cleanup with `[onClose]` as effect dependency. Popping back re-renders the *same* component instance with the previous modal's props, so the dependency change fired the just-popped modal's `onClose` — which is the stack's `close()` — a second time, closing the remaining modal too.
2. **`useAccountRequiredModal`** passed `onClose: close` into the modal props. Even a genuine unmount (which happens when the underlying modal is the common-ui `MyScrollViewModal`, a different component type) then triggered an extra `close()`.

## Fix

- The frontend `MyScrollViewModal` now uses the same ref-based pattern as the common-ui version: `onClose` fires only on a true unmount, never on prop identity changes.
- `useAccountRequiredModal` no longer passes the circular `onClose: close` — the callback only ever re-invoked the close that was already happening, and turned into a double-close when the modal unmounted while another modal remained on the stack.

## Result

Back chevron on the account-required modal now steps back to the underlying modal; closing the whole stack via swipe-down/backdrop is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTov4tSnGPkok5tVYypM3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTov4tSnGPkok5tVYypM3K)_