### PR TITLE
fix(common-ui): fix stacked SettingsList text collapsing to one character per line

### DIFF
--- a/packages/common-ui/src/components/SettingsList/SettingsList.tsx
+++ b/packages/common-ui/src/components/SettingsList/SettingsList.tsx
@@ -227,6 +227,7 @@ const styles = StyleSheet.create({
 		flexDirection: 'column',
 		alignItems: 'flex-start',
 		flex: 1,
+		minWidth: 0,
 	},
 	title: {
 		fontSize: 15,
@@ -238,6 +239,8 @@ const styles = StyleSheet.create({
 	},
 	titleContainerStacked: {
 		width: '100%',
+		flexShrink: 1,
+		minWidth: 0,
 	},
 	valueContainer: {
 		flexShrink: 1,
@@ -248,6 +251,8 @@ const styles = StyleSheet.create({
 	valueContainerStacked: {
 		width: '100%',
 		alignItems: 'flex-start',
+		flexShrink: 1,
+		minWidth: 0,
 	},
 	valueStacked: {
 		textAlign: 'left',


### PR DESCRIPTION
## Summary
- `SettingsList`'s stacked layout (`stackedValue`, used e.g. by the score-tracker's multi-column player tiles via `SettingsListAvatar`) was missing the `minWidth: 0` override that the non-stacked layout already has on its title/value containers.
- Without it, a flex child's implicit min-width prevents it from shrinking below its unwrapped content width. Once the row becomes narrower than that (e.g. a 2-column player tile with a large avatar), the text layout collapses and wraps almost character-by-character instead of at word boundaries.
- Added `minWidth: 0` (plus `flexShrink: 1` where missing) to `textWrapperStacked`, `titleContainerStacked`, and `valueContainerStacked`, mirroring the existing non-stacked `textWrapper`/`titleContainer` styles.

Per `AGENTS.md`, changes under `packages/common-ui` always go through a PR (even when triggered from the score-tracker app), so this fix is split out from the score-tracker-only commits already on `master`.

## Test plan
- [x] Reproduced the bug in the score-tracker app: active game screen, 2-column portrait layout, player names long enough to wrap (e.g. "Nils Codoban").
- [x] Before the fix: name text rendered one character per line with visible gaps.
- [x] After the fix: name text wraps in readable multi-character chunks at the available column width (still tight for long names next to an 84px avatar in 2-column mode, but no longer broken character-by-character).
- [x] `tsc --noEmit` on `apps/score-tracker/frontend` shows no new errors beyond the pre-existing, unrelated `nativeID` typing noise present across the whole app before this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ8cPVn7EGznhvBt9SmqTx)_