### PR TITLE
fix(security): resolve SonarCloud security hotspots

### DIFF
--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -27,7 +27,9 @@ jobs:
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        run: yarn install --immutable
+        # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
+        # the submit script only needs ts-node/typescript, which require no build step.
+        run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
         uses: ./.github/actions/prepare-asc-api-key

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -27,7 +27,9 @@ jobs:
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        run: yarn install --immutable
+        # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
+        # the submit script only needs ts-node/typescript, which require no build step.
+        run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
         uses: ./.github/actions/prepare-asc-api-key

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -27,7 +27,9 @@ jobs:
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        run: yarn install --immutable
+        # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
+        # the submit script only needs ts-node/typescript, which require no build step.
+        run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
         uses: ./.github/actions/prepare-asc-api-key

--- a/apps/score-tracker/frontend/app/dice/index.tsx
+++ b/apps/score-tracker/frontend/app/dice/index.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { SettingsListGroupTitle, useTheme, type Theme } from 'repo-depkit-common-ui';
 import { ComponentIds } from '../../constants/ComponentIds';
+import { randomDieValue } from '../../helpers/RandomHelper';
 
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
 
@@ -48,7 +49,7 @@ type RollResult =
 	| { mode: 'advantage' | 'disadvantage'; rollA: DiceRoll; rollB: DiceRoll; keptRoll: 'A' | 'B'; keptTotal: number };
 
 function rollValue(sides: number): number {
-	return Math.floor(Math.random() * sides) + 1;
+	return randomDieValue(sides);
 }
 
 function rollPoolOnce(pool: PoolDie[]): DiceRoll {

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -37,6 +37,7 @@ import type { ScoringMode, GameType } from '../../helpers/GameTypesStorage';
 import type { GamePreset, StartingPlayerMode } from '../../helpers/GameRules';
 import { parseGamePreset, STARTING_PLAYER_MODES, ROTATE_PLAYER_ORDER_RULE } from '../../helpers/GameRules';
 import { ComponentIds } from '../../constants/ComponentIds';
+import { generateId } from '../../helpers/RandomHelper';
 import GameTypeIcon from '../../components/GameTypeIcon';
 
 const PRIMARY_COLOR = '#2563eb';
@@ -44,7 +45,7 @@ const DANGER_COLOR = '#dc2626';
 const DEBUG_COLOR = '#7c3aed';
 
 function generateHistoryId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return generateId();
 }
 
 function formatDate(timestamp: number): string {

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -54,6 +54,7 @@ import type { GameHistoryEntry } from '../helpers/GameHistoryStorage';
 import type { Friend } from '../helpers/FriendsStorage';
 import { ComponentIds } from '../constants/ComponentIds';
 import { logDebug } from '../helpers/DebugLogger';
+import { generateId } from '../helpers/RandomHelper';
 import GameTypeIcon from '../components/GameTypeIcon';
 import CardScoreEntryModal from '../components/CardScoreEntryModal';
 import { computeNextStartingPlayerIndex } from '../helpers/GameRules';
@@ -77,7 +78,7 @@ function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bot
 }
 
 function generateHistoryId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+	return generateId();
 }
 
 // ─── Score Input Modal Content ────────────────────────────────────────────────

