### PR TITLE
refactor: fix 42 SonarCloud maintainability issues (??=, stderr, else-if)

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/RedirectWhitelistHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/RedirectWhitelistHelper.ts
@@ -65,59 +65,57 @@ export class RedirectWhitelistHelper {
       let redirect_allowed_http = RedirectWhitelistHelper.isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry_http, redirectUrl);
       let redirect_allowed_https = RedirectWhitelistHelper.isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry_https, redirectUrl);
       return redirect_allowed_http || redirect_allowed_https;
-    } else {
+    } else if (redirectUrlProtocol.includes(WILDCARD_REPLACEMENT)) {
       // okay we have a protocol which could be http, https, myapp, or a wildcard like *
       // we need to check if the protocol matches
       // if the redirectURL contains our WILDCARD_REPLACEMENT, then we reject it
-      if (redirectUrlProtocol.includes(WILDCARD_REPLACEMENT)) {
-        //console.log("redirectUrlProtocol contains WILDCARD_REPLACEMENT, this is not allowed")
+      //console.log("redirectUrlProtocol contains WILDCARD_REPLACEMENT, this is not allowed")
+      return false;
+    } else {
+      //console.log("redirectUrl seems to be valid")
+      // replace all * with WILDCARD_REPLACEMENT
+      //console.log("Replace whitelist entry all wildcards with WILDCARD_REPLACEMENT")
+      let replacedRedirect_whitelist_entry = StringHelper.replaceAllWithOptions({
+        str: redirect_whitelist_entry,
+        find: WILDCARD,
+        replace: WILDCARD_REPLACEMENT,
+      });
+      // create a new URL from the replaced string
+      //console.log("replacedRedirect_whitelist_entry: " + replacedRedirect_whitelist_entry)
+      let replacedRedirect_whitelist_entry_URL = new URL(replacedRedirect_whitelist_entry);
+      //console.log("replacedRedirect_whitelist_entry_URL: " + replacedRedirect_whitelist_entry_URL)
+
+      const replacedRedirect_whitelist_entry_URLProtocol = replacedRedirect_whitelist_entry_URL.protocol;
+      const replacedRedirect_whitelist_entry_URLHost = replacedRedirect_whitelist_entry_URL.host;
+      const replacedRedirect_whitelist_entry_URLPathname = replacedRedirect_whitelist_entry_URL.pathname;
+      const replacedRedirect_whitelist_entry_URLSearch = replacedRedirect_whitelist_entry_URL.search;
+
+      // check if the protocol matches
+      const protocolMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlProtocol, replacedRedirect_whitelist_entry_URLProtocol);
+      if (!protocolMatches) {
         return false;
-      } else {
-        //console.log("redirectUrl seems to be valid")
-        // replace all * with WILDCARD_REPLACEMENT
-        //console.log("Replace whitelist entry all wildcards with WILDCARD_REPLACEMENT")
-        let replacedRedirect_whitelist_entry = StringHelper.replaceAllWithOptions({
-          str: redirect_whitelist_entry,
-          find: WILDCARD,
-          replace: WILDCARD_REPLACEMENT,
-        });
-        // create a new URL from the replaced string
-        //console.log("replacedRedirect_whitelist_entry: " + replacedRedirect_whitelist_entry)
-        let replacedRedirect_whitelist_entry_URL = new URL(replacedRedirect_whitelist_entry);
-        //console.log("replacedRedirect_whitelist_entry_URL: " + replacedRedirect_whitelist_entry_URL)
-
-        const replacedRedirect_whitelist_entry_URLProtocol = replacedRedirect_whitelist_entry_URL.protocol;
-        const replacedRedirect_whitelist_entry_URLHost = replacedRedirect_whitelist_entry_URL.host;
-        const replacedRedirect_whitelist_entry_URLPathname = replacedRedirect_whitelist_entry_URL.pathname;
-        const replacedRedirect_whitelist_entry_URLSearch = replacedRedirect_whitelist_entry_URL.search;
-
-        // check if the protocol matches
-        const protocolMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlProtocol, replacedRedirect_whitelist_entry_URLProtocol);
-        if (!protocolMatches) {
-          return false;
-        }
-
-        // check if the host matches
-        const hostMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlHost, replacedRedirect_whitelist_entry_URLHost);
-        if (!hostMatches) {
-          return false;
-        }
-
-        // check if the pathname matches
-        const pathnameMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlPathname, replacedRedirect_whitelist_entry_URLPathname);
-        if (!pathnameMatches) {
-          return false;
-        }
-
-        // check if the search matches
-        const searchMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlSearch, replacedRedirect_whitelist_entry_URLSearch);
-        if (!searchMatches) {
-          return false;
-        }
-
-        // if all checks passed, then the redirect URL is allowed
-        return true;
       }
