### PR TITLE
Geonexia: Red-Line auf ≤10 m (h12), Straßen/Wege-Rendering mit Farbverlauf, User-Marker-Z-Order

### DIFF
--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -905,6 +905,37 @@ export default function ActivityDetailScreen() {
 		};
 	}, []);
 
+	// Build speed-colored segments along the road-matched line so that the road
+	// rendering uses the same red/green/blue speed gradient as the raw GPS track.
+	// The matched line has a different (usually higher) point count than the raw
+	// track, so each matched point takes the speed of the raw GPS point it
+	// originated from, tracked with a monotone forward sweep (both lines follow
+	// the same path in the same order).
+	const buildRoadMatchedSegments = useCallback((matchedCoords: [number, number][], points: RoutePoint[]) => {
+		if (matchedCoords.length < 2 || points.length === 0) return [];
+		const distSq = (coord: [number, number], p: RoutePoint) => {
+			const dLng = coord[0] - p.lng;
+			const dLat = coord[1] - p.lat;
+			return dLng * dLng + dLat * dLat;
+		};
+		const speedsKmh: number[] = [];
+		let rawIdx = 0;
+		for (const coord of matchedCoords) {
+			while (rawIdx < points.length - 1 && distSq(coord, points[rawIdx + 1]) <= distSq(coord, points[rawIdx])) {
+				rawIdx++;
+			}
+			speedsKmh.push((points[rawIdx].speed ?? 0) * 3.6);
+		}
+		const segments: { coords: [[number, number], [number, number]]; speedKmh: number }[] = [];
+		for (let i = 0; i < matchedCoords.length - 1; i++) {
+			segments.push({
+				coords: [matchedCoords[i], matchedCoords[i + 1]],
+				speedKmh: (speedsKmh[i] + speedsKmh[i + 1]) / 2,
+			});
+		}
+		return segments;
+	}, []);
+
 	// Compute the bounding box of a route using a loop (avoids spread-operator stack
 	// overflow for routes with thousands of GPS points).
 	const computeRouteBounds = useCallback((points: RoutePoint[]) => {
@@ -923,8 +954,10 @@ export default function ActivityDetailScreen() {
 	}, []);
 
 	// When enabled, fetch the real road/path network around the route and snap
-	// the raw GPS points onto it, so the map can show the actual street/path
-	// that was likely walked (like a navigation route) instead of the raw track.
+	// the raw GPS points onto it, so the map shows the actual street/path that
+	// was likely walked instead of the raw track. The matched line replaces the
+	// GPS track entirely and is rendered with the same red/green/blue speed
+	// gradient as the raw track (via the routeSegments layer), not in yellow.
 	useEffect(() => {
 		if (!showRoadMatch || !mapMounted || !activity || !mapRef.current) {
 			mapRef.current?.sendToMap({ matchedRoadCoordinates: null });
@@ -947,7 +980,14 @@ export default function ActivityDetailScreen() {
 				if (cancelled) return;
 				const rawCoords: [number, number][] = activity.routePoints.map((p) => [p.lng, p.lat]);
 				const matched = matchRouteToRoads(rawCoords, ways, { junctionMode: roadMatchJunctionMode });
-				mapRef.current?.sendToMap({ matchedRoadCoordinates: matched });
+				// The dedicated yellow road-match layer stays hidden; the matched
+				// line is shown speed-colored through the routeSegments layer.
+				mapRef.current?.sendToMap({ matchedRoadCoordinates: null });
+				const roadSegments = buildRoadMatchedSegments(matched, activity.routePoints);
+				const speedRange = buildRouteSegments(activity.routePoints, activity.stats)?.speedRange;
+				if (roadSegments.length > 0 && speedRange) {
+					mapRef.current?.sendToMap({ routeSegments: roadSegments, routeSpeedRange: speedRange });
+				}
 				setLastRoadWays(ways);
 				setLastMatchedRoadCoords(matched);
 			})
@@ -956,7 +996,7 @@ export default function ActivityDetailScreen() {
 			});
 
 		return () => { cancelled = true; };
-	}, [showRoadMatch, mapMounted, activity, computeRouteBounds, roadMatchJunctionMode]);
+	}, [showRoadMatch, mapMounted, activity, computeRouteBounds, roadMatchJunctionMode, buildRoadMatchedSegments, buildRouteSegments]);
 
 	// Highlight the hex tiles selected for test-case export.
 	useEffect(() => {
@@ -1029,7 +1069,12 @@ export default function ActivityDetailScreen() {
 			: rawCoords;
 
 		const result = buildRouteSegments(activity.routePoints, activity.stats);
-		if (result && result.segments.length > 0) {
+		if (showRoadMatch) {
+			// Straßen/Wege mode: the GPS-connected track is not rendered at all.
+			// The road-match effect below sends the road-matched line as
+			// speed-colored routeSegments once the road network has been fetched.
+			mapRef.current.sendToMap({ routeSegments: null, routeCoordinates: null });
+		} else if (result && result.segments.length > 0) {
 			// Rebuild segments using the (possibly smoothed) display coordinates
 			// while preserving the speed value from each original segment.
 			const smoothedSegments = result.segments.map((seg, i) => ({
@@ -1068,7 +1113,13 @@ export default function ActivityDetailScreen() {
 					hexTileRecords,
 				);
 				mapRef.current.sendToMap({ hexTileGeoJson });
-				mapRef.current.sendToMap({ hexWalkPathGeoJson });
+				// In Straßen/Wege mode the red GPS-connected walk path is hidden as
+				// well – only the road-matched line represents the route.
+				mapRef.current.sendToMap({
+					hexWalkPathGeoJson: showRoadMatch
+						? { type: 'FeatureCollection', features: [] }
+						: hexWalkPathGeoJson,
+				});
 			} catch (err) {
 				console.warn('[ActivityDetailScreen] Failed to build activity hex GeoJSON:', err);
 			}
@@ -1189,7 +1240,7 @@ export default function ActivityDetailScreen() {
 				mapRef.current.sendToMap({ autoRotate: false });
 			}
 		};
-	}, [mapMounted, activity, buildRouteSegments, computeRouteBounds, hexTileRecords, showGpsPoints, routeSmoothingLevel]);
+	}, [mapMounted, activity, buildRouteSegments, computeRouteBounds, hexTileRecords, showGpsPoints, routeSmoothingLevel, showRoadMatch]);
 
 	// Send enclosed tiles GeoJSON to the map (light blue fill), mirroring routes/[id].tsx
 	useEffect(() => {

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -698,7 +698,7 @@ export default function ActivitiesScreen() {
 												dispatch(addWalkedEdges(edges));
 											}
 											// Record red-line edges using the activity's already-computed
-											// h11 route points (synthesized in handleSave).
+											// red-line route points (synthesized in handleSave).
 											const edgesRedLine = computeEdgesFromRoutePoints(activity.routePoints, RED_LINE_GRID_RESOLUTION);
 											if (edgesRedLine.length > 0) {
 												dispatch(addWalkedEdgesRedLine(edgesRedLine));

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -388,8 +388,10 @@ function buildWalkPathGeoJson(
 	const features: WalkPathFeature[] = [];
 	const useRedLine = (walkedEdgesRedLine && walkedEdgesRedLine.length > 0);
 	const edgesToDraw = useRedLine ? walkedEdgesRedLine : walkedEdges;
-	// Parent resolution for red-line edges: RED_LINE_GRID_RESOLUTION - 1 = 10
-	const parentRes = RED_LINE_GRID_RESOLUTION - 1;
+	// Parent resolution for the viewport check of red-line edges: the viewport
+	// tiles are rendered at h10, so red-line cells (h12, legacy h11) are mapped
+	// to their h10 parent regardless of the red-line resolution.
+	const parentRes = H3_DEFAULT_RESOLUTION;
 
 	for (const edge of edgesToDraw) {
 		const colonIdx = edge.indexOf(':');

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -32,6 +32,7 @@ import { suggestRouteNamesForHexTiles } from '../../helpers/RouteNameSuggestionH
 import { queryTileFeaturesForHexCell } from '../../helpers/TileFeatureHelper';
 import { ROUTE_NAME_LANDMARK_NAME_NULL_ALLOW } from '../../helpers/OpenMapTilesSchema';
 import { computeActivityData, findEnclosedCellsFromHexTiles, RED_LINE_GRID_RESOLUTION, MIN_TILES_FOR_ENCLOSED_POLYGON, synthesizeManualActivityRoutePoints } from '../../helpers/ActivityMapRebuildHelper';
+import { fetchRoadWaysForBounds, matchRouteToRoads } from '../../helpers/RoadMatchHelper';
 import type { AppDispatch, RootState } from '../../store/store';
 import { startRun, markVisited, markEnclosed, addWalkedEdges } from '../../store/hexTileSlice';
 import { useDebugMode } from '../../hooks/useDebugMode';
@@ -315,6 +316,8 @@ export default function RouteDetailScreen() {
 	const [addAnchorTileIndex, setAddAnchorTileIndex] = useState<number | null>(null);
 	const [routeActivities, setRouteActivities] = useState<SavedActivity[]>([]);
 	const hexTileRecords = useSelector((state: RootState) => state.hexTiles.records);
+	const showRoadMatch = useSelector((state: RootState) => state.displaySettings.showRoadMatch);
+	const roadMatchJunctionMode = useSelector((state: RootState) => state.displaySettings.roadMatchJunctionMode);
 	const dispatch = useDispatch<AppDispatch>();
 	const isDebugMode = useDebugMode();
 	const { showAlert } = useGeonexiaAlert();
@@ -433,10 +436,15 @@ export default function RouteDetailScreen() {
 	}, [id]);
 
 	// Migration: compute walkedEdgesRedLine from the first activity's routePoints
-	// when the field is absent (older saves that pre-date this feature).
+	// when the field is absent (older saves that pre-date this feature) or when
+	// it was computed at an outdated red-line resolution (e.g. legacy h11 edges
+	// from before the switch to RED_LINE_GRID_RESOLUTION = 12).
 	useEffect(() => {
 		if (!route || !isH3Available()) return;
-		if (route.walkedEdgesRedLine !== undefined) return;
+		if (
+			route.walkedEdgesRedLine !== undefined &&
+			route.walkedEdgesRedLineResolution === RED_LINE_GRID_RESOLUTION
+		) return;
 		// Find the oldest activity with routePoints to use as the reference path.
 		// routeActivities is sorted newest-first, so iterate backwards.
 		let reference: SavedActivity | undefined;
@@ -468,7 +476,13 @@ export default function RouteDetailScreen() {
 			const { hexTileGeoJson, hexWalkPathGeoJson } = buildRouteDisplayData(route, hexTileRecords);
 			mapRef.current.sendToMap({ hexRouteOutlineMode: true });
 			mapRef.current.sendToMap({ hexTileGeoJson });
-			mapRef.current.sendToMap({ hexWalkPathGeoJson });
+			// In Straßen/Wege mode the direct cell-to-cell walk path stays hidden;
+			// the road-match effect below sends the road-matched route line instead.
+			mapRef.current.sendToMap({
+				hexWalkPathGeoJson: showRoadMatch
+					? { type: 'FeatureCollection', features: [] }
+					: hexWalkPathGeoJson,
+			});
 		} catch (err) {
 			console.warn('[RouteDetailScreen] Failed to build route display GeoJSON:', err);
 		}
@@ -504,7 +518,56 @@ export default function RouteDetailScreen() {
 				mapRef.current.sendToMap({ autoRotate: false });
 			}
 		};
-	}, [mapMounted, route, hexTileRecords]);
+	}, [mapMounted, route, hexTileRecords, showRoadMatch]);
+
+	// ── Straßen/Wege mode: render the route snapped onto the real road/path
+	// network. The route geometry starts from the red-line (hx) cell centres:
+	// each h10 tile is mapped to its center-child at RED_LINE_GRID_RESOLUTION
+	// and gaps are filled along the red-line grid (synthesizeManualActivityRoutePoints),
+	// then the resulting polyline is matched onto the fetched road network and
+	// sent as the walk-path line in place of the direct cell-to-cell path.
+	useEffect(() => {
+		if (!showRoadMatch || !mapMounted || !route || !mapRef.current) return;
+		if (!isH3Available() || route.hexTiles.length === 0) return;
+
+		// Synthetic points along the red-line grid; only the coordinates are
+		// used here, so duration/distance are dummy values.
+		const redLinePoints = synthesizeManualActivityRoutePoints(route.hexTiles, 0, 1, 0);
+		const redLineCoords: [number, number][] = redLinePoints.map((p) => [p.lng, p.lat]);
+		if (redLineCoords.length < 2) return;
+
+		const bounds = computeHexBounds(route.hexTiles);
+		if (!bounds) return;
+
+		let cancelled = false;
+		const marginDeg = 0.01; // ~1km padding so nearby roads just outside the route's bbox are still found
+		fetchRoadWaysForBounds({
+			minLat: bounds.minLat - marginDeg,
+			minLng: bounds.minLng - marginDeg,
+			maxLat: bounds.maxLat + marginDeg,
+			maxLng: bounds.maxLng + marginDeg,
+		})
+			.then((ways) => {
+				if (cancelled || !mapRef.current) return;
+				const matched = matchRouteToRoads(redLineCoords, ways, { junctionMode: roadMatchJunctionMode });
+				if (matched.length < 2) return;
+				mapRef.current.sendToMap({
+					hexWalkPathGeoJson: {
+						type: 'FeatureCollection',
+						features: [{
+							type: 'Feature',
+							geometry: { type: 'LineString', coordinates: matched },
+							properties: {},
+						}],
+					},
+				});
+			})
+			.catch((err) => {
+				console.warn('[RouteDetailScreen] Failed to match route to roads:', err);
+			});
+
+		return () => { cancelled = true; };
+	}, [showRoadMatch, mapMounted, route, roadMatchJunctionMode]);
 
 	// ── Fetch tile features for each hex tile using TileFeatureHelper ────
 	useEffect(() => {

--- a/apps/geonexia/frontend/assets/hexTileScript.ts
+++ b/apps/geonexia/frontend/assets/hexTileScript.ts
@@ -555,6 +555,8 @@ export const HEX_TILE_SCRIPT = `
     var ROUTE_LAYER_IDS = [
       'route-seg-border-layer',
       'route-seg-color-layer',
+      'road-match-border-layer',
+      'road-match-color-layer',
     ];
     for (var ri = 0; ri < ROUTE_LAYER_IDS.length; ri++) {
       if (map.getLayer(ROUTE_LAYER_IDS[ri])) map.moveLayer(ROUTE_LAYER_IDS[ri]);
@@ -565,6 +567,18 @@ export const HEX_TILE_SCRIPT = `
     var BILLBOARD_LAYER_REF = 'billboard-3d-layer';
     if (map.getLayer(BILLBOARD_LAYER_REF)) {
       map.moveLayer(BILLBOARD_LAYER_REF);
+    }
+    // Marker-like point layers (route start, raw GPS points, replay player)
+    // must always stay above route/road lines and billboards so the user/player
+    // marker is never covered. NOTE: ids must match the MapLibre HTML
+    // (index.html) and REPLAY_PLAYER_LAYER below.
+    var MARKER_LAYER_IDS = [
+      'route-start-layer',
+      'debug-gps-points-layer',
+      REPLAY_PLAYER_LAYER,
+    ];
+    for (var mi = 0; mi < MARKER_LAYER_IDS.length; mi++) {
+      if (map.getLayer(MARKER_LAYER_IDS[mi])) map.moveLayer(MARKER_LAYER_IDS[mi]);
     }
     notifyViewport();
   }

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -32,18 +32,30 @@ import { computeEdgesFromRoutePoints } from './RouteDisplayHelper';
  * in a way that should force all users' worlds to be recalculated from their
  * activity history on the next app start.
  */
-export const WORLD_BUILDING_ID = 16;
+export const WORLD_BUILDING_ID = 17;
 
 /** Fallback H3 resolution used for activities that pre-date the stored field. */
 export const H3_RESOLUTION_FALLBACK = 10;
 
 /**
- * H3 resolution used for the red walk-path line drawn on the map.  One step
- * finer than the displayed h10 tile resolution, giving a more accurate line.
+ * Maximum desired spacing (in metres) between consecutive red-line points.
+ * The red-line resolution below is chosen as the coarsest H3 resolution whose
+ * average edge length stays within this limit.
+ */
+export const RED_LINE_MAX_POINT_SPACING_METERS = 10;
+
+/**
+ * H3 resolution used for the red walk-path line drawn on the map.
  * This is the single authoritative definition — all red-line edge computations
  * import this constant rather than hard-coding the number.
+ *
+ * Resolution 12 is the coarsest H3 resolution whose average edge length
+ * (~9.4 m, see https://h3geo.org/docs/core-library/restable) stays within
+ * {@link RED_LINE_MAX_POINT_SPACING_METERS}; resolution 11 (previously used)
+ * averages ~24.9 m.  Legacy h11 edges stored on activities/routes are
+ * migrated lazily on load and via the {@link WORLD_BUILDING_ID} world rebuild.
  */
-export const RED_LINE_GRID_RESOLUTION = 11;
+export const RED_LINE_GRID_RESOLUTION = 12;
 
 const H3_RESOLUTION_MIN = 0;
 const H3_RESOLUTION_MAX = 15;
@@ -522,29 +534,29 @@ export function synthesizeManualActivityRoutePoints(
 		? (distanceKm * 1000) / durationSeconds
 		: 0;
 
-	// Build a fine-grained h11 path:
-	//  1. Convert every h10 tile to its h11 center-child.
-	//  2. Between consecutive h11 cells, fill in intermediate h11 cells using
-	//     gridPathCells so the synthetic route points follow the actual h11 grid
-	//     instead of jumping from h10 centre to h10 centre.
-	const h11Path: string[] = [];
+	// Build a fine-grained red-line path:
+	//  1. Convert every h10 tile to its center-child at RED_LINE_GRID_RESOLUTION.
+	//  2. Between consecutive red-line cells, fill in intermediate cells using
+	//     gridPathCells so the synthetic route points follow the actual red-line
+	//     grid instead of jumping from h10 centre to h10 centre.
+	const redLinePath: string[] = [];
 	for (let i = 0; i < hexTilesOrdered.length; i++) {
 		try {
-			const h11Cell = cellToCenterChild(hexTilesOrdered[i], RED_LINE_GRID_RESOLUTION) || hexTilesOrdered[i];
-			if (h11Path.length === 0) {
-				h11Path.push(h11Cell);
+			const redLineCell = cellToCenterChild(hexTilesOrdered[i], RED_LINE_GRID_RESOLUTION) || hexTilesOrdered[i];
+			if (redLinePath.length === 0) {
+				redLinePath.push(redLineCell);
 			} else {
-				const prev = h11Path[h11Path.length - 1];
-				if (prev === h11Cell) continue;
+				const prev = redLinePath[redLinePath.length - 1];
+				if (prev === redLineCell) continue;
 				try {
-					const pathCells = gridPathCells(prev, h11Cell);
+					const pathCells = gridPathCells(prev, redLineCell);
 					// pathCells[0] is prev (already included); add the rest.
 					for (let j = 1; j < pathCells.length; j++) {
-						h11Path.push(pathCells[j]);
+						redLinePath.push(pathCells[j]);
 					}
 				} catch {
 					// Cells on different icosahedron faces – add directly.
-					h11Path.push(h11Cell);
+					redLinePath.push(redLineCell);
 				}
 			}
 		} catch {
@@ -552,15 +564,15 @@ export function synthesizeManualActivityRoutePoints(
 		}
 	}
 
-	if (h11Path.length === 0) return [];
+	if (redLinePath.length === 0) return [];
 
 	// Distribute timestamps evenly: first point at startedAt, last at startedAt + durationMs.
-	const step = h11Path.length > 1 ? durationMs / (h11Path.length - 1) : 0;
+	const step = redLinePath.length > 1 ? durationMs / (redLinePath.length - 1) : 0;
 
 	const points: RoutePoint[] = [];
-	for (let i = 0; i < h11Path.length; i++) {
+	for (let i = 0; i < redLinePath.length; i++) {
 		try {
-			const [lat, lng] = cellToLatLng(h11Path[i]);
+			const [lat, lng] = cellToLatLng(redLinePath[i]);
 			points.push({
 				lat,
 				lng,

--- a/packages/common-ui/assets/maplibre/index.html
+++ b/packages/common-ui/assets/maplibre/index.html
@@ -3726,6 +3726,10 @@
         position: relative;
         width: 18px;
         height: 18px;
+        /* Keep the user marker above the 2D route-track canvas overlay
+           (z-index 1, see initRouteTrackCanvas) so the marker is always
+           rendered on top of route and path lines. */
+        z-index: 2;
       }
       #error {
         display: none;
@@ -5207,11 +5211,14 @@
 
       function initRouteTrackCanvas() {
         // Create a transparent canvas and append it inside the map container so
-        // it is positioned above the WebGL canvas but MapLibre HTML markers
-        // (appended after it) appear on top of the route line.
+        // it is positioned above the WebGL canvas. MapLibre HTML markers live in
+        // the canvas container (an earlier sibling), so without an explicit
+        // z-index this overlay would cover them: z-index 1 here combined with
+        // z-index 2 on .user-location-wrapper keeps the user marker on top of
+        // the route line.
         var container = map.getContainer();
         routeTrackCanvas = document.createElement('canvas');
-        routeTrackCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;';
+        routeTrackCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:1;';
         container.appendChild(routeTrackCanvas);
         syncRouteTrackCanvasSize();
         window.addEventListener('resize', function () {
@@ -5224,6 +5231,20 @@
       function updateRouteTrackLayer(coords) {
         routeTrackCoords = (coords && coords.length > 0) ? coords : null;
         drawRouteTrackCanvas();
+      }
+
+      // ─── Marker-like point layers ──────────────────────────────────────────────
+      // Circle layers that represent positions (route start, raw GPS points,
+      // replay player) must always render above route/road line layers. Called
+      // after (re)creating any line layer so newly added lines never cover them.
+      // NOTE: 'replay-player-layer' is created by the injected hexTileScript
+      // (Geonexia); the id must stay in sync with REPLAY_PLAYER_LAYER there.
+      function raiseMarkerLikeLayers() {
+        if (!map) return;
+        var ids = ['route-start-layer', 'debug-gps-points-layer', 'replay-player-layer'];
+        for (var i = 0; i < ids.length; i++) {
+          if (map.getLayer(ids[i])) map.moveLayer(ids[i]);
+        }
       }
 
       // ─── Speed-colored route segments (activity detail view) ──────────────────
@@ -5315,6 +5336,7 @@
             },
           });
         }
+        raiseMarkerLikeLayers();
       }
       // ─────────────────────────────────────────────────────────────────────────────
 
@@ -5355,6 +5377,7 @@
             paint: { 'line-color': '#eab308', 'line-width': ROUTE_LINE_WIDTH_EXPR, 'line-opacity': 0.95 },
           });
         }
+        raiseMarkerLikeLayers();
       }
 
       // ─── Selected hex tiles (test-case export tooling) ─────────────────────────


### PR DESCRIPTION
## Zusammenfassung

### 1. Red-Line-Auflösung: h11 → h12 (max. 10 m Punktabstand)
- Neue Konstante `RED_LINE_MAX_POINT_SPACING_METERS = 10`; `RED_LINE_GRID_RESOLUTION` ist jetzt **12** — die gröbste H3-Auflösung, deren mittlere Kantenlänge (~9,4 m) innerhalb von 10 m bleibt (h11 lag bei ~24,9 m).
- Der Viewport-Filter der Walk-Path-Linie mappt Red-Line-Zellen jetzt über die feste h10-Anzeige-Auflösung auf ihre Eltern-Kachel (statt `RED_LINE_GRID_RESOLUTION - 1`), damit alte h11- und neue h12-Edges gleichermaßen funktionieren.

### 2. Migration der bestehenden h11-Daten
- `WORLD_BUILDING_ID` 16 → 17: Beim nächsten App-Start wird die Welt (inkl. globaler `walkedEdgesRedLine`) aus der Aktivitätshistorie mit der neuen Auflösung neu aufgebaut.
- Routen: Die bestehende Lazy-Migration im Routen-Detailscreen greift jetzt auch, wenn `walkedEdgesRedLineResolution` von der aktuellen Auflösung abweicht (nicht nur wenn das Feld fehlt) — die Edges werden aus den GPS-Punkten der Referenz-Aktivität neu berechnet.
- Aktivitäten benötigen keine Migration: Der Aktivitäts-Detailscreen berechnet die Red-Line stets live aus den GPS-Punkten.

### 3. Straßen/Wege-Modus (showRoadMatch)
- **Aktivitäts-Detail:** Bei aktivem Modus werden die GPS-verbundenen Linien (speed-gefärbter Track + rote Walk-Path-Linie) nicht mehr gerendert. Stattdessen nur noch die auf das Straßen-/Wegenetz gematchte Linie — nicht mehr gelb, sondern mit dem bestehenden rot/grün/blau-Geschwindigkeits-Farbverlauf (gleiche `routeSegments`-Pipeline wie bisher der GPS-Track). Die Geschwindigkeiten werden per monotonem Nearest-Point-Sweep von den GPS-Punkten auf die gematchte Linie übertragen.
- **Routen-Detail:** Bei aktivem Modus wird die Routenlinie ebenfalls straßenbasiert gerendert — ausgehend von den h12-Zellmittelpunkten (Center-Children der geordneten Tiles, Lücken über das Red-Line-Grid gefüllt), auf das Wegenetz gematcht und anstelle der direkten Zell-zu-Zell-Linie angezeigt.

### 4. User-Marker immer über Routen/Linien
- Die Aufnahme-Routenlinie wird auf einem 2D-Canvas-Overlay gezeichnet, das bisher **nach** dem Marker-Container ins DOM eingehängt wurde und den User-Marker überdeckte. Das Overlay hat jetzt `z-index: 1`, der Marker `z-index: 2`.
- Marker-artige Punkt-Layer (Routen-Start, GPS-Punkte, Replay-Player) werden nach jedem (Neu-)Aufbau von Linien-/Hex-Layern wieder über die Linien gehoben.

## Verifikation
- TypeScript-Check vorher/nachher verglichen: keine neuen Fehler (alle gemeldeten existieren identisch auf `master`).
- Jest: 34/34 Tests grün, identisch zur Baseline (2 Suites schlagen lokal an einem vorbestehenden expo-sqlite/jest-expo-Importproblem fehl, unabhängig von diesem PR). Keine Tests hängen an der Red-Line-Auflösung.

## Hinweise
- Der Straßen/Wege-Modus in der Routen-Vorschau auf dem Aufnahme-Screen ist bewusst nicht enthalten (dort bleibt die direkte Linie); Umsetzung wäre ein Folgeschritt.
- Beim ersten App-Start nach dem Update läuft einmalig der World-Rebuild (kann bei großer Aktivitätshistorie kurz dauern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2L8N523Yx5CRtvPvFS2WS

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2L8N523Yx5CRtvPvFS2WS)_