### PR TITLE
fix(geonexia): use full GPS accuracy for 10-30s tracking intervals again

### DIFF
--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -632,25 +632,18 @@ const GPS_DISTANCE_INTERVAL_METERS = 5;
 const GPS_PATH_INTERPOLATION_MAX_CELLS = 200;
 
 /**
- * Battery-aware location options for activity recording, derived from the
- * user-selected GPS interval.
+ * Location options for activity recording, derived from the user-selected GPS
+ * interval.
  *
  * `Accuracy.BestForNavigation` keeps the GPS hardware permanently at full
  * power (Apple recommends it only for plugged-in turn-by-turn navigation), so
- * it is only used for near-continuous intervals. Longer intervals map to
- * lower-power accuracy levels. This matters especially on iOS, where
- * `timeInterval` is ignored by the OS (it is Android-only), so the accuracy
- * level and `distanceInterval` are the only effective battery levers for the
- * location hardware itself.
+ * it is only used for near-continuous intervals; all longer intervals use
+ * `Accuracy.Highest` so the background task keeps receiving reliable fixes
+ * regardless of the configured interval.
  */
 function getRecordingLocationOptions(gpsTimeIntervalMs: number): Location.LocationOptions {
 	const intervalSec = gpsTimeIntervalMs / 1000;
-	let accuracy = Location.Accuracy.High;
-	if (intervalSec <= 2) {
-		accuracy = Location.Accuracy.BestForNavigation;
-	} else if (intervalSec <= 10) {
-		accuracy = Location.Accuracy.Highest;
-	}
+	const accuracy = intervalSec <= 2 ? Location.Accuracy.BestForNavigation : Location.Accuracy.Highest;
 	return {
 		accuracy,
 		timeInterval: gpsTimeIntervalMs,


### PR DESCRIPTION
## Summary

The battery-drain fix from yesterday (3a59858, PR #3916) downgraded the GPS accuracy to the power-saving `Location.Accuracy.High` level whenever the configured tracking interval is above 10 seconds. With that level the background location task no longer received reliable fixes at 10–30 second intervals.

This PR removes that interval-specific power-save downgrade in `getRecordingLocationOptions`:

- Intervals **above 10 seconds** now request `Accuracy.Highest` again — exactly the same options as the 3–10 second intervals, so the background process is driven the same way.
- Near-continuous intervals (**≤ 2 s**) keep using `Accuracy.BestForNavigation`, unchanged.

All other parts of the battery fix (5 m `distanceInterval`, `ActivityType.Fitness`, `deferredUpdatesInterval`, speech-gated background audio, skipped display updates while backgrounded) remain in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXBJd53yUxKasbir7jXEwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXBJd53yUxKasbir7jXEwN)_