### PR TITLE
Web-Storage vereinheitlicht: alle Apps nutzen denselben localStorage-Backend wie frontend

### DIFF
--- a/apps/frontend/app/redux/storage/sqliteStorage.web.ts
+++ b/apps/frontend/app/redux/storage/sqliteStorage.web.ts
@@ -1,23 +1,30 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getStorageItem, setStorageItem, removeStorageItem, clearStorage } from 'repo-depkit-common-ui';
 import type { Storage } from 'redux-persist';
 
-// expo-sqlite's web support needs Metro wasm config plus COOP/COEP response headers
-// (for SharedArrayBuffer/OPFS) that this app's static web export doesn't set up, and the
-// 2MB ceiling being worked around on native is an Android/AsyncStorage-specific limit
-// anyway - so web keeps using AsyncStorage (its localStorage-backed shim) unchanged.
-// Metro picks this file over sqliteStorage.ts for web builds, so expo-sqlite's
-// wasm-dependent web module is never pulled into the web bundle.
+// Web storage for redux-persist and the app's key-value helpers, delegating to the
+// shared repo-depkit-common-ui SqliteKeyValueStorage. Its web backend is
+// window.localStorage with raw keys - byte-identical to the AsyncStorage web shim this
+// file used before (AsyncStorage's web implementation is itself just localStorage with
+// raw keys), so existing web data like "persist:root" or "auth_data" keeps working.
+// The shared module is also what score-tracker and geonexia persist through, so all
+// apps now use the same storage code on every platform. Metro picks this file over
+// sqliteStorage.ts for web builds, so expo-sqlite's wasm-dependent web module is never
+// pulled into the web bundle.
 export const sqliteKeyValueStorage = {
-	getItem: (key: string) => AsyncStorage.getItem(key),
-	setItem: (key: string, value: string) => AsyncStorage.setItem(key, value),
-	removeItem: (key: string) => AsyncStorage.removeItem(key),
-	multiRemove: (keys: string[]) => AsyncStorage.multiRemove(keys),
-	clear: () => AsyncStorage.clear(),
+	getItem: (key: string) => getStorageItem(key),
+	setItem: (key: string, value: string) => setStorageItem(key, value),
+	removeItem: (key: string) => removeStorageItem(key),
+	multiRemove: async (keys: string[]) => {
+		for (const key of keys) {
+			await removeStorageItem(key);
+		}
+	},
+	clear: () => clearStorage(),
 };
 
-// Web has no separate sqlite store to migrate into - AsyncStorage already is the store.
+// Web has no separate sqlite store to migrate into - localStorage already is the store.
 export async function migrateAsyncStorageToSqlite(): Promise<{ migratedKeys: string[] }> {
 	return { migratedKeys: [] };
 }
 
-export const sqliteStorage: Storage = AsyncStorage;
+export const sqliteStorage: Storage = sqliteKeyValueStorage;

--- a/packages/common-ui/src/helpers/SqliteKeyValueStorage.web.ts
+++ b/packages/common-ui/src/helpers/SqliteKeyValueStorage.web.ts
@@ -1,27 +1,31 @@
 import { getUtf8ByteLength } from './ByteSizeHelper';
 
-// Web backend for the shared key-value storage: window.localStorage.
+// Web backend for the shared key-value storage: window.localStorage with raw
+// (unprefixed) keys.
+//
+// This is deliberately byte-identical to what apps/frontend has always done on web:
+// its redux/storage/sqliteStorage.web.ts used AsyncStorage, and AsyncStorage's web
+// implementation is itself a thin wrapper around window.localStorage with raw keys
+// (see @react-native-async-storage/async-storage/src/AsyncStorage.ts). Implementing
+// it directly on localStorage keeps that exact storage format - existing frontend web
+// data (e.g. "persist:root", "auth_data") keeps working - without making every app
+// pull the AsyncStorage native module into its binary just for this web file.
 //
 // Why not expo-sqlite or expo-file-system:
 // - expo-sqlite's web build needs Metro wasm config plus COOP/COEP response headers
 //   (for SharedArrayBuffer/OPFS) that these apps' static web exports don't set up.
