### PR TITLE
Revert direkter Push: Web-Storage-Vereinheitlichung (kommt als eigener PR zurück)

### DIFF
--- a/apps/frontend/app/redux/storage/sqliteStorage.web.ts
+++ b/apps/frontend/app/redux/storage/sqliteStorage.web.ts
@@ -1,30 +1,23 @@
-import { getStorageItem, setStorageItem, removeStorageItem, clearStorage } from 'repo-depkit-common-ui';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Storage } from 'redux-persist';
 
-// Web storage for redux-persist and the app's key-value helpers, delegating to the
-// shared repo-depkit-common-ui SqliteKeyValueStorage. Its web backend is
-// window.localStorage with raw keys - byte-identical to the AsyncStorage web shim this
-// file used before (AsyncStorage's web implementation is itself just localStorage with
-// raw keys), so existing web data like "persist:root" or "auth_data" keeps working.
-// The shared module is also what score-tracker and geonexia persist through, so all
-// apps now use the same storage code on every platform. Metro picks this file over
-// sqliteStorage.ts for web builds, so expo-sqlite's wasm-dependent web module is never
-// pulled into the web bundle.
+// expo-sqlite's web support needs Metro wasm config plus COOP/COEP response headers
+// (for SharedArrayBuffer/OPFS) that this app's static web export doesn't set up, and the
+// 2MB ceiling being worked around on native is an Android/AsyncStorage-specific limit
+// anyway - so web keeps using AsyncStorage (its localStorage-backed shim) unchanged.
+// Metro picks this file over sqliteStorage.ts for web builds, so expo-sqlite's
+// wasm-dependent web module is never pulled into the web bundle.
 export const sqliteKeyValueStorage = {
-	getItem: (key: string) => getStorageItem(key),
-	setItem: (key: string, value: string) => setStorageItem(key, value),
-	removeItem: (key: string) => removeStorageItem(key),
-	multiRemove: async (keys: string[]) => {
-		for (const key of keys) {
-			await removeStorageItem(key);
-		}
-	},
-	clear: () => clearStorage(),
+	getItem: (key: string) => AsyncStorage.getItem(key),
+	setItem: (key: string, value: string) => AsyncStorage.setItem(key, value),
+	removeItem: (key: string) => AsyncStorage.removeItem(key),
+	multiRemove: (keys: string[]) => AsyncStorage.multiRemove(keys),
+	clear: () => AsyncStorage.clear(),
 };
 
-// Web has no separate sqlite store to migrate into - localStorage already is the store.
+// Web has no separate sqlite store to migrate into - AsyncStorage already is the store.
 export async function migrateAsyncStorageToSqlite(): Promise<{ migratedKeys: string[] }> {
 	return { migratedKeys: [] };
 }
 
-export const sqliteStorage: Storage = sqliteKeyValueStorage;
+export const sqliteStorage: Storage = AsyncStorage;

--- a/packages/common-ui/src/helpers/SqliteKeyValueStorage.web.ts
+++ b/packages/common-ui/src/helpers/SqliteKeyValueStorage.web.ts
@@ -1,31 +1,27 @@
 import { getUtf8ByteLength } from './ByteSizeHelper';
 
-// Web backend for the shared key-value storage: window.localStorage with raw
-// (unprefixed) keys.
-//
-// This is deliberately byte-identical to what apps/frontend has always done on web:
-// its redux/storage/sqliteStorage.web.ts used AsyncStorage, and AsyncStorage's web
-// implementation is itself a thin wrapper around window.localStorage with raw keys
-// (see @react-native-async-storage/async-storage/src/AsyncStorage.ts). Implementing
-// it directly on localStorage keeps that exact storage format - existing frontend web
-// data (e.g. "persist:root", "auth_data") keeps working - without making every app
-// pull the AsyncStorage native module into its binary just for this web file.
+// Web backend for the shared key-value storage: window.localStorage.
 //
 // Why not expo-sqlite or expo-file-system:
 // - expo-sqlite's web build needs Metro wasm config plus COOP/COEP response headers
 //   (for SharedArrayBuffer/OPFS) that these apps' static web exports don't set up.
-// - expo-file-system's new File/Paths API (SDK 54+) is a no-op stub on web: every
-//   operation only logs "expo-file-system is not supported on web", so nothing was
-//   ever persisted (only the legacy API had a web shim, and that one is a no-op too).
-// Metro picks this file over SqliteKeyValueStorage.ts for web builds, so expo-sqlite's
-// wasm-dependent web module is never pulled into the web bundle.
+// - expo-file-system's NEW File/Paths API (SDK 54+) is a no-op stub on web: every
+//   operation only logs "expo-file-system is not supported on web" (see
+//   expo-file-system/src/ExpoFileSystem.web.ts), so `new File(...).write(...)` throws
+//   and nothing is ever persisted. Only the *legacy* API ever had a web shim, and that
+//   one is a no-op too.
+// localStorage is the same mechanism apps/frontend already uses on web (AsyncStorage's
+// web shim is localStorage-backed), it is synchronous, universally available and
+// survives reloads. Metro picks this file over SqliteKeyValueStorage.ts for web builds,
+// so expo-sqlite's wasm-dependent web module is never pulled into the web bundle.
 
 export const DEFAULT_DB_NAME = 'app_storage.db';
 
