### PR TITLE
refactor: fix most frequent SonarCloud maintainability issue (nested ternaries) + issue counting script

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -447,7 +447,14 @@ export default function Layout() {
 				return;
 			}
                         if (response) {
-                                const platformKey = Platform.OS === 'ios' ? 'show_on_ios' : Platform.OS === 'android' ? 'show_on_android' : 'show_on_web';
+                                let platformKey: 'show_on_ios' | 'show_on_android' | 'show_on_web';
+                                if (Platform.OS === 'ios') {
+                                        platformKey = 'show_on_ios';
+                                } else if (Platform.OS === 'android') {
+                                        platformKey = 'show_on_android';
+                                } else {
+                                        platformKey = 'show_on_web';
+                                }
 
                                 // Keep each event's already-seen/closed state across refetches - only default
                                 // to unseen for events we haven't stored before. Without this, refetching

--- a/apps/frontend/app/app/(app)/campus/details/components/DetailsImage.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/components/DetailsImage.tsx
@@ -9,7 +9,14 @@ interface DetailsImageProps {
 }
 
 const DetailsImage: React.FC<DetailsImageProps> = ({ imageSource, screenWidth }) => {
-    const size = screenWidth > 1000 ? 400 : screenWidth > 900 ? 350 : screenWidth - 20;
+    let size: number;
+    if (screenWidth > 1000) {
+        size = 400;
+    } else if (screenWidth > 900) {
+        size = 350;
+    } else {
+        size = screenWidth - 20;
+    }
 
     return (
         <View

--- a/apps/frontend/app/app/(app)/chats/details/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/details/index.tsx
@@ -365,14 +365,16 @@ const ChatDetailsScreen = () => {
                 const fallbackName = alias ? alias.charAt(0).toUpperCase() + alias.slice(1) : undefined;
                 const foodName =
                         getFoodName(food, language) || fallbackName || translate(TranslationKeys.unknown);
-                const imageSource =
-                        food?.image_remote_url
-                                ? { uri: food.image_remote_url }
-                                : food?.image
-                                ? { uri: getImageUrl(String(food.image)) }
-                                : defaultFoodImage
-                                ? { uri: defaultFoodImage }
-                                : undefined;
+                let imageSource: { uri: string } | undefined;
+                if (food?.image_remote_url) {
+                        imageSource = { uri: food.image_remote_url };
+                } else if (food?.image) {
+                        imageSource = { uri: getImageUrl(String(food.image)) };
+                } else if (defaultFoodImage) {
+                        imageSource = { uri: defaultFoodImage };
+                } else {
+                        imageSource = undefined;
+                }
 
                 const handleFoodPress = () => {
                         if (food?.id) {

--- a/apps/frontend/app/app/(app)/chats/index.tsx
+++ b/apps/frontend/app/app/(app)/chats/index.tsx
@@ -131,7 +131,16 @@ const ChatsScreen = () => {
         const renderItem = ({ item, index }: { item: DatabaseTypes.Chats; index: number }) => {
                 const last = index === sortedChats.length - 1;
                 const first = index === 0;
-                const groupPosition = sortedChats.length === 1 ? 'single' : first ? 'top' : last ? 'bottom' : 'middle';
+                let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+                if (sortedChats.length === 1) {
+                        groupPosition = 'single';
+                } else if (first) {
+                        groupPosition = 'top';
+                } else if (last) {
+                        groupPosition = 'bottom';
+                } else {
+                        groupPosition = 'middle';
+                }
                 const isUnread = isChatUnread(item);
 
                 const rightElement = (

--- a/apps/frontend/app/app/(app)/eating-habits/index.tsx
+++ b/apps/frontend/app/app/(app)/eating-habits/index.tsx
@@ -178,7 +178,14 @@ const Index = () => {
 		];
 	}, [translate, theme.screen.icon, customerConfigValueLabel]);
 
-	const currentMarkingsBreakdownId = seperatedMarkingsValue === true ? 'true' : seperatedMarkingsValue === false ? 'false' : 'null';
+	let currentMarkingsBreakdownId: 'true' | 'false' | 'null';
+	if (seperatedMarkingsValue === true) {
+		currentMarkingsBreakdownId = 'true';
+	} else if (seperatedMarkingsValue === false) {
+		currentMarkingsBreakdownId = 'false';
+	} else {
+		currentMarkingsBreakdownId = 'null';
+	}
 
 	const markingsBreakdownLabel = useMemo(
 		() => markingsBreakdownOptions.find(o => o.id === currentMarkingsBreakdownId)?.label ?? '',
@@ -194,7 +201,14 @@ const Index = () => {
 						options={markingsBreakdownOptions}
 						selectedOption={currentMarkingsBreakdownId}
 						onSelect={(option) => {
-							const newValue = option.id === 'true' ? true : option.id === 'false' ? false : null;
+							let newValue: boolean | null;
+							if (option.id === 'true') {
+								newValue = true;
+							} else if (option.id === 'false') {
+								newValue = false;
+							} else {
+								newValue = null;
+							}
 							dispatch({ type: SET_FOODOFFERS_SHOW_SEPARATED_MARKINGS_BREAKDOWN, payload: newValue });
 							closeModal();
 						}}
@@ -208,18 +222,28 @@ const Index = () => {
 
 	const renderItem = useCallback(({ item, index }: { item: string; index: number }) => {
 		const total = markingIds.length;
-		const groupPosition: SettingsListProps['groupPosition'] =
-			total === 1 ? 'single' : index === 0 ? 'top' : index === total - 1 ? 'bottom' : 'middle';
+		let groupPosition: SettingsListProps['groupPosition'];
+		if (total === 1) {
+			groupPosition = 'single';
+		} else if (index === 0) {
+			groupPosition = 'top';
+		} else if (index === total - 1) {
+			groupPosition = 'bottom';
+		} else {
+			groupPosition = 'middle';
+		}
 		return <SettingsListMarkingLabelFast markingId={item} groupPosition={groupPosition} handleMenuSheet={openMenuSheet} />;
 	}, [markingIds.length, openMenuSheet]);
 
 	const keyExtractor = useCallback((id: string) => id, []);
 
-	const ListHeaderComponent = useMemo(() => (
+	const ListHeaderComponent = useMemo(() => {
+		const webHeaderWidth = screenWidth > 600 ? '80%' : '100%';
+		return (
 		<View
 			style={{
 				...styles.eatingHabitsContainer,
-				width: isWeb ? (screenWidth > 600 ? '80%' : '100%') : '100%',
+				width: isWeb ? webHeaderWidth : '100%',
 				alignSelf: 'center',
 			}}
 		>
@@ -255,7 +279,8 @@ const Index = () => {
 			/>
 			<View style={styles.markingsTopSpacer} />
 		</View>
-	), [readMore, screenWidth, theme, translate, primaryColor, contrastColor, handleReadMore, handleClearMarkingsWithConfirmation, markingsBreakdownLabel, openMarkingsBreakdownModal]);
+		);
+	}, [readMore, screenWidth, theme, translate, primaryColor, contrastColor, handleReadMore, handleClearMarkingsWithConfirmation, markingsBreakdownLabel, openMarkingsBreakdownModal]);
 
 	const ListFooterComponent = useMemo(() => (
 		<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_markings} />

--- a/apps/frontend/app/app/(app)/experimentell/food-wishlist/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/food-wishlist/index.tsx
@@ -109,14 +109,16 @@ const FoodWishlist = () => {
 	);
 
 	const renderFoodItem = (food: DatabaseTypes.Foods, index: number, totalItems: number) => {
-		const groupPosition =
-			totalItems === 1
-				? 'single'
-				: index === 0
-				? 'top'
-				: index === totalItems - 1
-				? 'bottom'
-				: 'middle';
+		let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+		if (totalItems === 1) {
+			groupPosition = 'single';
+		} else if (index === 0) {
+			groupPosition = 'top';
+		} else if (index === totalItems - 1) {
+			groupPosition = 'bottom';
+		} else {
+			groupPosition = 'middle';
+		}
 
 		const imageUri =
 			food.image_remote_url || getImageUrl(food.image as string) || undefined;

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -171,7 +171,16 @@ const Index = () => {
 				)}
 				{listItems.map((item, index) => {
 					const totalItems = listItems.length;
-					const groupPosition = totalItems === 1 ? 'single' : index === 0 ? 'top' : index === totalItems - 1 ? 'bottom' : 'middle';
+					let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+					if (totalItems === 1) {
+						groupPosition = 'single';
+					} else if (index === 0) {
+						groupPosition = 'top';
+					} else if (index === totalItems - 1) {
+						groupPosition = 'bottom';
+					} else {
+						groupPosition = 'middle';
+					}
 
 					return <SettingsList key={item.key} iconBgColor={primaryColor} leftIcon={item.leftIcon} label={item.label} rightIcon={<Entypo name="chevron-small-right" color={theme.screen.icon} size={24} />} handleFunction={item.onPress} groupPosition={groupPosition} />;
 				})}

--- a/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
@@ -491,7 +491,14 @@ const OnboardingScreen = () => {
 		},
 	], [translate, theme.screen.icon, customerConfigValueLabel]);
 
-	const currentMarkingsBreakdownId = seperatedMarkingsValue === true ? 'true' : seperatedMarkingsValue === false ? 'false' : 'null';
+	let currentMarkingsBreakdownId: 'true' | 'false' | 'null';
+	if (seperatedMarkingsValue === true) {
+		currentMarkingsBreakdownId = 'true';
+	} else if (seperatedMarkingsValue === false) {
+		currentMarkingsBreakdownId = 'false';
+	} else {
+		currentMarkingsBreakdownId = 'null';
+	}
 
 	const markingsBreakdownLabel = useMemo(
 		() => markingsBreakdownOptions.find(o => o.id === currentMarkingsBreakdownId)?.label ?? '',
@@ -507,7 +514,14 @@ const OnboardingScreen = () => {
 						options={markingsBreakdownOptions}
 						selectedOption={currentMarkingsBreakdownId}
 						onSelect={(option) => {
-							const newValue = option.id === 'true' ? true : option.id === 'false' ? false : null;
+							let newValue: boolean | null;
+							if (option.id === 'true') {
+								newValue = true;
+							} else if (option.id === 'false') {
+								newValue = false;
+							} else {
+								newValue = null;
+							}
 							dispatch({ type: SET_FOODOFFERS_SHOW_SEPARATED_MARKINGS_BREAKDOWN, payload: newValue });
 							closeModal();
 						}}
@@ -754,6 +768,29 @@ const OnboardingScreen = () => {
 		</View>
 	);
 
+	const nextOrStartButton = !isLastStep ? (
+		<TouchableOpacity
+			onPress={handleNext}
+			style={[styles.navButtonPrimary, { backgroundColor: primaryColor }]}
+		>
+			<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>
+				{translate(TranslationKeys.onboarding_next)}
+			</Text>
+			<MaterialCommunityIcons name="chevron-right" size={24} color={contrastColor} />
+		</TouchableOpacity>
+	) : (
+		<TouchableOpacity
+			onPress={handleStart}
+			style={[styles.navButtonPrimary, { backgroundColor: primaryColor }]}
+			activeOpacity={0.8}
+		>
+			<MaterialCommunityIcons name="rocket-launch" size={24} color={contrastColor} />
+			<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>
+				{translate(TranslationKeys.onboarding_start)}
+			</Text>
+		</TouchableOpacity>
+	);
+
 	return (
 		<SafeAreaView style={[styles.container, { backgroundColor: theme.screen.background }]}>
 			<ScrollView
@@ -797,28 +834,7 @@ const OnboardingScreen = () => {
 								{translate(TranslationKeys.onboarding_back)}
 							</Text>
 						</TouchableOpacity>
-						{!isLastStep ? (
-							<TouchableOpacity
-								onPress={handleNext}
-								style={[styles.navButtonPrimary, { backgroundColor: primaryColor }]}
-							>
-								<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>
-									{translate(TranslationKeys.onboarding_next)}
-								</Text>
-								<MaterialCommunityIcons name="chevron-right" size={24} color={contrastColor} />
-							</TouchableOpacity>
-						) : (
-							<TouchableOpacity
-								onPress={handleStart}
-								style={[styles.navButtonPrimary, { backgroundColor: primaryColor }]}
-								activeOpacity={0.8}
-							>
-								<MaterialCommunityIcons name="rocket-launch" size={24} color={contrastColor} />
-								<Text style={[styles.navButtonPrimaryText, { color: contrastColor }]}>
-									{translate(TranslationKeys.onboarding_start)}
-								</Text>
-							</TouchableOpacity>
-						)}
+						{nextOrStartButton}
 					</>
 				)}
 			</View>

--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -97,7 +97,14 @@ const FeedbackScreen = () => {
 		const isSimulator = !DeviceInfo.isDevice;
 		const isTablet = DeviceInfo.deviceType === DeviceInfo.DeviceType.TABLET;
 		const brand = DeviceInfo.brand;
-		const platform = Platform.OS === 'web' ? 'Web' : Platform.OS === 'ios' ? 'iOS' : 'Android';
+		let platform: string;
+		if (Platform.OS === 'web') {
+			platform = 'Web';
+		} else if (Platform.OS === 'ios') {
+			platform = 'iOS';
+		} else {
+			platform = 'Android';
+		}
 		const systemVersion = DeviceInfo.osVersion;
 		let isLandscape = getIsLandScape();
 
@@ -308,6 +315,33 @@ const FeedbackScreen = () => {
 		}
 	};
 
+	const webHeadingFontSize = isWeb ? 20 : 24;
+	const requestHeadingFontSize = windowWidth > 600 ? webHeadingFontSize : 24;
+	const webWarningFontSize = isWeb ? 17 : 20;
+	const warningFontSize = windowWidth > 600 ? webWarningFontSize : 20;
+	const webLinkFontSize = isWeb ? 18 : 16;
+	const linkFontSize = windowWidth > 600 ? webLinkFontSize : 16;
+
+	const getGroupPosition = (index: number, total: number) => {
+		if (index === 0) {
+			return 'top';
+		}
+		if (index === total - 1) {
+			return 'bottom';
+		}
+		return 'middle';
+	};
+
+	const getDeviceItemValue = (key: string) => {
+		if (key === 'device_brand') {
+			return inputValues[key] ? inputValues[key] : translate(TranslationKeys.unknown);
+		}
+		return inputValues[key] || '';
+	};
+
+	const submitButtonLabel = app_feedbacks_id ? translate(TranslationKeys.to_update) : translate(TranslationKeys.send);
+	const submitButtonIcon = app_feedbacks_id ? <FontAwesome5 name="save" size={24} color={contrastColor} /> : <MaterialCommunityIcons name="plus" size={24} color={contrastColor} />;
+
 	return (
 		<View
 			style={{
@@ -321,7 +355,7 @@ const FeedbackScreen = () => {
 					<View style={[styles.section, { width: windowWidth > 600 ? '85%' : '100%' }]}>
 						<Text
 							style={{
-								fontSize: windowWidth > 600 ? (isWeb ? 20 : 24) : 24,
+								fontSize: requestHeadingFontSize,
 								color: theme.screen.text,
 								padding: 15,
 							}}
@@ -343,7 +377,7 @@ const FeedbackScreen = () => {
 										keyboardType: item.keyboardType,
 									});
 								}}
-								groupPosition={index === 0 ? 'top' : index === feedbackSettingsItems.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(index, feedbackSettingsItems.length)}
 							/>
 						))}
 						{feedbackData
@@ -377,7 +411,7 @@ const FeedbackScreen = () => {
 						{!profile?.id && (
 							<Text
 								style={{
-									fontSize: windowWidth > 600 ? (isWeb ? 17 : 20) : 20,
+									fontSize: warningFontSize,
 									color: theme.screen.text,
 									padding: 15,
 								}}
@@ -419,14 +453,14 @@ const FeedbackScreen = () => {
 												styles.linkText,
 												{
 													color: contrastColor,
-													fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+													fontSize: linkFontSize,
 												},
 											]}
 										>
-											{app_feedbacks_id ? translate(TranslationKeys.to_update) : translate(TranslationKeys.send)}
+											{submitButtonLabel}
 										</Text>
 									</View>
-									<View>{app_feedbacks_id ? <FontAwesome5 name="save" size={24} color={contrastColor} /> : <MaterialCommunityIcons name="plus" size={24} color={contrastColor} />}</View>
+									<View>{submitButtonIcon}</View>
 								</>
 							)}
 						</TouchableOpacity>
@@ -448,7 +482,7 @@ const FeedbackScreen = () => {
 											styles.linkText,
 											{
 												color: theme.screen.text,
-												fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+												fontSize: linkFontSize,
 											},
 										]}
 									>
@@ -462,7 +496,7 @@ const FeedbackScreen = () => {
 											styles.linkText,
 											{
 												color: theme.screen.text,
-												fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+												fontSize: linkFontSize,
 											},
 										]}
 									>
@@ -487,7 +521,7 @@ const FeedbackScreen = () => {
 											styles.linkText,
 											{
 												color: theme.screen.text,
-												fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+												fontSize: linkFontSize,
 											},
 										]}
 									>
@@ -501,7 +535,7 @@ const FeedbackScreen = () => {
 											styles.linkText,
 											{
 												color: theme.screen.text,
-												fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+												fontSize: linkFontSize,
 											},
 										]}
 									>
@@ -518,7 +552,7 @@ const FeedbackScreen = () => {
 								key={item.key}
 								iconBgColor={primaryColor}
 								label={translate(item.title as any)}
-								value={excerpt(String(item.key === 'device_brand' ? (inputValues[item.key] ? inputValues[item.key] : translate(TranslationKeys.unknown)) : inputValues[item.key] || ''), windowWidth > 850 ? 50 : 20)}
+								value={excerpt(String(getDeviceItemValue(item.key)), windowWidth > 850 ? 50 : 20)}
 								rightIcon={<MaterialCommunityIcons name="pencil" size={24} color={theme.screen.icon} />}
 								handleFunction={() => {
 									openFeedbackSheet({
@@ -527,7 +561,7 @@ const FeedbackScreen = () => {
 										keyboardType: item.keyboardType,
 									});
 								}}
-								groupPosition={index === 0 ? 'top' : index === deviceSettingsItems.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(index, deviceSettingsItems.length)}
 								noIconIndent
 							/>
 						))}
@@ -564,7 +598,7 @@ const FeedbackScreen = () => {
 											styles.linkText,
 											{
 												color: theme.screen.text,
-												fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+												fontSize: linkFontSize,
 											},
 										]}
 									>

--- a/apps/frontend/app/app/(app)/foodoffers/components/FoodOfferListItem.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/FoodOfferListItem.tsx
@@ -50,6 +50,46 @@ const FoodOfferListItem: React.FC<FoodOfferListItemProps> = ({
     theme,
     amountColumnsForcard
 }) => {
+    let itemContent: React.ReactNode = null;
+    if (item.foodoffer) {
+        itemContent = (
+            <FoodItemBase
+                canteen={selectedCanteen as any}
+                item={item.foodoffer}
+                key={item.foodoffer.id || `food-item-${index}`}
+                handleMenuSheet={handleMenuSheet}
+                handleImageSheet={handleImageSheet}
+                cardWidth={cardWidth}
+                previousFeedback={previousFeedback}
+                language={language}
+                pirateLanguage={pirateLanguage}
+                funLanguageMode={funLanguageMode}
+                serverInfo={serverInfo}
+                appSettings={appSettings}
+                primaryColor={primaryColor}
+                user={user}
+                isManagement={isManagement}
+                profile={profile}
+                markings={markings}
+                screenWidth={screenWidth}
+                theme={theme}
+                amountColumnsForcard={amountColumnsForcard}
+            />
+        );
+    } else if (item.foodofferInfoItem) {
+        itemContent = (
+            <FoodOfferInfoItem
+                key={item.foodofferInfoItem.id || `info-item-${index}`}
+                item={item.foodofferInfoItem}
+                content={
+                    (getInfoItemContent(item.foodofferInfoItem) || {}).content || ''
+                }
+                cardWidth={cardWidth}
+                screenWidth={screenWidth}
+            />
+        );
+    }
+
     return (
         <View
             style={[
@@ -57,40 +97,7 @@ const FoodOfferListItem: React.FC<FoodOfferListItemProps> = ({
                 itemGap !== undefined && { marginHorizontal: itemGap, marginVertical: itemGap }
             ]}
         >
-            {item.foodoffer ? (
-                <FoodItemBase
-                    canteen={selectedCanteen as any}
-                    item={item.foodoffer}
-                    key={item.foodoffer.id || `food-item-${index}`}
-                    handleMenuSheet={handleMenuSheet}
-                    handleImageSheet={handleImageSheet}
-                    cardWidth={cardWidth}
-                    previousFeedback={previousFeedback}
-                    language={language}
-                    pirateLanguage={pirateLanguage}
-                    funLanguageMode={funLanguageMode}
-                    serverInfo={serverInfo}
-                    appSettings={appSettings}
-                    primaryColor={primaryColor}
-                    user={user}
-                    isManagement={isManagement}
-                    profile={profile}
-                    markings={markings}
-                    screenWidth={screenWidth}
-                    theme={theme}
-                    amountColumnsForcard={amountColumnsForcard}
-                />
-            ) : item.foodofferInfoItem ? (
-                <FoodOfferInfoItem
-                    key={item.foodofferInfoItem.id || `info-item-${index}`}
-                    item={item.foodofferInfoItem}
-                    content={
-                        (getInfoItemContent(item.foodofferInfoItem) || {}).content || ''
-                    }
-                    cardWidth={cardWidth}
-                    screenWidth={screenWidth}
-                />
-            ) : null}
+            {itemContent}
         </View>
     );
 };

--- a/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersList.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersList.tsx
@@ -75,7 +75,10 @@ const FoodOffersList: React.FC<FoodOffersListProps> = ({
         // Optimization: Lookup feedback directly from the map passed as prop
         // Use food.id for lookup as feedbackMap is keyed by food ID
         const food = item.foodoffer?.food;
-        const foodId = food ? (typeof food === 'string' ? food : food.id) : undefined;
+        let foodId: string | undefined;
+        if (food) {
+            foodId = typeof food === 'string' ? food : food.id;
+        }
         const previousFeedback = foodId ? feedbackMap.get(foodId) : undefined;
 
         return (

--- a/apps/frontend/app/app/(app)/form-queue/index.tsx
+++ b/apps/frontend/app/app/(app)/form-queue/index.tsx
@@ -78,7 +78,13 @@ const Index = () => {
                     } else if (custom_type === 'value_number') {
                         updatedValueFields = { value_number: value ? String(value).replace(',', '.') : null };
                     } else if (custom_type === 'value_boolean') {
-                        updatedValueFields = { value_boolean: value === 0 ? false : value === 1 ? true : null };
+                        let booleanValue: boolean | null = null;
+                        if (value === 0) {
+                            booleanValue = false;
+                        } else if (value === 1) {
+                            booleanValue = true;
+                        }
+                        updatedValueFields = { value_boolean: booleanValue };
                     } else if (custom_type === 'value_custom') {
                         updatedValueFields = { value_custom: value };
                     } else if (custom_type === 'value_date') {

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -402,7 +402,13 @@ const Index = () => {
 				} else if (FormHelperCommon.isFieldTypeNumber(fieldType)) {
 					value = defaultValue ? String(defaultValue)?.replace('.', ',') : null;
 				} else if (custom_type === 'value_boolean') {
-					value = defaultValue === false ? 0 : defaultValue === true ? 1 : null;
+					if (defaultValue === false) {
+						value = 0;
+					} else if (defaultValue === true) {
+						value = 1;
+					} else {
+						value = null;
+					}
 				} else if (FormHelperCommon.isDateFieldType(fieldType)) {
 					value = parseDateForEdit(fieldType, defaultValue);
 				} else if (custom_type === 'value_files') {
@@ -614,7 +620,10 @@ const Index = () => {
 
 	const handleAddToQueue = () => {
 		const rawFormId = (formSubmission as any)?.form;
-		const form_id = rawFormId ? (typeof rawFormId === 'object' ? String(rawFormId?.id || '') : String(rawFormId)) : '';
+		let form_id = '';
+		if (rawFormId) {
+			form_id = typeof rawFormId === 'object' ? String(rawFormId?.id || '') : String(rawFormId);
+		}
 		const alias = String(formSubmission?.alias || form_submission_id || '');
 		const entryId = queue_entry_id ? String(queue_entry_id) : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 		const entry = {
@@ -696,8 +705,14 @@ const Index = () => {
 						value_number: value ? value.replace(',', '.') : null,
 					};
 				} else if (custom_type === 'value_boolean') {
+					let booleanValue: boolean | null = null;
+					if (value === 0) {
+						booleanValue = false;
+					} else if (value === 1) {
+						booleanValue = true;
+					}
 					updatedValueFields = {
-						value_boolean: value === 0 ? false : value === 1 ? true : null,
+						value_boolean: booleanValue,
 					};
 				} else if (custom_type === 'value_custom') {
 					updatedValueFields = { value_custom: value };
@@ -869,6 +884,15 @@ const Index = () => {
 		fetchFolderIds();
 	}, []);
 
+	let aliasExcerptLength = 22;
+	if (screenWidth > 900) {
+		aliasExcerptLength = 100;
+	} else if (screenWidth > 700) {
+		aliasExcerptLength = 80;
+	}
+	const headerTitle = formSubmission ? excerpt(formSubmission?.alias as string, aliasExcerptLength) : '';
+	const formSubmissionIdText = formSubmission ? formSubmission?.id : '';
+
 	return (
 		<View
 			style={{
@@ -916,7 +940,7 @@ const Index = () => {
 						}} style={{ padding: 10 }}>
 							<Ionicons name="arrow-back" size={26} color={theme.header.text} />
 						</TouchableOpacity>
-						<Text style={{ ...styles.heading, color: theme.header.text }}>{formSubmission ? excerpt(formSubmission?.alias as string, screenWidth > 900 ? 100 : screenWidth > 700 ? 80 : 22) : ''}</Text>
+						<Text style={{ ...styles.heading, color: theme.header.text }}>{headerTitle}</Text>
 					</View>
 					<View style={{ ...styles.col2, gap: isWeb ? 30 : 15 }}>
 						<TouchableOpacity onPress={openEditSheet} style={{ padding: 10 }}>
@@ -946,7 +970,7 @@ const Index = () => {
 									backgroundColor: theme.screen.iconBg,
 								}}
 							>
-								<Text style={{ ...styles.body, color: theme.screen.text }}>{formSubmission ? formSubmission?.id : ''}</Text>
+								<Text style={{ ...styles.body, color: theme.screen.text }}>{formSubmissionIdText}</Text>
 							</View>
 							{formAnswers &&
 								formAnswers.map((answer, index) => {

--- a/apps/frontend/app/app/(app)/form-submissions/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submissions/index.tsx
@@ -400,6 +400,37 @@ const Index = () => {
 		[currentPath.length, router, theme.screen.icon, theme.screen.iconBg, theme.screen.text]
 	);
 
+	let headingExcerptLength = 22;
+	if (screenWidth > 900) {
+		headingExcerptLength = 100;
+	} else if (screenWidth > 700) {
+		headingExcerptLength = 80;
+	}
+
+	let submissionsContent: React.ReactNode;
+	if (loading) {
+		submissionsContent = (
+			<View
+				style={{
+					height: 200,
+					width: '100%',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
+			>
+				<ActivityIndicator size={30} color={theme.screen.text} />
+			</View>
+		);
+	} else if (formSubmissions?.length > 0) {
+		submissionsContent = <FlatList data={listData} keyExtractor={item => item.id} renderItem={renderItem} contentContainerStyle={{ paddingBottom: 10 }} />;
+	} else {
+		submissionsContent = (
+			<View style={{ padding: 20, alignItems: 'center' }}>
+				<Text style={{ color: theme.screen.text, fontSize: 16 }}>{translate(TranslationKeys.no_data_found)}</Text>
+			</View>
+		);
+	}
+
 	return (
 		<View
 			style={{
@@ -450,7 +481,7 @@ const Index = () => {
 						>
 							<Ionicons name="arrow-back" size={26} color={theme.header.text} />
 						</TouchableOpacity>
-						<Text style={{ ...styles.heading, color: theme.header.text }}>{excerpt(translate(TranslationKeys.select_a_form_submission), screenWidth > 900 ? 100 : screenWidth > 700 ? 80 : 22)}</Text>
+						<Text style={{ ...styles.heading, color: theme.header.text }}>{excerpt(translate(TranslationKeys.select_a_form_submission), headingExcerptLength)}</Text>
 					</View>
 					<View style={{ ...styles.col2, gap: isWeb ? 30 : 15 }}>
 						<TouchableOpacity onPress={openSortSheet} style={{ padding: 10 }}>
@@ -558,24 +589,7 @@ const Index = () => {
 			}}
 		>
 			<View style={{ flex: 1, width: screenWidth > 768 ? '70%' : '90%' }}>
-				{loading ? (
-					<View
-						style={{
-							height: 200,
-							width: '100%',
-							justifyContent: 'center',
-							alignItems: 'center',
-						}}
-					>
-						<ActivityIndicator size={30} color={theme.screen.text} />
-					</View>
-				) : formSubmissions?.length > 0 ? (
-					<FlatList data={listData} keyExtractor={item => item.id} renderItem={renderItem} contentContainerStyle={{ paddingBottom: 10 }} />
-				) : (
-					<View style={{ padding: 20, alignItems: 'center' }}>
-						<Text style={{ color: theme.screen.text, fontSize: 16 }}>{translate(TranslationKeys.no_data_found)}</Text>
-					</View>
-				)}
+				{submissionsContent}
 			</View>
 		</View>
 			<FilterFormSheet isVisible={isFilterModalVisible} closeSheet={closeFilterSheet} isFormSubmission={true} setSelectedOption={setSelectedOption} selectedOption={selectedOption} options={filterOptions} />

--- a/apps/frontend/app/app/(app)/licenseInformation/index.tsx
+++ b/apps/frontend/app/app/(app)/licenseInformation/index.tsx
@@ -36,6 +36,15 @@ const LicenseInformation = () => {
 		return <Text>Packages data not available.</Text>;
 	}
 
+	let sectionFontSize = 16;
+	if (windowWidth > 600) {
+		sectionFontSize = isWeb ? 18 : 16;
+	}
+	let detailFontSize = 12;
+	if (windowWidth > 600) {
+		detailFontSize = isWeb ? 14 : 12;
+	}
+
 	return (
 		<View style={{ flex: 1, backgroundColor: theme.screen.background }}>
 			<ScrollView>
@@ -54,7 +63,7 @@ const LicenseInformation = () => {
 										style={{
 											width: '70%',
 											color: theme.screen.text,
-											fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+											fontSize: sectionFontSize,
 										}}
 									>
 										{pkg.name}
@@ -64,7 +73,7 @@ const LicenseInformation = () => {
 											style={{
 												marginRight: 10,
 												color: theme.screen.text,
-												fontSize: windowWidth > 600 ? (isWeb ? 18 : 16) : 16,
+												fontSize: sectionFontSize,
 											}}
 										>
 											{pkg.version}
@@ -78,7 +87,7 @@ const LicenseInformation = () => {
 											<Text
 												style={{
 													color: theme.screen.text,
-													fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+													fontSize: detailFontSize,
 												}}
 											>
 												Package
@@ -86,7 +95,7 @@ const LicenseInformation = () => {
 											<Text
 												style={{
 													color: theme.screen.text,
-													fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+													fontSize: detailFontSize,
 												}}
 											>
 												{pkg.name}
@@ -96,7 +105,7 @@ const LicenseInformation = () => {
 											<Text
 												style={{
 													color: theme.screen.text,
-													fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+													fontSize: detailFontSize,
 												}}
 											>
 												Version
@@ -104,7 +113,7 @@ const LicenseInformation = () => {
 											<Text
 												style={{
 													color: theme.screen.text,
-													fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+													fontSize: detailFontSize,
 												}}
 											>
 												{pkg.version}
@@ -114,7 +123,7 @@ const LicenseInformation = () => {
 											<Text
 												style={{
 													color: theme.screen.text,
-													fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+													fontSize: detailFontSize,
 												}}
 											>
 												License
@@ -122,7 +131,7 @@ const LicenseInformation = () => {
 											<Text
 												style={{
 													color: theme.screen.text,
-													fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+													fontSize: detailFontSize,
 												}}
 											>
 												{pkg.license}
@@ -137,7 +146,7 @@ const LicenseInformation = () => {
 												<Text
 													style={{
 														color: theme.screen.text,
-														fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+														fontSize: detailFontSize,
 													}}
 												>
 													Repository
@@ -162,7 +171,7 @@ const LicenseInformation = () => {
 												<Text
 													style={{
 														color: theme.screen.text,
-														fontSize: windowWidth > 600 ? (isWeb ? 14 : 12) : 12,
+														fontSize: detailFontSize,
 													}}
 												>
 													License URL:

--- a/apps/frontend/app/app/(app)/map/components/JoggingOverlay.tsx
+++ b/apps/frontend/app/app/(app)/map/components/JoggingOverlay.tsx
@@ -85,12 +85,12 @@ function computeStats(points: RoutePoint[]): RunStats {
 		// Speed: prefer GPS speed, fall back to distance/time
 		const dtSec = (points[i].timestamp - points[i - 1].timestamp) / 1000;
 		const gpsSpeed = points[i].speed;
-		const segSpeedKmh =
-			gpsSpeed != null && gpsSpeed >= 0
-				? gpsSpeed * 3.6
-				: dtSec > 0
-				? (segKm / dtSec) * 3600
-				: 0;
+		let segSpeedKmh = 0;
+		if (gpsSpeed != null && gpsSpeed >= 0) {
+			segSpeedKmh = gpsSpeed * 3.6;
+		} else if (dtSec > 0) {
+			segSpeedKmh = (segKm / dtSec) * 3600;
+		}
 		if (segSpeedKmh > 0) speedsKmh.push(segSpeedKmh);
 	}
 

--- a/apps/frontend/app/app/(app)/map/index.tsx
+++ b/apps/frontend/app/app/(app)/map/index.tsx
@@ -86,6 +86,13 @@ type ControlButtonProps = {
 	size?: 'sm' | 'md' | 'lg';
 };
 
+const getListGroupPosition = (index: number, total: number): 'single' | 'top' | 'bottom' | 'middle' => {
+	if (total === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+};
+
 const ControlButton: React.FC<ControlButtonProps> = ({
 	onPressIn,
 	onPressOut,
@@ -95,7 +102,12 @@ const ControlButton: React.FC<ControlButtonProps> = ({
 	color = 'rgba(0,0,0,0.65)',
 	size = 'md',
 }) => {
-	const dim = size === 'sm' ? 38 : size === 'lg' ? 58 : 48;
+	let dim = 48;
+	if (size === 'sm') {
+		dim = 38;
+	} else if (size === 'lg') {
+		dim = 58;
+	}
 	return (
 		<TouchableOpacity
 			style={{
@@ -565,8 +577,7 @@ const OsmFilterContent: React.FC<OsmFilterContentProps> = ({
 			<View style={{ height: 16 }} />
 			{organisations.map((org, index) => {
 				const total = organisations.length;
-				const groupPosition =
-					total === 1 ? 'single' : index === 0 ? 'top' : index === total - 1 ? 'bottom' : 'middle';
+				const groupPosition = getListGroupPosition(index, total);
 				return (
 					<SettingsListOrganisationFast
 						key={org.id}
@@ -1502,6 +1513,15 @@ const OsmVectorMapScreen: React.FC = () => {
 
 	const isFilterActive = useMemo(() => Object.keys(organisationLikes).length > 0, [organisationLikes]);
 
+	const initialMapPitch = gameMode ? GAME_MODE_PITCH : INITIAL_PITCH;
+	const compassBackgroundColor = headingUpMode ? 'rgba(26,115,232,0.9)' : (theme.screen.background + 'ee');
+	const compassIconColor = headingUpMode ? 'white' : theme.screen.icon;
+	const locationIconColor = userLocation ? '#1a73e8' : theme.screen.icon;
+	const rotateLeftBackgroundColor = autoRotateSpeed < 0 ? 'rgba(26,115,232,0.9)' : theme.screen.background;
+	const rotateLeftIconColor = autoRotateSpeed < 0 ? 'white' : theme.screen.icon;
+	const rotateRightBackgroundColor = autoRotateSpeed > 0 ? 'rgba(26,115,232,0.9)' : theme.screen.background;
+	const rotateRightIconColor = autoRotateSpeed > 0 ? 'white' : theme.screen.icon;
+
 	return (
 		<SafeAreaView style={[styles.safeArea, { backgroundColor: isFullscreen ? 'transparent' : theme.header.background }]}>
 			{!isFullscreen && (
@@ -1520,7 +1540,7 @@ const OsmVectorMapScreen: React.FC = () => {
 						<MyMap
 							ref={myMapRef}
 							initialCenter={centerPosition}
-							initialPitch={gameMode ? GAME_MODE_PITCH : INITIAL_PITCH}
+							initialPitch={initialMapPitch}
 							loadingText={translate(TranslationKeys.loading_vector_map)}
 							onMessage={handleMessage}
 						/>
@@ -1575,12 +1595,12 @@ const OsmVectorMapScreen: React.FC = () => {
 								<TouchableOpacity
 									style={[
 										styles.gameCompassTouchable,
-										{ backgroundColor: headingUpMode ? 'rgba(26,115,232,0.9)' : (theme.screen.background + 'ee') },
+										{ backgroundColor: compassBackgroundColor },
 									]}
 									onPress={handleGameCompassToggle}
 									activeOpacity={0.75}
 								>
-									<MaterialIcons name="explore" size={26} color={headingUpMode ? 'white' : theme.screen.icon} />
+									<MaterialIcons name="explore" size={26} color={compassIconColor} />
 								</TouchableOpacity>
 							</View>
 
@@ -1612,24 +1632,24 @@ const OsmVectorMapScreen: React.FC = () => {
 									style={[styles.mapOverlayButton, { backgroundColor: theme.screen.background, marginTop: 8 }]}
 									onPress={handleLocationPress}
 								>
-									<MaterialIcons name="my-location" size={26} color={userLocation ? '#1a73e8' : theme.screen.icon} />
+									<MaterialIcons name="my-location" size={26} color={locationIconColor} />
 								</TouchableOpacity>
 								{autoRotateMode && (
 									<>
 										<TouchableOpacity
-											style={[styles.mapOverlayButton, { backgroundColor: autoRotateSpeed < 0 ? 'rgba(26,115,232,0.9)' : theme.screen.background, marginTop: 8 }]}
+											style={[styles.mapOverlayButton, { backgroundColor: rotateLeftBackgroundColor, marginTop: 8 }]}
 											onPress={handleAutoRotateSpeedLeft}
 										>
-											<MaterialIcons name="rotate-left" size={26} color={autoRotateSpeed < 0 ? 'white' : theme.screen.icon} />
+											<MaterialIcons name="rotate-left" size={26} color={rotateLeftIconColor} />
 										</TouchableOpacity>
 										<View style={{ alignItems: 'center', paddingVertical: 2 }}>
 											<Text style={{ color: theme.screen.text, fontSize: 10 }}>{`${autoRotateSpeed}°/s`}</Text>
 										</View>
 										<TouchableOpacity
-											style={[styles.mapOverlayButton, { backgroundColor: autoRotateSpeed > 0 ? 'rgba(26,115,232,0.9)' : theme.screen.background }]}
+											style={[styles.mapOverlayButton, { backgroundColor: rotateRightBackgroundColor }]}
 											onPress={handleAutoRotateSpeedRight}
 										>
-											<MaterialIcons name="rotate-right" size={26} color={autoRotateSpeed > 0 ? 'white' : theme.screen.icon} />
+											<MaterialIcons name="rotate-right" size={26} color={rotateRightIconColor} />
 										</TouchableOpacity>
 
 									</>
@@ -1672,15 +1692,7 @@ const OsmVectorMapScreen: React.FC = () => {
 								title={building.alias ?? ''}
 								onPress={() => handleSearchResultSelect(building)}
 								showSeparator={index < searchResults.length - 1}
-								groupPosition={
-									searchResults.length === 1
-										? 'single'
-										: index === 0
-										? 'top'
-										: index === searchResults.length - 1
-										? 'bottom'
-										: 'middle'
-								}
+								groupPosition={getListGroupPosition(index, searchResults.length)}
 								noIconIndent
 							/>
 						))}

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -697,14 +697,30 @@ const Settings = () => {
 		});
 
 		// === App Settings ===
+		let colorSchemeValue: string;
+		if (selectedTheme === 'systematic') {
+			colorSchemeValue = translate(TranslationKeys.color_scheme_system);
+		} else if (selectedTheme === 'dark') {
+			colorSchemeValue = translate(TranslationKeys.color_scheme_dark);
+		} else {
+			colorSchemeValue = translate(TranslationKeys.color_scheme_light);
+		}
+		let drawerPositionValue: string;
+		if (drawerPosition === 'left') {
+			drawerPositionValue = translate(TranslationKeys.drawer_config_position_left);
+		} else if (drawerPosition === 'right') {
+			drawerPositionValue = translate(TranslationKeys.drawer_config_position_right);
+		} else {
+			drawerPositionValue = translate(TranslationKeys.drawer_config_position_system);
+		}
 		rows.push({
 			key: 'section-app-settings',
 			element: (
 				<View style={sectionStyle}>
 					<SettingsGroupTitle nativeID={ComponentIds.SETTINGS_GROUP_APP_SETTINGS}>{translate(TranslationKeys.group_app_settings)}</SettingsGroupTitle>
 					<View style={groupStyle}>
-						<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="theme-light-dark" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.color_scheme)} value={selectedTheme === 'systematic' ? translate(TranslationKeys.color_scheme_system) : selectedTheme === 'dark' ? translate(TranslationKeys.color_scheme_dark) : translate(TranslationKeys.color_scheme_light)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openColorSchemeSheet()} groupPosition="top" nativeID={ComponentIds.SETTINGS_COLOR_SCHEME} />
-						<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="menu" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.drawer_config_position)} value={drawerPosition === 'left' ? translate(TranslationKeys.drawer_config_position_left) : drawerPosition === 'right' ? translate(TranslationKeys.drawer_config_position_right) : translate(TranslationKeys.drawer_config_position_system)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openMenuPositionModal} groupPosition="middle" />
+						<SettingsList iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="theme-light-dark" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.color_scheme)} value={colorSchemeValue} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => openColorSchemeSheet()} groupPosition="top" nativeID={ComponentIds.SETTINGS_COLOR_SCHEME} />
+						<SettingsList iconBgColor={primaryColor} leftIcon={<Entypo name="menu" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.drawer_config_position)} value={drawerPositionValue} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openMenuPositionModal} groupPosition="middle" />
 						<SettingsList iconBgColor={primaryColor} leftIcon={<FontAwesome5 name="columns" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.amount_columns_for_cards)} value={amountColumnsForcard === 0 ? translate(TranslationKeys.automatic) : amountColumnsForcard} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openCardColumnsModal} groupPosition="middle" />
 						<SettingsList iconBgColor={primaryColor} leftIcon={<Feather name="calendar" size={24} color={theme.screen.icon} />} label={translate(TranslationKeys.first_day_of_week)} value={translate(firstDayOfTheWeek?.name)} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={openFirstDayOfWeekModal} groupPosition="bottom" />
 					</View>
@@ -1031,6 +1047,11 @@ const Settings = () => {
 		isClearingAsyncStorage, handleClearAsyncStorage,
 	]);
 
+	let listWidth: '100%' | '80%' = '100%';
+	if (windowWidth >= 500 && isWeb) {
+		listWidth = '80%';
+	}
+
 	return (
 		<SafeAreaView style={{ flex: 1, backgroundColor: theme.screen.background }}>
 			<FlatList
@@ -1040,7 +1061,7 @@ const Settings = () => {
 				style={[
 					styles.container,
 					{
-						width: windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
+						width: listWidth,
 						alignSelf: 'center',
 					},
 				]}

--- a/apps/frontend/app/app/(app)/support-ticket/index.tsx
+++ b/apps/frontend/app/app/(app)/support-ticket/index.tsx
@@ -13,6 +13,13 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { useAppSelector } from '@/redux/hooks';
 import { DatabaseTypes } from 'repo-depkit-common';
 
+const getTicketGroupPosition = (index: number, total: number): 'single' | 'top' | 'bottom' | 'middle' => {
+	if (total === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+};
+
 const Index = () => {
 	useSetPageTitle(TranslationKeys.my_support_tickets);
 	const { theme } = useTheme();
@@ -49,6 +56,9 @@ const Index = () => {
 			subscription.remove();
 		};
 	}, []);
+
+	const sectionWidth = windowWidth > 600 ? '85%' : '95%';
+
 	return (
 		<ScrollView style={[styles.container, { backgroundColor: theme.screen.background }]} contentContainerStyle={styles.contentContainer}>
 			{loading ? (
@@ -65,7 +75,7 @@ const Index = () => {
 			) : (
 				<>
 					<Text style={{ ...styles.groupHeading, color: theme.screen.text }}>{translate(TranslationKeys.my_support_tickets)}</Text>
-					<View style={[styles.section, { width: windowWidth > 600 ? '85%' : '95%' }]}>{allTickets && allTickets?.map((item, index: number) => <SettingsList key={index} iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="bell" size={24} color={theme.screen.icon} />} label={item?.title ?? undefined} value={item?.date_created ? format(new Date(item.date_created), 'dd.MM.yyyy HH:mm') : 'N/A'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.push(`/feedback-support?app_feedbacks_id=${item.id}`)} groupPosition={allTickets.length === 1 ? 'single' : index === 0 ? 'top' : index === allTickets.length - 1 ? 'bottom' : 'middle'} />)}</View>
+					<View style={[styles.section, { width: sectionWidth }]}>{allTickets && allTickets?.map((item, index: number) => <SettingsList key={index} iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="bell" size={24} color={theme.screen.icon} />} label={item?.title ?? undefined} value={item?.date_created ? format(new Date(item.date_created), 'dd.MM.yyyy HH:mm') : 'N/A'} rightIcon={<Octicons name="chevron-right" size={24} color={theme.screen.icon} />} handleFunction={() => router.push(`/feedback-support?app_feedbacks_id=${item.id}`)} groupPosition={getTicketGroupPosition(index, allTickets.length)} />)}</View>
 				</>
 			)}
 		</ScrollView>

--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -72,7 +72,15 @@ const Index = () => {
 		[params?.showMarkingsOnCard]
 	);
 
-	const cardMarkingSize = useMemo(() => (screenWidth > 1200 ? 100 : screenWidth > 900 ? 80 : 60), [screenWidth]);
+	const cardMarkingSize = useMemo(() => {
+		if (screenWidth > 1200) {
+			return 100;
+		}
+		if (screenWidth > 900) {
+			return 80;
+		}
+		return 60;
+	}, [screenWidth]);
 	const cardMarkings = useMemo(
 		() => currentMarking.filter(mark => mark?.show_on_card),
 		[currentMarking]
@@ -221,9 +229,10 @@ const Index = () => {
 	}, [foods, params.nextFoodIntervalInSeconds]);
 
 	const updateLogoStyle = useCallback(() => {
+		const logoHeightForWideScreen = width > 600 ? 75 : 70;
 		setLogoStyle({
 			width: width < 600 ? 150 : 300,
-			height: width < 600 ? 70 : width > 600 ? 75 : 70,
+			height: width < 600 ? 70 : logoHeightForWideScreen,
 			marginRight: width > 600 ? 20 : 10,
 		});
 	}, [width]);
@@ -337,6 +346,9 @@ const Index = () => {
 		</View>
 	);
 
+	const orientationFlexDirection = width > height ? 'row' : 'column';
+	const contentFlexDirection = foods && foods?.length < 1 ? 'column' : orientationFlexDirection;
+
 	return (
 		<ScrollView
 			style={{
@@ -344,7 +356,7 @@ const Index = () => {
 				backgroundColor: theme.screen.background,
 			}}
 			contentContainerStyle={{
-				flexDirection: foods && foods?.length < 1 ? 'column' : width > height ? 'row' : 'column',
+				flexDirection: contentFlexDirection,
 			}}
 		>
 			<View style={[foods && foods?.length > 0 && { flex: 1 }]}>

--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -108,11 +108,14 @@ const Index = () => {
 	};
 
 	const openIntervalSheet = (intervalKey: string, intervalLabel: string) => {
-		const initialValue = intervalKey === 'foodInterval'
-			? (foodPlan?.nextFoodInterval ? String(foodPlan.nextFoodInterval) : '')
-			: (foodPlan?.refreshInterval ? String(foodPlan.refreshInterval) : '');
+		const foodIntervalValue = foodPlan?.nextFoodInterval ? String(foodPlan.nextFoodInterval) : '';
+		const refreshIntervalValue = foodPlan?.refreshInterval ? String(foodPlan.refreshInterval) : '';
+		const initialValue = intervalKey === 'foodInterval' ? foodIntervalValue : refreshIntervalValue;
 
 		let currentValue = initialValue;
+
+		const mediumScreenButtonWidth = windowWidth < 800 ? '50%' : '30%';
+		const buttonContainerWidth = windowWidth < 500 ? '70%' : mediumScreenButtonWidth;
 
 		showScrollViewModal({
 			title: intervalLabel,
@@ -138,7 +141,7 @@ const Index = () => {
 						style={[
 							styles.buttonContainer,
 							{
-								width: windowWidth < 500 ? '70%' : windowWidth < 800 ? '50%' : '30%',
+								width: buttonContainerWidth,
 							},
 						]}
 					>

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -596,6 +596,9 @@ const Index = () => {
 		chunkedMarkings.push(markings?.slice(i, i + 7));
 	}
 
+	const optionalFoodsAvailableMaxHeight = foods?.length > 0 ? tableMaxHeight / 2 - 20 : tableMaxHeight;
+	const optionalFoodsMaxHeight = optionalFoods?.length > 0 ? optionalFoodsAvailableMaxHeight : 0;
+
 	return (
 		<ScrollView style={[styles.outerContainer, { backgroundColor: theme.screen.background }]}>
 			<View ref={headerRef} onLayout={handleHeaderLayout} style={{ width: '100%', height: 100, position: 'relative' }}>
@@ -808,7 +811,7 @@ const Index = () => {
 							ref={optionalFoodsScrollRef}
 							style={[
 								{
-									maxHeight: optionalFoods?.length > 0 ? (foods?.length > 0 ? tableMaxHeight / 2 - 20 : tableMaxHeight) : 0,
+									maxHeight: optionalFoodsMaxHeight,
 								},
 								windowWidth < 900 && { minHeight: 200 },
 							]}

--- a/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -357,12 +357,14 @@ const Index = () => {
 		}
 	};
 
+	const noOffersFound = Object.entries(categories)?.length < 1;
+
 	return (
 		<View style={{ flex: 1, backgroundColor: theme.screen.iconBg }}>
 			<ListWeekHeader handlePrint={handlePrint} />
 
 			<View style={{ flex: 1 }}>
-				{loading ? (
+				{loading && (
 					<View
 						style={{
 							height: 200,
@@ -373,7 +375,8 @@ const Index = () => {
 					>
 						<ActivityIndicator size={30} color={foods_area_color} />
 					</View>
-				) : Object.entries(categories)?.length < 1 ? (
+				)}
+				{!loading && noOffersFound && (
 					<View
 						style={{
 							height: 200,
@@ -384,7 +387,8 @@ const Index = () => {
 					>
 						<Text style={{ ...styles.noDataFound, color: theme.screen.text }}>Keine Angebote an diesem Tag gefunden.</Text>
 					</View>
-				) : (
+				)}
+				{!loading && !noOffersFound && (
 					<ScrollView
 						style={{ flex: 1 }}
 						contentContainerStyle={[
@@ -432,6 +436,7 @@ const Index = () => {
 
 								const columns = getColumns();
 								const totalFlex = columns.reduce((sum, c) => sum + c.flex, 0);
+								const dayLabelFontFamily = isMobile ? 'Poppins_400Regular' : 'Poppins_700Bold';
 
 								// Check if any column for this day has food items
 								const hasAnyFood = columns.some(col => {
@@ -508,57 +513,68 @@ const Index = () => {
 																					const iconParts = marking?.icon?.split(':') || [];
 																					const [library, name] = iconParts;
 																					const Icon = library && iconLibraries[library];
-																					return marking?.icon ? (
-																						<View
-																							key={idx}
-																							style={{
-																								...styles.iconMarking,
-																								backgroundColor: marking?.bgColor,
-																								marginRight: 5,
-																								borderRadius: 5,
-																							}}
-																						>
-																							<Icon name={name} size={14} color={marking.color} />
-																						</View>
-																					) : !marking?.image?.uri && marking?.shortCode ? (
-																						<View
-																							key={idx}
-																							style={{
-																								...styles.shortCode,
-																								backgroundColor: marking?.bgColor,
-																								marginRight: 5,
-																								padding: 2,
-																								borderRadius: 5,
-																							}}
-																						>
-																							<Text
+																					if (marking?.icon) {
+																						return (
+																							<View
+																								key={idx}
 																								style={{
-																									color: marking.color,
-																									fontSize: fontSize,
+																									...styles.iconMarking,
+																									backgroundColor: marking?.bgColor,
+																									marginRight: 5,
+																									borderRadius: 5,
 																								}}
 																							>
-																								{marking?.shortCode}
-																							</Text>
-																						</View>
-																					) : marking?.image?.uri ? (
-																						<Image
-																							key={idx}
-																							source={marking.image.uri}
-																							style={{
-																								backgroundColor: marking?.bgColor,
-																								width: 15,
-																								height: 15,
-																								marginRight: 2,
-																								borderRadius: 5,
-																							}}
-																						/>
-																					) : null;
+																								<Icon name={name} size={14} color={marking.color} />
+																							</View>
+																						);
+																					}
+																					if (!marking?.image?.uri && marking?.shortCode) {
+																						return (
+																							<View
+																								key={idx}
+																								style={{
+																									...styles.shortCode,
+																									backgroundColor: marking?.bgColor,
+																									marginRight: 5,
+																									padding: 2,
+																									borderRadius: 5,
+																								}}
+																							>
+																								<Text
+																									style={{
+																										color: marking.color,
+																										fontSize: fontSize,
+																									}}
+																								>
+																									{marking?.shortCode}
+																								</Text>
+																							</View>
+																						);
+																					}
+																					if (marking?.image?.uri) {
+																						return (
+																							<Image
+																								key={idx}
+																								source={marking.image.uri}
+																								style={{
+																									backgroundColor: marking?.bgColor,
+																									width: 15,
+																									height: 15,
+																									marginRight: 2,
+																									borderRadius: 5,
+																								}}
+																							/>
+																						);
+																					}
+																					return null;
 																				})}
 																		</View>
 																	)}
 																</View>
 															);
 														});
+
+													const foodItemsContent = foodItems?.length > 0 ? foodItems : <Text style={{ color: theme.screen.text }}>-</Text>;
 
 													return (
 														<View
@@ -581,7 +597,7 @@ const Index = () => {
 																			styles.itemText,
 																			{
 																				fontSize: fontSize,
-																				fontFamily: isMobile ? 'Poppins_400Regular' : 'Poppins_700Bold',
+																				fontFamily: dayLabelFontFamily,
 																				textAlign: 'center',
 																				color: theme.screen.text,
 																			},
@@ -594,7 +610,7 @@ const Index = () => {
 																			styles.itemText,
 																			{
 																				fontSize: fontSize,
-																				fontFamily: isMobile ? 'Poppins_400Regular' : 'Poppins_700Bold',
+																				fontFamily: dayLabelFontFamily,
 																				textAlign: 'center',
 																				color: theme.screen.text,
 																			},
@@ -604,7 +620,7 @@ const Index = () => {
 																	</Text>
 																</View>
 															) : (
-																<View style={{ flexDirection: 'column' }}>{foodItems?.length > 0 ? foodItems : <Text style={{ color: theme.screen.text }}>-</Text>}</View>
+																<View style={{ flexDirection: 'column' }}>{foodItemsContent}</View>
 															)}
 														</View>
 													);
@@ -629,7 +645,7 @@ const Index = () => {
 																	styles.itemText,
 																	{
 																		fontSize: fontSize,
-																		fontFamily: isMobile ? 'Poppins_400Regular' : 'Poppins_700Bold',
+																		fontFamily: dayLabelFontFamily,
 																		textAlign: 'center',
 																		color: theme.screen.text,
 																	},
@@ -642,7 +658,7 @@ const Index = () => {
 																	styles.itemText,
 																	{
 																		fontSize: fontSize,
-																		fontFamily: isMobile ? 'Poppins_400Regular' : 'Poppins_700Bold',
+																		fontFamily: dayLabelFontFamily,
 																		textAlign: 'center',
 																		color: theme.screen.text,
 																	},

--- a/apps/frontend/app/app/(monitor)/list-week-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/index.tsx
@@ -107,6 +107,9 @@ const Index = () => {
 		setWeeks(generateWeeks(selectedYear - 1));
 	};
 
+	const wideScreenWeekButtonWidth = width > 900 ? 250 : 200;
+	const weekButtonWidth = width < 450 ? width / 2 - 20 : wideScreenWeekButtonWidth;
+
 	return (
 		<View style={[styles.container, { backgroundColor: theme.screen.background }]}>
 			<View style={[styles.header, { backgroundColor: theme.screen.background }]}>
@@ -184,7 +187,7 @@ const Index = () => {
 											},
 										],
 								{
-									width: width < 450 ? width / 2 - 20 : width > 900 ? 250 : 200,
+									width: weekButtonWidth,
 								},
 							]}
 							onPress={() => handleWeekPress('any', week.weekNumber)}

--- a/apps/frontend/app/app/(wikis)/wikis/index.tsx
+++ b/apps/frontend/app/app/(wikis)/wikis/index.tsx
@@ -54,6 +54,8 @@ const Index = () => {
 			.finally(() => setLoading(false));
 	}, [wikis, custom_id, id]);
 
+	const hasWikiContent = Boolean(wiki?.translations && getTextFromTranslation(wiki.translations, language)?.trim());
+
 	return (
 		<ScrollView style={{ ...styles.container, backgroundColor: theme.screen.background }}>
 			{deviceMock && deviceMock === 'iphone' && isWeb && <DeviceMock />}
@@ -74,7 +76,7 @@ const Index = () => {
 				</View>
 			</View>
 			<View style={styles.content}>
-				{loading ? (
+				{loading && (
 					<View
 						style={{
 							height: 200,
@@ -85,9 +87,11 @@ const Index = () => {
 					>
 						<ActivityIndicator size={30} color={theme.screen.text} />
 					</View>
-				) : wiki?.translations && getTextFromTranslation(wiki.translations, language)?.trim() ? (
+				)}
+				{!loading && hasWikiContent && wiki?.translations && (
 					<CustomMarkdown content={translateDynamic(getTextFromTranslation(wiki.translations, language))} backgroundColor={wiki?.color || primaryColor} imageWidth={'100%'} imageHeight={400} />
-				) : (
+				)}
+				{!loading && !hasWikiContent && (
 					<Text style={{ color: theme.screen.text, padding: 16 }}>{translate(TranslationKeys.no_data_found)}</Text>
 				)}
 			</View>

--- a/apps/frontend/app/components/BuildingDetailsContent/BuildingDetailsContent.tsx
+++ b/apps/frontend/app/components/BuildingDetailsContent/BuildingDetailsContent.tsx
@@ -150,14 +150,16 @@ const BuildingDetailsContent: React.FC<BuildingDetailsContentProps> = ({ id }) =
                         <SettingsGroupTitle>{translate(TranslationKeys.organisations)}</SettingsGroupTitle>
                         {buildingOrganisations.map((org, index) => {
                             const total = buildingOrganisations.length;
-                            const groupPosition =
-                                total === 1
-                                    ? 'single'
-                                    : index === 0
-                                    ? 'top'
-                                    : index === total - 1
-                                    ? 'bottom'
-                                    : 'middle';
+                            let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+                            if (total === 1) {
+                                groupPosition = 'single';
+                            } else if (index === 0) {
+                                groupPosition = 'top';
+                            } else if (index === total - 1) {
+                                groupPosition = 'bottom';
+                            } else {
+                                groupPosition = 'middle';
+                            }
                             return (
                                 <SettingsList
                                     key={org.id}

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -183,7 +183,7 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 					</View>
 
 					<View style={styles.imageActionContainer}>
-						{isManagement ? (
+						{isManagement && (
 							<TouchableOpacity
 								style={styles.editImageButton}
 								onPress={() => {
@@ -192,16 +192,16 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 							>
 								<View />
 							</TouchableOpacity>
-						) : isLastOpened ? (
+						)}
+						{!isManagement && isLastOpened && (
 							<TouchableOpacity
 								style={[styles.lastOpenedButton, { backgroundColor: campus_area_color }]}
 								onPress={handleOpenLastOpenedModal}
 							>
 								<MaterialCommunityIcons name="clock-outline" size={20} color={contrastColor} />
 							</TouchableOpacity>
-						) : (
-							<View />
 						)}
+						{!isManagement && !isLastOpened && <View />}
 
 						<View style={styles.distanceActions}>
 							<TouchableOpacity

--- a/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -270,6 +270,11 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 		}
 	};
 
+	const eventModeHeading = isUpdate ? `${translate(TranslationKeys.event)}: ${translate(TranslationKeys.edit)}` : `${translate(TranslationKeys.event)}: ${translate(TranslationKeys.create)}`;
+	const sheetHeading = selectedItem ? selectedItem.label : eventModeHeading;
+	const isColorSheet = selectedItem?.label === 'color';
+	const isWeekdaySheet = selectedItem?.label === 'weekday';
+
 	return (
 		<View style={{ flex: 1 }}>
 			<View
@@ -287,70 +292,71 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 						color: theme.sheet.text,
 					}}
 				>
-					{selectedItem ? selectedItem.label : isUpdate ? `${translate(TranslationKeys.event)}: ${translate(TranslationKeys.edit)}` : `${translate(TranslationKeys.event)}: ${translate(TranslationKeys.create)}`}
+					{sheetHeading}
 				</Text>
 			</View>
 
 			<View style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg, ...styles.contentContainer }}>
-				{selectedItem ? (
-					selectedItem.label === 'color' ? (
-						<View
-							style={{
-								width: '90%',
-								display: 'flex',
-								justifyContent: 'center',
-								alignSelf: 'center',
-							}}				
-							>
-							<View style={styles.weekdayView}>
-								{colorData.map((color, index) => (
-									<TouchableOpacity
-										key={index}
-										onPress={() => handleColorPress(color)}
-										style={[
-											styles.box,
-											{
-												width: isWeb ? 200 : '30%',
-												backgroundColor: color,
-											},
-										]}
-									></TouchableOpacity>
-								))}
-							</View>
-						</View>
-					) : selectedItem.label === 'weekday' ? (
-						<View style={styles.languageContainer}>
-							{days.map(firstDay => (
-								<FirstDayOfWeek key={firstDay.id} position={firstDay} isSelected={selectedFirstDay.name === firstDay.name} onPress={() => handleDaySelect(firstDay.id, firstDay.name)} />
+				{isColorSheet && (
+					<View
+						style={{
+							width: '90%',
+							display: 'flex',
+							justifyContent: 'center',
+							alignSelf: 'center',
+						}}				
+						>
+						<View style={styles.weekdayView}>
+							{colorData.map((color, index) => (
+								<TouchableOpacity
+									key={index}
+									onPress={() => handleColorPress(color)}
+									style={[
+										styles.box,
+										{
+											width: isWeb ? 200 : '30%',
+											backgroundColor: color,
+										},
+									]}
+								></TouchableOpacity>
 							))}
 						</View>
-					) : (
-						<View style={styles.titleBt}>
-							<ModalTextInput style={styles.input} value={inputValue} onChangeText={setInputValue} placeholder={'Enter a value'} autoFocus />
+					</View>
+				)}
+				{isWeekdaySheet && (
+					<View style={styles.languageContainer}>
+						{days.map(firstDay => (
+							<FirstDayOfWeek key={firstDay.id} position={firstDay} isSelected={selectedFirstDay.name === firstDay.name} onPress={() => handleDaySelect(firstDay.id, firstDay.name)} />
+						))}
+					</View>
+				)}
+				{selectedItem && !isColorSheet && !isWeekdaySheet && (
+					<View style={styles.titleBt}>
+						<ModalTextInput style={styles.input} value={inputValue} onChangeText={setInputValue} placeholder={'Enter a value'} autoFocus />
 
-							<View style={[styles.buttonContainer]}>
-								<TouchableOpacity
-									onPress={cancleSheet}
-									style={{
-										...styles.cancelButton,
-										borderColor: course_timetable_area_color,
-									}}
-								>
-									<Text style={[styles.buttonText, { color: theme.screen.text }]}>{translate(TranslationKeys.cancel)}</Text>
-								</TouchableOpacity>
-								<TouchableOpacity
-									onPress={handleSavePress}
-									style={{
-										...styles.saveButton,
-										backgroundColor: course_timetable_area_color,
-									}}
-								>
-									<Text style={[styles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.save)}</Text>
-								</TouchableOpacity>
-							</View>
+						<View style={[styles.buttonContainer]}>
+							<TouchableOpacity
+								onPress={cancleSheet}
+								style={{
+									...styles.cancelButton,
+									borderColor: course_timetable_area_color,
+								}}
+							>
+								<Text style={[styles.buttonText, { color: theme.screen.text }]}>{translate(TranslationKeys.cancel)}</Text>
+							</TouchableOpacity>
+							<TouchableOpacity
+								onPress={handleSavePress}
+								style={{
+									...styles.saveButton,
+									backgroundColor: course_timetable_area_color,
+								}}
+							>
+								<Text style={[styles.buttonText, { color: contrastColor }]}>{translate(TranslationKeys.save)}</Text>
+							</TouchableOpacity>
 						</View>
-					)
-				) : (
+					</View>
+				)}
+				{!selectedItem && (
 					<View>
 						{data.map(item => (
 							<TouchableOpacity

--- a/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
+++ b/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
@@ -73,6 +73,9 @@ const CustomStackHeader: React.FC<CustomStackHeaderProps> = ({ label, rightEleme
 		return () => subscription?.remove();
 	}, []);
 
+	const mediumScreenHeadingLength = screenWidth > 700 ? 80 : 22;
+	const headingMaxLength = screenWidth > 900 ? 100 : mediumScreenHeadingLength;
+
 	return (
 		<View
 			style={{
@@ -98,7 +101,7 @@ const CustomStackHeader: React.FC<CustomStackHeaderProps> = ({ label, rightEleme
 						</TooltipContent>
 					</CustomTooltip>
 
-					<Text style={{ ...styles.heading, color: theme.header.text }}>{excerpt(label, screenWidth > 900 ? 100 : screenWidth > 700 ? 80 : 22)}</Text>
+					<Text style={{ ...styles.heading, color: theme.header.text }}>{excerpt(label, headingMaxLength)}</Text>
                                 </View>
                                 {rightElement ? <View style={styles.col2}>{rightElement}</View> : null}
                         </View>

--- a/apps/frontend/app/components/DataAcces/DataAccess.tsx
+++ b/apps/frontend/app/components/DataAcces/DataAccess.tsx
@@ -95,6 +95,9 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
                 { label: 'Collectible Events', value: collectibleEvents },
         ];
 
+	const webListWidth = isWeb ? '80%' : '100%';
+	const listContainerWidth = windowWidth < 500 ? '100%' : webListWidth;
+
 	return (
 		<View style={{ ...styles.container, backgroundColor: theme.screen.background }}>
 			<ScrollView
@@ -114,13 +117,20 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
 				<CollectibleSpot collectibleKey={CollectibleAt.collectible_at_data_access} />
 				<View
 					style={{
-						width: windowWidth < 500 ? '100%' : isWeb ? '80%' : '100%',
+						width: listContainerWidth,
 					}}
 				>
 					{infoItems.map((item, index) => {
 						const last = index === infoItems.length - 1;
 						const first = index === 0;
-						const groupPosition = infoItems.length === 1 ? 'single' : first ? 'top' : last ? 'bottom' : 'middle';
+						let groupPosition = 'middle';
+						if (infoItems.length === 1) {
+							groupPosition = 'single';
+						} else if (first) {
+							groupPosition = 'top';
+						} else if (last) {
+							groupPosition = 'bottom';
+						}
 						return <SettingsList key={index} iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="database-eye" size={24} color={theme.screen.icon} />} label={item.label} rightIcon={<Entypo name="chevron-small-right" size={24} color={theme.screen.icon} />} handleFunction={() => onOpenBottomSheet(item)} groupPosition={groupPosition as any} />;
 					})}
 
@@ -130,7 +140,14 @@ const DataAccess = ({ onOpenBottomSheet }: any) => {
                                                 if (!data?.value) return null;
                                                 const last = index === dataDevice.length - 1;
                                                 const first = index === 0;
-                                                const groupPosition = dataDevice.length === 1 ? 'single' : first ? 'top' : last ? 'bottom' : 'middle';
+                                                let groupPosition = 'middle';
+                                                if (dataDevice.length === 1) {
+                                                        groupPosition = 'single';
+                                                } else if (first) {
+                                                        groupPosition = 'top';
+                                                } else if (last) {
+                                                        groupPosition = 'bottom';
+                                                }
                                                 return <SettingsList key={index} iconBgColor={primaryColor} leftIcon={<MaterialCommunityIcons name="database-eye" size={24} color={theme.screen.icon} />} label={data.label} rightIcon={<Entypo name="chevron-small-right" size={24} color={theme.screen.icon} />} handleFunction={() => onOpenBottomSheet(data)} groupPosition={groupPosition as any} />;
                                         })}
                                 </View>

--- a/apps/frontend/app/components/DebugView/index.tsx
+++ b/apps/frontend/app/components/DebugView/index.tsx
@@ -52,11 +52,10 @@ const DebugView: React.FC<DebugViewProps> = ({
                         ?.map(log => {
                                 if (typeof log === 'string') return log;
 
-                                const timestamp = log.timestamp
-                                        ? typeof log.timestamp === 'string'
-                                                ? log.timestamp
-                                                : log.timestamp.toLocaleString()
-                                        : null;
+                                let timestamp: string | null = null;
+                                if (log.timestamp) {
+                                        timestamp = typeof log.timestamp === 'string' ? log.timestamp : log.timestamp.toLocaleString();
+                                }
 
                                 return timestamp ? `${timestamp} - ${log.message}` : log.message;
                         })

--- a/apps/frontend/app/components/Details/index.tsx
+++ b/apps/frontend/app/components/Details/index.tsx
@@ -54,14 +54,16 @@ const Details: React.FC<DetailsProps> = ({ groupedAttributes, loading }) => {
 							{title ? <SettingsGroupTitle>{title}</SettingsGroupTitle> : null}
 							<View style={styles.attributeList}>
 								{attributeItems.map((attribute: any, index: number) => {
-									const groupPosition =
-										attributeItems.length === 1
-											? 'single'
-											: index === 0
-												? 'top'
-												: index === attributeItems.length - 1
-													? 'bottom'
-													: 'middle';
+									let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+									if (attributeItems.length === 1) {
+										groupPosition = 'single';
+									} else if (index === 0) {
+										groupPosition = 'top';
+									} else if (index === attributeItems.length - 1) {
+										groupPosition = 'bottom';
+									} else {
+										groupPosition = 'middle';
+									}
 									return (
 										<AttributeItem
 											key={attribute?.id ?? `${item?.id}-${index}`}

--- a/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
+++ b/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
@@ -102,9 +102,11 @@ const DropdownInput = ({ id, value, onChange, error, isDisabled, custom_type, op
 	const customLabel = translate(TranslationKeys.enter_custom_value);
 
 	const trimmedValue = currentValue.trim();
-	const displayValue = showCustomInput ? trimmedValue : valueMatchesOption ? currentValue : trimmedValue;
+	const selectedOptionValue = valueMatchesOption ? currentValue : trimmedValue;
+	const displayValue = showCustomInput ? trimmedValue : selectedOptionValue;
 	console.log('[DropdownInput] render with currentValue=', currentValue, ' displayValue=', displayValue, ' showCustomInput=', showCustomInput, ' valueMatchesOption=', valueMatchesOption);
-	const labelToShow = displayValue.length > 0 ? displayValue : showCustomInput ? customLabel : placeholderLabel;
+	const emptyValueLabel = showCustomInput ? customLabel : placeholderLabel;
+	const labelToShow = displayValue.length > 0 ? displayValue : emptyValueLabel;
 	const isPlaceholderDisplay = displayValue.length === 0;
 
 	return (

--- a/apps/frontend/app/components/FeedbackSupport/FeedbackSupport.tsx
+++ b/apps/frontend/app/components/FeedbackSupport/FeedbackSupport.tsx
@@ -61,7 +61,11 @@ const FeedbackItem: React.FC<FeedbackItemProps> = ({ icon, title, value, extraIc
 				>
 					{excerpt(String(value), windowWidth > 850 ? 50 : 20)}
 				</Text>
-				{extraIcons.map((iconName, idx) => (
+				{extraIcons.map((iconName, idx) => {
+					const isThumbUpActive = iconName === 'thumb-up-outline' && inputValues?.positive === true;
+					const isThumbDownActive = iconName === 'thumb-down-outline' && inputValues?.positive === false;
+					const likeButtonBackgroundColor = isThumbUpActive || isThumbDownActive ? primaryColor : 'transparent';
+					return (
 					<TouchableOpacity
 						style={{
 							...styles.likeButton,
@@ -70,7 +74,7 @@ const FeedbackItem: React.FC<FeedbackItemProps> = ({ icon, title, value, extraIc
 							borderBottomLeftRadius: iconName === 'thumb-up-outline' ? 5 : 0,
 							borderBottomRightRadius: iconName === 'thumb-down-outline' ? 5 : 0,
 							borderTopRightRadius: iconName === 'thumb-down-outline' ? 5 : 0,
-							backgroundColor: iconName === 'thumb-up-outline' && inputValues?.positive === true ? primaryColor : iconName === 'thumb-down-outline' && inputValues?.positive === false ? primaryColor : 'transparent',
+							backgroundColor: likeButtonBackgroundColor,
 						}}
 						onPress={() => {
 							if (iconName === 'thumb-up-outline') {
@@ -89,7 +93,8 @@ const FeedbackItem: React.FC<FeedbackItemProps> = ({ icon, title, value, extraIc
 					>
 						<MaterialCommunityIcons key={idx} name={iconName as any} size={22} color={theme.screen.icon} style={{ marginHorizontal: 5 }} />
 					</TouchableOpacity>
-				))}
+					);
+				})}
 				{title !== 'like_status' && <MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} style={{ marginHorizontal: 5 }} />}
 			</View>
 		</TouchableOpacity>

--- a/apps/frontend/app/components/Feedbacks/index.tsx
+++ b/apps/frontend/app/components/Feedbacks/index.tsx
@@ -26,6 +26,19 @@ const loadingState = {
 	deleteLoading: false,
 };
 
+const getGroupPosition = (index: number, total: number): 'single' | 'top' | 'bottom' | 'middle' => {
+	if (total === 1) {
+		return 'single';
+	}
+	if (index === 0) {
+		return 'top';
+	}
+	if (index === total - 1) {
+		return 'bottom';
+	}
+	return 'middle';
+};
+
 const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId, isManagement }) => {
 	const toast = useToast();
 	const { theme } = useTheme();
@@ -195,8 +208,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId, 
 			{ratingSummaryItems.length > 0 && (
 				<View style={styles.ratingSummaryContainer}>
 					{ratingSummaryItems.map((item, index) => {
-						const groupPosition =
-							ratingSummaryItems.length === 1 ? 'single' : index === 0 ? 'top' : index === ratingSummaryItems.length - 1 ? 'bottom' : 'middle';
+						const groupPosition = getGroupPosition(index, ratingSummaryItems.length);
 						return (
 							<SettingsList
 								key={item.key}
@@ -222,7 +234,7 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId, 
 			</Text>
 			{labels.map((label: any, index: number) => {
 				const total = labels.length;
-				const groupPosition = total === 1 ? 'single' : index === 0 ? 'top' : index === total - 1 ? 'bottom' : 'middle';
+				const groupPosition = getGroupPosition(index, total);
 				return (
 					<FeedbackLabel key={label.id} label={label.translations} icon={label.icon ? label.icon : undefined} imageUrl={label.image ? label.image : undefined} labelEntries={labelEntries} foodId={foodDetails?.id} offerId={offerId} groupPosition={groupPosition} isAccountRequired={!user?.id} />
 				);

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -148,7 +148,8 @@ export const FoodItemBase: React.FC<FoodItemProps> = memo(
       return numToOneDecimal(avg);
     }, [showAverageOnCard, foodItem?.rating_average, foodItem?.rating_average_legacy]);
 
-    const borderWidth = dislikedMarkings.length > 0 ? 3 : isLiked ? 3 : 0;
+    const hasMarkingBorder = dislikedMarkings.length > 0 || isLiked;
+    const borderWidth = hasMarkingBorder ? 3 : 0;
     const borderColor = dislikedMarkings.length > 0 ? '#FF000095' : '#00B050';
 
     
@@ -275,9 +276,17 @@ export const FoodItemBase: React.FC<FoodItemProps> = memo(
 
     const foodName = useMemo(
       () => {
+        let excerptLength = 40;
+        if (screenWidth > 1000) {
+          excerptLength = 120;
+        } else if (screenWidth > 700) {
+          excerptLength = 80;
+        } else if (screenWidth > 460) {
+          excerptLength = 60;
+        }
         const name = excerpt(
           getTextFromTranslation(foodItem?.translations, language || 'de'),
-          screenWidth > 1000 ? 120 : screenWidth > 700 ? 80 : screenWidth > 460 ? 60 : 40
+          excerptLength
         );
         if (!name) return name;
         let result = name;
@@ -417,8 +426,17 @@ export const FoodItemBase: React.FC<FoodItemProps> = memo(
                   </View>
 
                   <View style={styles.categoriesContainer}>
-                    {markingsData?.map(mark =>
-                      (mark?.image_remote_url || mark?.image) && mark?.show_on_card ? (
+                    {markingsData?.map(mark => {
+                      if (!((mark?.image_remote_url || mark?.image) && mark?.show_on_card)) {
+                        return null;
+                      }
+                      let markBorderRadius = 0;
+                      if (mark?.background_color) {
+                        markBorderRadius = 8;
+                      } else if (mark.hide_border) {
+                        markBorderRadius = 5;
+                      }
+                      return (
                         <TouchableOpacity key={mark.id} onPress={() => openMarkingLabel(mark)}>
                           <MyImage
                             remote_image_url={mark?.image_remote_url || getImageUrl(mark?.image as string)}
@@ -427,13 +445,13 @@ export const FoodItemBase: React.FC<FoodItemProps> = memo(
                               styles.categoryLogo,
                               {
                                 backgroundColor: mark?.background_color || undefined,
-                                borderRadius: mark?.background_color ? 8 : mark.hide_border ? 5 : 0,
+                                borderRadius: markBorderRadius,
                               }
                             ]}
                           />
                         </TouchableOpacity>
-                      ) : null
-                    )}
+                      );
+                    })}
                   </View>
 
                   <TouchableOpacity style={styles.priceTag} onPress={handlePriceChange}>
@@ -532,7 +550,10 @@ const FoodItemConnected: React.FC<FoodItemProps> = (props) => {
     const previousFeedback = useMemo(() => {
         if (props.previousFeedback) return props.previousFeedback;
         const food = item?.food as any;
-        const foodId = food ? (typeof food === 'string' ? food : food.id) : undefined;
+        let foodId: string | undefined;
+        if (food) {
+            foodId = typeof food === 'string' ? food : food.id;
+        }
         if (!foodId) return undefined;
         return getpreviousFeedback(ownFoodFeedbacks as any, foodId);
     }, [props.previousFeedback, item, ownFoodFeedbacks]);

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -438,7 +438,14 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 	const renderDay = ({ item }: { item: DayData }) => {
 		const feedbacks = canteenFeedbackLabels?.map((label, idx) => {
 			const total = canteenFeedbackLabels.length;
-			const groupPosition = total === 1 ? 'single' : idx === 0 ? 'top' : idx === total - 1 ? 'bottom' : 'middle';
+			let groupPosition: 'single' | 'top' | 'bottom' | 'middle' = 'middle';
+			if (total === 1) {
+				groupPosition = 'single';
+			} else if (idx === 0) {
+				groupPosition = 'top';
+			} else if (idx === total - 1) {
+				groupPosition = 'bottom';
+			}
 			return <CanteenFeedbackLabels key={`fl-${idx}`} label={label} date={item.date} groupPosition={groupPosition} isAccountRequired={!user?.id} />;
 		});
 		const dayItems = buildDayItems(item.offers, item.date);

--- a/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
+++ b/apps/frontend/app/components/ForecastSheet/ForecastSheet.tsx
@@ -141,6 +141,53 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({ forDate, canteen }) => {
             debugInformationInTitle = `all_time_high ${currentUtilizationGroup?.all_time_high ?? 'N/A'}, threshold_until_max ${currentUtilizationGroup?.threshold_until_max ?? 'N/A'}`;
         }
 
+        let forecastContent: React.ReactNode;
+        if (loading) {
+                forecastContent = (
+                        <View style={styles.loadingContainer}>
+                                <ActivityIndicator size={40} color={theme.screen.icon} />
+                        </View>
+                );
+        } else if (forecastEntries.length > 0) {
+                forecastContent = forecastEntries.map((entry, index) => {
+                        const isSingle = forecastEntries.length === 1;
+                        const isFirst = index === 0;
+                        const isLast = index === forecastEntries.length - 1;
+
+                        let groupPosition: 'single' | 'top' | 'bottom' | 'middle' = 'middle';
+                        if (isSingle) {
+                                groupPosition = 'single';
+                        } else if (isFirst) {
+                                groupPosition = 'top';
+                        } else if (isLast) {
+                                groupPosition = 'bottom';
+                        }
+
+                        let valueToShow = entry.percentage+'%'
+                        if(showDebugInformation) {
+                            valueToShow += " (" + (entry.value_real ?? entry.value_forecast_current) + ")";
+                        }
+
+                        return (
+                                <SettingsList
+                                        key={`${entry.time}-${index}`}
+                                        leftIcon={<View style={[styles.colorIndicator, { backgroundColor: entry.color }]} />}
+                                        title={entry.time}
+                                        value={valueToShow}
+                                        showSeparator={!isLast}
+                                        groupPosition={groupPosition}
+                                        iconBackgroundColor={theme.sheet.sheetBg}
+                                />
+                        );
+                });
+        } else {
+                forecastContent = (
+                        <Text style={[styles.noDataText, { color: theme.sheet.text }]}>
+                                {translate(TranslationKeys.no_data_found)}
+                        </Text>
+                );
+        }
+
         return (
                 <View style={styles.container}>
                         {showDebugInformation && (
@@ -149,46 +196,7 @@ const ForecastSheet: React.FC<ForecastSheetProps> = ({ forDate, canteen }) => {
                                 </Text>
                         )}
                         <View style={styles.forecastContainer}>
-                                {loading ? (
-                                        <View style={styles.loadingContainer}>
-                                                <ActivityIndicator size={40} color={theme.screen.icon} />
-                                        </View>
-                                ) : forecastEntries.length > 0 ? (
-                                        forecastEntries.map((entry, index) => {
-                                                const isSingle = forecastEntries.length === 1;
-                                                const isFirst = index === 0;
-                                                const isLast = index === forecastEntries.length - 1;
-
-                                                const groupPosition = isSingle
-                                                        ? 'single'
-                                                        : isFirst
-                                                        ? 'top'
-                                                        : isLast
-                                                        ? 'bottom'
-                                                        : 'middle';
-
-                                                let valueToShow = entry.percentage+'%'
-                                                if(showDebugInformation) {
-                                                    valueToShow += " (" + (entry.value_real ?? entry.value_forecast_current) + ")";
-                                                }
-
-                                                return (
-                                                        <SettingsList
-                                                                key={`${entry.time}-${index}`}
-                                                                leftIcon={<View style={[styles.colorIndicator, { backgroundColor: entry.color }]} />}
-                                                                title={entry.time}
-                                                                value={valueToShow}
-                                                                showSeparator={!isLast}
-                                                                groupPosition={groupPosition}
-                                                                iconBackgroundColor={theme.sheet.sheetBg}
-                                                        />
-                                                );
-                                        })
-                                ) : (
-                                        <Text style={[styles.noDataText, { color: theme.sheet.text }]}>
-                                                {translate(TranslationKeys.no_data_found)}
-                                        </Text>
-                                )}
+                                {forecastContent}
                         </View>
                 </View>
         );

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -174,24 +174,31 @@ const ScanModalContent: React.FC<ScanModalContentProps> = ({ onSubmit, checkAlre
 		);
 	}
 
+	let cameraSectionContent: React.ReactNode = null;
+	if (showCamera) {
+		cameraSectionContent = (
+			<View style={scanStyles.cameraWrapper}>
+				<CameraView
+					style={scanStyles.camera}
+					facing="back"
+					barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+					onBarcodeScanned={handleBarCodeScanned}
+				/>
+			</View>
+		);
+	} else if (canRequestPermission) {
+		cameraSectionContent = (
+			<TouchableOpacity style={[scanStyles.permissionButton, { backgroundColor: primaryColor }]} onPress={requestPermission}>
+				<MaterialCommunityIcons name="camera" size={24} color={contrastColor} />
+				<Text style={[scanStyles.permissionText, { color: contrastColor }]}>{translate(TranslationKeys.friendships_allow_camera)}</Text>
+			</TouchableOpacity>
+		);
+	}
+
 	return (
 		<View style={scanStyles.container}>
 			<View style={scanStyles.cameraSection}>
-				{showCamera ? (
-					<View style={scanStyles.cameraWrapper}>
-						<CameraView
-							style={scanStyles.camera}
-							facing="back"
-							barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
-							onBarcodeScanned={handleBarCodeScanned}
-						/>
-					</View>
-				) : canRequestPermission ? (
-					<TouchableOpacity style={[scanStyles.permissionButton, { backgroundColor: primaryColor }]} onPress={requestPermission}>
-						<MaterialCommunityIcons name="camera" size={24} color={contrastColor} />
-						<Text style={[scanStyles.permissionText, { color: contrastColor }]}>{translate(TranslationKeys.friendships_allow_camera)}</Text>
-					</TouchableOpacity>
-				) : null}
+				{cameraSectionContent}
 			</View>
 		</View>
 	);
@@ -685,7 +692,14 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 			const displayLabel = otherNickname || otherProfileId;
 			const statusColor = friendshipStatusColor(friendship.friendship_status);
 			const totalItems = items.length;
-			const groupPosition = totalItems === 1 ? 'single' : index === 0 ? 'top' : index === totalItems - 1 ? 'bottom' : 'middle';
+			let groupPosition: 'single' | 'top' | 'bottom' | 'middle' = 'middle';
+			if (totalItems === 1) {
+				groupPosition = 'single';
+			} else if (index === 0) {
+				groupPosition = 'top';
+			} else if (index === totalItems - 1) {
+				groupPosition = 'bottom';
+			}
 
 			return (
 				<SettingsList

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -394,7 +394,14 @@ export const HoursSheetContent: React.FC = () => {
                         const isFirst = index === 0;
                         const isLast = index === hoursData.length - 1;
                         const isSingle = hoursData.length === 1;
-                        const groupPosition = isSingle ? 'single' : isFirst ? 'top' : isLast ? 'bottom' : 'middle';
+                        let groupPosition: 'single' | 'top' | 'bottom' | 'middle' = 'middle';
+                        if (isSingle) {
+                                groupPosition = 'single';
+                        } else if (isFirst) {
+                                groupPosition = 'top';
+                        } else if (isLast) {
+                                groupPosition = 'bottom';
+                        }
 
                         return (
                                 <SettingsList
@@ -408,6 +415,43 @@ export const HoursSheetContent: React.FC = () => {
                         );
                 });
         };
+
+	let hoursContent: React.ReactNode;
+	if (hours && Object.keys(hours).length > 0) {
+		hoursContent = (
+			<View
+				style={{
+					...styles.hoursContainer,
+					width: '100%',
+				}}
+			>
+				{getSortedBusinessHoursGroups(businessHoursGroups)
+					.filter(group => hours[group.id])
+					.map(group => {
+						const { name, entries } = hours[group.id];
+						return (
+							<View key={group.id} style={{ marginBottom: 20 }}>
+								<SettingsGroupTitle>{name}</SettingsGroupTitle>
+								{renderHours(group.id, entries)}
+							</View>
+						);
+					})}
+			</View>
+		);
+	} else {
+		hoursContent = (
+			<View
+				style={{
+					height: 200,
+					width: '100%',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
+			>
+				<Text style={{ ...styles.empty, color: theme.screen.text }}>{translate(TranslationKeys.no_business_hours_available)}</Text>
+			</View>
+		);
+	}
 
 	return (
 		<>
@@ -429,37 +473,7 @@ export const HoursSheetContent: React.FC = () => {
 						width: '100%',
 					}}
 				>
-					{hours && Object.keys(hours).length > 0 ? (
-						<View
-							style={{
-								...styles.hoursContainer,
-								width: '100%',
-							}}
-						>
-							{getSortedBusinessHoursGroups(businessHoursGroups)
-								.filter(group => hours[group.id])
-								.map(group => {
-									const { name, entries } = hours[group.id];
-									return (
-										<View key={group.id} style={{ marginBottom: 20 }}>
-											<SettingsGroupTitle>{name}</SettingsGroupTitle>
-											{renderHours(group.id, entries)}
-										</View>
-									);
-								})}
-						</View>
-					) : (
-						<View
-							style={{
-								height: 200,
-								width: '100%',
-								justifyContent: 'center',
-								alignItems: 'center',
-							}}
-						>
-							<Text style={{ ...styles.empty, color: theme.screen.text }}>{translate(TranslationKeys.no_business_hours_available)}</Text>
-						</View>
-					)}
+					{hoursContent}
 				</View>
 			)}
 		</>

--- a/apps/frontend/app/components/LocationInformation/LocationInformation.tsx
+++ b/apps/frontend/app/components/LocationInformation/LocationInformation.tsx
@@ -59,8 +59,14 @@ const LocationInformation: React.FC<any> = ({ campusDetails }) => {
 			<Text style={{ ...styles.heading, color: theme.screen.text }}>{translate(TranslationKeys.information)}</Text>
 			<View style={{ gap: 0 }}>
 				{infoItems.map((item, index) => {
-					const groupPosition =
-						infoItems.length === 1 ? 'single' : index === 0 ? 'top' : index === infoItems.length - 1 ? 'bottom' : 'middle';
+					let groupPosition: 'single' | 'top' | 'bottom' | 'middle' = 'middle';
+					if (infoItems.length === 1) {
+						groupPosition = 'single';
+					} else if (index === 0) {
+						groupPosition = 'top';
+					} else if (index === infoItems.length - 1) {
+						groupPosition = 'bottom';
+					}
 					const showSeparator = index !== infoItems.length - 1;
 					if (item.type === 'location') {
 						return (

--- a/apps/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
+++ b/apps/frontend/app/components/ManagementCanteensSheet/ManagementCanteensSheet.tsx
@@ -97,6 +97,11 @@ const ManagementCanteensSheet: React.FC<ManagementCanteensSheetProps> = ({ close
 		return () => subscription?.remove();
 	}, []);
 
+	let canteensContainerGap = 5;
+	if (isWeb) {
+		canteensContainerGap = screenWidth < 500 ? 10 : 20;
+	}
+
 	return (
 		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
 			<View
@@ -119,7 +124,7 @@ const ManagementCanteensSheet: React.FC<ManagementCanteensSheetProps> = ({ close
 				style={{
 					...styles.canteensContainer,
 					width: '100%',
-					gap: isWeb ? (screenWidth < 500 ? 10 : 20) : 5,
+					gap: canteensContainerGap,
 					marginTop: isWeb ? 40 : 20,
 				}}
 			>

--- a/apps/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
+++ b/apps/frontend/app/components/MarkingBottomSheet/MarkingBottomSheet.tsx
@@ -24,6 +24,13 @@ export const MarkingContent: React.FC = () => {
 	const { language } = useAppSelector((state: RootState) => state.settings);
 	const description = getDescriptionFromTranslation(markingDetails?.translations, language);
 
+	let markingImageBorderRadius = 0;
+	if (markingDetails?.background_color) {
+		markingImageBorderRadius = 8;
+	} else if (markingDetails?.hide_border) {
+		markingImageBorderRadius = 5;
+	}
+
 	return (
 		<>
 			<View
@@ -54,7 +61,7 @@ export const MarkingContent: React.FC = () => {
 						style={{
 							...styles.image,
 							backgroundColor: markingDetails?.background_color ? markingDetails?.background_color : 'transparent',
-							borderRadius: markingDetails?.background_color ? 8 : markingDetails?.hide_border ? 5 : 0,
+							borderRadius: markingImageBorderRadius,
 						}}
 					/>
 				</View>

--- a/apps/frontend/app/components/MarkingIcon/index.tsx
+++ b/apps/frontend/app/components/MarkingIcon/index.tsx
@@ -25,11 +25,12 @@ const MarkingIcon: React.FC<MarkingIconProps> = ({ marking, size = 24, color, co
 
 	if (!marking) return null;
 
-	const markingImage = marking.image_remote_url
-		? { uri: marking.image_remote_url }
-		: marking.image
-		? { uri: getImageUrl(String(marking.image)) || undefined }
-		: null;
+	let markingImage: { uri: string | undefined } | null = null;
+	if (marking.image_remote_url) {
+		markingImage = { uri: marking.image_remote_url };
+	} else if (marking.image) {
+		markingImage = { uri: getImageUrl(String(marking.image)) || undefined };
+	}
 	const textColor = color || contrast;
 
 	const iconParts = marking.icon?.split(':') || [];

--- a/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -47,7 +47,12 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 	const { primaryColor, selectedTheme } = useAppSelector((state) => state.settings);
 
 	const colorScheme = Appearance.getColorScheme();
-	const theme = selectedTheme === 'systematic' ? (colorScheme === 'dark' ? darkTheme : lightTheme) : selectedTheme === 'dark' ? darkTheme : lightTheme;
+	let theme = lightTheme;
+	if (selectedTheme === 'systematic') {
+		theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+	} else if (selectedTheme === 'dark') {
+		theme = darkTheme;
+	}
 
 	const { width } = useWindowDimensions();
 	const md = new MarkdownIt({ html: true, breaks: true });

--- a/apps/frontend/app/components/NewsItem/NewsItem.tsx
+++ b/apps/frontend/app/components/NewsItem/NewsItem.tsx
@@ -48,6 +48,16 @@ const NewsItem: React.FC<any> = ({ news }) => {
 			}
 		}
 	};
+
+	let imageContainerWidth: '20%' | '30%' | '100%' = '100%';
+	if (screenWidth > 768) {
+		imageContainerWidth = screenWidth > 900 ? '20%' : '30%';
+	}
+	let newsContentWidth: '79%' | '69%' | '100%' = '100%';
+	if (screenWidth > 768) {
+		newsContentWidth = screenWidth > 900 ? '79%' : '69%';
+	}
+
 	return (
 		<View
 			style={{
@@ -59,7 +69,7 @@ const NewsItem: React.FC<any> = ({ news }) => {
 			<View
 				style={{
 					...styles.imageContainer,
-					width: screenWidth > 768 ? (screenWidth > 900 ? '20%' : '30%') : '100%',
+					width: imageContainerWidth,
 					height: screenWidth > 768 ? 220 : 180,
 				}}
 			>
@@ -72,7 +82,7 @@ const NewsItem: React.FC<any> = ({ news }) => {
 			</View>
 			<View
 				style={{
-					width: screenWidth > 768 ? (screenWidth > 900 ? '79%' : '69%') : '100%',
+					width: newsContentWidth,
 					justifyContent: screenWidth > 768 ? 'space-between' : 'flex-start',
 					padding: screenWidth > 768 ? 10 : 0,
 				}}

--- a/apps/frontend/app/components/NotificationSheet/NotificationSheet.tsx
+++ b/apps/frontend/app/components/NotificationSheet/NotificationSheet.tsx
@@ -97,6 +97,10 @@ const NotificationSheet: React.FC<NotificationSheetProps> = ({ closeSheet, previ
 
 		return () => subscription?.remove();
 	}, []);
+
+	const sheetHeadingFontSize = isWeb() && screenWidth > 800 ? 40 : 28;
+	const bodyFontSize = isWeb() && screenWidth > 800 ? 18 : 16;
+
 	return (
 		<View style={[{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }, styles.contentContainer]}>
 			<View
@@ -110,7 +114,7 @@ const NotificationSheet: React.FC<NotificationSheetProps> = ({ closeSheet, previ
 				<Text
 					style={{
 						...styles.sheetHeading,
-						fontSize: isWeb() ? (screenWidth > 800 ? 40 : 28) : 28,
+						fontSize: sheetHeadingFontSize,
 						color: theme.sheet.text,
 					}}
 				>
@@ -123,7 +127,7 @@ const NotificationSheet: React.FC<NotificationSheetProps> = ({ closeSheet, previ
 					style={{
 						...styles.body,
 						color: theme.screen.text,
-						fontSize: isWeb() ? (screenWidth > 800 ? 18 : 16) : 16,
+						fontSize: bodyFontSize,
 					}}
 				>
 					{translate(TranslationKeys.notification_please_notify_me_on_my_smartphones_if_they_allow_to_be_notified)}

--- a/apps/frontend/app/components/PriceGroupSettingsList/index.tsx
+++ b/apps/frontend/app/components/PriceGroupSettingsList/index.tsx
@@ -78,14 +78,14 @@ const PriceGroupSettingsList = ({ onSelect }: PriceGroupSettingsListProps) => {
 		<View style={{ width: '100%' }}>
 			{options.map((option, index) => {
 				const isSelected = selectedOption === option.id;
-				const groupPosition =
-					options.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === options.length - 1
-								? 'bottom'
-								: 'middle';
+				let groupPosition: 'single' | 'top' | 'bottom' | 'middle' = 'middle';
+				if (options.length === 1) {
+					groupPosition = 'single';
+				} else if (index === 0) {
+					groupPosition = 'top';
+				} else if (index === options.length - 1) {
+					groupPosition = 'bottom';
+				}
 
 				return (
 					<SettingsList

--- a/apps/frontend/app/components/ProjectButton/index.tsx
+++ b/apps/frontend/app/components/ProjectButton/index.tsx
@@ -10,7 +10,12 @@ const ProjectButton: React.FC<ProjectButtonProps> = ({ text, onPress, iconLeft, 
 	const { primaryColor, selectedTheme } = useAppSelector(state => state.settings);
 
 	const colorScheme = Appearance.getColorScheme();
-	const theme = selectedTheme === 'systematic' ? (colorScheme === 'dark' ? darkTheme : lightTheme) : selectedTheme === 'dark' ? darkTheme : lightTheme;
+	let theme = lightTheme;
+	if (selectedTheme === 'systematic') {
+		theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+	} else if (selectedTheme === 'dark') {
+		theme = darkTheme;
+	}
 
 	const contrastColor = myContrastColor(primaryColor, theme, selectedTheme === 'dark');
 

--- a/apps/frontend/app/components/RedirectButton/index.tsx
+++ b/apps/frontend/app/components/RedirectButton/index.tsx
@@ -32,6 +32,15 @@ const RedirectButton: React.FC<RedirectButtonProps> = ({ type, label, background
 		containerWidth = '100%';
 	}
 
+	let typeIcon: React.ReactNode;
+	if (type === 'email') {
+		typeIcon = <MaterialCommunityIcons name="email" size={24} color={color || contrastColor} />;
+	} else if (type === 'location') {
+		typeIcon = <Ionicons name="navigate" size={24} color={color || contrastColor} />;
+	} else {
+		typeIcon = <FontAwesome6 name="arrow-up-right-from-square" size={20} color={color || contrastColor} />;
+	}
+
 	return (
 		<TouchableOpacity
 			style={{
@@ -43,13 +52,7 @@ const RedirectButton: React.FC<RedirectButtonProps> = ({ type, label, background
 			}}
 			onPress={onClick}
 		>
-			{type === 'email' ? (
-				<MaterialCommunityIcons name="email" size={24} color={color || contrastColor} />
-			) : type === 'location' ? (
-				<Ionicons name="navigate" size={24} color={color || contrastColor} />
-			) : (
-				<FontAwesome6 name="arrow-up-right-from-square" size={20} color={color || contrastColor} />
-			)}
+			{typeIcon}
 			<Text style={{ ...styles.label, color: color || contrastColor, fontSize }}>{label}</Text>
 		</TouchableOpacity>
 	);

--- a/apps/frontend/app/components/RssFeed/index.tsx
+++ b/apps/frontend/app/components/RssFeed/index.tsx
@@ -26,11 +26,17 @@ const parseFeed = (xml: string) => {
 		const enclosureMatch = itemXml.match(/<enclosure[^>]*url=['"](.*?)['"]/);
 		const htmlContent = (contentEncodedMatch ? contentEncodedMatch[1] : '') || (descMatch ? descMatch[1] : '');
 		const imageMatch = htmlContent.match(/<img[^>]*src=['"]([^'"]+)['"]/);
+		let image = '';
+		if (enclosureMatch) {
+			image = enclosureMatch[1];
+		} else if (imageMatch) {
+			image = imageMatch[1];
+		}
 		items.push({
 			title: titleMatch ? titleMatch[1] : '',
 			link: linkMatch ? linkMatch[1] : '',
 			content: descMatch ? descMatch[1] : '',
-			image: enclosureMatch ? enclosureMatch[1] : imageMatch ? imageMatch[1] : '',
+			image,
 		});
 	}
 	return items;

--- a/apps/frontend/app/components/SettingsListMarkingLabelFast/SettingsListMarkingLabelFast.tsx
+++ b/apps/frontend/app/components/SettingsListMarkingLabelFast/SettingsListMarkingLabelFast.tsx
@@ -136,17 +136,23 @@ const SettingsListMarkingLabelFast: React.FC<SettingsListMarkingLabelFastProps> 
 		[marking?.translations, language]
 	);
 
-	const leftIconComponent = useMemo(() => (
-		<View style={styles.leftIconWrapper}>
-			{handleMenuSheet && marking ? (
+	const leftIconComponent = useMemo(() => {
+		let markingIconContent: React.ReactNode = null;
+		if (handleMenuSheet && marking) {
+			markingIconContent = (
 				<Pressable onPress={() => openMarkingLabel(marking)}>
 					<MarkingIcon marking={marking} size={size} />
 				</Pressable>
-			) : marking ? (
-				<MarkingIcon marking={marking} size={size} />
-			) : null}
-		</View>
-	), [marking, size, handleMenuSheet, openMarkingLabel]);
+			);
+		} else if (marking) {
+			markingIconContent = <MarkingIcon marking={marking} size={size} />;
+		}
+		return (
+			<View style={styles.leftIconWrapper}>
+				{markingIconContent}
+			</View>
+		);
+	}, [marking, size, handleMenuSheet, openMarkingLabel]);
 
 	const rightElement = useMemo(() => (
 		<View style={styles.rightRow}>

--- a/apps/frontend/app/components/SignatureInterface/SignatureInterface.tsx
+++ b/apps/frontend/app/components/SignatureInterface/SignatureInterface.tsx
@@ -104,54 +104,63 @@ const SignatureInterface = ({ id, value, onChange, error, isDisabled, custom_typ
 		return () => subscription?.remove();
 	}, []);
 
+	let signatureContent: React.ReactNode;
+	if (value && typeof value === 'string' && value?.startsWith('https')) {
+		signatureContent = (
+			<View style={styles.fileContainer}>
+				{authToken !== undefined && (
+					<Image
+						key={authToken || 'no-auth'}
+						source={getImageSource(value)}
+						style={{
+							...styles.filePreview,
+							width: screenWidth > 768 ? screenWidth * 0.6 : screenWidth * 0.8,
+						}}
+					/>
+				)}
+			</View>
+		);
+	} else if (isWeb) {
+		signatureContent = (
+			<SignatureCanvas
+				ref={signatureRef}
+				onEnd={handleSave}
+				descriptionText="Sign here"
+				penColor={'#000000'}
+				clearText="Clear"
+				confirmText="Save"
+				backgroundColor={'#ffffff'}
+				webStyle={styles.signaturePad}
+				autoClear={false}
+				canvasProps={{
+					width: screenWidth > 768 ? screenWidth * 0.6 : screenWidth * 0.8,
+					height: 250,
+				}}
+				disabled={isDisabled}
+			/>
+		);
+	} else {
+		signatureContent = (
+			<SignatureScreen
+				ref={signatureRef}
+				onBegin={handleBegin}
+				onEnd={handleEnd}
+				onOK={handleSignature}
+				autoClear={false}
+				descriptionText="Sign here"
+				backgroundColor="#ffffff"
+				penColor="#000000"
+				style={{
+					width: screenWidth > 768 ? screenWidth * 0.6 : screenWidth * 0.8,
+					height: 250,
+				}}
+			/>
+		);
+	}
+
 	return (
 		<View style={{ ...styles.container, backgroundColor: theme.screen.iconBg }}>
-			{value && typeof value === 'string' && value?.startsWith('https') ? (
-				<View style={styles.fileContainer}>
-					{authToken !== undefined && (
-						<Image
-							key={authToken || 'no-auth'}
-							source={getImageSource(value)}
-							style={{
-								...styles.filePreview,
-								width: screenWidth > 768 ? screenWidth * 0.6 : screenWidth * 0.8,
-							}}
-						/>
-					)}
-				</View>
-			) : isWeb ? (
-				<SignatureCanvas
-					ref={signatureRef}
-					onEnd={handleSave}
-					descriptionText="Sign here"
-					penColor={'#000000'}
-					clearText="Clear"
-					confirmText="Save"
-					backgroundColor={'#ffffff'}
-					webStyle={styles.signaturePad}
-					autoClear={false}
-					canvasProps={{
-						width: screenWidth > 768 ? screenWidth * 0.6 : screenWidth * 0.8,
-						height: 250,
-					}}
-					disabled={isDisabled}
-				/>
-			) : (
-				<SignatureScreen
-					ref={signatureRef}
-					onBegin={handleBegin}
-					onEnd={handleEnd}
-					onOK={handleSignature}
-					autoClear={false}
-					descriptionText="Sign here"
-					backgroundColor="#ffffff"
-					penColor="#000000"
-					style={{
-						width: screenWidth > 768 ? screenWidth * 0.6 : screenWidth * 0.8,
-						height: 250,
-					}}
-				/>
-			)}
+			{signatureContent}
 
 			<View style={{ ...styles.buttonContainer }}>
 				<TouchableOpacity style={{ ...styles.button, backgroundColor: primaryColor }} onPress={handleClear} activeOpacity={0.7}>

--- a/apps/frontend/app/components/SubmissionWarningModal/SubmissionWarningModal.tsx
+++ b/apps/frontend/app/components/SubmissionWarningModal/SubmissionWarningModal.tsx
@@ -45,6 +45,13 @@ const SubmissionWarningModal: React.FC<SubmissionWarningModalProps> = ({ isVisib
 		return () => subscription?.remove();
 	}, []);
 
+	let modalWidth: '90%' | 700 | 600 = 600;
+	if (screenWidth < 800) {
+		modalWidth = '90%';
+	} else if (screenWidth < 1200) {
+		modalWidth = 700;
+	}
+
 	return (
 		<Modal
 			isVisible={isVisible}
@@ -62,7 +69,7 @@ const SubmissionWarningModal: React.FC<SubmissionWarningModalProps> = ({ isVisib
 				style={{
 					...styles.modalView,
 					backgroundColor: theme.modal.modalBg,
-					width: screenWidth < 800 ? '90%' : screenWidth < 1200 ? 700 : 600,
+					width: modalWidth,
 				}}
 			>
 				<View style={styles.modalHeader}>

--- a/apps/frontend/app/components/TriStateCheckbox/TriStateCheckbox.tsx
+++ b/apps/frontend/app/components/TriStateCheckbox/TriStateCheckbox.tsx
@@ -28,7 +28,14 @@ const TriStateCheckbox = ({
 
 	// If onlyTwo === true we normalize any non-1 value to 0 (false).
 	// Otherwise keep tri-state semantics where value can be 1, 0 or null/undefined.
-	const currentValue: number | null | undefined = onlyTwo ? (value === 1 ? 1 : 0) : value === 2 ? null : value;
+	let currentValue: number | null | undefined;
+	if (onlyTwo) {
+		currentValue = value === 1 ? 1 : 0;
+	} else if (value === 2) {
+		currentValue = null;
+	} else {
+		currentValue = value;
+	}
 
 	const translation_yes = translate(TranslationKeys.yes);
 	const translation_no = translate(TranslationKeys.no);

--- a/apps/frontend/app/helper/CardDimensionHelper.ts
+++ b/apps/frontend/app/helper/CardDimensionHelper.ts
@@ -28,7 +28,14 @@ export default class CardDimensionHelper {
 	}
 
 	static getCardWidth(screenWidth: number, columns: number): number {
-		const offset = screenWidth < 500 ? 10 : screenWidth < 900 ? 25 : 35;
+		let offset: number;
+		if (screenWidth < 500) {
+			offset = 10;
+		} else if (screenWidth < 900) {
+			offset = 25;
+		} else {
+			offset = 35;
+		}
 		return screenWidth / columns - offset;
 	}
 

--- a/apps/frontend/app/helper/FoodOffersCacheHelper.ts
+++ b/apps/frontend/app/helper/FoodOffersCacheHelper.ts
@@ -2,6 +2,15 @@ import { sqliteKeyValueStorage } from '@/redux/storage/sqliteStorage';
 import { DatabaseTypes } from 'repo-depkit-common';
 
 const CACHE_KEY_PREFIX = 'food_offers_cache_';
+
+/**
+ * Deterministic UTF-16 code unit comparator, independent of the runtime locale.
+ */
+function compareCodeUnits(a: string, b: string): number {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
 const TRACKER_KEY = 'food_offers_cache_tracker';
 const META_KEY = 'food_offers_cache_meta';
 
@@ -15,7 +24,7 @@ export function computeFoodOffersHash(offers: DatabaseTypes.Foodoffers[]): strin
     const parts = offers.map(o => `${o.id}:${o.result_hash || o.date_updated || ''}`);
     // Deterministic UTF-16 code unit comparison - fingerprint parts are technical IDs,
     // so the order must not depend on the runtime locale.
-    parts.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    parts.sort(compareCodeUnits);
     return parts.join('|');
 }
 
@@ -145,7 +154,7 @@ export async function cacheFoodOffers(
         if (!dates.includes(date)) {
             dates.push(date);
             // ISO date strings - deterministic code unit comparison sorts them chronologically
-            dates.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+            dates.sort(compareCodeUnits);
             tracker[canteenId] = dates;
         }
         await setTracker(tracker);

--- a/apps/frontend/app/hooks/useLanguageModal.tsx
+++ b/apps/frontend/app/hooks/useLanguageModal.tsx
@@ -121,14 +121,16 @@ export const useLanguageModal = () => {
                 ({ languageCode, index }: { languageCode: LanguageCode; index: number }) => {
                         const languageOption = languageDict[languageCode];
                         const isSelected = language === languageCode;
-                        const groupPosition =
-                                languageOrder.length === 1
-                                        ? 'single'
-                                        : index === 0
-                                                        ? 'top'
-                                                        : index === languageOrder.length - 1
-                                                        ? 'bottom'
-                                                        : 'middle';
+                        let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+                        if (languageOrder.length === 1) {
+                                groupPosition = 'single';
+                        } else if (index === 0) {
+                                groupPosition = 'top';
+                        } else if (index === languageOrder.length - 1) {
+                                groupPosition = 'bottom';
+                        } else {
+                                groupPosition = 'middle';
+                        }
 
                         return (
                                 <SettingsList

--- a/apps/frontend/app/hooks/useLastOpenedBuildings.ts
+++ b/apps/frontend/app/hooks/useLastOpenedBuildings.ts
@@ -40,7 +40,12 @@ const useLastOpenedBuildings = () => {
 			// Remove duplicate, then prepend, then limit to MAX_LAST_OPENED
 			const filtered = current.filter(entry => {
 				const id = typeof entry === 'string' ? entry : (entry as DatabaseTypes.ProfilesBuildingsLastOpened)?.buildings_id;
-				const resolvedId = typeof id === 'string' ? id : typeof id === 'object' && id !== null ? String((id as any)?.id ?? '') : '';
+				let resolvedId = '';
+				if (typeof id === 'string') {
+					resolvedId = id;
+				} else if (typeof id === 'object' && id !== null) {
+					resolvedId = String((id as any)?.id ?? '');
+				}
 				return resolvedId !== buildingId;
 			});
 

--- a/apps/frontend/app/hooks/useLinkCoordinateModal.tsx
+++ b/apps/frontend/app/hooks/useLinkCoordinateModal.tsx
@@ -84,14 +84,16 @@ const useLinkCoordinateModal = () => {
 					<View style={{ gap: 12 }}>
 						<View>
 							{options.map((option, index) => {
-								const groupPosition =
-									options.length === 1
-										? 'single'
-										: index === 0
-											? 'top'
-											: index === options.length - 1
-												? 'bottom'
-												: 'middle';
+								let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+								if (options.length === 1) {
+									groupPosition = 'single';
+								} else if (index === 0) {
+									groupPosition = 'top';
+								} else if (index === options.length - 1) {
+									groupPosition = 'bottom';
+								} else {
+									groupPosition = 'middle';
+								}
 
 								return (
 									<SettingsList

--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -315,18 +315,23 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 
 	const actionItems = useMemo(() => {
 		const withGrouping = (items: Omit<ActionItem, 'groupPosition' | 'showSeparator'>[]): ActionItem[] =>
-			items.map((item, index) => ({
-				...item,
-				groupPosition:
-					items.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === items.length - 1
-								? 'bottom'
-								: 'middle',
-				showSeparator: index !== items.length - 1,
-			}));
+			items.map((item, index) => {
+				let groupPosition: ActionItem['groupPosition'];
+				if (items.length === 1) {
+					groupPosition = 'single';
+				} else if (index === 0) {
+					groupPosition = 'top';
+				} else if (index === items.length - 1) {
+					groupPosition = 'bottom';
+				} else {
+					groupPosition = 'middle';
+				}
+				return {
+					...item,
+					groupPosition,
+					showSeparator: index !== items.length - 1,
+				};
+			});
 
 		const cancelItem: ActionItem = {
 			key: isDelete ? 'delete-cancel' : 'cancel',

--- a/apps/frontend/app/hooks/useMyScrollviewModalFoodOffersOptions.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewModalFoodOffersOptions.tsx
@@ -117,14 +117,16 @@ const FoodOffersOptionsContent: React.FC<FoodOffersOptionsContentProps> = ({
 	return (
 		<View style={styles.container}>
 			{options.map((option, index) => {
-				const groupPosition =
-					options.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === options.length - 1
-								? 'bottom'
-								: 'middle';
+				let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+				if (options.length === 1) {
+					groupPosition = 'single';
+				} else if (index === 0) {
+					groupPosition = 'top';
+				} else if (index === options.length - 1) {
+					groupPosition = 'bottom';
+				} else {
+					groupPosition = 'middle';
+				}
 				const showSeparator = index !== options.length - 1;
 
 				if (option.kind === 'boolean') {

--- a/apps/frontend/app/hooks/useUpdateCheckModal.tsx
+++ b/apps/frontend/app/hooks/useUpdateCheckModal.tsx
@@ -60,14 +60,12 @@ const UpdateCheckModalContent: React.FC = () => {
 		}
 	}, []);
 
-	const checkValue =
-		step === 'checking'
-			? undefined
-			: step === 'unavailable'
-				? translate(TranslationKeys.update_not_available_on_platform)
-				: step === 'no_update'
-					? translate(TranslationKeys.update_current_version)
-					: undefined;
+	let checkValue: string | undefined = undefined;
+	if (step === 'unavailable') {
+		checkValue = translate(TranslationKeys.update_not_available_on_platform);
+	} else if (step === 'no_update') {
+		checkValue = translate(TranslationKeys.update_current_version);
+	}
 
 	return (
 		<View style={{ width: '100%', gap: 0 }}>

--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -127,12 +127,11 @@ function computeActivityStats(points: RoutePoint[]): RunStats {
 		}
 		const dtSec = (points[i].timestamp - points[i - 1].timestamp) / 1000;
 		const gpsSpeed = points[i].speed;
+		const derivedSpeedKmh = dtSec > 0 ? (segKm / dtSec) * 3600 : 0;
 		const segSpeedKmh =
 			gpsSpeed != null && gpsSpeed >= 0
 				? gpsSpeed * 3.6
-				: dtSec > 0
-				? (segKm / dtSec) * 3600
-				: 0;
+				: derivedSpeedKmh;
 		if (points[i].timestamp - startTimestamp >= SPEED_WARMUP_MS && segSpeedKmh > 0) {
 			speedsKmh.push(segSpeedKmh);
 		}
@@ -1335,10 +1334,11 @@ export default function ActivityDetailScreen() {
 						const updated: SavedActivity = { ...activity, routePoints: filtered, stats: newStats };
 						saveActivity(updated);
 						setActivity(updated);
+						const pointsSuffix = removedCount !== 1 ? 's' : '';
 						showAlert(
 							'Done',
 							removedCount > 0
-								? `Removed ${removedCount} unrealistic point${removedCount !== 1 ? 's' : ''}.`
+								? `Removed ${removedCount} unrealistic point${pointsSuffix}.`
 								: 'No unrealistic points found.',
 						);
 					},
@@ -1463,11 +1463,8 @@ export default function ActivityDetailScreen() {
 
 	const { stats } = activity;
 
-	const routeDisplayValue = assignedRoute
-		? assignedRoute.name
-		: activity.routeId === null
-		? 'Keine'
-		: '—';
+	const noRouteDisplayValue = activity.routeId === null ? 'Keine' : '—';
+	const routeDisplayValue = assignedRoute ? assignedRoute.name : noRouteDisplayValue;
 
 	const currentWeatherDef = activity.weatherType ? WEATHER_TYPES.find(w => w.type === activity.weatherType) : null;
 

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -324,7 +324,11 @@ function RouteSelectionContent({
 			<View>
 				{routes.map((route, idx) => {
 					const count = routes.length;
-					const groupPosition = count === 1 ? 'single' : idx === 0 ? 'top' : idx === count - 1 ? 'bottom' : 'middle';
+					let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+					if (count === 1) groupPosition = 'single';
+					else if (idx === 0) groupPosition = 'top';
+					else if (idx === count - 1) groupPosition = 'bottom';
+					else groupPosition = 'middle';
 					return (
 						<SettingsList
 							key={route.id}
@@ -836,8 +840,11 @@ export default function ActivitiesScreen() {
 						<SettingsListGroupTitle title={routeName} />
 						{groupActivities.map((item, idx) => {
 							const count = groupActivities.length;
-							const groupPosition =
-								count === 1 ? 'single' : idx === 0 ? 'top' : idx === count - 1 ? 'bottom' : 'middle';
+							let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+							if (count === 1) groupPosition = 'single';
+							else if (idx === 0) groupPosition = 'top';
+							else if (idx === count - 1) groupPosition = 'bottom';
+							else groupPosition = 'middle';
 							return (
 								<SettingsListActivity
 									key={item.id}

--- a/apps/geonexia/frontend/app/experimental/3d-kyle-test/index.tsx
+++ b/apps/geonexia/frontend/app/experimental/3d-kyle-test/index.tsx
@@ -348,7 +348,11 @@ export default function KyleTest3DScreen() {
 			{MODELS.map((entry, idx) => {
 				const isFirst = idx === 0;
 				const isLast = idx === MODELS.length - 1;
-				const groupPosition = isFirst && isLast ? 'single' : isFirst ? 'top' : isLast ? 'bottom' : 'middle';
+				let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+				if (isFirst && isLast) groupPosition = 'single';
+				else if (isFirst) groupPosition = 'top';
+				else if (isLast) groupPosition = 'bottom';
+				else groupPosition = 'middle';
 				return (
 					<SettingsListSelectOptionSingle
 						key={entry.key}
@@ -401,7 +405,11 @@ export default function KyleTest3DScreen() {
 				debugLog.map((entry, idx) => {
 					const isFirst = idx === 0;
 					const isLast = idx === debugLog.length - 1;
-					const groupPosition = isFirst && isLast ? 'single' : isFirst ? 'top' : isLast ? 'bottom' : 'middle';
+					let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+					if (isFirst && isLast) groupPosition = 'single';
+					else if (isFirst) groupPosition = 'top';
+					else if (isLast) groupPosition = 'bottom';
+					else groupPosition = 'middle';
 					return (
 						<SettingsList
 							key={idx}

--- a/apps/geonexia/frontend/app/experimental/hex-tile-info/index.tsx
+++ b/apps/geonexia/frontend/app/experimental/hex-tile-info/index.tsx
@@ -67,6 +67,13 @@ const BOUNDS_RECT_SCRIPT = `
 })();
 `;
 
+function getGroupPosition(idx: number, count: number): 'single' | 'top' | 'bottom' | 'middle' {
+	if (count === 1) return 'single';
+	if (idx === 0) return 'top';
+	if (idx === count - 1) return 'bottom';
+	return 'middle';
+}
+
 export default function HexTileInfoScreen() {
 	const { theme } = useTheme();
 	const { showAlert } = useGeonexiaAlert();
@@ -280,7 +287,7 @@ export default function HexTileInfoScreen() {
 								leftIcon={<MaterialIcons name="directions" size={22} color="#ffffff" />}
 								label={f.name ?? f.highway ?? f.class ?? `Straße ${idx + 1}`}
 								value={JSON.stringify(f)}
-								groupPosition={streets.length === 1 ? 'single' : idx === 0 ? 'top' : idx === streets.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(idx, streets.length)}
 							/>
 						))}
 					</>
@@ -296,7 +303,7 @@ export default function HexTileInfoScreen() {
 								leftIcon={<MaterialIcons name="water" size={22} color="#ffffff" />}
 								label={f.name ?? f.waterway ?? f.class ?? `Gewässer ${idx + 1}`}
 								value={JSON.stringify(f)}
-								groupPosition={waterways.length === 1 ? 'single' : idx === 0 ? 'top' : idx === waterways.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(idx, waterways.length)}
 							/>
 						))}
 					</>
@@ -312,7 +319,7 @@ export default function HexTileInfoScreen() {
 								leftIcon={<MaterialIcons name="apartment" size={22} color="#ffffff" />}
 								label={f.name ?? f.building ?? f.class ?? `Gebäude ${idx + 1}`}
 								value={JSON.stringify(f)}
-								groupPosition={buildings.length === 1 ? 'single' : idx === 0 ? 'top' : idx === buildings.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(idx, buildings.length)}
 							/>
 						))}
 					</>
@@ -328,7 +335,7 @@ export default function HexTileInfoScreen() {
 								leftIcon={<MaterialIcons name="place" size={22} color="#ffffff" />}
 								label={f.name ?? f.amenity ?? f.natural ?? f.landuse ?? f.subclass ?? f.class ?? `POI ${idx + 1}`}
 								value={JSON.stringify(f)}
-								groupPosition={pois.length === 1 ? 'single' : idx === 0 ? 'top' : idx === pois.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(idx, pois.length)}
 							/>
 						))}
 					</>

--- a/apps/geonexia/frontend/app/experimental/onboarding/index.tsx
+++ b/apps/geonexia/frontend/app/experimental/onboarding/index.tsx
@@ -69,15 +69,12 @@ function GpsStep({
 	status: PermStatus;
 	onRequest: () => void;
 }) {
-	const statusColor = status === 'granted' ? COLOR_PRIMARY : status === 'denied' ? '#dc2626' : COLOR_PRIMARY;
-	const statusLabel =
-		status === 'granted'
-			? '✅ Berechtigung erteilt'
-			: status === 'denied'
-			? '❌ Berechtigung verweigert'
-			: status === 'loading'
-			? '⏳ Wird angefragt…'
-			: null;
+	const statusColor = status === 'denied' ? '#dc2626' : COLOR_PRIMARY;
+	let statusLabel: string | null;
+	if (status === 'granted') statusLabel = '✅ Berechtigung erteilt';
+	else if (status === 'denied') statusLabel = '❌ Berechtigung verweigert';
+	else if (status === 'loading') statusLabel = '⏳ Wird angefragt…';
+	else statusLabel = null;
 
 	return (
 		<View style={styles.stepContent}>
@@ -126,15 +123,12 @@ function NotificationsStep({
 	status: PermStatus;
 	onRequest: () => void;
 }) {
-	const statusColor = status === 'granted' ? COLOR_PRIMARY : status === 'denied' ? '#dc2626' : COLOR_PRIMARY;
-	const statusLabel =
-		status === 'granted'
-			? '✅ Benachrichtigungen aktiviert'
-			: status === 'denied'
-			? '❌ Berechtigung verweigert'
-			: status === 'loading'
-			? '⏳ Wird angefragt…'
-			: null;
+	const statusColor = status === 'denied' ? '#dc2626' : COLOR_PRIMARY;
+	let statusLabel: string | null;
+	if (status === 'granted') statusLabel = '✅ Benachrichtigungen aktiviert';
+	else if (status === 'denied') statusLabel = '❌ Berechtigung verweigert';
+	else if (status === 'loading') statusLabel = '⏳ Wird angefragt…';
+	else statusLabel = null;
 
 	return (
 		<View style={styles.stepContent}>

--- a/apps/geonexia/frontend/app/experimental/tts-test/index.tsx
+++ b/apps/geonexia/frontend/app/experimental/tts-test/index.tsx
@@ -205,6 +205,10 @@ export default function TTSTestScreen() {
 		: 'System Default';
 	const rateLabel = rate.toFixed(1) + '×';
 	const pitchLabel = pitch.toFixed(1);
+	let availableVoicesLabel: string;
+	if (voicesAvailable === null) availableVoicesLabel = 'Loading…';
+	else if (voicesAvailable === false) availableVoicesLabel = 'Not supported';
+	else availableVoicesLabel = `${availableVoices.length} voice${availableVoices.length !== 1 ? 's' : ''}`;
 
 	return (
 		<ScrollView
@@ -309,7 +313,11 @@ export default function TTSTestScreen() {
 				const text = buildKmAnnouncement(km, pace, locale);
 				const isFirst = index === 0;
 				const isLast = index === KM_EXAMPLES.length - 1;
-				const groupPosition = isFirst && isLast ? 'single' : isFirst ? 'top' : isLast ? 'bottom' : 'middle';
+				let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+				if (isFirst && isLast) groupPosition = 'single';
+				else if (isFirst) groupPosition = 'top';
+				else if (isLast) groupPosition = 'bottom';
+				else groupPosition = 'middle';
 				return (
 					<SettingsList
 						key={km}
@@ -377,13 +385,7 @@ export default function TTSTestScreen() {
 				iconBgColor="#6b7280"
 				leftIcon={<MaterialCommunityIcons name="microphone" size={22} color="#ffffff" />}
 				label="Available Voices"
-				value={
-					voicesAvailable === null
-						? 'Loading…'
-						: voicesAvailable === false
-						? 'Not supported'
-						: `${availableVoices.length} voice${availableVoices.length !== 1 ? 's' : ''}`
-				}
+				value={availableVoicesLabel}
 				groupPosition="bottom"
 			/>
 
@@ -394,8 +396,11 @@ export default function TTSTestScreen() {
 					{availableVoices.map((v, index) => {
 						const isFirst = index === 0;
 						const isLast = index === availableVoices.length - 1;
-						const groupPosition =
-							isFirst && isLast ? 'single' : isFirst ? 'top' : isLast ? 'bottom' : 'middle';
+						let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+						if (isFirst && isLast) groupPosition = 'single';
+						else if (isFirst) groupPosition = 'top';
+						else if (isLast) groupPosition = 'bottom';
+						else groupPosition = 'middle';
 						return (
 							<SettingsList
 								key={v.identifier}

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -113,6 +113,24 @@ function getAnchorAngleDeg(anchorPosition: string): number {
 	return match ? (240 - Number.parseInt(match[1], 10) + 360) % 360 : 0;
 }
 
+/**
+ * Group position of a list entry for settings list styling:
+ * 'single' for one-item lists, otherwise 'top' / 'middle' / 'bottom'.
+ */
+function getListGroupPosition(index: number, length: number): 'top' | 'middle' | 'bottom' | 'single' {
+	if (length === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === length - 1) return 'bottom';
+	return 'middle';
+}
+
+/** Locale-independent code unit comparison for deterministic string sorting. */
+function compareByCodeUnit(a: string, b: string): number {
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+}
+
 const PRIMARY_COLOR = '#2563eb';
 
 /** Billboard key for the castle2 sprite. Used to mark the player's home tile. */
@@ -905,12 +923,12 @@ function computeStats(points: RoutePoint[]): RunStats {
 
 		const dtSec = (points[i].timestamp - points[i - 1].timestamp) / 1000;
 		const gpsSpeed = points[i].speed;
-		const segSpeedKmh =
-			gpsSpeed != null && gpsSpeed >= 0
-				? gpsSpeed * 3.6
-				: dtSec > 0
-				? (segKm / dtSec) * 3600
-				: 0;
+		let segSpeedKmh = 0;
+		if (gpsSpeed != null && gpsSpeed >= 0) {
+			segSpeedKmh = gpsSpeed * 3.6;
+		} else if (dtSec > 0) {
+			segSpeedKmh = (segKm / dtSec) * 3600;
+		}
 		if (points[i].timestamp - startTimestamp >= SPEED_WARMUP_MS) {
 			if (segSpeedKmh > 0) speedsKmh.push(segSpeedKmh);
 			speedDistanceKm += segKm;
@@ -1091,35 +1109,35 @@ function DebugInfoContent({
 
 	const tilesExpected = info != null && (showGridAlways || info.zoom >= minZoom);
 
-	const statusColor = !h3Available
-		? STATUS_ERROR_COLOR
-		: info == null
-		? STATUS_WARNING_COLOR
-		: !tilesExpected
-		? STATUS_WARNING_COLOR
-		: info.tileCount > 0
-		? STATUS_SUCCESS_COLOR
-		: STATUS_ERROR_COLOR;
+	let statusColor: string;
+	let statusText: string;
+	if (!h3Available) {
+		statusColor = STATUS_ERROR_COLOR;
+		statusText = '❌ H3 library failed to initialise';
+	} else if (info == null) {
+		statusColor = STATUS_WARNING_COLOR;
+		statusText = '⚠️ No viewport data yet. Move or zoom the map.';
+	} else if (!tilesExpected) {
+		statusColor = STATUS_WARNING_COLOR;
+		statusText = `⚠️ Zoom in to ≥${minZoom} to see tiles`;
+	} else if (info.tileCount > 0) {
+		statusColor = STATUS_SUCCESS_COLOR;
+		statusText = `✅ ${info.tileCount} H3 tiles computed`;
+	} else {
+		statusColor = STATUS_ERROR_COLOR;
+		statusText = '❌ 0 tiles – H3 library may not be working';
+	}
 
-	const statusText = !h3Available
-		? '❌ H3 library failed to initialise'
-		: info == null
-		? '⚠️ No viewport data yet. Move or zoom the map.'
-		: !tilesExpected
-		? `⚠️ Zoom in to ≥${minZoom} to see tiles`
-		: info.tileCount > 0
-		? `✅ ${info.tileCount} H3 tiles computed`
-		: '❌ 0 tiles – H3 library may not be working';
-
-	const viewportRows: { label: string; value: string }[] = info
-		? [
+	let viewportRows: { label: string; value: string }[] = [];
+	if (info) {
+		viewportRows = [
 			{ label: 'Tiles Visible', value: tilesExpected ? `${info.tileCount} cells` : `0 (zoom < ${minZoom})` },
 			{ label: 'North', value: info.bounds.north.toFixed(5) },
 			{ label: 'South', value: info.bounds.south.toFixed(5) },
 			{ label: 'East', value: info.bounds.east.toFixed(5) },
 			{ label: 'West', value: info.bounds.west.toFixed(5) },
-		]
-		: [];
+		];
+	}
 
 	return (
 		<View style={styles.debugContainer}>
@@ -1316,8 +1334,7 @@ function DebugInfoContent({
 					<SettingsListGroupTitle title={`⬠ Pentagon Tiles (Res ${Math.round(h3Resolution)})`} />
 					{pentagons.map((cell, i) => {
 						const [lat, lng] = cellToLatLng(cell);
-						const position: 'top' | 'middle' | 'bottom' | 'single' =
-							pentagons.length === 1 ? 'single' : i === 0 ? 'top' : i === pentagons.length - 1 ? 'bottom' : 'middle';
+						const position: 'top' | 'middle' | 'bottom' | 'single' = getListGroupPosition(i, pentagons.length);
 						return (
 							<SettingsListSelectOptionSingle
 								key={cell}
@@ -1767,6 +1784,9 @@ function HexAnchorPicker({ selected, onSelect, occupiedAnchors }: { selected: Bi
 					const isSelected = selected === ac.id;
 					const isOccupied = occupiedAnchors ? !!occupiedAnchors[ac.id] : false;
 					const dotSize = isSelected ? HEX_DOT_SELECTED_SIZE : HEX_DOT_SIZE;
+					const isWhiteSwatch = ac.hex === '#ffffff';
+					const unselectedBorderColor = isWhiteSwatch ? '#d1d5db' : 'transparent';
+					const unselectedBorderWidth = isWhiteSwatch ? 1 : 0;
 					return (
 						<TouchableOpacity
 							key={ac.id}
@@ -1780,8 +1800,8 @@ function HexAnchorPicker({ selected, onSelect, occupiedAnchors }: { selected: Bi
 									left: pos.x - dotSize / 2,
 									top: pos.y - dotSize / 2,
 									backgroundColor: ac.hex,
-									borderColor: isSelected ? PRIMARY_COLOR : (ac.hex === '#ffffff' ? '#d1d5db' : 'transparent'),
-									borderWidth: isSelected ? 3 : (ac.hex === '#ffffff' ? 1 : 0),
+									borderColor: isSelected ? PRIMARY_COLOR : unselectedBorderColor,
+									borderWidth: isSelected ? 3 : unselectedBorderWidth,
 									shadowColor: isSelected ? PRIMARY_COLOR : 'transparent',
 									shadowOpacity: isSelected ? 0.6 : 0,
 									shadowRadius: 4,
@@ -1881,7 +1901,7 @@ function HexTileInfoContent({ h3Index }: { h3Index: string }) {
 		if (!parentIndex) return null;
 		// H3 index strings - deterministic code unit comparison keeps child numbering
 		// identical across devices regardless of locale.
-		const siblings = cellToChildren(parentIndex, res).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+		const siblings = cellToChildren(parentIndex, res).sort(compareByCodeUnit);
 		const childNumber = siblings.indexOf(h3Index);
 		return {
 			parentIndex,
@@ -1890,19 +1910,30 @@ function HexTileInfoContent({ h3Index }: { h3Index: string }) {
 		};
 	}, [h3Index]);
 
+	let walkedOnValue = '⬜ No';
+	if (record) {
+		walkedOnValue = record.walkedOn ? '✅ Yes' : '⬜ No (enclosed only)';
+	}
+
+	const parentRows: { label: string; value: string }[] = [];
+	if (parentInfo) {
+		const childNumberValue = parentInfo.childNumber !== null ? `${parentInfo.childNumber} / ${parentInfo.totalChildren}` : '—';
+		parentRows.push(
+			{ label: 'Parent H3', value: parentInfo.parentIndex },
+			{ label: 'Nr. im Parent', value: childNumberValue },
+		);
+	}
+
 	const infoRows: { label: string; value: string }[] = [
 		{ label: 'H3 Index', value: h3Index },
 		{ label: 'Level', value: record ? String(record.level) : '0' },
-		{ label: 'Walked On', value: record ? (record.walkedOn ? '✅ Yes' : '⬜ No (enclosed only)') : '⬜ No' },
+		{ label: 'Walked On', value: walkedOnValue },
 		{ label: 'Visit Count', value: record ? String(record.visitCount) : '0' },
 		{ label: 'Enclosed Count', value: record ? String(record.enclosedCount) : '0' },
 		{ label: 'Avenue Count', value: record ? String(record.avenueCount) : '0' },
 		{ label: 'Last Visited', value: record ? formatTimestamp(record.lastVisitedAt) : '—' },
 		{ label: 'Last Enclosed', value: record ? formatTimestamp(record.lastEnclosedAt) : '—' },
-		...(parentInfo ? [
-			{ label: 'Parent H3', value: parentInfo.parentIndex },
-			{ label: 'Nr. im Parent', value: parentInfo.childNumber !== null ? `${parentInfo.childNumber} / ${parentInfo.totalChildren}` : '—' },
-		] : []),
+		...parentRows,
 	];
 
 	const openTileSelection = useCallback(() => {
@@ -1917,7 +1948,7 @@ function HexTileInfoContent({ h3Index }: { h3Index: string }) {
 							<View key={cat}>
 								<SettingsListGroupTitle title={cat} />
 								{entries.map((entry, i) => {
-									const position = entries.length === 1 ? 'single' : i === 0 ? 'top' : i === entries.length - 1 ? 'bottom' : 'middle';
+									const position = getListGroupPosition(i, entries.length);
 									return (
 										<SettingsListHexTile
 											key={entry.key}
@@ -2098,7 +2129,7 @@ function HexTileInfoContent({ h3Index }: { h3Index: string }) {
 							iconBackgroundColor={PRIMARY_COLOR}
 							title={feature.name ?? feature.layerId ?? `Feature ${idx + 1}`}
 							value={JSON.stringify(feature, null, 2)}
-							groupPosition={mapFeatures.length === 1 ? 'single' : idx === 0 ? 'top' : idx === mapFeatures.length - 1 ? 'bottom' : 'middle'}
+							groupPosition={getListGroupPosition(idx, mapFeatures.length)}
 						/>
 					))}
 				</>
@@ -2265,7 +2296,7 @@ function MagnifyModalContent({ h3Index }: { h3Index: string }) {
 							iconBackgroundColor="#f97316"
 							title={f.name ?? f.highway ?? f.class ?? `Straße ${idx + 1}`}
 							value={JSON.stringify(f)}
-							groupPosition={streets.length === 1 ? 'single' : idx === 0 ? 'top' : idx === streets.length - 1 ? 'bottom' : 'middle'}
+							groupPosition={getListGroupPosition(idx, streets.length)}
 						/>
 					))}
 				</>
@@ -2280,7 +2311,7 @@ function MagnifyModalContent({ h3Index }: { h3Index: string }) {
 							iconBackgroundColor="#3b82f6"
 							title={f.name ?? f.waterway ?? f.class ?? `Gewässer ${idx + 1}`}
 							value={JSON.stringify(f)}
-							groupPosition={waterways.length === 1 ? 'single' : idx === 0 ? 'top' : idx === waterways.length - 1 ? 'bottom' : 'middle'}
+							groupPosition={getListGroupPosition(idx, waterways.length)}
 						/>
 					))}
 				</>
@@ -2295,7 +2326,7 @@ function MagnifyModalContent({ h3Index }: { h3Index: string }) {
 							iconBackgroundColor="#8b5cf6"
 							title={f.name ?? f.building ?? f.class ?? `Gebäude ${idx + 1}`}
 							value={JSON.stringify(f)}
-							groupPosition={buildings.length === 1 ? 'single' : idx === 0 ? 'top' : idx === buildings.length - 1 ? 'bottom' : 'middle'}
+							groupPosition={getListGroupPosition(idx, buildings.length)}
 						/>
 					))}
 				</>
@@ -2310,7 +2341,7 @@ function MagnifyModalContent({ h3Index }: { h3Index: string }) {
 							iconBackgroundColor="#10b981"
 							title={f.name ?? f.amenity ?? f.natural ?? f.landuse ?? f.subclass ?? f.class ?? `POI ${idx + 1}`}
 							value={JSON.stringify(f)}
-							groupPosition={pois.length === 1 ? 'single' : idx === 0 ? 'top' : idx === pois.length - 1 ? 'bottom' : 'middle'}
+							groupPosition={getListGroupPosition(idx, pois.length)}
 						/>
 					))}
 				</>
@@ -2424,15 +2455,7 @@ function MapSearchModalContent({ availableKeys }: { availableKeys: string[] }) {
 							label={key}
 							isEnabled={enabledKeys.includes(key)}
 							onToggle={() => dispatch(toggleMapSearchKey(key))}
-							groupPosition={
-								availableKeys.length === 1
-									? 'single'
-									: idx === 0
-										? 'top'
-										: idx === availableKeys.length - 1
-											? 'bottom'
-											: 'middle'
-							}
+							groupPosition={getListGroupPosition(idx, availableKeys.length)}
 						/>
 					))}
 				</>
@@ -2655,9 +2678,10 @@ function InterruptedRecoveryContent({
 				<Text style={{ color: '#ffffff', fontSize: 15, fontWeight: '600' }}>Aktivität speichern (wie aufgezeichnet)</Text>
 			</TouchableOpacity>
 
-			{loading ? (
+			{loading && (
 				<Text style={{ color: theme.screen.text, opacity: 0.5 }}>Routen werden geladen…</Text>
-			) : matchingRoutes.length > 0 ? (
+			)}
+			{!loading && matchingRoutes.length > 0 && (
 				<>
 					<Text style={{ color: theme.screen.text, fontSize: 14, fontWeight: '600' }}>
 						Route zuordnen und fehlende Strecke ergänzen:
@@ -2676,7 +2700,7 @@ function InterruptedRecoveryContent({
 						</TouchableOpacity>
 					))}
 				</>
-			) : null}
+			)}
 
 			<TouchableOpacity
 				style={{ paddingVertical: 12, alignItems: 'center' }}
@@ -2862,7 +2886,7 @@ export default function RecordScreen() {
 		Object.entries(state.hexTiles.records)
 			.filter(([, r]) => r.tileImage || r.billboard || r.billboards || r.billboardsTexture)
 			.map(([h3, r]) => `${h3}=${r.tileImage ?? ''}|${r.billboard ?? ''}|${JSON.stringify(r.billboards ?? {})}|${JSON.stringify(r.billboardsTexture ?? {})}`)
-			.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+			.sort(compareByCodeUnit)
 			.join('\n'),
 	);
 
@@ -3960,7 +3984,7 @@ export default function RecordScreen() {
 							<View key={cat}>
 								<SettingsListGroupTitle title={cat} />
 								{entries.map((entry, i) => {
-									const position = entries.length === 1 ? 'single' : i === 0 ? 'top' : i === entries.length - 1 ? 'bottom' : 'middle';
+									const position = getListGroupPosition(i, entries.length);
 									return (
 										<SettingsListSelectOptionSingle
 											key={entry.key}
@@ -4154,8 +4178,9 @@ export default function RecordScreen() {
 				<View>
 					<SettingsListGroupTitle title="Sport" />
 					{SPORT_TYPES.map((sportDef, i) => {
-						const position =
-							i === 0 ? 'top' : i === SPORT_TYPES.length - 1 ? 'bottom' : 'middle';
+						let position: 'top' | 'middle' | 'bottom' = 'middle';
+						if (i === 0) position = 'top';
+						else if (i === SPORT_TYPES.length - 1) position = 'bottom';
 						const icon =
 							sportDef.iconLibrary === 'MaterialCommunityIcons' ? (
 								<MaterialCommunityIcons
@@ -4434,10 +4459,12 @@ export default function RecordScreen() {
 				const elapsedSec = startTimeRef.current > 0
 					? (Date.now() - startTimeRef.current) / 1000 + accumulatedSecondsRef.current
 					: accumulatedSecondsRef.current;
-				const currentPace =
-					point.speed != null && point.speed > 0.5
-						? 1000 / (point.speed * 60) // instantaneous pace: min/km from m/s
-						: elapsedSec > 0 ? elapsedSec / 60 / d : null; // average fallback
+				let currentPace: number | null = null;
+				if (point.speed != null && point.speed > 0.5) {
+					currentPace = 1000 / (point.speed * 60); // instantaneous pace: min/km from m/s
+				} else if (elapsedSec > 0) {
+					currentPace = elapsedSec / 60 / d; // average fallback
+				}
 				if (currentPace != null) {
 					const targetPace = curSs.paceTargetMinutes + curSs.paceTargetSeconds / 60;
 					const fasterThreshold = curSs.paceHintFasterMinutes + curSs.paceHintFasterSeconds / 60;
@@ -5171,6 +5198,27 @@ export default function RecordScreen() {
 	const livePaceMinPerKm = liveDistanceKm > 0 ? elapsedSeconds / 60 / liveDistanceKm : null;
 	const liveAvgSpeedKmh = elapsedSeconds > 0 ? (liveDistanceKm / elapsedSeconds) * 3600 : 0;
 
+	// Home button icon: white while placing home, green when a home tile is set.
+	let homeButtonIconColor = '#555555';
+	if (isSettingHome) {
+		homeButtonIconColor = '#ffffff';
+	} else if (homeHexTile !== null) {
+		homeButtonIconColor = STATUS_SUCCESS_COLOR;
+	}
+
+	// Live distance: metres below 1 km, kilometres afterwards.
+	const liveDistanceValue = liveDistanceKm < 1 ? (liveDistanceKm * 1000).toFixed(0) : liveDistanceKm.toFixed(2);
+
+	// Central record button: green when idle or paused (start/resume), amber while recording (pause).
+	const recordButtonColor = !isRecording || isPaused ? '#43a047' : '#f59e0b';
+	const recordButtonIcon = !isRecording || isPaused ? 'play-arrow' : 'pause';
+	let recordButtonAction: () => void | Promise<void> = pauseRecording;
+	if (!isRecording) {
+		recordButtonAction = handleRecordButtonPress;
+	} else if (isPaused) {
+		recordButtonAction = resumeRecording;
+	}
+
 	if (!osmConsent) {
 		return (
 			<SafeAreaView style={[styles.container, { backgroundColor: theme.screen.background }]}>
@@ -5244,7 +5292,7 @@ export default function RecordScreen() {
 								<MaterialIcons
 									name="home"
 									size={20}
-									color={isSettingHome ? '#ffffff' : homeHexTile !== null ? STATUS_SUCCESS_COLOR : '#555555'}
+									color={homeButtonIconColor}
 								/>
 							</TouchableOpacity>
 							<View style={styles.buttonSpacer} />
@@ -5344,7 +5392,7 @@ export default function RecordScreen() {
 
 			{/* Bottom control panel */}
 			<View style={[styles.liveBar, { backgroundColor: theme.screen.background }]}>
-				{isPanelCollapsed ? (
+				{isPanelCollapsed && (
 					/* Collapsed: only show expand chevron – aligned right to match expanded position */
 					<View style={styles.liveBarCollapsedRow}>
 						<View style={styles.liveBarSideSlot}>
@@ -5357,16 +5405,15 @@ export default function RecordScreen() {
 							</TouchableOpacity>
 						</View>
 					</View>
-				) : (
+				)}
+				{!isPanelCollapsed && (
 					<>
 						{/* Stats row */}
 						<View style={styles.liveBarStatsRow}>
 							<View style={styles.liveStatCard}>
 								<MaterialIcons name="straighten" size={20} color={PRIMARY_COLOR} />
 								<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
-									{isRecording
-										? (liveDistanceKm < 1 ? (liveDistanceKm * 1000).toFixed(0) : liveDistanceKm.toFixed(2))
-										: '--'}
+									{isRecording ? liveDistanceValue : '--'}
 								</Text>
 								<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>
 									{isRecording && liveDistanceKm < 1 ? 'm' : 'km'}
@@ -5421,7 +5468,7 @@ export default function RecordScreen() {
 						<View style={styles.liveBarControlsRow}>
 							{/* Left side: stop button when recording, activity type picker otherwise */}
 							<View style={styles.liveBarSideSlot}>
-								{isRecording ? (
+								{isRecording && (
 									<TouchableOpacity
 										style={[styles.stopButton, { backgroundColor: '#e53935' }]}
 										onPress={stopRecording}
@@ -5429,7 +5476,8 @@ export default function RecordScreen() {
 									>
 										<MaterialIcons name="stop" size={32} color="white" />
 									</TouchableOpacity>
-								) : (
+								)}
+								{!isRecording && (
 									<TouchableOpacity
 										style={[styles.activityTypeButton, { backgroundColor: activeSport.color + '22' }]}
 										onPress={showActivityTypeModal}
@@ -5456,25 +5504,13 @@ export default function RecordScreen() {
 							<TouchableOpacity
 								style={[
 									styles.mainRecordButton,
-									{
-										backgroundColor: !isRecording
-											? '#43a047'
-											: isPaused
-											? '#43a047'
-											: '#f59e0b',
-									},
+									{ backgroundColor: recordButtonColor },
 								]}
-								onPress={
-									!isRecording
-										? handleRecordButtonPress
-										: isPaused
-										? resumeRecording
-										: pauseRecording
-								}
+								onPress={recordButtonAction}
 								activeOpacity={0.8}
 							>
 								<MaterialIcons
-									name={!isRecording ? 'play-arrow' : isPaused ? 'play-arrow' : 'pause'}
+									name={recordButtonIcon}
 									size={32}
 									color="white"
 								/>
@@ -5482,7 +5518,7 @@ export default function RecordScreen() {
 
 							{/* Chevron-down collapse button – right side */}
 							<View style={styles.liveBarSideSlot}>
-								{!isRecording ? (
+								{!isRecording && (
 									<TouchableOpacity
 										style={[styles.routeButton, selectedRoute ? { backgroundColor: PRIMARY_COLOR + '22' } : {}]}
 										onPress={showRouteSelectionModal}
@@ -5490,7 +5526,8 @@ export default function RecordScreen() {
 									>
 										<MaterialIcons name="route" size={24} color={selectedRoute ? PRIMARY_COLOR : theme.screen.icon} />
 									</TouchableOpacity>
-								) : (
+								)}
+								{isRecording && (
 									<TouchableOpacity
 										style={styles.chevronButton}
 										onPress={() => setIsPanelCollapsed(true)}

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -100,6 +100,13 @@ function formatDate(timestamp: number): string {
 	});
 }
 
+function getGroupPosition(idx: number, count: number): 'single' | 'top' | 'bottom' | 'middle' {
+	if (count === 1) return 'single';
+	if (idx === 0) return 'top';
+	if (idx === count - 1) return 'bottom';
+	return 'middle';
+}
+
 // ─── Manual Activity Modal Content ───────────────────────────────────────────
 
 function ManualActivityContent({
@@ -1310,7 +1317,7 @@ export default function RouteDetailScreen() {
 											<SettingsListActivity
 												key={act.id}
 												activity={act}
-												groupPosition={routeActivities.length === 1 ? 'single' : idx === 0 ? 'top' : idx === routeActivities.length - 1 ? 'bottom' : 'middle'}
+												groupPosition={getGroupPosition(idx, routeActivities.length)}
 												showSeparator={idx < routeActivities.length - 1}
 												onPress={() => { closeActivitiesModal(); router.navigate(`/activities/${act.id}`); }}
 											/>
@@ -1357,7 +1364,7 @@ export default function RouteDetailScreen() {
 									title={hexId}
 									value={String(features.length)}
 									showSeparator={idx < route.hexTiles.length - 1}
-									groupPosition={route.hexTiles.length === 1 ? 'single' : idx === 0 ? 'top' : idx === route.hexTiles.length - 1 ? 'bottom' : 'middle'}
+									groupPosition={getGroupPosition(idx, route.hexTiles.length)}
 									onPress={() => {
 										showHexTileModal({
 											title: `⬡ ${hexId}`,
@@ -1392,7 +1399,7 @@ export default function RouteDetailScreen() {
 								feature={entry.feature}
 								count={entry.count}
 								showSeparator={idx < entries.length - 1}
-								groupPosition={entries.length === 1 ? 'single' : idx === 0 ? 'top' : idx === entries.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(idx, entries.length)}
 								iconBackgroundColor="#7c3aed"
 								onPress={() => {
 									showAggregatedModal({
@@ -1430,7 +1437,7 @@ export default function RouteDetailScreen() {
 								feature={entry.feature}
 								count={entry.count}
 								showSeparator={idx < entries.length - 1}
-								groupPosition={entries.length === 1 ? 'single' : idx === 0 ? 'top' : idx === entries.length - 1 ? 'bottom' : 'middle'}
+								groupPosition={getGroupPosition(idx, entries.length)}
 								iconBackgroundColor="#059669"
 								onPress={() => {
 									showEnclosedAggregatedModal({

--- a/apps/geonexia/frontend/app/routes/index.tsx
+++ b/apps/geonexia/frontend/app/routes/index.tsx
@@ -83,8 +83,11 @@ export default function RoutesScreen() {
 		<ScrollView style={[styles.container, { backgroundColor: theme.screen.background }]}>
 			<SettingsListGroupTitle title="Gespeicherte Routen" />
 			{routes.map((route, idx) => {
-				const groupPosition =
-					routes.length === 1 ? 'single' : idx === 0 ? 'top' : idx === routes.length - 1 ? 'bottom' : 'middle';
+				let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+				if (routes.length === 1) groupPosition = 'single';
+				else if (idx === 0) groupPosition = 'top';
+				else if (idx === routes.length - 1) groupPosition = 'bottom';
+				else groupPosition = 'middle';
 				return (
 					<SettingsListRoute
 						key={route.id}

--- a/apps/geonexia/frontend/app/statistics/index.tsx
+++ b/apps/geonexia/frontend/app/statistics/index.tsx
@@ -76,7 +76,10 @@ export default function StatisticsScreen() {
 			children: (
 				<View>
 					{options.map((opt, i) => {
-						const position = i === 0 ? 'top' : i === options.length - 1 ? 'bottom' : 'middle';
+						let position: 'top' | 'bottom' | 'middle';
+						if (i === 0) position = 'top';
+						else if (i === options.length - 1) position = 'bottom';
+						else position = 'middle';
 						const sportDef = SPORT_TYPES.find((s) => s.type === opt.type);
 						const bgColor = sportDef?.color ?? PRIMARY_COLOR;
 						const icon = sportDef

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -485,9 +485,14 @@ function computeParentInfo(
 		const allChildren = cellToChildren(parentH3Index, res);
 		// H3 index strings - deterministic code unit comparison keeps child numbering
 		// identical across devices regardless of locale.
+		const compareH3Strings = (a: string, b: string): number => {
+			if (a < b) return -1;
+			if (a > b) return 1;
+			return 0;
+		};
 		const nonCenterChildren = allChildren
 			.filter((c) => c !== centerChild)
-			.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+			.sort(compareH3Strings);
 		const idx = nonCenterChildren.indexOf(h3Index);
 		// idx is 0–5 for the non-center children → add 1 to reserve 0 for center
 		const parentChildIndex = idx >= 0 ? idx + 1 : -1;

--- a/apps/geonexia/frontend/helpers/RoadMatchHelper.ts
+++ b/apps/geonexia/frontend/helpers/RoadMatchHelper.ts
@@ -72,10 +72,10 @@ async function fetchRoadWaysForTile(
 			if (feat.type !== GEOMETRY_TYPE_LINE) continue;
 
 			const geometry = feat.toGeoJSON(x, y, z).geometry;
-			const lines: [number, number][][] =
-				geometry.type === 'MultiLineString' ? geometry.coordinates
-					: geometry.type === 'LineString' ? [geometry.coordinates]
-					: [];
+			let lines: [number, number][][];
+			if (geometry.type === 'MultiLineString') lines = geometry.coordinates;
+			else if (geometry.type === 'LineString') lines = [geometry.coordinates];
+			else lines = [];
 
 			for (const line of lines) {
 				if (line.length >= 2) ways.push({ points: line });

--- a/apps/geonexia/frontend/hooks/useGeonexiaAlert.tsx
+++ b/apps/geonexia/frontend/hooks/useGeonexiaAlert.tsx
@@ -27,7 +27,10 @@ export const useGeonexiaAlert = () => {
 					{effectiveButtons.map((btn, idx) => {
 						const isDestructive = btn.style === 'destructive';
 						const isCancel = btn.style === 'cancel';
-						const textColor = isDestructive ? '#ef4444' : isCancel ? theme.screen.icon : '#2563eb';
+						let textColor: string;
+						if (isDestructive) textColor = '#ef4444';
+						else if (isCancel) textColor = theme.screen.icon;
+						else textColor = '#2563eb';
 						return (
 							<TouchableOpacity
 								key={idx}

--- a/apps/score-tracker/frontend/app/dice/index.tsx
+++ b/apps/score-tracker/frontend/app/dice/index.tsx
@@ -68,7 +68,8 @@ function computeRoll(pool: PoolDie[], mode: RollMode): RollResult {
 		return { mode, dice: rollA.dice, total: rollA.total };
 	}
 	const rollB = rollPoolOnce(pool);
-	const keptRoll = (mode === 'advantage' ? rollA.total >= rollB.total : rollA.total <= rollB.total) ? 'A' : 'B';
+	const rollAWins = mode === 'advantage' ? rollA.total >= rollB.total : rollA.total <= rollB.total;
+	const keptRoll = rollAWins ? 'A' : 'B';
 	return { mode, rollA, rollB, keptRoll, keptTotal: keptRoll === 'A' ? rollA.total : rollB.total };
 }
 
@@ -144,6 +145,13 @@ export default function DiceScreen() {
 			if (animationRef.current) clearInterval(animationRef.current);
 		};
 	}, []);
+
+	let rollButtonLabel = 'Würfeln';
+	if (isRolling) {
+		rollButtonLabel = 'Würfeln...';
+	} else if (pool.length === 0) {
+		rollButtonLabel = 'Wähle zuerst Würfel';
+	}
 
 	return (
 		<View style={[styles.container, { backgroundColor: theme.screen.background, paddingLeft: insets.left, paddingRight: insets.right }]}>
@@ -314,7 +322,7 @@ export default function DiceScreen() {
 				>
 					<MaterialCommunityIcons name={FALLBACK_ICON} size={24} color="#ffffff" />
 					<Text style={styles.rollButtonText}>
-						{isRolling ? 'Würfeln...' : pool.length === 0 ? 'Wähle zuerst Würfel' : 'Würfeln'}
+						{rollButtonLabel}
 					</Text>
 				</TouchableOpacity>
 			</View>

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -52,6 +52,13 @@ function formatDate(timestamp: number): string {
 	return new Date(timestamp).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
+// Helper to determine groupPosition for list items
+function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bottom' {
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
 /** Strip the instance-specific id/createdAt so a game type can be shared/re-imported as a template. */
 function gameTypeToPreset(gameType: GameType): GamePreset {
 	return {
@@ -175,7 +182,7 @@ function StartingPlayerModeSection({ gameTypeId }: { gameTypeId: string }) {
 							);
 						}
 					}}
-					groupPosition={index === 0 ? 'top' : index === STARTING_PLAYER_MODES.length - 1 ? 'bottom' : 'middle'}
+					groupPosition={getGroupPosition(index, STARTING_PLAYER_MODES.length)}
 				/>
 			))}
 			{mode === 'custom' && (
@@ -624,7 +631,7 @@ export default function GameTypeDetailScreen() {
 							leftIcon={<Ionicons name="calendar-outline" size={20} color="#ffffff" />}
 							iconBgColor={PRIMARY_COLOR}
 							rightElement={<MatchParticipants players={match.players} />}
-							groupPosition={index === 0 ? 'top' : index === matches.length - 1 ? 'bottom' : 'middle'}
+							groupPosition={getGroupPosition(index, matches.length)}
 						/>
 					))
 				)}

--- a/apps/score-tracker/frontend/app/games/index.tsx
+++ b/apps/score-tracker/frontend/app/games/index.tsx
@@ -13,6 +13,13 @@ import GameTypeIcon from '../../components/GameTypeIcon';
 
 const PRIMARY_COLOR = '#2563eb';
 
+// Helper to determine groupPosition for list items
+function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bottom' {
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
 export default function GamesScreen() {
 	const { theme } = useTheme();
 	const insets = useSafeAreaInsets();
@@ -122,6 +129,34 @@ export default function GamesScreen() {
 		});
 	}, [navigation, theme.header.text, handleAddGameType, handleOpenImportModal]);
 
+	const searchResultsContent =
+		filteredGameTypes.length === 0 ? (
+			<Text style={[styles.emptySubtext, styles.noResultsText, { color: theme.screen.placeholder }]}>
+				Kein Spiel gefunden für „{searchQuery}“.
+			</Text>
+		) : (
+			filteredGameTypes.map((gameType, index) => {
+				const count = matchCounts[gameType.id] ?? 0;
+				return (
+					<SettingsList
+						key={gameType.id}
+						nativeID={`${ComponentIds.GAMES_SCREEN_GAME_ROW_PREFIX}${gameType.id}`}
+						leftIconComponent={
+							<View style={styles.gameIconWrapper}>
+								<GameTypeIcon icon={gameType.icon} size={56} />
+							</View>
+						}
+						label={gameType.name}
+						value={count === 1 ? '1 Partie' : `${count} Partien`}
+						stackedValue
+						rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+						handleFunction={() => router.push({ pathname: '/games/[id]', params: { id: gameType.id } })}
+						groupPosition={getGroupPosition(index, filteredGameTypes.length)}
+					/>
+				);
+			})
+		);
+
 	return (
 		<View style={[styles.container, { backgroundColor: theme.screen.background, paddingLeft: insets.left, paddingRight: insets.right }]}>
 			{gameTypes.length > 0 && (
@@ -157,31 +192,8 @@ export default function GamesScreen() {
 							Lege ein Spiel (z.B. Skat, Phase 10, ...) über den + Button im Header an
 						</Text>
 					</View>
-				) : filteredGameTypes.length === 0 ? (
-					<Text style={[styles.emptySubtext, styles.noResultsText, { color: theme.screen.placeholder }]}>
-						Kein Spiel gefunden für „{searchQuery}“.
-					</Text>
 				) : (
-					filteredGameTypes.map((gameType, index) => {
-						const count = matchCounts[gameType.id] ?? 0;
-						return (
-							<SettingsList
-								key={gameType.id}
-								nativeID={`${ComponentIds.GAMES_SCREEN_GAME_ROW_PREFIX}${gameType.id}`}
-								leftIconComponent={
-									<View style={styles.gameIconWrapper}>
-										<GameTypeIcon icon={gameType.icon} size={56} />
-									</View>
-								}
-								label={gameType.name}
-								value={count === 1 ? '1 Partie' : `${count} Partien`}
-								stackedValue
-								rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
-								handleFunction={() => router.push({ pathname: '/games/[id]', params: { id: gameType.id } })}
-								groupPosition={index === 0 ? 'top' : index === filteredGameTypes.length - 1 ? 'bottom' : 'middle'}
-							/>
-						);
-					})
+					searchResultsContent
 				)}
 			</ScrollView>
 		</View>

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -184,24 +184,38 @@ function ScoreInputContent({
 				<Text style={styles.scoreInputSaveText}>Save</Text>
 			</TouchableOpacity>
 			<View style={styles.quickButtonsRow}>
-				{QUICK_SCORES.map((v) => (
-					<TouchableOpacity
-						key={v}
-						style={[
-							styles.quickButton,
-							{
-								backgroundColor: v < 0 ? DANGER_COLOR + '20' : v > 0 ? PRIMARY_COLOR + '20' : theme.screen.border + '40',
-								borderColor: v < 0 ? DANGER_COLOR : v > 0 ? PRIMARY_COLOR : theme.screen.border,
-							},
-						]}
-						onPress={() => handleQuickScore(v)}
-						activeOpacity={0.7}
-					>
-						<Text style={[styles.quickButtonText, { color: v < 0 ? DANGER_COLOR : v > 0 ? PRIMARY_COLOR : theme.screen.text }]}>
-							{v > 0 ? `+${v}` : String(v)}
-						</Text>
-					</TouchableOpacity>
-				))}
+				{QUICK_SCORES.map((v) => {
+					let quickButtonBackground = theme.screen.border + '40';
+					let quickButtonBorder = theme.screen.border;
+					let quickButtonTextColor = theme.screen.text;
+					if (v < 0) {
+						quickButtonBackground = DANGER_COLOR + '20';
+						quickButtonBorder = DANGER_COLOR;
+						quickButtonTextColor = DANGER_COLOR;
+					} else if (v > 0) {
+						quickButtonBackground = PRIMARY_COLOR + '20';
+						quickButtonBorder = PRIMARY_COLOR;
+						quickButtonTextColor = PRIMARY_COLOR;
+					}
+					return (
+						<TouchableOpacity
+							key={v}
+							style={[
+								styles.quickButton,
+								{
+									backgroundColor: quickButtonBackground,
+									borderColor: quickButtonBorder,
+								},
+							]}
+							onPress={() => handleQuickScore(v)}
+							activeOpacity={0.7}
+						>
+							<Text style={[styles.quickButtonText, { color: quickButtonTextColor }]}>
+								{v > 0 ? `+${v}` : String(v)}
+							</Text>
+						</TouchableOpacity>
+					);
+				})}
 			</View>
 		</View>
 	);
@@ -666,6 +680,14 @@ export default function GameScreen() {
 	const isLastPossibleRound =
 		(matchFinished && currentRoundIndex >= rounds.length - 1) || (maxRounds != null && currentRoundNumber >= maxRounds);
 
+	// Label for the "next round" navigation button
+	let nextRoundLabel = `Runde ${currentRoundNumber + 1}`;
+	if (matchFinished) {
+		nextRoundLabel = 'Spiel beendet';
+	} else if (maxRounds != null && currentRoundNumber >= maxRounds) {
+		nextRoundLabel = 'Letzte Runde';
+	}
+
 	// Tile width, only needed once a multi-column layout is active
 	const tileWidth = useMemo(() => {
 		if (columnCount === 1) return undefined;
@@ -902,6 +924,19 @@ export default function GameScreen() {
 
 	// ─── Render ───────────────────────────────────────────────────────────────
 
+	const gameTypeRowValue = selectedGameType ? selectedGameType.name : 'Kein bestimmtes Spiel';
+	const gameTypeRowIconComponent = selectedGameType ? (
+		<View style={styles.gameTypeIconWrapper}>
+			<GameTypeIcon icon={selectedGameType.icon} size={40} />
+		</View>
+	) : undefined;
+	const gameTypeRowLeftIcon = selectedGameType ? undefined : <Ionicons name="game-controller-outline" size={20} color="#ffffff" />;
+	const finishedBannerWinnerSuffix = leaderId ? ` von ${players.find((p) => p.id === leaderId)?.name}` : '';
+	const startButtonOpacity = players.length === 0 ? 0.5 : 1;
+	const prevRoundOpacity = currentRoundIndex === 0 ? 0.4 : 1;
+	const maxRoundsSuffix = maxRounds != null ? ` / ${maxRounds}` : '';
+	const nextRoundOpacity = isLastPossibleRound ? 0.4 : 1;
+
 	return (
 		<View style={[styles.container, { backgroundColor: theme.screen.background, paddingLeft: insets.left, paddingRight: insets.right }]}>
 			<ScrollView
@@ -920,17 +955,9 @@ export default function GameScreen() {
 								<SettingsList
 									nativeID={ComponentIds.GAME_SETUP_GAME_TYPE_ROW}
 									label="Spiel"
-									value={selectedGameType ? selectedGameType.name : 'Kein bestimmtes Spiel'}
-									leftIconComponent={
-										selectedGameType ? (
-											<View style={styles.gameTypeIconWrapper}>
-												<GameTypeIcon icon={selectedGameType.icon} size={40} />
-											</View>
-										) : undefined
-									}
-									leftIcon={
-										selectedGameType ? undefined : <Ionicons name="game-controller-outline" size={20} color="#ffffff" />
-									}
+									value={gameTypeRowValue}
+									leftIconComponent={gameTypeRowIconComponent}
+									leftIcon={gameTypeRowLeftIcon}
 									iconBgColor={PRIMARY_COLOR}
 									rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
 									handleFunction={handleOpenGameTypeModal}
@@ -975,7 +1002,7 @@ export default function GameScreen() {
 								<Ionicons name="trophy-outline" size={18} color="#ffffff" />
 								<Text style={styles.finishedBannerText}>
 									Spiel beendet - Zielscore {maxScore} erreicht
-									{leaderId ? ` von ${players.find((p) => p.id === leaderId)?.name}` : ''}
+									{finishedBannerWinnerSuffix}
 								</Text>
 							</View>
 						)}
@@ -1003,7 +1030,7 @@ export default function GameScreen() {
 					{status === 'setup' ? (
 						<TouchableOpacity
 							nativeID={ComponentIds.GAME_START_BUTTON}
-							style={[styles.nextRoundButton, { backgroundColor: PRIMARY_COLOR, opacity: players.length === 0 ? 0.5 : 1 }]}
+							style={[styles.nextRoundButton, { backgroundColor: PRIMARY_COLOR, opacity: startButtonOpacity }]}
 							onPress={() => dispatch(startGame())}
 							disabled={players.length === 0}
 							activeOpacity={0.8}
@@ -1014,7 +1041,7 @@ export default function GameScreen() {
 						<>
 							<TouchableOpacity
 								nativeID={ComponentIds.GAME_ROUND_PREV_BUTTON}
-								style={[styles.roundNavButton, { backgroundColor: theme.screen.border, opacity: currentRoundIndex === 0 ? 0.4 : 1 }]}
+								style={[styles.roundNavButton, { backgroundColor: theme.screen.border, opacity: prevRoundOpacity }]}
 								onPress={handlePrevRound}
 								disabled={currentRoundIndex === 0}
 								activeOpacity={0.8}
@@ -1026,24 +1053,20 @@ export default function GameScreen() {
 							</TouchableOpacity>
 							<Text nativeID={ComponentIds.GAME_ROUND_LABEL} style={[styles.roundLabel, { color: theme.screen.text }]}>
 								Runde {currentRoundNumber}
-								{maxRounds != null ? ` / ${maxRounds}` : ''}
+								{maxRoundsSuffix}
 							</Text>
 							<TouchableOpacity
 								nativeID={ComponentIds.GAME_ROUND_NEXT_BUTTON}
 								style={[
 									styles.roundNavButton,
-									{ backgroundColor: PRIMARY_COLOR, opacity: isLastPossibleRound ? 0.4 : 1 },
+									{ backgroundColor: PRIMARY_COLOR, opacity: nextRoundOpacity },
 								]}
 								onPress={handleNextRound}
 								disabled={isLastPossibleRound}
 								activeOpacity={0.8}
 							>
 								<Text style={styles.roundNavText}>
-									{matchFinished
-										? 'Spiel beendet'
-										: maxRounds != null && currentRoundNumber >= maxRounds
-											? 'Letzte Runde'
-											: `Runde ${currentRoundNumber + 1}`}
+									{nextRoundLabel}
 								</Text>
 								<Ionicons name="chevron-forward" size={18} color="#ffffff" />
 							</TouchableOpacity>

--- a/apps/score-tracker/frontend/app/players/index.tsx
+++ b/apps/score-tracker/frontend/app/players/index.tsx
@@ -35,6 +35,13 @@ const DANGER_COLOR = '#dc2626';
 const DEBUG_COLOR = '#7c3aed';
 const FRIEND_AVATAR_SIZE = 84; // Same size as the Game scoreboard's player avatars
 
+// Helper to determine groupPosition for list items
+function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bottom' {
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
 // ─── Import/export rows (shared between the header "Optionen" modal and the
 // friend detail modal) ─────────────────────────────────────────────────────
 
@@ -260,7 +267,7 @@ function FriendEditContent({ friendId, onClose }: { friendId: string; onClose: (
 						stackedValue
 						leftIcon={<Ionicons name="trophy-outline" size={20} color="#ffffff" />}
 						iconBgColor={friend.color}
-						groupPosition={index === 0 ? 'top' : index === friendGames.length - 1 ? 'bottom' : 'middle'}
+						groupPosition={getGroupPosition(index, friendGames.length)}
 					/>
 				))
 			)}
@@ -334,6 +341,27 @@ export default function PlayersScreen() {
 		});
 	}, [navigation, theme.header.text, handleOpenOptionsModal]);
 
+	const searchResultsContent =
+		filteredFriends.length === 0 ? (
+			<Text style={[styles.emptySubtext, styles.noResultsText, { color: theme.screen.placeholder }]}>
+				Kein Freund gefunden für „{searchQuery}“.
+			</Text>
+		) : (
+			filteredFriends.map((friend, index) => (
+				<SettingsListAvatar
+					key={friend.id}
+					nativeID={`${ComponentIds.PLAYERS_SCREEN_FRIEND_ROW_PREFIX}${friend.id}`}
+					config={friend.avatarConfig}
+					avatarBackgroundColor={friend.color}
+					previewSize={FRIEND_AVATAR_SIZE}
+					label={friend.name}
+					rightIcon={<MaterialCommunityIcons name="pencil" size={20} color="#9ca3af" />}
+					onPressOverride={() => handleOpenFriendModal(friend.id)}
+					groupPosition={getGroupPosition(index, filteredFriends.length)}
+				/>
+			))
+		);
+
 	return (
 		<View style={[styles.container, { backgroundColor: theme.screen.background, paddingLeft: insets.left, paddingRight: insets.right }]}>
 			{friends.length > 0 && (
@@ -379,24 +407,8 @@ export default function PlayersScreen() {
 							Lege oben deinen ersten Spieler an
 						</Text>
 					</View>
-				) : filteredFriends.length === 0 ? (
-					<Text style={[styles.emptySubtext, styles.noResultsText, { color: theme.screen.placeholder }]}>
-						Kein Freund gefunden für „{searchQuery}“.
-					</Text>
 				) : (
-					filteredFriends.map((friend, index) => (
-						<SettingsListAvatar
-							key={friend.id}
-							nativeID={`${ComponentIds.PLAYERS_SCREEN_FRIEND_ROW_PREFIX}${friend.id}`}
-							config={friend.avatarConfig}
-							avatarBackgroundColor={friend.color}
-							previewSize={FRIEND_AVATAR_SIZE}
-							label={friend.name}
-							rightIcon={<MaterialCommunityIcons name="pencil" size={20} color="#9ca3af" />}
-							onPressOverride={() => handleOpenFriendModal(friend.id)}
-							groupPosition={index === 0 ? 'top' : index === filteredFriends.length - 1 ? 'bottom' : 'middle'}
-						/>
-					))
+					searchResultsContent
 				)}
 			</ScrollView>
 		</View>

--- a/packages/common-ui/src/components/AppDrawer/AppDrawer.tsx
+++ b/packages/common-ui/src/components/AppDrawer/AppDrawer.tsx
@@ -78,15 +78,15 @@ const AppDrawer: React.FC<AppDrawerProps> = ({
 		);
 	};
 
+	const fallbackLogo = logoSource ? (
+		<View style={[styles.logoContainer, { backgroundColor: theme.drawer.logoBg }]}>
+			<Image source={logoSource} style={styles.logo} />
+		</View>
+	) : null;
+
 	const headerContent = (
 		<>
-			{renderLogo ? (
-				renderLogo()
-			) : logoSource ? (
-				<View style={[styles.logoContainer, { backgroundColor: theme.drawer.logoBg }]}>
-					<Image source={logoSource} style={styles.logo} />
-				</View>
-			) : null}
+			{renderLogo ? renderLogo() : fallbackLogo}
 			{title ? (
 				<Text style={[styles.heading, { color: theme.drawerHeading }]}>{title}</Text>
 			) : null}

--- a/packages/common-ui/src/components/CardWithText/index.tsx
+++ b/packages/common-ui/src/components/CardWithText/index.tsx
@@ -105,6 +105,20 @@ const CardWithText: React.FC<CardWithTextProps> = ({
 		? [styles.imageContainer, ...(imageContainerStyle as StyleProp<ViewStyle>[])]
 		: [styles.imageContainer, imageContainerStyle as StyleProp<ViewStyle>];
 
+	let resolvedAspectRatio: number | undefined = 1;
+	if (aspectRatio === false) {
+		resolvedAspectRatio = undefined;
+	} else if (typeof aspectRatio === 'number') {
+		resolvedAspectRatio = aspectRatio;
+	}
+
+	let imageContent: React.ReactNode = null;
+	if (imageSource) {
+		imageContent = renderImage
+			? renderImage(imageSource, [styles.image, imageStyle], imageAccessibilityLabel)
+			: <Image source={imageSource} style={[styles.image, imageStyle]} resizeMode="cover" accessible={!!imageAccessibilityLabel} accessibilityLabel={imageAccessibilityLabel} />;
+	}
+
 	return (
 		<TouchableOpacity
 			activeOpacity={0.9}
@@ -116,15 +130,11 @@ const CardWithText: React.FC<CardWithTextProps> = ({
 				style={[
 					styles.squareWrapper,
 					{ borderTopLeftRadius: topRadius, borderTopRightRadius: topRadius },
-					{ aspectRatio: aspectRatio === false ? undefined : (typeof aspectRatio === 'number' ? aspectRatio : 1) },
+					{ aspectRatio: resolvedAspectRatio },
 				]}
 			>
 				<View style={[{ borderTopLeftRadius: topRadius, borderTopRightRadius: topRadius }, ...resolvedImageContainerStyle]}>
-					{imageSource ? (
-						renderImage
-							? renderImage(imageSource, [styles.image, imageStyle], imageAccessibilityLabel)
-							: <Image source={imageSource} style={[styles.image, imageStyle]} resizeMode="cover" accessible={!!imageAccessibilityLabel} accessibilityLabel={imageAccessibilityLabel} />
-					) : null}
+					{imageContent}
 					{imageChildren}
 				</View>
 			</View>

--- a/packages/common-ui/src/components/FeatureWishesScreen/FeatureWishesScreen.tsx
+++ b/packages/common-ui/src/components/FeatureWishesScreen/FeatureWishesScreen.tsx
@@ -234,8 +234,16 @@ const FeatureWishesScreen: React.FC<FeatureWishesScreenProps> = ({
 	const renderItem = useCallback(
 		({ item, index }: { item: FeatureWishItem; index: number }) => {
 			const total = visibleItems.length;
-			const groupPosition =
-				total === 1 ? 'single' : index === 0 ? 'top' : index === total - 1 ? 'bottom' : 'middle';
+			let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+			if (total === 1) {
+				groupPosition = 'single';
+			} else if (index === 0) {
+				groupPosition = 'top';
+			} else if (index === total - 1) {
+				groupPosition = 'bottom';
+			} else {
+				groupPosition = 'middle';
+			}
 			const isLiked = likedIds.has(item.id ?? '');
 
 			return (

--- a/packages/common-ui/src/components/MyAvatar/index.tsx
+++ b/packages/common-ui/src/components/MyAvatar/index.tsx
@@ -175,10 +175,12 @@ const MyAvatar: React.FC<MyAvatarProps> = ({
 		// Normalize flip to a proper boolean.
 		// Supports both the current boolean format and legacy ["true"]/["false"] string-array format.
 		const rawFlip = renderOptions['flip'];
-		const flipValue: boolean =
-			typeof rawFlip === 'boolean' ? rawFlip :
-			Array.isArray(rawFlip) ? rawFlip[0] === 'true' :
-			false;
+		let flipValue = false;
+		if (typeof rawFlip === 'boolean') {
+			flipValue = rawFlip;
+		} else if (Array.isArray(rawFlip)) {
+			flipValue = rawFlip[0] === 'true';
+		}
 		renderOptions['flip'] = flipValue;
 		// When flip is true, mirror translateX so the avatar faces the correct direction.
 		if (flipValue) {

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -650,6 +650,14 @@ function stripHashPrefix(color: string): string {
 	return color.startsWith('#') ? color.slice(1) : color;
 }
 
+/** Position of an item within a visually grouped settings list. */
+function getGroupPosition(length: number, index: number): 'single' | 'top' | 'bottom' | 'middle' {
+	if (length === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === length - 1) return 'bottom';
+	return 'middle';
+}
+
 /** Size used for avatar previews inside selection modals. */
 const PREVIEW_AVATAR_SIZE = 100;
 
@@ -828,14 +836,7 @@ const ColorPickerModalContent: React.FC<ColorPickerModalContentProps> = ({
 			)}
 			<SettingsListGroupTitle title={translate ? translate('avatar_section_preset_colors') : 'Presets'} />
 			{colors.map((color, index) => {
-				const groupPosition =
-					colors.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === colors.length - 1
-								? 'bottom'
-								: 'middle';
+				const groupPosition = getGroupPosition(colors.length, index);
 				const previewOptions = { ...(config.options ?? {}), [colorKey]: [stripHashPrefix(color)] };
 				const borderColor = myContrastColor(color, theme, isDark);
 				const colorCircle = (
@@ -900,14 +901,7 @@ const StylePickerModalContent: React.FC<StylePickerModalContentProps> = ({
 	return (
 		<>
 			{allStyles.map((style, index) => {
-				const groupPosition =
-					allStyles.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === allStyles.length - 1
-								? 'bottom'
-								: 'middle';
+				const groupPosition = getGroupPosition(allStyles.length, index);
 				return (
 					<SettingsListSelectOptionSingle
 						key={style}
@@ -957,14 +951,7 @@ const ComponentPickerModalContent: React.FC<ComponentPickerModalContentProps> = 
 	return (
 		<>
 			{values.map((value, index) => {
-				const groupPosition =
-					values.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === values.length - 1
-								? 'bottom'
-								: 'middle';
+				const groupPosition = getGroupPosition(values.length, index);
 				const isNone = value === NONE_OPTION;
 				const previewOptions = { ...(config.options ?? {}) };
 				if (isNone) {
@@ -1421,14 +1408,7 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 
 			<SettingsListGroupTitle title={translate ? translate('avatar_section_category') : 'Category'} />
 			{allCategories.map((cat, index) => {
-				const groupPosition =
-					allCategories.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === allCategories.length - 1
-								? 'bottom'
-								: 'middle';
+				const groupPosition = getGroupPosition(allCategories.length, index);
 				const rawColor = colorKeys.includes(cat) ? config.options?.[cat] : null;
 				const colorKey = Array.isArray(rawColor) ? rawColor[0] ?? null : null;
 				const swatchColor = colorKey ? '#' + colorKey : undefined;
@@ -1581,10 +1561,12 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 						/>
 						{(() => {
 							const rawFlip = config.options?.flip;
-							const isFlipEnabled =
-								typeof rawFlip === 'boolean' ? rawFlip :
-								Array.isArray(rawFlip) ? rawFlip[0] === 'true' :
-								false;
+							let isFlipEnabled = false;
+							if (typeof rawFlip === 'boolean') {
+								isFlipEnabled = rawFlip;
+							} else if (Array.isArray(rawFlip)) {
+								isFlipEnabled = rawFlip[0] === 'true';
+							}
 							return (
 								<SettingsListBoolean
 									title="flip"
@@ -1604,10 +1586,12 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 						})()}
 						{(() => {
 							const rawClip = config.options?.clip;
-							const isClipEnabled =
-								typeof rawClip === 'boolean' ? rawClip :
-								Array.isArray(rawClip) ? rawClip[0] === 'true' :
-								false;
+							let isClipEnabled = false;
+							if (typeof rawClip === 'boolean') {
+								isClipEnabled = rawClip;
+							} else if (Array.isArray(rawClip)) {
+								isClipEnabled = rawClip[0] === 'true';
+							}
 							return (
 								<SettingsListBoolean
 									title="clip"
@@ -1627,14 +1611,18 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 						})()}
 						{hasHiddenProps &&
 							Object.entries(hiddenProps ?? {}).map(([key, value], index, arr) => {
-								const groupPosition =
-									arr.length === 1
-										? 'bottom'
-										: index === 0
-											? 'middle'
-											: index === arr.length - 1
-												? 'bottom'
-												: 'middle';
+								// These rows continue the group started by the rows above, so the
+								// first (and a single) hidden prop is never 'top'/'single'.
+								let groupPosition: 'bottom' | 'middle';
+								if (arr.length === 1) {
+									groupPosition = 'bottom';
+								} else if (index === 0) {
+									groupPosition = 'middle';
+								} else if (index === arr.length - 1) {
+									groupPosition = 'bottom';
+								} else {
+									groupPosition = 'middle';
+								}
 								if (key === AvatarPropKey.OpenPeeps.SCALE) {
 									const scaleVal = config.options?.scale;
 									const scaleArr = Array.isArray(scaleVal) ? scaleVal : null;

--- a/packages/common-ui/src/components/QrCode/index.tsx
+++ b/packages/common-ui/src/components/QrCode/index.tsx
@@ -4,7 +4,8 @@ import QRCode from 'react-native-qrcode-svg';
 import { QrCodeEcl, QrCodeProps } from './types';
 
 const QrCode: React.FC<QrCodeProps> = ({ value, size = 200, image, imageUrl, innerSize = 21, ecl, backgroundColor = 'white', margin = 0, quietZone = 5 }) => {
-	const imageSource = image ? image : imageUrl ? { uri: imageUrl } : undefined;
+	const imageSourceFromUrl = imageUrl ? { uri: imageUrl } : undefined;
+	const imageSource = image ? image : imageSourceFromUrl;
 
 	const clampedInnerSize = Math.max(0, Math.min(30, innerSize));
 	const marginSize = size * (margin / 100);

--- a/packages/common-ui/src/components/SettingsList/SettingsList.tsx
+++ b/packages/common-ui/src/components/SettingsList/SettingsList.tsx
@@ -61,11 +61,10 @@ const SettingsList: React.FC<SettingsListProps> = ({
 	const showIconWrapper = hasIcon && !noIconIndent;
 	const shouldReserveIconSpace = !hasIcon && !noIconIndent;
 
-	const renderedLeftIcon = React.isValidElement(leftIcon)
-		? noIconIndent
-			? leftIcon
-			: React.cloneElement(leftIcon as any, { color: iconColor })
-		: leftIcon;
+	let renderedLeftIcon = leftIcon;
+	if (React.isValidElement(leftIcon) && !noIconIndent) {
+		renderedLeftIcon = React.cloneElement(leftIcon as any, { color: iconColor });
+	}
 
 	const containerStyles: ViewStyle[] = [styles.container, { backgroundColor: backgroundColor ?? theme.screen.iconBg } as ViewStyle];
 	if (width !== undefined) {
@@ -105,17 +104,20 @@ const SettingsList: React.FC<SettingsListProps> = ({
 		wrapperBorderRadius = { borderRadius: borderRadiusContainer };
 	}
 
+	const valueContainerStyle = stackedValue ? styles.valueContainerStacked : styles.valueContainer;
+	const valueStackedStyle = stackedValue ? styles.valueStacked : null;
+	const valueFontSizeStyle = valueFontSize ? { fontSize: valueFontSize } : null;
+
+	let leftIconContent: React.ReactNode = null;
+	if (showIconWrapper) {
+		leftIconContent = leftIconComponent ? leftIconComponent : <View style={iconWrapperStyles}>{renderedLeftIcon}</View>;
+	} else if (hasIcon) {
+		leftIconContent = leftIconComponent ? leftIconComponent : renderedLeftIcon;
+	}
+
 	const inner = (
 		<Container onPress={pressHandler} style={containerStyles} nativeID={nativeID}>
-			{showIconWrapper ? (
-				leftIconComponent ? (
-					leftIconComponent
-				) : (
-					<View style={iconWrapperStyles}>{renderedLeftIcon}</View>
-				)
-			) : hasIcon ? (
-				leftIconComponent ? leftIconComponent : renderedLeftIcon
-			) : null}
+			{leftIconContent}
 			{shouldReserveIconSpace ? <View style={styles.iconPlaceholder} /> : null}
 			<View style={stackedValue ? styles.textWrapperStacked : styles.textWrapper}>
 				<View style={stackedValue ? styles.titleContainerStacked : styles.titleContainer}>
@@ -133,14 +135,14 @@ const SettingsList: React.FC<SettingsListProps> = ({
 					</Text>
 				</View>
 				{value ? (
-					<View style={stackedValue ? styles.valueContainerStacked : styles.valueContainer}>
+					<View style={valueContainerStyle}>
 						<Text
 							selectable
 							style={[
 								styles.value,
-								stackedValue ? styles.valueStacked : null,
+								valueStackedStyle,
 								{ color: valueColor ?? theme.screen.text } as TextStyle,
-								valueFontSize ? { fontSize: valueFontSize } : null,
+								valueFontSizeStyle,
 							]}
 							numberOfLines={0}
 						>
@@ -153,7 +155,8 @@ const SettingsList: React.FC<SettingsListProps> = ({
 		</Container>
 	);
 
-	const separator = showSeparator ? <View style={[styles.separator, { backgroundColor: theme.screen.background, marginLeft: noIconIndent ? 0 : 54 }]} /> : null;
+	const separatorMarginLeft = noIconIndent ? 0 : 54;
+	const separator = showSeparator ? <View style={[styles.separator, { backgroundColor: theme.screen.background, marginLeft: separatorMarginLeft }]} /> : null;
 
 	const accountRequiredPosition = accountRequiredGroupPosition ?? groupPosition;
 	const accountRequiredBorderStyle: ViewStyle =

--- a/packages/common-ui/src/components/SettingsListNumberInput/SettingsListNumberInput.tsx
+++ b/packages/common-ui/src/components/SettingsListNumberInput/SettingsListNumberInput.tsx
@@ -102,6 +102,15 @@ const ModalSheet: React.FC<ModalSheetProps> = ({
 		onSave(clamp(numericValue, min, max));
 	}, [isValid, numericValue, min, max, onSave]);
 
+	let rangeHintText: string;
+	if (min != null && max != null) {
+		rangeHintText = `${min} – ${max}`;
+	} else if (min != null) {
+		rangeHintText = `Min: ${min}`;
+	} else {
+		rangeHintText = `Max: ${max}`;
+	}
+
 	const content = (
 		<View style={styles.sheetView}>
 			<View style={styles.inputRow}>
@@ -145,11 +154,7 @@ const ModalSheet: React.FC<ModalSheetProps> = ({
 			</View>
 			{min != null || max != null ? (
 				<Text style={[styles.rangeHint, { color: theme.sheet.placeholder }]}>
-					{min != null && max != null
-						? `${min} – ${max}`
-						: min != null
-						? `Min: ${min}`
-						: `Max: ${max}`}
+					{rangeHintText}
 				</Text>
 			) : null}
 			<TouchableOpacity
@@ -204,17 +209,15 @@ const SettingsListNumberInput: React.FC<SettingsListNumberInputProps> = ({
 	const resolvedTitle = useMemo(() => modalTitle ?? title ?? label ?? '', [label, modalTitle, title]);
 	const resolvedPrimaryColor = primaryColor ?? settingsCtx?.primaryColor ?? theme.primary;
 
-	const resolvedRightIcon = useMemo(
-		() =>
-			rightIcon ? (
-				rightIcon
-			) : rightElement ? (
-				undefined
-			) : (
-				<MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />
-			),
-		[rightElement, rightIcon, theme.screen.icon],
-	);
+	const resolvedRightIcon = useMemo(() => {
+		if (rightIcon) {
+			return rightIcon;
+		}
+		if (rightElement) {
+			return undefined;
+		}
+		return <MaterialCommunityIcons name="pencil" size={20} color={theme.screen.icon} />;
+	}, [rightElement, rightIcon, theme.screen.icon]);
 
 	const handleOpen = useCallback(() => {
 		show({

--- a/packages/common-ui/src/components/SettingsListSelectOption/SettingsListSelectOption.tsx
+++ b/packages/common-ui/src/components/SettingsListSelectOption/SettingsListSelectOption.tsx
@@ -26,14 +26,16 @@ const SettingsListSelectOption = <T extends string | number>({
 	return (
 		<>
 			{options.map((option, index) => {
-				const groupPosition =
-					options.length === 1
-						? 'single'
-						: index === 0
-							? 'top'
-							: index === options.length - 1
-								? 'bottom'
-								: 'middle';
+				let groupPosition: 'single' | 'top' | 'bottom' | 'middle';
+				if (options.length === 1) {
+					groupPosition = 'single';
+				} else if (index === 0) {
+					groupPosition = 'top';
+				} else if (index === options.length - 1) {
+					groupPosition = 'bottom';
+				} else {
+					groupPosition = 'middle';
+				}
 
 				return (
 					<SettingsListSelectOptionSingle

--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -242,7 +242,13 @@ export function sortByPrice(foodOffers: DatabaseTypes.Foodoffers[], priceGroup?:
 
   foodOffers.sort((a, b) => {
     const getPrice = (offer: DatabaseTypes.Foodoffers) => {
-      return priceGroup === 'guest' ? (offer?.price_guest ?? 0) : priceGroup === 'employee' ? (offer?.price_employee ?? 0) : (offer?.price_student ?? 0);
+      if (priceGroup === 'guest') {
+        return offer?.price_guest ?? 0;
+      }
+      if (priceGroup === 'employee') {
+        return offer?.price_employee ?? 0;
+      }
+      return offer?.price_student ?? 0;
     };
 
     const priceA = getPrice(a);

--- a/scripts/count-sonar-maintainability-issues.js
+++ b/scripts/count-sonar-maintainability-issues.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Counts SonarCloud maintainability issues grouped by message type.
+ * Numbers in messages are stripped so that issues of the same kind
+ * (e.g. "Reduce ... from 21 to 15" vs "... from 18 to 15") are grouped together.
+ *
+ * Usage: node scripts/count-sonar-maintainability-issues.js [path/to/report.csv] [topN]
+ */
+const fs = require('fs');
+const path = require('path');
+
+const csvPath = process.argv[2] || path.join(__dirname, '..', 'reports', 'sonarCloud', 'report_maintainability.csv');
+const topN = parseInt(process.argv[3] || '10', 10);
+
+function parseCsvLine(line) {
+    const fields = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        if (inQuotes) {
+            if (char === '"') {
+                if (line[i + 1] === '"') {
+                    current += '"';
+                    i++;
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                current += char;
+            }
+        } else if (char === '"') {
+            inQuotes = true;
+        } else if (char === ',') {
+            fields.push(current);
+            current = '';
+        } else {
+            current += char;
+        }
+    }
+    fields.push(current);
+    return fields;
+}
+
+function normalizeMessage(message) {
+    return message.replace(/\d+/g, 'N');
+}
+
+const content = fs.readFileSync(csvPath, 'utf8');
+const lines = content.split('\n').filter((line) => line.trim().length > 0);
+const dataLines = lines.slice(1); // skip header
+
+const counts = new Map();
+for (const line of dataLines) {
+    const [, message] = parseCsvLine(line);
+    if (message === undefined) continue;
+    const normalized = normalizeMessage(message);
+    counts.set(normalized, (counts.get(normalized) || 0) + 1);
+}
+
+const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+
+console.log(`Total issues: ${dataLines.length}`);
+console.log(`Distinct issue types (numbers stripped): ${sorted.length}`);
+console.log('');
+console.log(`Top ${topN} issue types by frequency:`);
+sorted.slice(0, topN).forEach(([message, count], index) => {
+    console.log(`${String(index + 1).padStart(2)}. ${String(count).padStart(4)}x  ${message}`);
+});


### PR DESCRIPTION
## Summary

Fixes the most frequent SonarCloud maintainability issue type and adds a small script to count issue types by frequency.

### Issue counting script

`scripts/count-sonar-maintainability-issues.js` parses `reports/sonarCloud/report_maintainability.csv`, strips numbers from the messages (so e.g. "reduce complexity from 21 to 15" and "from 18 to 15" group together) and sorts the issue types by frequency.

Usage: `node scripts/count-sonar-maintainability-issues.js [csvPath] [topN]`

Top 10 issue types (numbers replaced by "N"):

| # | Count | Issue type |
|---|-------|-----------|
| 1 | 269 | Extract this nested ternary operation into an independent statement. |
| 2 | 242 | Make this public static property readonly. |
| 3 | 120 | Refactor this function to reduce its Cognitive Complexity from N to the N allowed. |
| 4 | 97 | Move this component definition out of the parent component and pass data as props. |
| 5 | 81 | Prefer using an optional chain expression instead. |
| 6 | 62 | Redundant double negation. |
| 7 | 61 | Do not call `Array#push()` multiple times. |
| 8 | 60 | Do not use Array index in keys |
| 9 | 58 | Mark the props of the component as read-only. |
| 10 | 53 | The empty object is useless. |

### Fix: nested ternaries (SonarCloud rule S3358, #1 with 269 reports)

The 269 reported issues correspond to 227 unique locations across 91 files (the CSV contains duplicates). All of them are fixed in this PR, plus a few additional nested ternaries found in the same files during verification.

Refactoring patterns used (behavior preserved exactly):
- Extracted inner ternaries into well-named `const`s before their use
- Converted `a ? x : b ? y : z` chains into `if`/`else if` chains or small helper functions with early returns (e.g. a shared `getGroupPosition(index, total)` helper for the very common single/top/bottom/middle list-position pattern)
- In JSX, computed values in consts above the `return`, or split nested conditional rendering into flat `&amp;&amp;` blocks where all guards are booleans
- Short-circuit/lazy evaluation kept wherever branches call functions; no hook calls were moved

### Verification

Every changed file was checked with a TypeScript-AST-based script that confirms (a) the file parses without syntax errors and (b) no nested ternary expressions remain. All 91 changed files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v9DWyLhghDUcvbb9ww9y8

---
_Generated by [Claude Code](https://claude.ai/code/session_011v9DWyLhghDUcvbb9ww9y8)_