+
+      // check if the host matches
+      const hostMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlHost, replacedRedirect_whitelist_entry_URLHost);
+      if (!hostMatches) {
+        return false;
+      }
+
+      // check if the pathname matches
+      const pathnameMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlPathname, replacedRedirect_whitelist_entry_URLPathname);
+      if (!pathnameMatches) {
+        return false;
+      }
+
+      // check if the search matches
+      const searchMatches = RedirectWhitelistHelper.startsWithUntilWildcardReplacement(redirectUrlSearch, replacedRedirect_whitelist_entry_URLSearch);
+      if (!searchMatches) {
+        return false;
+      }
+
+      // if all checks passed, then the redirect URL is allowed
+      return true;
     }
   }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
@@ -492,21 +492,19 @@ export class FormHelper {
     if (value_image) {
       if (typeof value_image === 'string' && (value_image.startsWith('http') || value_image.startsWith('data:'))) {
         assetUrl = value_image;
+      } else if (isSignature) {
+        // The signature should not be in a 1:1 format and shall not use Form_IMAGE_TRANSFORM_OPTIONS
+        assetUrl = DirectusFilesAssetHelper.getDirectAssetUrlByObjectOrId(
+            value_image,
+            myDatabaseHelperInterface,
+            FormHelper.FORM_IMAGE_SIGNATURE_TRANSFORM_OPTIONS,
+        );
       } else {
-        if(isSignature){
-          // The signature should not be in a 1:1 format and shall not use Form_IMAGE_TRANSFORM_OPTIONS
-          assetUrl = DirectusFilesAssetHelper.getDirectAssetUrlByObjectOrId(
-              value_image,
-              myDatabaseHelperInterface,
-              FormHelper.FORM_IMAGE_SIGNATURE_TRANSFORM_OPTIONS,
-          );
-        } else {
-          assetUrl = DirectusFilesAssetHelper.getDirectAssetUrlByObjectOrId(
-              value_image,
-              myDatabaseHelperInterface,
-              FormHelper.FORM_IMAGE_TRANSFORM_OPTIONS,
-          );
-        }
+        assetUrl = DirectusFilesAssetHelper.getDirectAssetUrlByObjectOrId(
+            value_image,
+            myDatabaseHelperInterface,
+            FormHelper.FORM_IMAGE_TRANSFORM_OPTIONS,
+        );
       }
     }
     return this.generateHtmlForImageUrl(fieldName, assetUrl, isSignature);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/redirect-with-token-endpoint/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/redirect-with-token-endpoint/index.ts
@@ -84,59 +84,57 @@ function isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry: string 
     let redirect_allowed_http = isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry_http, redirectUrl);
     let redirect_allowed_https = isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry_https, redirectUrl);
     return redirect_allowed_http || redirect_allowed_https;