-// Short-lived predecessor of this implementation namespaced keys as
-// "kv:<dbName>:<key>" - migrate such entries to the raw key on first read.
-function legacyPrefixedKey(key: string, dbName: string = DEFAULT_DB_NAME): string {
-	return `kv:${dbName}:${key}`;
+// Namespace prefix so getStorageUsage()/clearStorage() only ever touch keys owned by
+// this helper and never entries other libraries put into localStorage. The dbName is
+// part of the prefix for signature parity with the native per-db separation.
+function keyPrefix(dbName: string = DEFAULT_DB_NAME): string {
+	return `kv:${dbName}:`;
 }
 
 function getLocalStorage(): Storage | null {
@@ -44,55 +40,56 @@ export function getKvDatabase(dbName?: string): Promise<never> {
 export async function getStorageItem(key: string, dbName?: string): Promise<string | null> {
 	const storage = getLocalStorage();
 	if (!storage) return null;
-	const value = storage.getItem(key);
-	if (value !== null) return value;
-	const legacyValue = storage.getItem(legacyPrefixedKey(key, dbName));
-	if (legacyValue !== null) {
-		storage.setItem(key, legacyValue);
-		storage.removeItem(legacyPrefixedKey(key, dbName));
-	}
-	return legacyValue;
+	return storage.getItem(keyPrefix(dbName) + key);
 }
 
 export async function setStorageItem(key: string, value: string, dbName?: string): Promise<void> {
 	const storage = getLocalStorage();
 	if (!storage) return;
-	storage.setItem(key, value);
+	storage.setItem(keyPrefix(dbName) + key, value);
 }
 
 export async function removeStorageItem(key: string, dbName?: string): Promise<void> {
 	const storage = getLocalStorage();
 	if (!storage) return;
-	storage.removeItem(key);
-	storage.removeItem(legacyPrefixedKey(key, dbName));
+	storage.removeItem(keyPrefix(dbName) + key);
 }
 
 export type SqliteStorageKeyUsage = { key: string; bytes: number };
 
 // Powers the debug "storage usage" settings list (see SettingsListSqliteStorage) - lists
-// every localStorage key with its approximate size. Skips internal sentinel keys wrapped
-// in double underscores, mirroring the native implementation.
+// every key owned by this helper with its approximate size. Skips internal sentinel keys
+// wrapped in double underscores, mirroring the native implementation.
 export async function getStorageUsage(
 	dbName?: string
 ): Promise<{ items: SqliteStorageKeyUsage[]; totalBytes: number }> {
 	const storage = getLocalStorage();
 	if (!storage) return { items: [], totalBytes: 0 };
+	const prefix = keyPrefix(dbName);
 	const items: SqliteStorageKeyUsage[] = [];
 	for (let i = 0; i < storage.length; i++) {
-		const key = storage.key(i);
-		if (key === null) continue;
+		const fullKey = storage.key(i);
+		if (fullKey === null || !fullKey.startsWith(prefix)) continue;
+		const key = fullKey.slice(prefix.length);
 		if (key.startsWith('__') && key.endsWith('__')) continue;
-		items.push({ key, bytes: getUtf8ByteLength(storage.getItem(key) ?? '') });
+		items.push({ key, bytes: getUtf8ByteLength(storage.getItem(fullKey) ?? '') });
 	}
 	items.sort((a, b) => b.bytes - a.bytes);
 	const totalBytes = items.reduce((sum, item) => sum + item.bytes, 0);
 	return { items, totalBytes };
 }
 
-// Clears the whole localStorage - same behavior as the AsyncStorage.clear() the
-// frontend app's web storage exposed before this was shared here.
 export async function clearStorage(dbName?: string): Promise<void> {
 	const storage = getLocalStorage();
 	if (!storage) return;
-	storage.clear();
+	const prefix = keyPrefix(dbName);
+	// Collect first - removing while iterating shifts localStorage's key indices.
+	const keysToRemove: string[] = [];
+	for (let i = 0; i < storage.length; i++) {
+		const fullKey = storage.key(i);
+		if (fullKey !== null && fullKey.startsWith(prefix)) keysToRemove.push(fullKey);
+	}
+	for (const fullKey of keysToRemove) {
+		storage.removeItem(fullKey);
+	}
 }


### PR DESCRIPTION
Macht den direkten Push `92752dc` („Storage vereinheitlicht: alle Apps nutzen auf Web denselben localStorage-Backend wie frontend") auf `master` rückgängig.

Die Änderung selbst ist gewünscht, soll aber per Pull Request reviewt werden statt direkt auf master zu landen. Nach dem Merge dieses Reverts wird dieselbe Änderung als eigener PR neu geöffnet:

- `packages/common-ui/src/helpers/SqliteKeyValueStorage.web.ts` zurück auf den Stand mit `kv:`-Namespace (Persistenz-Fix aus `96d8717` bleibt unangetastet)
- `apps/frontend/app/redux/storage/sqliteStorage.web.ts` zurück auf den direkten AsyncStorage-Import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTi899EM5w8XocY24Jf6oX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTi899EM5w8XocY24Jf6oX)_