-// - expo-file-system's NEW File/Paths API (SDK 54+) is a no-op stub on web: every
-//   operation only logs "expo-file-system is not supported on web" (see
-//   expo-file-system/src/ExpoFileSystem.web.ts), so `new File(...).write(...)` throws
-//   and nothing is ever persisted. Only the *legacy* API ever had a web shim, and that
-//   one is a no-op too.
-// localStorage is the same mechanism apps/frontend already uses on web (AsyncStorage's
-// web shim is localStorage-backed), it is synchronous, universally available and
-// survives reloads. Metro picks this file over SqliteKeyValueStorage.ts for web builds,
-// so expo-sqlite's wasm-dependent web module is never pulled into the web bundle.
+// - expo-file-system's new File/Paths API (SDK 54+) is a no-op stub on web: every
+//   operation only logs "expo-file-system is not supported on web", so nothing was
+//   ever persisted (only the legacy API had a web shim, and that one is a no-op too).
+// Metro picks this file over SqliteKeyValueStorage.ts for web builds, so expo-sqlite's
+// wasm-dependent web module is never pulled into the web bundle.
 
 export const DEFAULT_DB_NAME = 'app_storage.db';
 
-// Namespace prefix so getStorageUsage()/clearStorage() only ever touch keys owned by
-// this helper and never entries other libraries put into localStorage. The dbName is
-// part of the prefix for signature parity with the native per-db separation.
-function keyPrefix(dbName: string = DEFAULT_DB_NAME): string {
-	return `kv:${dbName}:`;
+// Short-lived predecessor of this implementation namespaced keys as
+// "kv:<dbName>:<key>" - migrate such entries to the raw key on first read.
+function legacyPrefixedKey(key: string, dbName: string = DEFAULT_DB_NAME): string {
+	return `kv:${dbName}:${key}`;
 }
 
 function getLocalStorage(): Storage | null {
@@ -40,56 +44,55 @@ export function getKvDatabase(dbName?: string): Promise<never> {
 export async function getStorageItem(key: string, dbName?: string): Promise<string | null> {
 	const storage = getLocalStorage();
 	if (!storage) return null;
-	return storage.getItem(keyPrefix(dbName) + key);
+	const value = storage.getItem(key);
+	if (value !== null) return value;
+	const legacyValue = storage.getItem(legacyPrefixedKey(key, dbName));
+	if (legacyValue !== null) {
+		storage.setItem(key, legacyValue);
+		storage.removeItem(legacyPrefixedKey(key, dbName));
+	}
+	return legacyValue;
 }
 
 export async function setStorageItem(key: string, value: string, dbName?: string): Promise<void> {
 	const storage = getLocalStorage();
 	if (!storage) return;
-	storage.setItem(keyPrefix(dbName) + key, value);
+	storage.setItem(key, value);
 }
 
 export async function removeStorageItem(key: string, dbName?: string): Promise<void> {
 	const storage = getLocalStorage();
 	if (!storage) return;
-	storage.removeItem(keyPrefix(dbName) + key);
+	storage.removeItem(key);
+	storage.removeItem(legacyPrefixedKey(key, dbName));
 }
 
 export type SqliteStorageKeyUsage = { key: string; bytes: number };
 
 // Powers the debug "storage usage" settings list (see SettingsListSqliteStorage) - lists
-// every key owned by this helper with its approximate size. Skips internal sentinel keys
-// wrapped in double underscores, mirroring the native implementation.
+// every localStorage key with its approximate size. Skips internal sentinel keys wrapped
+// in double underscores, mirroring the native implementation.
 export async function getStorageUsage(
 	dbName?: string
 ): Promise<{ items: SqliteStorageKeyUsage[]; totalBytes: number }> {
 	const storage = getLocalStorage();
 	if (!storage) return { items: [], totalBytes: 0 };
-	const prefix = keyPrefix(dbName);
 	const items: SqliteStorageKeyUsage[] = [];
 	for (let i = 0; i < storage.length; i++) {
-		const fullKey = storage.key(i);
-		if (fullKey === null || !fullKey.startsWith(prefix)) continue;
-		const key = fullKey.slice(prefix.length);
+		const key = storage.key(i);
+		if (key === null) continue;
 		if (key.startsWith('__') && key.endsWith('__')) continue;
-		items.push({ key, bytes: getUtf8ByteLength(storage.getItem(fullKey) ?? '') });
+		items.push({ key, bytes: getUtf8ByteLength(storage.getItem(key) ?? '') });
 	}
 	items.sort((a, b) => b.bytes - a.bytes);
 	const totalBytes = items.reduce((sum, item) => sum + item.bytes, 0);
 	return { items, totalBytes };
 }
 
+// Clears the whole localStorage - same behavior as the AsyncStorage.clear() the
+// frontend app's web storage exposed before this was shared here.
 export async function clearStorage(dbName?: string): Promise<void> {
 	const storage = getLocalStorage();
 	if (!storage) return;
-	const prefix = keyPrefix(dbName);
-	// Collect first - removing while iterating shifts localStorage's key indices.
-	const keysToRemove: string[] = [];
-	for (let i = 0; i < storage.length; i++) {
-		const fullKey = storage.key(i);
-		if (fullKey !== null && fullKey.startsWith(prefix)) keysToRemove.push(fullKey);
-	}
-	for (const fullKey of keysToRemove) {
-		storage.removeItem(fullKey);
-	}
+	storage.clear();
 }


### PR DESCRIPTION
## Was

Die gemeinsame Web-Storage-Implementierung in `packages/common-ui` (`SqliteKeyValueStorage.web.ts`) speichert jetzt mit **rohen, unpräfixten Keys direkt in `window.localStorage`** – byte-identisch zum AsyncStorage-Web-Shim, den `apps/frontend` bisher nutzte (AsyncStorages Web-Implementierung ist selbst nur eine dünne Hülle um localStorage mit rohen Keys). `apps/frontend`s `sqliteStorage.web.ts` delegiert nun an dieses gemeinsame Modul statt AsyncStorage direkt zu importieren.

Damit laufen **frontend, score-tracker und geonexia auf Web durch exakt denselben Storage-Code**. Nativ bleibt alles wie gehabt (SQLite-kv-Tabelle über `getKvDatabase`; die rocket-meals-spezifische AsyncStorage→SQLite-Migration bleibt in `apps/frontend`).

## Warum

- Score-Tracker/Geonexia persistierten auf Web zuvor über die neue File/Paths-API von expo-file-system, die dort ein No-op-Stub ist – nichts wurde gespeichert. Der Zwischenstand auf master fixt das bereits mit einem `kv:`-Namespace; dieser PR gleicht das Format an frontend an (rohe Keys) und lässt frontend denselben Code nutzen.
- Bestehende Frontend-Web-Daten (`persist:root`, `auth_data`, …) bleiben unverändert gültig, da das Speicherformat identisch ist – keine Migration nötig.
- Keys aus dem kurzlebigen `kv:<dbName>:`-Namespace werden beim ersten Lesen automatisch auf den rohen Key migriert.
- Bewusst ohne AsyncStorage-Import in common-ui gelöst: gleiches Speicherformat, aber score-tracker/geonexia bekommen kein zusätzliches natives Modul in ihre Binaries (kein Build-Number-Bump nötig).

## Verifiziert

- Playwright gegen den statischen Score-Tracker-Web-Export: Spiel anlegen → Reload → Daten vorhanden; localStorage enthält rohe Keys (`score-tracker-game.json`, `score-tracker-friends.json`, …) wie bei der Frontend-App.
- Legacy-`kv:`-Key-Migration im Browser getestet.
- Typecheck von score-tracker und frontend ohne neue Fehler.

Ersetzt den zuvor direkt gepushten und wieder revertierten Commit `92752dc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTi899EM5w8XocY24Jf6oX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTi899EM5w8XocY24Jf6oX)_