### PR TITLE
fix: resolve 11 SonarCloud reliability bugs (thenable objects, unawaited promises in try)

### DIFF
--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -392,7 +392,7 @@ function RouteAssignmentModalContent({ activity, savedRoutes, bestMatch, onDone,
 				const oldRoute = await loadRoute(activity.routeId);
 				if (oldRoute) {
 					const updatedIds = (oldRoute.activityIds ?? []).filter((activityId) => activityId !== activity.id);
-					saveRoute({ ...oldRoute, activityIds: updatedIds });
+					await saveRoute({ ...oldRoute, activityIds: updatedIds });
 				}
 			} catch (err) {
 				console.warn('[RouteAssignment] Failed to update old route activityIds:', err);
@@ -404,7 +404,7 @@ function RouteAssignmentModalContent({ activity, savedRoutes, bestMatch, onDone,
 				const newRoute = await loadRoute(routeId);
 				if (newRoute) {
 					const updatedIds = [...new Set([...(newRoute.activityIds ?? []), activity.id])];
-					saveRoute({ ...newRoute, activityIds: updatedIds });
+					await saveRoute({ ...newRoute, activityIds: updatedIds });
 				}
 			} catch (err) {
 				console.warn('[RouteAssignment] Failed to update new route activityIds:', err);
@@ -412,7 +412,7 @@ function RouteAssignmentModalContent({ activity, savedRoutes, bestMatch, onDone,
 		}
 		const updated: SavedActivity = { ...activity, routeId };
 		try {
-			saveActivity(updated);
+			await saveActivity(updated);
 		} catch {
 			showAlert('Fehler', 'Die Aktivität konnte nicht gespeichert werden.');
 			return;
@@ -436,7 +436,7 @@ function RouteAssignmentModalContent({ activity, savedRoutes, bestMatch, onDone,
 			walkedEdgesRedLineResolution: RED_LINE_GRID_RESOLUTION,
 		};
 		try {
-			saveRoute(newRoute);
+			await saveRoute(newRoute);
 		} catch {
 			showAlert('Fehler', 'Die Route konnte nicht gespeichert werden.');
 			return;

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -601,7 +601,7 @@ export default function ActivitiesScreen() {
 							}
 
 							if (updated) {
-								try { saveActivity(activity); } catch (err) { console.warn('[Rebuild] Failed to save migrated activity:', activity.id, err); }
+								try { await saveActivity(activity); } catch (err) { console.warn('[Rebuild] Failed to save migrated activity:', activity.id, err); }
 							}
 						}
 

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -3483,8 +3483,8 @@ export default function RecordScreen() {
 								clearRecordingSnapshot();
 								closeRecoveryModal();
 							}}
-							onSave={(activity) => {
-								try { saveActivity(activity); } catch (err) { console.warn('[RecordScreen] Failed to save recovered activity:', err); }
+							onSave={async (activity) => {
+								try { await saveActivity(activity); } catch (err) { console.warn('[RecordScreen] Failed to save recovered activity:', err); }
 								clearRecordingSnapshot();
 								closeRecoveryModal();
 								router.push(`/activities/${activity.id}`);
@@ -5088,7 +5088,7 @@ export default function RecordScreen() {
 		};
 		activity.computed = computeActivityData(activity, enclosedCells);
 		try {
-			saveActivity(activity);
+			await saveActivity(activity);
 		} catch (err) {
 			console.warn('[RecordScreen] Failed to save activity:', err);
 		}

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -668,7 +668,7 @@ export default function RouteDetailScreen() {
 				// immediately on subsequent screen visits without recomputation.
 				const updatedRoute: SavedRoute = { ...route, enclosedTiles: tiles };
 				try {
-					saveRoute(updatedRoute);
+					await saveRoute(updatedRoute);
 				} catch (err) {
 					console.warn('[RouteDetailScreen] Failed to save enclosed tiles to route:', err);
 				}
@@ -1263,12 +1263,12 @@ export default function RouteDetailScreen() {
 					initialValue={route.name}
 					groupPosition={infoRows.length === 0 ? 'bottom' : 'middle'}
 					showSeparator={infoRows.length > 0}
-					onSave={(newName) => {
+					onSave={async (newName) => {
 						const trimmed = newName.trim();
 						if (!trimmed) return;
 						const updated: SavedRoute = { ...route, name: trimmed };
 						try {
-							saveRoute(updated);
+							await saveRoute(updated);
 						} catch {
 							showAlert('Fehler', 'Der Name der Route konnte nicht gespeichert werden.');
 							return;

--- a/apps/geonexia/frontend/app/settings/index.tsx
+++ b/apps/geonexia/frontend/app/settings/index.tsx
@@ -482,7 +482,7 @@ export default function SettingsScreen() {
 							}
 							const newComputed = computeActivityData(activity, enclosedTiles);
 							try {
-								saveActivity({ ...activity, computed: newComputed });
+								await saveActivity({ ...activity, computed: newComputed });
 								updatedCount++;
 							} catch (err) {
 								console.warn('[Recalculate] Failed to save activity:', activity.id, err);
@@ -547,7 +547,7 @@ export default function SettingsScreen() {
 							}
 							if (updated) {
 								try {
-									saveActivity(activity);
+									await saveActivity(activity);
 								} catch (err) {
 									console.warn('[Rebuild] Failed to save migrated activity:', activity.id, err);
 								}

--- a/apps/score-tracker/frontend/helpers/GameRules.ts
+++ b/apps/score-tracker/frontend/helpers/GameRules.ts
@@ -27,8 +27,18 @@ export type RuleExpr =
 	| { op: 'hasItem'; itemId: string }
 	| { op: 'add'; args: RuleExpr[] }
 	| { op: 'multiply'; args: RuleExpr[] }
-	| { op: 'if'; cond: RuleExpr; then: RuleExpr; else: RuleExpr }
+	| { op: 'if'; cond: RuleExpr; thenExpr: RuleExpr; elseExpr: RuleExpr }
 	| { op: 'gte'; a: RuleExpr; b: RuleExpr };
+
+// The `if` branches used to be called `then`/`else`. A `then` property makes an
+// object a thenable, which `await`/Promise chains treat specially, so new rules
+// are written with `thenExpr`/`elseExpr` - but persisted game types and shared
+// preset JSON from older app versions still carry the legacy keys, so every
+// reader below accepts both.
+function getIfBranches<T>(expr: { thenExpr?: T; elseExpr?: T }): { thenBranch: T | undefined; elseBranch: T | undefined } {
+	const legacy = expr as { then?: T; else?: T };
+	return { thenBranch: expr.thenExpr ?? legacy.then, elseBranch: expr.elseExpr ?? legacy.else };
+}
 
 export type ScoreEntryRules = {
 	/** The palette of selectable cards shown when entering a score. Tapping a
@@ -100,8 +110,10 @@ export function evaluateRuleExpr(expr: RuleExpr, ctx: RuleEvalContext): number {
 			return expr.args.reduce((sum, arg) => sum + evaluateRuleExpr(arg, ctx), 0);
 		case 'multiply':
 			return expr.args.reduce((product, arg) => product * evaluateRuleExpr(arg, ctx), 1);
-		case 'if':
-			return evaluateRuleExpr(expr.cond, ctx) !== 0 ? evaluateRuleExpr(expr.then, ctx) : evaluateRuleExpr(expr.else, ctx);
+		case 'if': {
+			const { thenBranch, elseBranch } = getIfBranches(expr);
+			return evaluateRuleExpr(expr.cond, ctx) !== 0 ? evaluateRuleExpr(thenBranch!, ctx) : evaluateRuleExpr(elseBranch!, ctx);
+		}
 		case 'gte':
 			return evaluateRuleExpr(expr.a, ctx) >= evaluateRuleExpr(expr.b, ctx) ? 1 : 0;
 	}
@@ -132,7 +144,7 @@ export type PlayerOrderRuleExpr =
 	| { op: 'roundWinnerIndex' }
 	| { op: 'add'; args: PlayerOrderRuleExpr[] }
 	| { op: 'mod'; a: PlayerOrderRuleExpr; b: PlayerOrderRuleExpr }
-	| { op: 'if'; cond: PlayerOrderRuleExpr; then: PlayerOrderRuleExpr; else: PlayerOrderRuleExpr }
+	| { op: 'if'; cond: PlayerOrderRuleExpr; thenExpr: PlayerOrderRuleExpr; elseExpr: PlayerOrderRuleExpr }
 	| { op: 'gte'; a: PlayerOrderRuleExpr; b: PlayerOrderRuleExpr };
 
 /**
@@ -194,10 +206,12 @@ export function evaluatePlayerOrderExpr(expr: PlayerOrderRuleExpr, ctx: PlayerOr
 			const a = evaluatePlayerOrderExpr(expr.a, ctx);
 			return ((a % b) + b) % b;
 		}
-		case 'if':
+		case 'if': {
+			const { thenBranch, elseBranch } = getIfBranches(expr);
 			return evaluatePlayerOrderExpr(expr.cond, ctx) !== 0
-				? evaluatePlayerOrderExpr(expr.then, ctx)
-				: evaluatePlayerOrderExpr(expr.else, ctx);
+				? evaluatePlayerOrderExpr(thenBranch!, ctx)
+				: evaluatePlayerOrderExpr(elseBranch!, ctx);
+		}
 		case 'gte':
 			return evaluatePlayerOrderExpr(expr.a, ctx) >= evaluatePlayerOrderExpr(expr.b, ctx) ? 1 : 0;
 	}
@@ -272,8 +286,10 @@ function isRuleExpr(value: unknown): value is RuleExpr {
 		case 'add':
 		case 'multiply':
 			return Array.isArray(v.args) && v.args.length > 0 && v.args.every(isRuleExpr);
-		case 'if':
-			return isRuleExpr(v.cond) && isRuleExpr(v.then) && isRuleExpr(v.else);
+		case 'if': {
+			const { thenBranch, elseBranch } = getIfBranches(v as { thenExpr?: unknown; elseExpr?: unknown });
+			return isRuleExpr(v.cond) && isRuleExpr(thenBranch) && isRuleExpr(elseBranch);
+		}
 		case 'gte':
 			return isRuleExpr(v.a) && isRuleExpr(v.b);
 		default:
@@ -317,8 +333,10 @@ function isPlayerOrderRuleExpr(value: unknown): value is PlayerOrderRuleExpr {
 			return Array.isArray(v.args) && v.args.length > 0 && v.args.every(isPlayerOrderRuleExpr);
 		case 'mod':
 			return isPlayerOrderRuleExpr(v.a) && isPlayerOrderRuleExpr(v.b);
-		case 'if':
-			return isPlayerOrderRuleExpr(v.cond) && isPlayerOrderRuleExpr(v.then) && isPlayerOrderRuleExpr(v.else);
+		case 'if': {
+			const { thenBranch, elseBranch } = getIfBranches(v as { thenExpr?: unknown; elseExpr?: unknown });
+			return isPlayerOrderRuleExpr(v.cond) && isPlayerOrderRuleExpr(thenBranch) && isPlayerOrderRuleExpr(elseBranch);
+		}
 		case 'gte':
 			return isPlayerOrderRuleExpr(v.a) && isPlayerOrderRuleExpr(v.b);
 		default:
@@ -436,15 +454,15 @@ const FLIP_SEVEN_SCORE_FORMULA: RuleExpr = {
 			op: 'multiply',
 			args: [
 				{ op: 'sumValues', category: 'number' },
-				{ op: 'if', cond: { op: 'hasItem', itemId: 'x2' }, then: { op: 'const', value: 2 }, else: { op: 'const', value: 1 } },
+				{ op: 'if', cond: { op: 'hasItem', itemId: 'x2' }, thenExpr: { op: 'const', value: 2 }, elseExpr: { op: 'const', value: 1 } },
 			],
 		},
 		{ op: 'sumValues', category: 'modifier' },
 		{
 			op: 'if',
 			cond: { op: 'gte', a: { op: 'countItems', category: 'number' }, b: { op: 'const', value: 7 } },
-			then: { op: 'const', value: 15 },
-			else: { op: 'const', value: 0 },
+			thenExpr: { op: 'const', value: 15 },
+			elseExpr: { op: 'const', value: 0 },
 		},
 	],
 };


### PR DESCRIPTION
Fixes the 11 SonarCloud issues of type **Bug** from `reports/sonarCloud/report_reliability.csv` (the remaining reliability entries are code smells such as `replaceAll`/`parseInt`/regex/shell `[[` suggestions).

## Do not add `then` to an object (2 issues — score-tracker)

`apps/score-tracker/frontend/helpers/GameRules.ts:439,446`

The rule DSL's `if` expression used `then`/`else` keys, which makes every `if` rule object a *thenable* — an object `await`/Promise chains treat specially.

- Renamed the branch keys to `thenExpr`/`elseExpr` in the `RuleExpr` and `PlayerOrderRuleExpr` types and the built-in Flip Seven preset.
- **Backward compatible:** all readers (both evaluators and the import validators) accept the legacy `then`/`else` keys via a shared `getIfBranches` helper, so persisted game types and shared preset JSON from older app versions keep working. Verified with a runtime test covering new-key evaluation, legacy-key evaluation, and preset import validation for both key variants.

## Unawaited promise inside `try` (9 issues — geonexia)

`saveActivity`/`saveRoute` are `async`, but were called without `await` inside `try` blocks — the surrounding `catch` (error alerts / warnings) could never fire, and failures became unhandled promise rejections:

- `app/activities/[id].tsx:414,438` — route assignment & "create and assign" (plus the two sibling un-awaited `saveRoute` calls in the same callback)
- `app/activities/index.tsx:604` — rebuild migration save
- `app/index.tsx:3487,5090` — interrupted-recording recovery save & stop-recording save
- `app/routes/[id].tsx:670,1270` — enclosed-tiles persistence & route rename
- `app/settings/index.tsx:484,549` — recalculate & rebuild migration saves

All call sites now `await` the save (enclosing functions were already `async` or are `void`/Promise-accepting callbacks). Side effect: the recovery/stop-recording flows now finish writing the activity before navigating to its detail screen, removing a race where the detail screen could load before the data existed on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDG6Krb9UZ5dHEBcN9fP2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDG6Krb9UZ5dHEBcN9fP2N)_