-  } else {
+  } else if (redirectUrlProtocol.includes(WILDCARD_REPLACEMENT)) {
     // okay we have a protocol which could be http, https, myapp, or a wildcard like *
     // we need to check if the protocol matches
     // if the redirectURL contains our WILDCARD_REPLACEMENT, then we reject it
-    if (redirectUrlProtocol.includes(WILDCARD_REPLACEMENT)) {
-      //console.log("redirectUrlProtocol contains WILDCARD_REPLACEMENT, this is not allowed")
+    //console.log("redirectUrlProtocol contains WILDCARD_REPLACEMENT, this is not allowed")
+    return false;
+  } else {
+    //console.log("redirectUrl seems to be valid")
+    // replace all * with WILDCARD_REPLACEMENT
+    //console.log("Replace whitelist entry all wildcards with WILDCARD_REPLACEMENT")
+    let replacedRedirect_whitelist_entry = StringHelper.replaceAllWithOptions({
+      str: redirect_whitelist_entry,
+      find: WILDCARD,
+      replace: WILDCARD_REPLACEMENT,
+    });
+    // create a new URL from the replaced string
+    //console.log("replacedRedirect_whitelist_entry: " + replacedRedirect_whitelist_entry)
+    let replacedRedirect_whitelist_entry_URL = new URL(replacedRedirect_whitelist_entry);
+    //console.log("replacedRedirect_whitelist_entry_URL: " + replacedRedirect_whitelist_entry_URL)
+
+    const replacedRedirect_whitelist_entry_URLProtocol = replacedRedirect_whitelist_entry_URL.protocol;
+    const replacedRedirect_whitelist_entry_URLHost = replacedRedirect_whitelist_entry_URL.host;
+    const replacedRedirect_whitelist_entry_URLPathname = replacedRedirect_whitelist_entry_URL.pathname;
+    const replacedRedirect_whitelist_entry_URLSearch = replacedRedirect_whitelist_entry_URL.search;
+
+    // check if the protocol matches
+    const protocolMatches = startsWithUntilWildcardReplacement(redirectUrlProtocol, replacedRedirect_whitelist_entry_URLProtocol);
+    if (!protocolMatches) {
       return false;
-    } else {
-      //console.log("redirectUrl seems to be valid")
-      // replace all * with WILDCARD_REPLACEMENT
-      //console.log("Replace whitelist entry all wildcards with WILDCARD_REPLACEMENT")
-      let replacedRedirect_whitelist_entry = StringHelper.replaceAllWithOptions({
-        str: redirect_whitelist_entry,
-        find: WILDCARD,
-        replace: WILDCARD_REPLACEMENT,
-      });
-      // create a new URL from the replaced string
-      //console.log("replacedRedirect_whitelist_entry: " + replacedRedirect_whitelist_entry)
-      let replacedRedirect_whitelist_entry_URL = new URL(replacedRedirect_whitelist_entry);
-      //console.log("replacedRedirect_whitelist_entry_URL: " + replacedRedirect_whitelist_entry_URL)
-
-      const replacedRedirect_whitelist_entry_URLProtocol = replacedRedirect_whitelist_entry_URL.protocol;
-      const replacedRedirect_whitelist_entry_URLHost = replacedRedirect_whitelist_entry_URL.host;
-      const replacedRedirect_whitelist_entry_URLPathname = replacedRedirect_whitelist_entry_URL.pathname;
-      const replacedRedirect_whitelist_entry_URLSearch = replacedRedirect_whitelist_entry_URL.search;
-
-      // check if the protocol matches
-      const protocolMatches = startsWithUntilWildcardReplacement(redirectUrlProtocol, replacedRedirect_whitelist_entry_URLProtocol);
-      if (!protocolMatches) {
-        return false;
-      }
-
-      // check if the host matches
-      const hostMatches = startsWithUntilWildcardReplacement(redirectUrlHost, replacedRedirect_whitelist_entry_URLHost);
-      if (!hostMatches) {
-        return false;
-      }
-
-      // check if the pathname matches
-      const pathnameMatches = startsWithUntilWildcardReplacement(redirectUrlPathname, replacedRedirect_whitelist_entry_URLPathname);
-      if (!pathnameMatches) {
-        return false;
-      }
-
-      // check if the search matches
-      const searchMatches = startsWithUntilWildcardReplacement(redirectUrlSearch, replacedRedirect_whitelist_entry_URLSearch);
-      if (!searchMatches) {
-        return false;
-      }
-
-      // if all checks passed, then the redirect URL is allowed
-      return true;
     }
+
+    // check if the host matches
+    const hostMatches = startsWithUntilWildcardReplacement(redirectUrlHost, replacedRedirect_whitelist_entry_URLHost);
+    if (!hostMatches) {
+      return false;
+    }
+
+    // check if the pathname matches
+    const pathnameMatches = startsWithUntilWildcardReplacement(redirectUrlPathname, replacedRedirect_whitelist_entry_URLPathname);
+    if (!pathnameMatches) {
+      return false;
+    }
+
+    // check if the search matches
+    const searchMatches = startsWithUntilWildcardReplacement(redirectUrlSearch, replacedRedirect_whitelist_entry_URLSearch);
+    if (!searchMatches) {
+      return false;
+    }
+
+    // if all checks passed, then the redirect URL is allowed
+    return true;
   }
 }
 

--- a/apps/backend/dockerDatabaseBackupRestore/restore.sh
+++ b/apps/backend/dockerDatabaseBackupRestore/restore.sh
@@ -43,6 +43,6 @@ if [[ -f "/dump/${BACKUP_FILE}" ]]; then
 
   echo 'Database restore completed successfully.'
 else
-  echo "Error: Backup file /dump/${BACKUP_FILE} not found!"
+  echo "Error: Backup file /dump/${BACKUP_FILE} not found!" >&2
   exit 1
 fi

--- a/apps/backend/genSSO_Apple.sh
+++ b/apps/backend/genSSO_Apple.sh
@@ -77,7 +77,7 @@ fi
 # Read the EC key
 if [[ -n "$KEY_FILE_PATH" ]]; then
     if [[ ! -f "$KEY_FILE_PATH" ]]; then
-        echo "Error: Key file '$KEY_FILE_PATH' not found."
+        echo "Error: Key file '$KEY_FILE_PATH' not found." >&2
         exit 1
     fi
     ECDSA_KEY=$(cat "$KEY_FILE_PATH")

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -327,12 +327,10 @@ const Index = () => {
 					// update fails silently on network error
 				}
 			}
