### PR TITLE
fix: SonarCloud Security-Hotspots und Reliability-Bugs beheben (MathHelper für Zufallswerte)

### DIFF
--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -27,7 +27,10 @@ jobs:
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        run: yarn install --immutable
+        # --mode=skip-build disables dependency lifecycle scripts (postinstall etc.):
+        # this job only needs ts-node to call the App Store Connect API, so no
+        # third-party package gets to execute arbitrary code during install.
+        run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
         uses: ./.github/actions/prepare-asc-api-key

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -27,7 +27,10 @@ jobs:
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        run: yarn install --immutable
+        # --mode=skip-build disables dependency lifecycle scripts (postinstall etc.):
+        # this job only needs ts-node to call the App Store Connect API, so no
+        # third-party package gets to execute arbitrary code during install.
+        run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
         uses: ./.github/actions/prepare-asc-api-key

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -27,7 +27,10 @@ jobs:
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        run: yarn install --immutable
+        # --mode=skip-build disables dependency lifecycle scripts (postinstall etc.):
+        # this job only needs ts-node to call the App Store Connect API, so no
+        # third-party package gets to execute arbitrary code during install.
+        run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
         uses: ./.github/actions/prepare-asc-api-key

--- a/apps/accessibilityTester/src/report.ts
+++ b/apps/accessibilityTester/src/report.ts
@@ -105,7 +105,7 @@ function impactEmoji(impact: ImpactLevel): string {
 }
 
 function escapeMarkdownTableCell(text: string): string {
-  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  return text.replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
 
 export function generateMarkdownReport(report: AccessibilityReport): string {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodTL1Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodTL1Parser.ts
@@ -574,7 +574,9 @@ export class FoodTL1Parser implements FoodParserInterface {
     let nutritionValuesString = parsedReportItem[FoodTL1Parser.DEFAULT_NUTRITIONS_FIELD];
     if (nutritionValuesString) {
       let kcalEndString = ' kcal)';
-      let match = nutritionValuesString.match(/\(.* kcal/gm);
+      // Digit/decimal class instead of ".*" keeps the pattern unambiguous and
+      // linear-time (SonarCloud S5852) and only matches the actual kcal number.
+      let match = nutritionValuesString.match(/\([\d.,]+ kcal/gm);
       // e. G. (XXXXXXX kcal)
       if (match) {
         let kcal = match[0].slice(1, kcalEndString.length); //remove starting bracket "(" and kcal)
@@ -686,7 +688,9 @@ export class FoodTL1Parser implements FoodParserInterface {
   static getMarkingLabelsDictFromFoodName(name: string) {
     let markingsDict: { [x: string]: string } = {};
     //e. G. "Strawberries (g, b) with Cream (2)"
-    let rawMarkingsInName = name.match(/\([^)]+\)/gm); //http://regex.inginf.units.it/
+    // The class excludes "(" as well, so the pattern is unambiguous and
+    // linear-time (SonarCloud S5852).
+    let rawMarkingsInName = name.match(/\([^()]+\)/gm); //http://regex.inginf.units.it/
     //e. G. ["(g, b)", "(2)"]
     if (rawMarkingsInName) {
       for (let rawMarkingsPart of rawMarkingsInName) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/aachen/FoodWebParserAachenParseHtml.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/aachen/FoodWebParserAachenParseHtml.ts
@@ -37,7 +37,11 @@ export class FoodWebParserAachenParseHtml {
 
     const paragraphText = paragraph.text().trim();
     // extract all codes and descriptions from the paragraph text
-    const regex = /\(([^)]+)\)\s*([^,(]+)/g;
+    // The code class excludes "(" and the description must start with a
+    // non-whitespace character, so the pattern is unambiguous and linear-time
+    // (SonarCloud S5852). Behavior is unchanged: whitespace-only descriptions
+    // were skipped by the `if (code && description)` check anyway.
+    const regex = /\(([^()]+)\)\s*([^\s,(][^,(]*)/g;
     let match;
     while ((match = regex.exec(paragraphText)) !== null) {
       const code = match[1]!.trim(); // e.g. "A", "A1", "1"

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
@@ -508,7 +508,9 @@ export class MaxManagerConnector implements FoodParserInterface, MarkingParserIn
                 const codeElement = $(element).find('td').first();
                 let externalIdentifier: string | undefined = undefined;
                 const codeText = codeElement.text().trim();
-                const codeMatch = codeText.match(/\(([^)]+)\)/);
+                // The class excludes "(" as well, so the pattern is unambiguous
+                // and linear-time (SonarCloud S5852).
+                const codeMatch = codeText.match(/\(([^()]+)\)/);
                 if(codeMatch && codeMatch.length > 1){
                     externalIdentifier = codeMatch[1] || undefined;
                 } else {

--- a/apps/frontend/app/app/(app)/course-timetable/index.tsx
+++ b/apps/frontend/app/app/(app)/course-timetable/index.tsx
@@ -23,7 +23,9 @@ const extractTextAndLink = (description: string) => {
 	// Remove unintended spaces between `]` and `(`
 	const cleanedDescription = StringHelper.replaceAllWithOptions({ str: description, find: ']\\s+\\(', replace: '](' });
 
-	const regex = /\[(.*?)\]\((.*?)\)/g;
+	// Negated character classes instead of lazy dots keep the pattern
+	// unambiguous and linear-time (SonarCloud S5852).
+	const regex = /\[([^[\]]*)\]\(([^()]*)\)/g;
 	const match = regex.exec(cleanedDescription);
 
 	if (match) {
@@ -104,7 +106,9 @@ const TimetableScreen = () => {
 	};
 
 	const parseMarkdown = (text: string) => {
-		const regex = /(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g;
+		// Negated character classes instead of lazy dots keep the pattern
+		// unambiguous and linear-time (SonarCloud S5852).
+		const regex = /(\*\*[^*]*\*\*|\*[^*]*\*|\[[^[\]]*\]\([^()]*\))/g;
 		const parts = text?.split(regex);
 
 		return parts?.map((part, index) => {

--- a/apps/frontend/app/app/index.tsx
+++ b/apps/frontend/app/app/index.tsx
@@ -13,7 +13,9 @@ import { markOnboardingShouldBeShownAfterLogin } from '@/helper/onboardingIntent
 
 const extractRawExpoToken = (token: string | null) => {
 	if (!token) return null;
-	const m = String(token).match(/\[(.+?)\]/);
+	// Bracket-free character class keeps the pattern unambiguous and linear-time
+	// (SonarCloud S5852); Expo tokens look like "ExponentPushToken[xxxx]".
+	const m = String(token).match(/\[([^[\]]+)\]/);
 	return m ? m[1] : token;
 };
 

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -15,13 +15,16 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 	const { primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
 
 	const getContent = () => {
-		// Regex patterns for different content types
+		// Regex patterns for different content types.
+		// The character classes exclude the opening bracket/parenthesis as well, so the
+		// patterns are unambiguous and run in linear time (SonarCloud S5852: no
+		// catastrophic backtracking).
 		const contentPatterns = {
-			email: /\[([^\]]+)]\((mailto:[^\)]+)\)/,
-			location: /\[([^\]]+)]\(((?:geo|maps):[^\)]+)\)/i,
-			link: /\[([^\]]+)]\((https?:\/\/[^\)]+)\)/,
+			email: /\[([^[\]]+)]\((mailto:[^()]+)\)/,
+			location: /\[([^[\]]+)]\(((?:geo|maps):[^()]+)\)/i,
+			link: /\[([^[\]]+)]\((https?:\/\/[^()]+)\)/,
 			image: /!\[([^\]]*)]\(([^)]+)\)/,
-			heading: /^#{1,3}\s*(.*)$/,
+			heading: /^#{1,3}[ \t]*(\S.*)?$/,
 		};
 
 		if (content) {
@@ -59,7 +62,7 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 						flushTextContent();
 
 						const level = headingMatch[0].match(/#/g)?.length || 1;
-						const headerText = headingMatch[1].trim();
+						const headerText = (headingMatch[1] ?? '').trim();
 
 						if (level === 1) {
 							while (stack.length > 1) {

--- a/apps/frontend/app/components/EmailInput/EmailInput.tsx
+++ b/apps/frontend/app/components/EmailInput/EmailInput.tsx
@@ -6,7 +6,9 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { isWeb } from '@/constants/Constants';
 import { TranslationKeys } from '@/locales/keys';
 
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Domain is matched as dot-separated, dot-free labels: unambiguous and thus
+// linear-time (no catastrophic backtracking, SonarCloud S5852).
+const emailRegex = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 const EmailInput = ({
 	id,

--- a/apps/frontend/app/constants/MarkdownPatterns.ts
+++ b/apps/frontend/app/constants/MarkdownPatterns.ts
@@ -9,9 +9,12 @@ type ContentPatterns = {
 
 const LINK_SCHEME_PATTERN = `(?:https?:\\/\\/|${UriScheme.GEO}|${UriScheme.MAPS}|${UriScheme.TEL})`;
 
+// The character classes exclude the opening bracket/parenthesis as well, so the
+// patterns are unambiguous and run in linear time (SonarCloud S5852: no
+// catastrophic backtracking).
 export const markdownContentPatterns: ContentPatterns = {
-	email: new RegExp(`\\[([^\\]]+)]\\((${UriScheme.MAILTO}[^\\)]+)\\)`),
-	link: new RegExp(`\\[([^\\]]+)]\\((${LINK_SCHEME_PATTERN}[^\\)]+)\\)`),
+	email: new RegExp(`\\[([^\\[\\]]+)]\\((${UriScheme.MAILTO}[^()]+)\\)`),
+	link: new RegExp(`\\[([^\\[\\]]+)]\\((${LINK_SCHEME_PATTERN}[^()]+)\\)`),
 	image: /!\[([^\]]*)]\(([^)]+)\)/,
-	heading: /^#{1,6}\s*(.*)$/,
+	heading: /^#{1,6}[ \t]*(\S.*)?$/,
 };

--- a/apps/frontend/run-maestro-web-test.sh
+++ b/apps/frontend/run-maestro-web-test.sh
@@ -73,7 +73,7 @@ for i in $(seq 1 $MAX_WAIT); do
         echo "Server is ready."
         break
     fi
-    if [ "$i" -eq "$MAX_WAIT" ]; then
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
         echo "ERROR: Dev server did not start within ${MAX_WAIT}s."
         exit 1
     fi
@@ -91,7 +91,7 @@ if ! command -v maestro &> /dev/null; then
     # sanity-checked before it is executed, and pin the transport to TLS.
     MAESTRO_INSTALLER="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 -o "$MAESTRO_INSTALLER" "https://get.maestro.mobile.dev"
-    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty."; exit 1; }
+    [[ -s "$MAESTRO_INSTALLER" ]] || { echo "ERROR: Downloaded Maestro installer is empty."; exit 1; }
     head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script."; exit 1; }
     bash "$MAESTRO_INSTALLER"
     rm -f "$MAESTRO_INSTALLER"
@@ -116,7 +116,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # 5. Generate YAML test files from TypeScript
 # ---------------------------------------------------------------------------
-if [ "$SKIP_GENERATE" = true ]; then
+if [[ "$SKIP_GENERATE" = true ]]; then
     echo "Skipping YAML generation (--skip-generate flag set)."
 else
     echo "Generating YAML test files from TypeScript..."
@@ -140,7 +140,7 @@ set -e
 # ---------------------------------------------------------------------------
 # 7. Report failed tests and screenshot paths
 # ---------------------------------------------------------------------------
-if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
+if [[ "$MAESTRO_EXIT_CODE" -ne 0 ]]; then
     echo ""
     echo "=== Failed Tests & Screenshots ==="
     FOUND_SCREENSHOTS=false
@@ -148,7 +148,7 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
         echo "  📸 $png"
         FOUND_SCREENSHOTS=true
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f -name "*.png" -print0 2>/dev/null)
-    if [ "$FOUND_SCREENSHOTS" = false ]; then
+    if [[ "$FOUND_SCREENSHOTS" = false ]]; then
         echo "  (no screenshots found)"
     fi
 
@@ -158,14 +158,14 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
     # Search for error/failure messages in Maestro debug log files
     while IFS= read -r -d '' logfile; do
         ERRORS=$(grep -iE "(FAILED|ERROR|Exception|Element not found|No element|Timeout|assert|tapOn)" "$logfile" 2>/dev/null | grep -v "^#" | head -20)
-        if [ -n "$ERRORS" ]; then
+        if [[ -n "$ERRORS" ]]; then
             echo ""
             echo "  📄 $(basename "$logfile"):"
             echo "$ERRORS" | sed 's/^/    /'
             FOUND_ERRORS=true
         fi
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.xml" \) -print0 2>/dev/null)
-    if [ "$FOUND_ERRORS" = false ]; then
+    if [[ "$FOUND_ERRORS" = false ]]; then
         echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)"
     fi
     echo ""

--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -412,7 +412,7 @@ function RouteAssignmentModalContent({ activity, savedRoutes, bestMatch, onDone,
 		}
 		const updated: SavedActivity = { ...activity, routeId };
 		try {
-			saveActivity(updated);
+			await saveActivity(updated);
 		} catch {
 			showAlert('Fehler', 'Die Aktivität konnte nicht gespeichert werden.');
 			return;
@@ -436,7 +436,7 @@ function RouteAssignmentModalContent({ activity, savedRoutes, bestMatch, onDone,
 			walkedEdgesRedLineResolution: RED_LINE_GRID_RESOLUTION,
 		};
 		try {
-			saveRoute(newRoute);
+			await saveRoute(newRoute);
 		} catch {
 			showAlert('Fehler', 'Die Route konnte nicht gespeichert werden.');
 			return;

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -601,7 +601,7 @@ export default function ActivitiesScreen() {
 							}
 
 							if (updated) {
-								try { saveActivity(activity); } catch (err) { console.warn('[Rebuild] Failed to save migrated activity:', activity.id, err); }
+								try { await saveActivity(activity); } catch (err) { console.warn('[Rebuild] Failed to save migrated activity:', activity.id, err); }
 							}
 						}
 

--- a/apps/geonexia/frontend/app/billboard-config/index.tsx
+++ b/apps/geonexia/frontend/app/billboard-config/index.tsx
@@ -111,7 +111,7 @@ function SpriteThumbnailIcon({ spriteIndex }: { spriteIndex: number }) {
 
 	return (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replace(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={modalStyles.thumb}
 			originWhitelist={['*']}
 			scrollEnabled={false}
@@ -484,7 +484,7 @@ export default function BillboardConfigScreen() {
 								<View style={[styles.previewContainer, { backgroundColor: theme.screen.text + '08' }]}>
 									{svgUri ? (
 										<WebView
-											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replace(/"/g, '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
+											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
 											style={[styles.previewImage, { backgroundColor: 'transparent' }]}
 											originWhitelist={['*']}
 											scrollEnabled={false}

--- a/apps/geonexia/frontend/app/hex-texture-config/index.tsx
+++ b/apps/geonexia/frontend/app/hex-texture-config/index.tsx
@@ -105,7 +105,7 @@ function TerrainThumbnailIcon({ terrainEntry }: { terrainEntry: TerrainAssetEntr
 
 	return (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${imgUri.replace(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${imgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={modalStyles.thumb}
 			originWhitelist={['*']}
 			scrollEnabled={false}
@@ -507,7 +507,7 @@ export default function HexTextureConfigScreen() {
 								<View style={[styles.previewContainer, { backgroundColor: theme.screen.text + '08' }]}>
 									{imgUri ? (
 										<WebView
-											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${imgUri.replace(/"/g, '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
+											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${imgUri.replaceAll('"', '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
 											style={[styles.previewImage, { backgroundColor: 'transparent' }]}
 											originWhitelist={['*']}
 											scrollEnabled={false}

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -3484,7 +3484,7 @@ export default function RecordScreen() {
 								closeRecoveryModal();
 							}}
 							onSave={(activity) => {
-								try { saveActivity(activity); } catch (err) { console.warn('[RecordScreen] Failed to save recovered activity:', err); }
+								saveActivity(activity).catch((err) => console.warn('[RecordScreen] Failed to save recovered activity:', err));
 								clearRecordingSnapshot();
 								closeRecoveryModal();
 								router.push(`/activities/${activity.id}`);
@@ -5088,7 +5088,7 @@ export default function RecordScreen() {
 		};
 		activity.computed = computeActivityData(activity, enclosedCells);
 		try {
-			saveActivity(activity);
+			await saveActivity(activity);
 		} catch (err) {
 			console.warn('[RecordScreen] Failed to save activity:', err);
 		}

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -668,7 +668,7 @@ export default function RouteDetailScreen() {
 				// immediately on subsequent screen visits without recomputation.
 				const updatedRoute: SavedRoute = { ...route, enclosedTiles: tiles };
 				try {
-					saveRoute(updatedRoute);
+					await saveRoute(updatedRoute);
 				} catch (err) {
 					console.warn('[RouteDetailScreen] Failed to save enclosed tiles to route:', err);
 				}
@@ -1263,12 +1263,12 @@ export default function RouteDetailScreen() {
 					initialValue={route.name}
 					groupPosition={infoRows.length === 0 ? 'bottom' : 'middle'}
 					showSeparator={infoRows.length > 0}
-					onSave={(newName) => {
+					onSave={async (newName) => {
 						const trimmed = newName.trim();
 						if (!trimmed) return;
 						const updated: SavedRoute = { ...route, name: trimmed };
 						try {
-							saveRoute(updated);
+							await saveRoute(updated);
 						} catch {
 							showAlert('Fehler', 'Der Name der Route konnte nicht gespeichert werden.');
 							return;

--- a/apps/geonexia/frontend/app/settings/index.tsx
+++ b/apps/geonexia/frontend/app/settings/index.tsx
@@ -482,7 +482,7 @@ export default function SettingsScreen() {
 							}
 							const newComputed = computeActivityData(activity, enclosedTiles);
 							try {
-								saveActivity({ ...activity, computed: newComputed });
+								await saveActivity({ ...activity, computed: newComputed });
 								updatedCount++;
 							} catch (err) {
 								console.warn('[Recalculate] Failed to save activity:', activity.id, err);
@@ -547,7 +547,7 @@ export default function SettingsScreen() {
 							}
 							if (updated) {
 								try {
-									saveActivity(activity);
+									await saveActivity(activity);
 								} catch (err) {
 									console.warn('[Rebuild] Failed to save migrated activity:', activity.id, err);
 								}

--- a/apps/geonexia/frontend/components/SettingsListBillboard/index.tsx
+++ b/apps/geonexia/frontend/components/SettingsListBillboard/index.tsx
@@ -61,7 +61,7 @@ const SettingsListBillboard: React.FC<Props> = ({
 
 	const thumbnail = svgUri ? (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replace(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={[styles.thumb, { backgroundColor: 'transparent' }]}
 			originWhitelist={['*']}
 			scrollEnabled={false}

--- a/apps/geonexia/frontend/components/SettingsListHexTile/index.tsx
+++ b/apps/geonexia/frontend/components/SettingsListHexTile/index.tsx
@@ -73,7 +73,7 @@ const SettingsListHexTile: React.FC<Props> = ({
 
 	const thumbnail = svgUri ? (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${svgUri.replace(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={[styles.thumb, { backgroundColor: 'transparent' }]}
 			originWhitelist={['*']}
 			scrollEnabled={false}

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -372,7 +372,7 @@ export function hasForestFeature(features: MapFeatureInfo[]): boolean {
 export function getSmallTreeAnchorForHexId(hexId: string): BillboardAnchorPosition {
 	let hash = 0;
 	for (let i = 0; i < hexId.length; i++) {
-		hash = (hash * 31 + hexId.charCodeAt(i)) >>> 0;
+		hash = (hash * 31 + (hexId.codePointAt(i) ?? 0)) >>> 0;
 	}
 	return MIDDLE_RING_BY_DEGREE[hash % MIDDLE_RING_BY_DEGREE.length];
 }

--- a/apps/geonexia/frontend/helpers/TTSHelper.ts
+++ b/apps/geonexia/frontend/helpers/TTSHelper.ts
@@ -65,6 +65,14 @@ export interface KmAnnouncementContent {
 }
 
 /**
+ * Default content toggles for {@link buildKmAnnouncement} when none are given.
+ */
+const DEFAULT_KM_ANNOUNCEMENT_CONTENT: Readonly<KmAnnouncementContent> = Object.freeze({
+	announcePace: true,
+	announceSpeedKmh: false,
+});
+
+/**
  * Build a localised TTS announcement for a km milestone during recording.
  * Falls back to English for unrecognised language codes. Only the primary
  * language subtag is used (e.g. "de" from "de-DE"); regional variants are not
@@ -79,8 +87,9 @@ export function buildKmAnnouncement(
 	km: number,
 	paceMinPerKm: number | null,
 	locale: string,
-	content: KmAnnouncementContent = { announcePace: true, announceSpeedKmh: false },
+	content?: KmAnnouncementContent,
 ): string {
+	const resolvedContent = content ?? DEFAULT_KM_ANNOUNCEMENT_CONTENT;
 	const langCode = locale.split('-')[0].toLowerCase();
 	const paceMin = paceMinPerKm != null ? Math.floor(paceMinPerKm) : null;
 	const paceSec = paceMinPerKm != null ? Math.round((paceMinPerKm - Math.floor(paceMinPerKm)) * 60) : null;
@@ -93,10 +102,10 @@ export function buildKmAnnouncement(
 		speedUnit: string,
 	): string {
 		const parts: string[] = [];
-		if (content.announcePace && paceMin != null && paceSec != null) {
+		if (resolvedContent.announcePace && paceMin != null && paceSec != null) {
 			parts.push(`${paceLabel} ${paceMin} ${paceUnit.replace('{sec}', String(paceSec))}`);
 		}
-		if (content.announceSpeedKmh && speedKmh != null) {
+		if (resolvedContent.announceSpeedKmh && speedKmh != null) {
 			parts.push(`${formatSpeedForSpeech(speedKmh)} ${speedUnit}`);
 		}
 		return parts.length > 0 ? `, ${parts.join(', ')}` : '';

--- a/apps/score-tracker/frontend/app/dice/index.tsx
+++ b/apps/score-tracker/frontend/app/dice/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, ScrollView, TextInput, StyleSheet } from 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { SettingsListGroupTitle, useTheme, type Theme } from 'repo-depkit-common-ui';
+import { MathHelper } from 'repo-depkit-common';
 import { ComponentIds } from '../../constants/ComponentIds';
 
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
@@ -48,7 +49,7 @@ type RollResult =
 	| { mode: 'advantage' | 'disadvantage'; rollA: DiceRoll; rollB: DiceRoll; keptRoll: 'A' | 'B'; keptTotal: number };
 
 function rollValue(sides: number): number {
-	return Math.floor(Math.random() * sides) + 1;
+	return MathHelper.randomIntBetween(1, sides);
 }
 
 function rollPoolOnce(pool: PoolDie[]): DiceRoll {

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -12,6 +12,7 @@ import {
 	useMyScrollViewModal,
 	useTheme,
 } from 'repo-depkit-common-ui';
+import { MathHelper } from 'repo-depkit-common';
 import * as Clipboard from 'expo-clipboard';
 import { useDispatch, useSelector } from 'react-redux';
 import { router, useLocalSearchParams, useNavigation } from 'expo-router';
@@ -44,7 +45,7 @@ const DANGER_COLOR = '#dc2626';
 const DEBUG_COLOR = '#7c3aed';
 
 function generateHistoryId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return Date.now().toString(36) + MathHelper.randomBase36String(6);
 }
 
 function formatDate(timestamp: number): string {

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -23,6 +23,7 @@ import {
 	AvatarStyle,
 } from 'repo-depkit-common-ui';
 import type { AvatarConfig } from 'repo-depkit-common-ui';
+import { MathHelper } from 'repo-depkit-common';
 import { useDispatch, useSelector } from 'react-redux';
 import { router, useNavigation } from 'expo-router';
 import {
@@ -77,7 +78,7 @@ function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bot
 }
 
 function generateHistoryId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return Date.now().toString(36) + MathHelper.randomBase36String(6);
 }
 
 // ─── Score Input Modal Content ────────────────────────────────────────────────

--- a/apps/score-tracker/frontend/helpers/GameRules.ts
+++ b/apps/score-tracker/frontend/helpers/GameRules.ts
@@ -429,6 +429,9 @@ const FLIP_SEVEN_ITEMS: CardItem[] = [
 	{ id: 'x2', label: 'x2', category: 'multiplier', value: 2 },
 ];
 
+// Note on `then`: it is a persisted schema key of RuleExpr (stored game types
+// and shareable preset JSON rely on it) and never holds a function, so these
+// objects are not actually thenable - renaming it would break existing data.
 const FLIP_SEVEN_SCORE_FORMULA: RuleExpr = {
 	op: 'add',
 	args: [
@@ -436,14 +439,14 @@ const FLIP_SEVEN_SCORE_FORMULA: RuleExpr = {
 			op: 'multiply',
 			args: [
 				{ op: 'sumValues', category: 'number' },
-				{ op: 'if', cond: { op: 'hasItem', itemId: 'x2' }, then: { op: 'const', value: 2 }, else: { op: 'const', value: 1 } },
+				{ op: 'if', cond: { op: 'hasItem', itemId: 'x2' }, then: { op: 'const', value: 2 }, else: { op: 'const', value: 1 } }, // NOSONAR - data schema key, not a thenable
 			],
 		},
 		{ op: 'sumValues', category: 'modifier' },
 		{
 			op: 'if',
 			cond: { op: 'gte', a: { op: 'countItems', category: 'number' }, b: { op: 'const', value: 7 } },
-			then: { op: 'const', value: 15 },
+			then: { op: 'const', value: 15 }, // NOSONAR - data schema key, not a thenable
 			else: { op: 'const', value: 0 },
 		},
 	],

--- a/apps/score-tracker/frontend/store/friendsSlice.ts
+++ b/apps/score-tracker/frontend/store/friendsSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { MathHelper } from 'repo-depkit-common';
 import type { AvatarConfig } from 'repo-depkit-common-ui';
 import type { Friend } from '../helpers/FriendsStorage';
 export type { Friend };
@@ -16,7 +17,7 @@ const initialState: FriendsSliceState = {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function generateId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return Date.now().toString(36) + MathHelper.randomBase36String(6);
 }
 
 // ─── Slice ────────────────────────────────────────────────────────────────────

--- a/apps/score-tracker/frontend/store/gameSlice.ts
+++ b/apps/score-tracker/frontend/store/gameSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { MathHelper } from 'repo-depkit-common';
 import type { AvatarConfig } from 'repo-depkit-common-ui';
 import type { Player, Round, GameState, GameStatus } from '../helpers/GameStorage';
 import { PLAYER_COLORS } from '../helpers/GameStorage';
@@ -32,7 +33,7 @@ const initialState: GameSliceState = {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function generateId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return Date.now().toString(36) + MathHelper.randomBase36String(6);
 }
 
 function emptyScoresFor(players: Player[]): Record<string, number | null> {

--- a/apps/score-tracker/frontend/store/gameTypesSlice.ts
+++ b/apps/score-tracker/frontend/store/gameTypesSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { MathHelper } from 'repo-depkit-common';
 import type { GameType, ScoringMode } from '../helpers/GameTypesStorage';
 import { DEFAULT_GAME_TYPE_ICON } from '../helpers/GameTypesStorage';
 import type { GamePreset, GameRules, StartingPlayerMode } from '../helpers/GameRules';
@@ -17,7 +18,7 @@ const initialState: GameTypesSliceState = {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function generateId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return Date.now().toString(36) + MathHelper.randomBase36String(6);
 }
 
 // ─── Slice ────────────────────────────────────────────────────────────────────

--- a/apps/score-tracker/run-maestro-web-test.sh
+++ b/apps/score-tracker/run-maestro-web-test.sh
@@ -78,7 +78,7 @@ for i in $(seq 1 $MAX_WAIT); do
         echo "Server is ready."
         break
     fi
-    if [ "$i" -eq "$MAX_WAIT" ]; then
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
         echo "ERROR: Dev server did not start within ${MAX_WAIT}s."
         exit 1
     fi
@@ -94,7 +94,7 @@ if ! command -v maestro &> /dev/null; then
     echo "Maestro CLI not found – installing..."
     MAESTRO_INSTALLER="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 -o "$MAESTRO_INSTALLER" "https://get.maestro.mobile.dev"
-    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty."; exit 1; }
+    [[ -s "$MAESTRO_INSTALLER" ]] || { echo "ERROR: Downloaded Maestro installer is empty."; exit 1; }
     head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script."; exit 1; }
     bash "$MAESTRO_INSTALLER"
     rm -f "$MAESTRO_INSTALLER"
@@ -119,7 +119,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # 5. Generate YAML test files from TypeScript
 # ---------------------------------------------------------------------------
-if [ "$SKIP_GENERATE" = true ]; then
+if [[ "$SKIP_GENERATE" = true ]]; then
     echo "Skipping YAML generation (--skip-generate flag set)."
 else
     echo "Generating YAML test files from TypeScript..."
@@ -143,7 +143,7 @@ set -e
 # ---------------------------------------------------------------------------
 # 7. Report failed tests and screenshot paths
 # ---------------------------------------------------------------------------
-if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
+if [[ "$MAESTRO_EXIT_CODE" -ne 0 ]]; then
     echo ""
     echo "=== Failed Tests & Screenshots ==="
     FOUND_SCREENSHOTS=false
@@ -151,7 +151,7 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
         echo "  📸 $png"
         FOUND_SCREENSHOTS=true
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f -name "*.png" -print0 2>/dev/null)
-    if [ "$FOUND_SCREENSHOTS" = false ]; then
+    if [[ "$FOUND_SCREENSHOTS" = false ]]; then
         echo "  (no screenshots found)"
     fi
 
@@ -160,14 +160,14 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
     FOUND_ERRORS=false
     while IFS= read -r -d '' logfile; do
         ERRORS=$(grep -iE "(FAILED|ERROR|Exception|Element not found|No element|Timeout|assert|tapOn)" "$logfile" 2>/dev/null | grep -v "^#" | head -20)
-        if [ -n "$ERRORS" ]; then
+        if [[ -n "$ERRORS" ]]; then
             echo ""
             echo "  📄 $(basename "$logfile"):"
             echo "$ERRORS" | sed 's/^/    /'
             FOUND_ERRORS=true
         fi
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.xml" \) -print0 2>/dev/null)
-    if [ "$FOUND_ERRORS" = false ]; then
+    if [[ "$FOUND_ERRORS" = false ]]; then
         echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)"
     fi
     echo ""

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -23,7 +23,9 @@ type JsonApiDocument = {
 
 function base64url(input: Buffer | string): string {
   const buffer = typeof input === 'string' ? Buffer.from(input) : input;
-  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  // Base64 padding is at most two "=" characters, so the bounded quantifier
+  // keeps the pattern linear-time (SonarCloud S5852).
+  return buffer.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/={1,2}$/, '');
 }
 
 function createAppStoreConnectToken(keyId: string, issuerId: string, privateKeyPath: string): string {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,6 +1,7 @@
 export * from './src/StringHelper';
 export * from './src/DateHelper';
 export * from './src/NumberHelper';
+export * from './src/MathHelper';
 export * as DatabaseTypes from './src/databaseTypes/types';
 export * from './src/databaseTypes/CollectionNames';
 export * from './src/AppLinks';

--- a/packages/common/src/EmailHelper.ts
+++ b/packages/common/src/EmailHelper.ts
@@ -1,5 +1,7 @@
 export class EmailHelper {
-  private static readonly EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  // Domain is matched as dot-separated, dot-free labels: unambiguous and thus
+  // linear-time (no catastrophic backtracking, SonarCloud S5852).
+  private static readonly EMAIL_REGEX = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
   static sanitize(email: string): string {
     return email.trim();

--- a/packages/common/src/EventHelper.ts
+++ b/packages/common/src/EventHelper.ts
@@ -27,8 +27,8 @@ export const isPopupEventActive = (
 const VERSION_CONSTRAINT_REGEX = /^(<=|>=|<|>|=)?\s*(\d+(?:\.\d+)*)$/;
 
 export const compareAppVersions = (a: string, b: string): number => {
-  const partsA = a.split('.').map((part) => parseInt(part, 10) || 0);
-  const partsB = b.split('.').map((part) => parseInt(part, 10) || 0);
+  const partsA = a.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const partsB = b.split('.').map((part) => Number.parseInt(part, 10) || 0);
   const length = Math.max(partsA.length, partsB.length);
 
   for (let i = 0; i < length; i++) {

--- a/packages/common/src/MathHelper.ts
+++ b/packages/common/src/MathHelper.ts
@@ -1,0 +1,72 @@
+// Minimal structural type so this helper works in every runtime (Node, browser,
+// Expo/React Native) without depending on DOM or Node type definitions.
+type CryptoLike = {
+  getRandomValues(array: Uint32Array): Uint32Array;
+};
+
+/**
+ * Central place for all randomness in the repository.
+ *
+ * `Math.random()` is a pseudorandom number generator and gets flagged by
+ * SonarCloud (rule S2245) wherever it is used. All random values should
+ * therefore be produced through this class: it prefers the cryptographically
+ * secure Web Crypto API (`crypto.getRandomValues`, available in Node 19+,
+ * browsers and Expo/React Native) and only falls back to `Math.random()` in
+ * exotic runtimes without Web Crypto support.
+ */
+export class MathHelper {
+  private static readonly BASE36_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+  private static readonly UINT32_RANGE = 4294967296; // 2^32
+
+  private static getCrypto(): CryptoLike | undefined {
+    const cryptoCandidate = (globalThis as { crypto?: CryptoLike }).crypto;
+    if (cryptoCandidate && typeof cryptoCandidate.getRandomValues === 'function') {
+      return cryptoCandidate;
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns a random float in the interval [0, 1) - a drop-in replacement for
+   * `Math.random()`, but backed by a cryptographically secure generator where
+   * available.
+   */
+  static random(): number {
+    const cryptoObj = MathHelper.getCrypto();
+    if (cryptoObj) {
+      const buffer = new Uint32Array(1);
+      cryptoObj.getRandomValues(buffer);
+      return buffer[0] / MathHelper.UINT32_RANGE;
+    }
+    // Fallback for runtimes without Web Crypto. The random values produced by
+    // this class are used for non-security purposes (dice rolls, local ids),
+    // so a pseudorandom fallback is acceptable here.
+    return Math.random(); // NOSONAR (typescript:S2245) - deliberate single fallback, see comment above
+  }
+
+  /**
+   * Returns a random integer in the inclusive range [minInclusive, maxInclusive].
+   * Example: `randomIntBetween(1, 6)` rolls a standard die.
+   */
+  static randomIntBetween(minInclusive: number, maxInclusive: number): number {
+    const min = Math.ceil(minInclusive);
+    const max = Math.floor(maxInclusive);
+    if (max < min) {
+      throw new Error(`randomIntBetween: max (${maxInclusive}) must not be smaller than min (${minInclusive})`);
+    }
+    return min + Math.floor(MathHelper.random() * (max - min + 1));
+  }
+
+  /**
+   * Returns a random string of the given length using the base36 alphabet
+   * (0-9, a-z). Useful as the random part of locally generated ids and a
+   * replacement for the `Math.random().toString(36).slice(2)` idiom.
+   */
+  static randomBase36String(length: number): string {
+    let result = '';
+    for (let i = 0; i < length; i++) {
+      result += MathHelper.BASE36_ALPHABET[MathHelper.randomIntBetween(0, MathHelper.BASE36_ALPHABET.length - 1)];
+    }
+    return result;
+  }
+}

--- a/packages/common/src/NumberHelper.ts
+++ b/packages/common/src/NumberHelper.ts
@@ -35,7 +35,7 @@ export class NumberHelper {
       if (!integerPart) {
         formattedValue = `0${fractionsSeparator}${fractionPart || ''}`;
       } else {
-        const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparator);
+        const formattedInteger = NumberHelper.insertThousandsSeparator(integerPart, thousandsSeparator);
         formattedValue = fractionPart ? `${formattedInteger}${fractionsSeparator}${fractionPart}` : formattedInteger;
       }
     }
@@ -43,6 +43,22 @@ export class NumberHelper {
     // Add unit suffix if provided
     const suffix = unit ? StringHelper.NONBREAKING_SPACE + unit : '';
     return formattedValue + suffix;
+  }
+
+  // Inserts the separator between every group of three digits (counted from the
+  // right). Implemented without a regex: the previously used lookahead pattern
+  // had super-linear worst-case runtime (SonarCloud S5852).
+  private static insertThousandsSeparator(integerPart: string, separator: string): string {
+    const sign = integerPart.startsWith('-') ? '-' : '';
+    const digits = sign ? integerPart.slice(1) : integerPart;
+    let result = '';
+    for (let i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 === 0) {
+        result += separator;
+      }
+      result += digits[i];
+    }
+    return sign + result;
   }
 
   // Formats a number with compact abbreviations: up to 999 shown as-is,

--- a/packages/common/src/__tests__/MathHelper.test.ts
+++ b/packages/common/src/__tests__/MathHelper.test.ts
@@ -1,0 +1,51 @@
+import { MathHelper } from 'repo-depkit-common';
+
+describe('MathHelper.random', () => {
+  it('returns values in the interval [0, 1)', () => {
+    for (let i = 0; i < 1000; i++) {
+      const value = MathHelper.random();
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+});
+
+describe('MathHelper.randomIntBetween', () => {
+  it('stays within the inclusive bounds', () => {
+    for (let i = 0; i < 1000; i++) {
+      const value = MathHelper.randomIntBetween(1, 6);
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(1);
+      expect(value).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it('eventually hits both endpoints', () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 1000; i++) {
+      seen.add(MathHelper.randomIntBetween(1, 2));
+    }
+    expect(seen.has(1)).toBe(true);
+    expect(seen.has(2)).toBe(true);
+  });
+
+  it('returns min when min equals max', () => {
+    expect(MathHelper.randomIntBetween(5, 5)).toBe(5);
+  });
+
+  it('throws when max is smaller than min', () => {
+    expect(() => MathHelper.randomIntBetween(2, 1)).toThrow();
+  });
+});
+
+describe('MathHelper.randomBase36String', () => {
+  it('returns a string of the requested length', () => {
+    expect(MathHelper.randomBase36String(6)).toHaveLength(6);
+    expect(MathHelper.randomBase36String(0)).toBe('');
+  });
+
+  it('only contains base36 characters', () => {
+    const value = MathHelper.randomBase36String(100);
+    expect(value).toMatch(/^[0-9a-z]+$/);
+  });
+});


### PR DESCRIPTION
## Zusammenfassung

Behebt alle 8 SonarCloud-**Security**-Hotspots und die gemeldeten **Reliability**-Bugs (siehe `reports/sonarCloud/`).

### 🔒 Security

**Math.random → neue `MathHelper`-Klasse in `packages/common`** (5 Hotspots)
- Neue Klasse `MathHelper` (`packages/common/src/MathHelper.ts`) als zentrale Stelle für alle Zufallswerte: nutzt `crypto.getRandomValues` (Web Crypto, in Node 19+/Browsern/Expo verfügbar), mit `Math.random`-Fallback nur für exotische Runtimes (dokumentiert + NOSONAR).
- API: `MathHelper.random()`, `MathHelper.randomIntBetween(min, max)`, `MathHelper.randomBase36String(length)` — inkl. Jest-Tests.
- Alle `Math.random`-Verwendungen im score-tracker umgestellt: Würfelwürfe (`dice/index.tsx`) und ID-Generierung (`friendsSlice`, `gameSlice`, `gameTypesSlice`, `app/index.tsx`, `games/[id].tsx` — `gameSlice` war noch nicht von Sonar gelistet, nutzte aber dasselbe Muster).

**Yarn-Lifecycle-Scripts in CI** (3 Hotspots)
- Die drei `ios-submit-review-*`-Workflows installieren jetzt mit `yarn install --immutable --mode=skip-build`. Der Job braucht nur ts-node für die App-Store-Connect-API — keine Postinstall-Scripts von Dependencies nötig.

### 🐛 Reliability

**Super-lineare Regexe (S5852)** — umgebaut auf eindeutige, linear laufende Muster (negierte Zeichenklassen statt `.*?`/überlappender Quantifier), Verhalten per Node-Skript gegen realistische Eingaben verifiziert:
- `CustomMarkdown.tsx`, `MarkdownPatterns.ts`, `course-timetable/index.tsx` (Markdown-Link/Heading-Parsing)
- `EmailHelper.ts` + `EmailInput.tsx` (E-Mail-Validierung; Domain jetzt als punktgetrennte Labels)
- `NumberHelper.ts` (Tausendertrenner jetzt regex-frei implementiert)
- `FoodTL1Parser.ts` (kcal + Markings), `FoodWebParserAachenParseHtml.ts`, `MaxManagerConnector.ts`
- `submit-ios-review.ts` (base64url-Padding mit begrenztem Quantifier)
- `app/index.tsx` (Expo-Push-Token-Extraktion)

**Floating Promises in try-Blöcken (Geonexia, 9 Stellen)** — `saveActivity`/`saveRoute` werden jetzt `await`et, wo der catch-Block die Fehlerbehandlung übernimmt (Alerts, Zähler, Folge-Navigation); an der einen nicht-async Stelle stattdessen `.catch()` im Stil der Datei.

**Weitere Fixes**
- `run-maestro-web-test.sh` (frontend + score-tracker): `[[ ]]` statt `[ ]` (14 Stellen)
- `String#replaceAll` statt `replace(/…/g)` (report.ts, Geonexia SVG/Hex/Billboard-Configs)
- `Number.parseInt` in `EventHelper.ts`, `String#codePointAt` in `ActivityMapRebuildHelper.ts` (ASCII-Input, Hash bit-identisch)
- `TTSHelper.ts`: kein Objekt-Literal mehr als Parameter-Default (eingefrorene Modul-Konstante)
- `GameRules.ts` („Do not add `then` to an object“): **bewusst nicht umbenannt** — `then`/`else` sind persistierte Schema-Keys der gespeicherten Spielregeln/Presets; ein Rename würde bestehende Daten brechen. Da nie eine Funktion darin liegt (kein echtes Thenable), als begründetes NOSONAR dokumentiert.

### ✅ Verifikation
- `packages/common`: 7 Suites / 45 Tests grün (inkl. neuer MathHelper-Tests, NumberHelper-Tausendertrenner)
- Backend `food-sync-hook`: 9 Suites / 62 Tests grün (decken die geänderten Parser-Regexe mit echten Fixtures ab)
- `tsc --noEmit` für score-tracker, frontend und geonexia: keine neuen Fehler durch diese Änderungen (Geonexia-Baseline identisch: 29 vorbestehende Fehler vorher wie nachher)
- `bash -n` für beide Shell-Skripte OK
- Regex-Verhaltensvergleich alt/neu per Node-Skript für alle umgebauten Muster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WT3sXStDLZWEqGx7gDoRxS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT3sXStDLZWEqGx7gDoRxS)_