### PR TITLE
Bottom-Sheet-Modals: BottomSheetTextInput-Pflicht dokumentieren und verbleibende plain TextInputs fixen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,25 @@ Bei React-Dateien sollen **Styles, Export und Logik in derselben Datei** bleiben
 
 - **Never use React Native's `Alert` in Geonexia.** Use `useMyScrollviewModal` instead for all user-facing dialogs, confirmations, and notifications.
 
+## Bottom-Sheet-Modals: Texteingaben müssen `BottomSheetTextInput` verwenden
+
+Gilt für **alle Apps** (`apps/frontend`, `apps/geonexia`, `apps/score-tracker`) und `packages/common-ui`.
+
+- **Niemals ein plain `TextInput` aus `react-native` innerhalb von Bottom-Sheet-Modal-Inhalten rendern.** Das betrifft alles, was über `useMyScrollViewModal().show({ children })` bzw. `useModal` angezeigt wird oder sonst innerhalb von `BaseBottomSheet` / `MyScrollViewModal` (aus `repo-depkit-common-ui`) landet — auch Sheet-Komponenten wie `*Sheet.tsx`.
+- **Grund:** Das Keyboard-Tracking von `@gorhom/bottom-sheet` erkennt nur `BottomSheetTextInput`. Ein plain `TextInput` ist dafür unsichtbar, das Sheet schiebt sich beim Öffnen der Tastatur **nicht** nach oben und die Tastatur verdeckt das Eingabefeld (besonders auf Android mit Edge-to-Edge; siehe Fix in `packages/common-ui/src/components/BaseBottomSheet/index.tsx`, `android_keyboardInputMode="adjustPan"`).
+- **Muster** (Web kennt kein Sheet-Keyboard-Handling, daher Fallback):
+  ```tsx
+  import { Platform, TextInput } from 'react-native';
+  import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
+
+  const ResolvedTextInput = Platform.OS === 'web' ? TextInput : BottomSheetTextInput;
+  ```
+- **Vorhandene Helper wiederverwenden statt neu bauen:**
+  - Geonexia: `apps/geonexia/frontend/components/ModalTextInput.tsx`
+  - Frontend-App: `ResolvedTextInput` in `apps/frontend/app/components/SettingsListTextInput.tsx`
+  - common-ui: `SettingsListTextInput`, `SettingsListNumberInput`, `SettingsListDate` folgen dem Muster bereits.
+- `TextInput` auf normalen Screens (außerhalb von Sheets) ist in Ordnung.
+
 ## String replacement
 
 - **Never use `String.prototype.replaceAll()` or `String.prototype.replace()` for simple substitutions.** Use `StringHelper` from `repo-depkit-common` instead:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,9 @@ Gilt für **alle Apps** (`apps/frontend`, `apps/geonexia`, `apps/score-tracker`)
   ```
 - **Vorhandene Helper wiederverwenden statt neu bauen:**
   - Geonexia: `apps/geonexia/frontend/components/ModalTextInput.tsx`
-  - Frontend-App: `ResolvedTextInput` in `apps/frontend/app/components/SettingsListTextInput.tsx`
+  - Frontend-App: `apps/frontend/app/components/ModalTextInput.tsx`
   - common-ui: `SettingsListTextInput`, `SettingsListNumberInput`, `SettingsListDate` folgen dem Muster bereits.
-- `TextInput` auf normalen Screens (außerhalb von Sheets) ist in Ordnung.
+- `TextInput` auf normalen Screens (außerhalb von Sheets) ist in Ordnung. **Achtung umgekehrt:** `BottomSheetTextInput` wirft auf Native außerhalb eines BottomSheet — Komponenten, die sowohl auf Screens als auch in Sheets verwendet werden, brauchen einen Opt-in-Prop (siehe `insideBottomSheet` in `apps/frontend/app/components/SingleLineInput/SingleLineInput.tsx`).
 
 ## String replacement
 

--- a/apps/frontend/app/app/(app)/map/index.tsx
+++ b/apps/frontend/app/app/(app)/map/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Keyboard, Platform, SafeAreaView, ScrollView, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Alert, Keyboard, Platform, SafeAreaView, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { TranslationKeys } from '@/locales/keys';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
@@ -243,7 +244,7 @@ const OsmSettingsContent: React.FC<OsmSettingsContentProps> = ({
 				title="Cluster-Abstand (px)"
 				leftIcon={<MaterialCommunityIcons name="dots-grid" size={20} color={theme.screen.icon} />}
 				rightElement={
-					<TextInput
+					<ModalTextInput
 						value={localClusterDistance}
 						onChangeText={(text) => {
 							setLocalClusterDistance(text);
@@ -371,7 +372,7 @@ const OsmSettingsContent: React.FC<OsmSettingsContentProps> = ({
 					title="Anzahl simulierter Menschen"
 					leftIcon={<MaterialIcons name="person-add" size={20} color={theme.screen.icon} />}
 					rightElement={
-						<TextInput
+						<ModalTextInput
 							value={localPeopleCount}
 							onChangeText={(text) => {
 								setLocalPeopleCount(text);

--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Dimensions, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import { router } from 'expo-router';
 import { useDispatch } from 'react-redux';
 import styles from './styles';
@@ -117,7 +118,7 @@ const Index = () => {
 			title: intervalLabel,
 			children: (
 				<View style={[styles.modalContent, { paddingHorizontal: windowWidth < 600 ? 5 : 30 }]}>
-					<TextInput
+					<ModalTextInput
 						style={{
 							...styles.input,
 							color: 'black',

--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -1,7 +1,8 @@
-import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import React, { useState } from 'react';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import { CalendarSheetProps, Direction } from './types';
 import MyScrollViewModal from '@/components/MyScrollViewModal';
 import { isWeb } from '@/constants/Constants';
@@ -107,7 +108,7 @@ export const CalendarSheetContent: React.FC<CalendarSheetProps> = ({ closeSheet,
     return (
         <>
             <View style={styles.manualInputWrapper}>
-                <TextInput
+                <ModalTextInput
                     style={[
                         styles.manualInput,
                         {

--- a/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Dimensions, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import { FontAwesome5, MaterialCommunityIcons } from '@expo/vector-icons';
 import { useDispatch } from 'react-redux';
 import { days } from '../../constants/SettingData';
@@ -8,6 +8,7 @@ import { BaseCourseTimetableEvent, CourseBottomSheetProps } from './types';
 import styles from './styles';
 import { isWeb } from '@/constants/Constants';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { UPDATE_PROFILE } from '@/redux/Types/types';
 import { colorData } from './constant';
@@ -325,7 +326,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 						</View>
 					) : (
 						<View style={styles.titleBt}>
-							<TextInput style={styles.input} value={inputValue} onChangeText={setInputValue} placeholder={'Enter a value'} autoFocus />
+							<ModalTextInput style={styles.input} value={inputValue} onChangeText={setInputValue} placeholder={'Enter a value'} autoFocus />
 
 							<View style={[styles.buttonContainer]}>
 								<TouchableOpacity

--- a/apps/frontend/app/components/DropdownInput/DropdownSheet.tsx
+++ b/apps/frontend/app/components/DropdownInput/DropdownSheet.tsx
@@ -138,6 +138,7 @@ const DropdownSheet: React.FC<DropdownSheetProps> = ({ closeSheet, options, allo
                 error={error || ''}
                 isDisabled={!!isDisabled}
                 custom_type="string"
+                insideBottomSheet
                 prefix={prefix}
                 suffix={suffix}
                 autoFocus

--- a/apps/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
+++ b/apps/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
@@ -1,8 +1,9 @@
-import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 import React, { useState } from 'react';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import { isWeb } from '@/constants/Constants';
 import { sheetProps } from './types';
 import { useDispatch } from 'react-redux';
@@ -66,7 +67,7 @@ const EditFormSubmissionSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
 						...styles.inputContainer,
 					}}
 				>
-					<TextInput style={[styles.input, { color: theme.screen.text }]} cursorColor={theme.screen.text} placeholderTextColor={theme.screen.placeholder} onChangeText={setAlias} value={alias || ''} placeholder="Type here..." />
+					<ModalTextInput style={[styles.input, { color: theme.screen.text }]} cursorColor={theme.screen.text} placeholderTextColor={theme.screen.placeholder} onChangeText={setAlias} value={alias || ''} placeholder="Type here..." />
 				</View>
 				<View style={styles.actionContainer}>
 					<TouchableOpacity

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Platform, RefreshControl, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Platform, RefreshControl, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import { useLanguage } from '@/hooks/useLanguage';
 import { myContrastColor } from '@/helper/ColorHelper';
 import { useAppSelector } from '@/redux/hooks';
@@ -145,7 +146,7 @@ const ScanModalContent: React.FC<ScanModalContentProps> = ({ onSubmit, checkAlre
 		// Manual-only input mode
 		return (
 			<View style={scanStyles.container}>
-				<TextInput
+				<ModalTextInput
 					style={[
 						scanStyles.manualInput,
 						{

--- a/apps/frontend/app/components/ManagementFoodCategorySheet/ManagementFoodCategorySheet.tsx
+++ b/apps/frontend/app/components/ManagementFoodCategorySheet/ManagementFoodCategorySheet.tsx
@@ -1,8 +1,9 @@
-import { Dimensions, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import { ManagementFoodCategorySheetProps } from './types';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
+import ModalTextInput from '@/components/ModalTextInput';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/redux/hooks';
@@ -111,7 +112,7 @@ export const ManagementFoodCategoryContent: React.FC<ManagementFoodCategorySheet
 			</View>
 			{isCustom ? (
 				<View style={styles.modalContent}>
-					<TextInput
+					<ModalTextInput
 						style={{
 							...styles.input,
 							color: 'black',

--- a/apps/frontend/app/components/ModalTextInput.tsx
+++ b/apps/frontend/app/components/ModalTextInput.tsx
@@ -1,0 +1,20 @@
+import { Platform, TextInput } from 'react-native';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
+
+/**
+ * Text input for use inside bottom-sheet modal content (anything shown via
+ * useMyScrollViewModal / showScrollViewModal or rendered inside a @gorhom
+ * BottomSheet).
+ *
+ * Plain react-native TextInputs are invisible to @gorhom/bottom-sheet's
+ * keyboard tracking, so the sheet does not lift above the keyboard when they
+ * gain focus. BottomSheetTextInput registers with the sheet and triggers its
+ * keyboard avoidance (see BaseBottomSheet in common-ui). On web the sheet
+ * handles no keyboard, so the plain TextInput is used there.
+ *
+ * Only use this inside sheet content — BottomSheetTextInput throws when
+ * rendered outside a BottomSheet on native.
+ */
+const ModalTextInput = Platform.OS === 'web' ? TextInput : BottomSheetTextInput;
+
+export default ModalTextInput;

--- a/apps/frontend/app/components/SingleLineInput/SingleLineInput.tsx
+++ b/apps/frontend/app/components/SingleLineInput/SingleLineInput.tsx
@@ -2,15 +2,20 @@ import { Text, View } from 'react-native';
 import React from 'react';
 import styles from './styles';
 import { TextInput } from 'react-native-gesture-handler';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/hooks/useTheme';
 import { useLanguage } from '@/hooks/useLanguage';
 import { isWeb } from '@/constants/Constants';
 import { TranslationKeys } from '@/locales/keys';
 
-const SingleLineInput = ({ id, value, onChange, error, isDisabled, custom_type, prefix, suffix, autoFocus }: { id: string; value: string; onChange: (id: string, value: string, custom_type: string) => void; error: string; isDisabled: boolean; custom_type: string; prefix: string | null | undefined; suffix: string | null | undefined; autoFocus?: boolean }) => {
+const SingleLineInput = ({ id, value, onChange, error, isDisabled, custom_type, prefix, suffix, autoFocus, insideBottomSheet }: { id: string; value: string; onChange: (id: string, value: string, custom_type: string) => void; error: string; isDisabled: boolean; custom_type: string; prefix: string | null | undefined; suffix: string | null | undefined; autoFocus?: boolean; insideBottomSheet?: boolean }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const flag = !suffix && !prefix;
+	// Inside bottom-sheet content the input must be BottomSheetTextInput, otherwise
+	// the sheet's keyboard tracking cannot see it and the keyboard covers the field.
+	// BottomSheetTextInput throws outside a sheet, so it must stay opt-in.
+	const ResolvedTextInput = !isWeb && insideBottomSheet ? BottomSheetTextInput : TextInput;
 
 	return (
 		<View style={styles.container}>
@@ -29,7 +34,7 @@ const SingleLineInput = ({ id, value, onChange, error, isDisabled, custom_type, 
 						<Text style={{ ...styles.label, color: theme.screen.text }}>{prefix}</Text>
 					</View>
 				)}
-				<TextInput
+				<ResolvedTextInput
 					style={[
 						styles.input,
 						{

--- a/packages/common-ui/src/components/FeatureWishesScreen/FeatureWishesScreen.tsx
+++ b/packages/common-ui/src/components/FeatureWishesScreen/FeatureWishesScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { FlatList, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { useTheme } from '../../context/ThemeContext';
@@ -361,6 +362,11 @@ interface CreateWishContentProps {
 	onConfirm: (description: string) => void;
 }
 
+// Text inputs inside the bottom-sheet modal must use BottomSheetTextInput so the
+// sheet lifts above the keyboard (plain TextInputs are invisible to the sheet's
+// keyboard tracking). Web has no sheet keyboard handling, so it keeps TextInput.
+const ResolvedTextInput = Platform.OS === 'web' ? TextInput : BottomSheetTextInput;
+
 const CreateWishContent: React.FC<CreateWishContentProps> = ({
 	descriptionPlaceholder,
 	createConfirmLabel,
@@ -374,7 +380,7 @@ const CreateWishContent: React.FC<CreateWishContentProps> = ({
 
 	return (
 		<View style={createStyles.container}>
-			<TextInput
+			<ResolvedTextInput
 				style={[
 					createStyles.descriptionInput,
 					{

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -125,7 +125,8 @@
  *   own BottomSheetScrollView — that is fine.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import * as Clipboard from 'expo-clipboard';
 import MyAvatar, { AvatarStyle, AvatarSize, STYLE_MAP, AvatarConfig, AvatarAppearanceProps, getStyleProbabilityKeys } from '../MyAvatar';
 import { Style } from '@dicebear/core';
@@ -1009,6 +1010,11 @@ type DebugJsonInputProps = {
 	theme: any;
 };
 
+// Text inputs inside the bottom-sheet modal must use BottomSheetTextInput so the
+// sheet lifts above the keyboard (plain TextInputs are invisible to the sheet's
+// keyboard tracking). Web has no sheet keyboard handling, so it keeps TextInput.
+const ResolvedTextInput = Platform.OS === 'web' ? TextInput : BottomSheetTextInput;
+
 const DebugJsonInput: React.FC<DebugJsonInputProps> = ({ config, onApply, accentColor, theme }) => {
 	const [jsonText, setJsonText] = useState<string>(JSON.stringify(config, null, 2));
 	const [error, setError] = useState<string | null>(null);
@@ -1045,7 +1051,7 @@ const DebugJsonInput: React.FC<DebugJsonInputProps> = ({ config, onApply, accent
 			<Text style={[styles.debugJson, { color: theme.screen.text }]}>
 				{JSON.stringify(config, null, 2)}
 			</Text>
-			<TextInput
+			<ResolvedTextInput
 				style={[styles.debugJsonInput, { color: theme.screen.text, borderColor: theme.screen.text + '33' }]}
 				multiline
 				value={jsonText}

--- a/packages/common-ui/src/components/MyCustomColorPicker/index.tsx
+++ b/packages/common-ui/src/components/MyCustomColorPicker/index.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { GestureResponderEvent, LayoutChangeEvent, PanResponder, StyleSheet, TextInput, View } from 'react-native';
+import { GestureResponderEvent, LayoutChangeEvent, PanResponder, Platform, StyleSheet, TextInput, View } from 'react-native';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import Svg, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg';
 import { useTheme } from '../../context/ThemeContext';
+
+// Text inputs inside the bottom-sheet modal must use BottomSheetTextInput so the
+// sheet lifts above the keyboard (plain TextInputs are invisible to the sheet's
+// keyboard tracking). Web has no sheet keyboard handling, so it keeps TextInput.
+const ResolvedTextInput = Platform.OS === 'web' ? TextInput : BottomSheetTextInput;
 
 /**
  * MyCustomColorPicker — a dependency-free custom color selector.
@@ -301,7 +307,7 @@ const MyCustomColorPicker: React.FC<MyCustomColorPickerProps> = ({ color, onColo
 
 			{/* Hex input + preview swatch */}
 			<View style={styles.hexRow}>
-				<TextInput
+				<ResolvedTextInput
 					style={[
 						styles.hexInput,
 						{


### PR DESCRIPTION
## Zusammenfassung

Plain `TextInput` aus `react-native` ist für das Keyboard-Tracking von `@gorhom/bottom-sheet` unsichtbar — Sheets mit solchen Eingabefeldern schieben sich beim Öffnen der Tastatur **nicht** nach oben (die Tastatur verdeckt das Feld, besonders auf Android mit Edge-to-Edge). Der Fix ist das bestehende Muster `Platform.OS === 'web' ? TextInput : BottomSheetTextInput` (wie in `SettingsListTextInput`).

Dieser PR:

1. **AGENTS.md**: Neue verbindliche Regel „Bottom-Sheet-Modals: Texteingaben müssen `BottomSheetTextInput` verwenden" — inkl. Begründung, Muster, Verweis auf die vorhandenen Helper pro App und Warnung, dass `BottomSheetTextInput` außerhalb eines Sheets wirft (Opt-in-Prop für dual verwendete Komponenten).
2. **Audit-Fixes** aller verbleibenden Verstöße (Audit über alle Apps + common-ui):

### apps/frontend (neuer Helper `components/ModalTextInput.tsx`)
- `EditFormSubmissionSheet` — Alias-Eingabe
- `CalendarSheet` — manuelle Datumseingabe (DD.MM.YYYY)
- `CourseBottomSheet` — Wert-Eingabe (Stundenplan)
- `ManagementFoodCategorySheet` — Custom-Kategorie-Eingabe
- `foodPlanList` — Intervall-Sheet-Eingabe (die On-Screen-Eingabe bleibt unverändert)
- `map` `OsmSettingsContent` — Cluster-Abstand & Anzahl simulierter Menschen
- `FriendsContent` `ScanModalContent` — manuelle ID-Eingabe
- `SingleLineInput` — neuer Opt-in-Prop `insideBottomSheet` (Komponente wird auch auf normalen Screens genutzt, wo `BottomSheetTextInput` werfen würde); `DropdownSheet` setzt ihn für die Custom-Wert-Eingabe

### packages/common-ui (lokales `ResolvedTextInput`-Muster wie in `SettingsListTextInput`)
- `FeatureWishesScreen` — Wunsch-Beschreibung im Create-Modal (Such-Eingabe auf dem Screen bleibt plain)
- `MyCustomColorPicker` — Hex-Eingabe
- `MyAvatarEditor` — Debug-JSON-Eingabe

Geonexia- und Score-Tracker-Funde wurden bereits direkt auf `master` gefixt bzw. waren bereits konform (Score-Tracker nutzt das Muster überall korrekt).

## Verifikation

- `yarn tsc --noEmit` in `apps/frontend/app` und `apps/geonexia/frontend` (deckt `packages/common-ui` mit ab): vor/nach-Vergleich der Fehlerlisten — **keine neuen Fehler**, nur Zeilennummern-Verschiebungen vorbestehender Fehler.
- Alle geänderten Render-Pfade wurden geprüft: `BottomSheetTextInput` wird ausschließlich in Sheet-Inhalten gerendert; auf Web bleibt überall der plain `TextInput` (unverändertes Verhalten).

## Hinweis zu Screenshots

Kein Screenshot beigefügt: Die Änderung ist rein verhaltensbezogen (Keyboard-Avoidance auf iOS/Android); im Ruhezustand und auf Web (Playwright-Screenshots) ist die UI pixelidentisch, da Web weiterhin den plain `TextInput` rendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Pr3Js5RzgZgzqysk9ooUs

---
_Generated by [Claude Code](https://claude.ai/code/session_016Pr3Js5RzgZgzqysk9ooUs)_