+		} else if (offlineMode) {
+			toast(translate(TranslationKeys.form_submission_not_found_offline), 'error');
 		} else {
-			if (offlineMode) {
-				toast(translate(TranslationKeys.form_submission_not_found_offline), 'error');
-			} else {
-				toast(translate(TranslationKeys.form_submission_not_found), 'error');
-			}
+			toast(translate(TranslationKeys.form_submission_not_found), 'error');
 		}
 		return result;
 	};

--- a/apps/frontend/app/components/AutoImageScroller/index.tsx
+++ b/apps/frontend/app/components/AutoImageScroller/index.tsx
@@ -35,9 +35,7 @@ const AutoImageScroller: React.FC<AutoImageScrollerProps> = ({ images, numColumn
 		const pxPerSecond = (speedPercent / 100) * screenHeight;
 
 		const step = (time: number) => {
-			if (lastTime === null) {
-				lastTime = time;
-			}
+			lastTime ??= time;
 			const delta = time - lastTime;
 			lastTime = time;
 			const distance = (pxPerSecond * delta) / 1000;

--- a/apps/frontend/app/components/FoodOfferDetailsContent/FoodOfferDetailsContent.tsx
+++ b/apps/frontend/app/components/FoodOfferDetailsContent/FoodOfferDetailsContent.tsx
@@ -324,20 +324,16 @@ const FoodOfferDetailsContent: React.FC<FoodOfferDetailsContentProps> = ({ offer
             if (isAndroid()) {
                 if (result?.granted) {
                     updateFoodFeedbackNotification();
-                } else {
-                    if (NotificationHelper.isDeviceNotificationPermissionUndetermined(pushTokenObj)) {
-                        requestDeviceNotificationPermission();
-                    }
+                } else if (NotificationHelper.isDeviceNotificationPermissionUndetermined(pushTokenObj)) {
+                    requestDeviceNotificationPermission();
                 }
             }
             if (isIOS()) {
                 const result = await NotificationHelper.requestDeviceNotificationPermission();
                 if (result?.granted) {
                     updateFoodFeedbackNotification();
-                } else {
-                    if (NotificationHelper.isDeviceNotificationPermissionUndetermined(pushTokenObj)) {
-                        requestDeviceNotificationPermission();
-                    }
+                } else if (NotificationHelper.isDeviceNotificationPermissionUndetermined(pushTokenObj)) {
+                    requestDeviceNotificationPermission();
                 }
             }
         } else {

--- a/apps/frontend/app/components/Login/Header.tsx
+++ b/apps/frontend/app/components/Login/Header.tsx
@@ -59,13 +59,11 @@ const LoginHeader = () => {
 					payload: 'right',
 				});
 			}
-		} else {
-			if (language === LanguageCode.AR) {
-				dispatch({
-					type: SET_DRAWER_POSITION,
-					payload: 'right',
-				});
-			}
+		} else if (language === LanguageCode.AR) {
+			dispatch({
+				type: SET_DRAWER_POSITION,
+				payload: 'right',
+			});
 		}
 	}, []);
 