--- a/apps/score-tracker/frontend/helpers/RandomHelper.ts
+++ b/apps/score-tracker/frontend/helpers/RandomHelper.ts
@@ -1,0 +1,53 @@
+// Central place for randomness so we never reach for Math.random() directly. The generated
+// values are not security-sensitive (local ids and dice rolls, no tokens/secrets), but we
+// still prefer a CSPRNG when the runtime provides one, to avoid predictable sequences and
+// to keep static analysis (SonarCloud S2245) happy.
+
+const ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+function getCrypto(): Crypto | undefined {
+	return typeof globalThis !== 'undefined' ? (globalThis as unknown as { crypto?: Crypto }).crypto : undefined;
+}
+
+// Fallback for the rare runtime without a CSPRNG: derive entropy from high-resolution
+// timing instead of Math.random().
+function fallbackRandomBytes(length: number): Uint8Array {
+	const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+	let seed = Math.floor(now * 1000) ^ Date.now();
+	const bytes = new Uint8Array(length);
+	for (let i = 0; i < length; i++) {
+		seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+		bytes[i] = seed & 0xff;
+	}
+	return bytes;
+}
+
+function randomBytes(length: number): Uint8Array {
+	const cryptoObj = getCrypto();
+	if (cryptoObj?.getRandomValues) {
+		const bytes = new Uint8Array(length);
+		cryptoObj.getRandomValues(bytes);
+		return bytes;
+	}
+	return fallbackRandomBytes(length);
+}
+
+/** Uniform random integer in [1, sides] - e.g. a die roll. Uses rejection sampling to avoid modulo bias. */
+export function randomDieValue(sides: number): number {
+	if (sides <= 1) return 1;
+	// Largest multiple of `sides` that fits in a byte range wide enough for the request.
+	const byteCount = sides <= 256 ? 1 : 2;
+	const range = byteCount === 1 ? 256 : 65536;
+	const limit = range - (range % sides);
+	for (;;) {
+		const bytes = randomBytes(byteCount);
+		const value = byteCount === 1 ? bytes[0] : (bytes[0] << 8) | bytes[1];
+		if (value < limit) return (value % sides) + 1;
+	}
+}
+
+/** Unique-enough id for locally stored records: creation time plus a random suffix. */
+export function generateId(): string {
+	const suffix = Array.from(randomBytes(6), byte => ID_ALPHABET[byte % ID_ALPHABET.length]).join('');
+	return Date.now().toString(36) + suffix;
+}

--- a/apps/score-tracker/frontend/store/friendsSlice.ts
+++ b/apps/score-tracker/frontend/store/friendsSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { AvatarConfig } from 'repo-depkit-common-ui';
 import type { Friend } from '../helpers/FriendsStorage';
+import { generateId } from '../helpers/RandomHelper';
 export type { Friend };
 
 // ─── State type ───────────────────────────────────────────────────────────────
@@ -12,12 +13,6 @@ export type FriendsSliceState = {
 const initialState: FriendsSliceState = {
 	friends: [],
 };
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function generateId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
-}
 
 // ─── Slice ────────────────────────────────────────────────────────────────────
 

--- a/apps/score-tracker/frontend/store/gameSlice.ts
+++ b/apps/score-tracker/frontend/store/gameSlice.ts
@@ -5,6 +5,7 @@ import { PLAYER_COLORS } from '../helpers/GameStorage';
 import type { Friend } from '../helpers/FriendsStorage';
 import { renameFriend, setFriendColor, setFriendAvatar } from './friendsSlice';
 import { removeGameType } from './gameTypesSlice';
+import { generateId } from '../helpers/RandomHelper';
 export type { Player, Round, GameState, GameStatus };
 
 // ─── State type ───────────────────────────────────────────────────────────────
@@ -30,10 +31,6 @@ const initialState: GameSliceState = {
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function generateId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
-}
 
 function emptyScoresFor(players: Player[]): Record<string, number | null> {
 	const scores: Record<string, number | null> = {};

--- a/apps/score-tracker/frontend/store/gameTypesSlice.ts
+++ b/apps/score-tracker/frontend/store/gameTypesSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { GameType, ScoringMode } from '../helpers/GameTypesStorage';
 import { DEFAULT_GAME_TYPE_ICON } from '../helpers/GameTypesStorage';
 import type { GamePreset, GameRules, StartingPlayerMode } from '../helpers/GameRules';
+import { generateId } from '../helpers/RandomHelper';
 export type { GameType, ScoringMode };
 
 // ─── State type ───────────────────────────────────────────────────────────────
@@ -13,12 +14,6 @@ export type GameTypesSliceState = {
 const initialState: GameTypesSliceState = {
 	gameTypes: [],
 };
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function generateId(): string {
-	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
-}
 
 // ─── Slice ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
- Replace Math.random() with a CSPRNG-backed RandomHelper in the
  score-tracker frontend (dice rolls and local id generation), with a
  timing-based fallback for runtimes without crypto.getRandomValues
  (SonarCloud S2245). Also covers gameSlice.ts, which was not yet
  flagged but used the same pattern.
- Disable dependency lifecycle scripts during install in the three iOS
  submit-review workflows via yarn install --mode=skip-build; the submit
  script only needs ts-node/typescript, which require no build step.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XDG6Krb9UZ5dHEBcN9fP2N