--- a/apps/frontend/app/helper/nfcCardReaderHelper/CardReader.ts
+++ b/apps/frontend/app/helper/nfcCardReaderHelper/CardReader.ts
@@ -32,9 +32,7 @@ export default class CardReader {
 	}
 
 	async readCard(message?: string) {
-		if (message === undefined) {
-			message = 'Hold your phone near the card';
-		}
+		message ??= 'Hold your phone near the card';
 		let cardInformations;
 		try {
 			const result = await this.NfcManager.start();

--- a/apps/frontend/app/redux/storage/sqliteStorage.ts
+++ b/apps/frontend/app/redux/storage/sqliteStorage.ts
@@ -122,12 +122,10 @@ async function ensureAsyncStorageMigrated(db: KvDatabase): Promise<void> {
 // Exported so the debug storage-usage settings screen (SettingsListSqliteStorage, dbName
 // "redux_persist.db") can query the same kv table without opening a second connection.
 export function getSqliteDb(): Promise<KvDatabase> {
-	if (!migratedDbPromise) {
-		migratedDbPromise = getKvDatabase(DB_NAME).then(async (db) => {
-			await ensureAsyncStorageMigrated(db);
-			return db;
-		});
-	}
+	migratedDbPromise ??= getKvDatabase(DB_NAME).then(async (db) => {
+		await ensureAsyncStorageMigrated(db);
+		return db;
+	});
 	return migratedDbPromise;
 }
 

--- a/apps/frontend/run-maestro-web-test.sh
+++ b/apps/frontend/run-maestro-web-test.sh
@@ -74,7 +74,7 @@ for i in $(seq 1 $MAX_WAIT); do
         break
     fi
     if [ "$i" -eq "$MAX_WAIT" ]; then
-        echo "ERROR: Dev server did not start within ${MAX_WAIT}s."
+        echo "ERROR: Dev server did not start within ${MAX_WAIT}s." >&2
         exit 1
     fi
     echo "  Waiting... ($i/${MAX_WAIT}s)"
@@ -91,15 +91,15 @@ if ! command -v maestro &> /dev/null; then
     # sanity-checked before it is executed, and pin the transport to TLS.
     MAESTRO_INSTALLER="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 -o "$MAESTRO_INSTALLER" "https://get.maestro.mobile.dev"
-    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty."; exit 1; }
-    head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script."; exit 1; }
+    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty." >&2; exit 1; }
+    head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script." >&2; exit 1; }
     bash "$MAESTRO_INSTALLER"
     rm -f "$MAESTRO_INSTALLER"
     export PATH="$HOME/.maestro/bin:$PATH"
 fi
 
 if ! command -v maestro &> /dev/null; then
-    echo "ERROR: Maestro CLI installation failed."
+    echo "ERROR: Maestro CLI installation failed." >&2
     echo "Install manually: curl -fsSL \"https://get.maestro.mobile.dev\" | bash"
     exit 1
 fi
@@ -166,7 +166,7 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
         fi
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.xml" \) -print0 2>/dev/null)
     if [ "$FOUND_ERRORS" = false ]; then
-        echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)"
+        echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)" >&2
     fi
     echo ""
     exit "$MAESTRO_EXIT_CODE"

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -589,9 +589,7 @@ export default function ActivitiesScreen() {
 
 							if (!activity.computed) {
 								activity.computed = computeActivityData(activity, enclosedTiles);
-								if (activity.enclosedTileCount == null) {
-									activity.enclosedTileCount = enclosedTiles.length;
-								}
+								activity.enclosedTileCount ??= enclosedTiles.length;
 								updated = true;
 							} else if (
 								!Array.isArray(activity.computed.enclosedHexTiles) ||

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -426,8 +426,8 @@ function buildWalkPathGeoJson(
 			} catch {
 				continue;
 			}
-		} else {
-			if (!viewportSet.has(cellA) || !viewportSet.has(cellB)) continue;
+		} else if (!viewportSet.has(cellA) || !viewportSet.has(cellB)) {
+			continue;
 		}
 		try {
 			const [aLat, aLng] = cellToLatLng(cellA);

--- a/apps/geonexia/frontend/app/settings/index.tsx
+++ b/apps/geonexia/frontend/app/settings/index.tsx
@@ -531,18 +531,14 @@ export default function SettingsScreen() {
 							}
 							if (!activity.computed) {
 								activity.computed = computeActivityData(activity, enclosedTiles);
-								if (activity.enclosedTileCount == null) {
-									activity.enclosedTileCount = enclosedTiles.length;
-								}
+								activity.enclosedTileCount ??= enclosedTiles.length;
 								updated = true;
 							} else if (
 								!Array.isArray(activity.computed.enclosedHexTiles) ||
 								(activity.computed.enclosedHexTiles.length === 0 && enclosedTiles.length > 0)
 							) {
 								activity.computed = { ...activity.computed, enclosedHexTiles: enclosedTiles };
-								if (activity.enclosedTileCount == null) {
-									activity.enclosedTileCount = enclosedTiles.length;
-								}
+								activity.enclosedTileCount ??= enclosedTiles.length;
 								updated = true;
 							}
 							if (updated) {

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -396,7 +396,7 @@ export function checkAndApplyForest(
 	features: MapFeatureInfo[] | undefined,
 ): void {
 	if (!features || !hasForestFeature(features)) return;
-	if (!rec.billboards) rec.billboards = {};
+	rec.billboards ??= {};
 
 	// Large tree at the hex centroid.
 	rec.billboards[BillboardAnchorPosition.CENTER] = BILLBOARD_PINE_TREE_LARGE;
@@ -744,7 +744,7 @@ export function rebuildMapFromActivities(
 			}
 
 			// Add or merge the activity reference
-			if (!rec.activityReferences) rec.activityReferences = [];
+			rec.activityReferences ??= [];
 			const existingRef = refByHexId.get(hexId);
 			if (existingRef) {
 				existingRef.walkedIndex = i;
@@ -791,7 +791,7 @@ export function rebuildMapFromActivities(
 			}
 
 			// Add or merge the activity reference
-			if (!rec.activityReferences) rec.activityReferences = [];
+			rec.activityReferences ??= [];
 			const existingRef = refByHexId.get(hexId);
 			if (existingRef) {
 				existingRef.enclosedIndex = i;
@@ -890,7 +890,7 @@ export function rebuildMapFromActivities(
 					const edgeIdx = getEdgeIndexTowardNeighbor(hexId, neighbor);
 					if (edgeIdx < 0 || edgeIdx >= EDGE_INDEX_TO_ANCHOR.length) continue;
 					const anchorPosition = EDGE_INDEX_TO_ANCHOR[edgeIdx];
-					if (!rec.billboardsTexture) rec.billboardsTexture = {};
+					rec.billboardsTexture ??= {};
 					rec.billboardsTexture[anchorPosition] = BILLBOARD_PATH_ROUNDED;
 				}
 			}
@@ -913,7 +913,7 @@ export function rebuildMapFromActivities(
 	// Apply home tile castle2 billboard if a home tile is set.
 	if (homeHexTile) {
 		const homeRec = getOrCreateRecord(records, homeHexTile);
-		if (!homeRec.billboards) homeRec.billboards = {};
+		homeRec.billboards ??= {};
 		homeRec.billboards[BillboardAnchorPosition.CENTER] = BILLBOARD_CASTLE2;
 	}
 
@@ -1046,7 +1046,7 @@ export function applyRouteBenches(
 			if (rec.tileImage !== TILE_IMAGE_DIRT) continue;
 			if (rec.billboards?.[BillboardAnchorPosition.CENTER]) continue;
 
-			if (!rec.billboards) rec.billboards = {};
+			rec.billboards ??= {};
 			rec.billboards[BillboardAnchorPosition.CENTER] = BILLBOARD_BENCH;
 			break;
 		}

--- a/apps/geonexia/frontend/helpers/RoadMatchHelper.ts
+++ b/apps/geonexia/frontend/helpers/RoadMatchHelper.ts
@@ -499,7 +499,7 @@ export function matchRouteToRoads(
 		} else if (prevMatch && currMatch) {
 			// 'network': search for a real road/path route between them instead of
 			// cutting a straight line across the corner.
-			if (!graph) graph = buildRoadGraph(ways);
+			graph ??= buildRoadGraph(ways);
 			const sources = segmentEndpointsAsWeightedNodes(graph, ways[prevMatch.wayIndex].points, prevMatch);
 			const targets = segmentEndpointsAsWeightedNodes(graph, ways[currMatch.wayIndex].points, currMatch);
 			const connection = findConnectingPath(graph, sources, targets, maxConnectDistDeg);

--- a/apps/geonexia/frontend/helpers/TTSHelper.ts
+++ b/apps/geonexia/frontend/helpers/TTSHelper.ts
@@ -263,12 +263,10 @@ export function buildPeriodicAnnouncement(
 			} else {
 				parts.push(`${m} Minuten ${s} Sekunden`);
 			}
+		} else if (h > 0) {
+			parts.push(`${h} hour${h > 1 ? 's' : ''} ${m} minutes ${s} seconds`);
 		} else {
-			if (h > 0) {
-				parts.push(`${h} hour${h > 1 ? 's' : ''} ${m} minutes ${s} seconds`);
-			} else {
-				parts.push(`${m} minutes ${s} seconds`);
-			}
+			parts.push(`${m} minutes ${s} seconds`);
 		}
 	}
 

--- a/apps/geonexia/frontend/store/hexTileSlice.ts
+++ b/apps/geonexia/frontend/store/hexTileSlice.ts
@@ -196,7 +196,7 @@ const hexTileSlice = createSlice({
 		) {
 			const { h3Index, anchorColor, flat } = action.payload;
 			const rec = getOrCreate(state.records, h3Index);
-			if (!rec.billboardsFlat) rec.billboardsFlat = {};
+			rec.billboardsFlat ??= {};
 			if (!flat) {
 				delete rec.billboardsFlat[anchorColor];
 			} else {
@@ -216,7 +216,7 @@ const hexTileSlice = createSlice({
 		) {
 			const { h3Index, anchorColor, billboard } = action.payload;
 			const rec = getOrCreate(state.records, h3Index);
-			if (!rec.billboardsTexture) rec.billboardsTexture = {};
+			rec.billboardsTexture ??= {};
 			if (billboard === null) {
 				delete rec.billboardsTexture[anchorColor];
 			} else {

--- a/apps/score-tracker/run-maestro-web-test.sh
+++ b/apps/score-tracker/run-maestro-web-test.sh
@@ -79,7 +79,7 @@ for i in $(seq 1 $MAX_WAIT); do
         break
     fi
     if [ "$i" -eq "$MAX_WAIT" ]; then
-        echo "ERROR: Dev server did not start within ${MAX_WAIT}s."
+        echo "ERROR: Dev server did not start within ${MAX_WAIT}s." >&2
         exit 1
     fi
     echo "  Waiting... ($i/${MAX_WAIT}s)"
@@ -94,15 +94,15 @@ if ! command -v maestro &> /dev/null; then
     echo "Maestro CLI not found – installing..."
     MAESTRO_INSTALLER="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 -o "$MAESTRO_INSTALLER" "https://get.maestro.mobile.dev"
-    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty."; exit 1; }
-    head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script."; exit 1; }
+    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty." >&2; exit 1; }
+    head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script." >&2; exit 1; }
     bash "$MAESTRO_INSTALLER"
     rm -f "$MAESTRO_INSTALLER"
     export PATH="$HOME/.maestro/bin:$PATH"
 fi
 
 if ! command -v maestro &> /dev/null; then
-    echo "ERROR: Maestro CLI installation failed."
+    echo "ERROR: Maestro CLI installation failed." >&2
     echo "Install manually: curl -fsSL \"https://get.maestro.mobile.dev\" | bash"
     exit 1
 fi
@@ -168,7 +168,7 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
         fi
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.xml" \) -print0 2>/dev/null)
     if [ "$FOUND_ERRORS" = false ]; then
-        echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)"
+        echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)" >&2
     fi
     echo ""
     exit "$MAESTRO_EXIT_CODE"

--- a/apps/sonarCloudReportDownloader/src/generateIssueMarkdown.ts
+++ b/apps/sonarCloudReportDownloader/src/generateIssueMarkdown.ts
@@ -97,15 +97,13 @@ function parseCsvLine(line: string): string[] {
       } else {
         current += char;
       }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      fields.push(current);
+      current = '';
     } else {
-      if (char === '"') {
-        inQuotes = true;
-      } else if (char === ',') {
-        fields.push(current);
-        current = '';
-      } else {
-        current += char;
-      }
+      current += char;
     }
   }
   fields.push(current);

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -68,6 +68,9 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Use the "RegExp.exec()" method instead. | 20 von 20 (nur Regexe ohne `g`-Flag) | #3946 |
 | 2026-07-20 | Prefer `String#replaceAll()`. | 10 von 10 | #3946 |
 | 2026-07-20 | Kleintypen: Fragment (7), case-Block (7), useless constructor (6), redundantes `\| undefined` (6), unnötige Escapes (6), Boolean-Literal-Ternary (5), `Math.hypot` (5), `Number.parseInt` (3), `Date.now()` (3) | 48 von 48 | #3946 |
+| 2026-07-20 | Prefer using nullish coalescing operator (`??=` / `??`). | 18 von 18 (Codemod mit Zeilenverifikation; alle Ziel-Typen `X \| null` bzw. `boolean \| undefined`) | – |
+| 2026-07-20 | Redirect this error message to stderr (>&2). | 14 von 14 (nur Shell-Skripte, `bash -n` geprüft) | – |
+| 2026-07-20 | 'If' statement should not be the only statement in 'else' block. | 10 von 10 (`else { if }` → `else if`) | – |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 
@@ -75,7 +78,7 @@ Neu abgearbeitete Typen bitte hier ergänzen.
 „Cognitive Complexity" (113x), „Move this component definition out of the parent
 component" (97x), „Array index in keys" (60x, braucht stabile IDs), TODO-Kommentare
 (39x), Funktions-Verschachtelung (35x), Exception-Handling (23x), „Default parameters
-should be last" (20x, ändert Aufrufer), „Add an explicit return" (20x), `??=` (18x),
+should be last" (20x, ändert Aufrufer), „Add an explicit return" (20x),
 `await` auf Non-Promise (16x), Parameter-Reihenfolge (16x), for-of (12x).
 Diese Typen in kleinen, thematisch gruppierten PRs separat angehen.
 

--- a/packages/common-ui/src/components/MapOverlayButtons/index.tsx
+++ b/packages/common-ui/src/components/MapOverlayButtons/index.tsx
@@ -51,7 +51,7 @@ export function MapLocationButton({
 	zoom,
 }: Readonly<MapLocationButtonProps>) {
 	const [internalActive, setInternalActive] = useState(false);
-	const showActive = isFollowing !== undefined ? isFollowing : internalActive;
+	const showActive = isFollowing ?? internalActive;
 
 	const handlePress = useCallback(async () => {
 		try {

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -231,13 +231,11 @@ const DEFAULT_AVATAR_STYLE = AvatarStyle.AVATAAARS;
 
 let _defaultAvatarConfig: AvatarConfig | null = null;
 function getDefaultAvatarConfig(): AvatarConfig {
-	if (!_defaultAvatarConfig) {
-		_defaultAvatarConfig = {
-			style: DEFAULT_AVATAR_STYLE,
-			size: AvatarSize.LARGE,
-			options: getDefaultOptionsForStyle(DEFAULT_AVATAR_STYLE),
-		};
-	}
+	_defaultAvatarConfig ??= {
+		style: DEFAULT_AVATAR_STYLE,
+		size: AvatarSize.LARGE,
+		options: getDefaultOptionsForStyle(DEFAULT_AVATAR_STYLE),
+	};
 	return _defaultAvatarConfig;
 }
 

--- a/packages/maestro-framework/src/MaestroTestCase.ts
+++ b/packages/maestro-framework/src/MaestroTestCase.ts
@@ -65,9 +65,7 @@ export class MaestroTestCase {
 		// The first URL is used as the YAML header `url:` field, which Maestro uses
 		// to identify this as a web flow and as the default navigation target for
 		// all launchApp steps (the header url becomes the appId for the web driver).
-		if (this.url === null) {
-			this.url = url;
-		}
+		this.url ??= url;
 		this.steps.push({ type: 'launchApp', url });
 		return this;
 	}

--- a/scripts/generateIcons.sh
+++ b/scripts/generateIcons.sh
@@ -216,7 +216,7 @@ generate_images() {
 
 # Main script execution
 if [[ $# -lt 2 ]]; then
-    echo "Error: Missing required arguments."
+    echo "Error: Missing required arguments." >&2
     print_usage
     exit 1
 fi
@@ -230,7 +230,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --project-dir)
             if [[ -z "$2" ]]; then
-                echo "Error: --project-dir requires a directory argument."
+                echo "Error: --project-dir requires a directory argument." >&2
                 print_usage
                 exit 1
             fi


### PR DESCRIPTION
## Behobene Issue-Typen

Drei rein mechanische, gut reviewbare Typen aus `reports/sonarCloud/report_maintainability.csv`:

| Issue-Typ | Behoben |
|---|---|
| Prefer using nullish coalescing operator (`??=` / `??`) | 18 von 18 |
| Redirect this error message to stderr (`>&2`) | 14 von 14 |
| 'If' statement should not be the only statement in 'else' block | 10 von 10 |

## Details

**`??=` / `??` (18x):** `if (!x) x = v;`, `if (x == null) { x = v; }` und `x !== undefined ? x : y` per Codemod mit exakter Zeilenverifikation (0 Mismatches) umgestellt. Vor jeder Umstellung wurde der deklarierte Typ geprüft — alle Ziele sind `X | null` bzw. `boolean | undefined` (Objekte/Arrays/Promises), sodass die Truthiness→Nullish-Umstellung die Semantik nicht ändert.

**stderr (14x):** Nur Shell-Skripte (`run-maestro-web-test.sh` x2, `generateIcons.sh`, `restore.sh`, `genSSO_Apple.sh`). Alle Stellen sind Fehlermeldungen unmittelbar vor `exit 1` bzw. im Fehler-Reporting-Block. Nicht gemeldete Nachbar-Echos wurden bewusst nicht angefasst. Syntax mit `bash -n` geprüft.

**else-if (10x):** `else { if (…) {…} }` zu `else if (…) {…}` zusammengefasst, inkl. der beiden Redirect-Whitelist-Duplikate im Backend (dort nur Dedent + Kommentar-Verschiebung, Logik unverändert — am besten mit „Hide whitespace" reviewen).

## Verifikation

- `directus-extension-rocket-meals-bundle`: `yarn typecheck` grün
- `apps/geonexia/frontend`: `tsc --noEmit` = 28 Fehler, identisch zum master-Stand (pre-existing)
- `apps/frontend/app`: `tsc --noEmit` = 105 Fehler, identisch zum master-Stand (pre-existing)
- `packages/maestro-framework`, `apps/sonarCloudReportDownloader`: `tsc --noEmit` = 0 Fehler
- Shell-Skripte: `bash -n` ohne Befund

## Ausgelassen

Keine — alle gemeldeten Vorkommen der drei Typen wurden behoben. Die Workflow-Doku (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`) wurde um die drei Typen ergänzt.

## Aktuelle Top 10 (nach diesem PR)

1. 113x Cognitive Complexity (übersprungen, individuelle Refactorings)
2. 97x Move this component definition out of the parent component (übersprungen)
3. 60x Array index in keys (übersprungen, braucht stabile IDs)
4. 39x TODO-Kommentare (übersprungen)
5. 35x Funktions-Verschachtelung (übersprungen)
6. 23x Exception-Handling (übersprungen)
7. 20x Default parameters should be last (übersprungen, ändert Aufrufer)
8. 20x Add an explicit return statement (übersprungen)
9. 16x `await` auf Non-Promise (übersprungen)
10. 16x Parameter-Reihenfolge (übersprungen)

Nächste gut machbare Kandidaten: „Redirect… nested template literals" (10x), Pattern `'"'` (6x), useless assignments (~20x verteilt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg8nvAHxekyNQMMpwhVMjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg8nvAHxekyNQMMpwhVMjc)_