### PR TITLE
refactor: fix 34 SonarCloud maintainability issues (for-of, any-unions, nested template literals)

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/MarkingTL1Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/MarkingTL1Parser.ts
@@ -27,8 +27,7 @@ export class MarkingTL1Parser implements MarkingParserInterface {
 
   async getMarkingsJSONList(): Promise<MarkingsTypeForParser[]> {
     let markings: MarkingsTypeForParser[] = [];
-    for (let i = 0; i < this.parsedReport.length; i++) {
-      let parsedLineObject = this.parsedReport[i];
+    for (const parsedLineObject of this.parsedReport) {
       if (parsedLineObject) {
         let marking = MarkingTL1Parser.getMarkingJSONFromRawMarking(parsedLineObject);
         if (marking) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelperInterface.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelperInterface.ts
@@ -14,7 +14,7 @@ export interface MyDatabaseTestableHelperInterface {
 
 export class MyDatabaseTestableHelper implements MyDatabaseTestableHelperInterface {
   private cachedServerInfo: ServerInfo | undefined = undefined;
-  private cachedClient: any | undefined = undefined;
+  private cachedClient: any = undefined;
   public useOfflineServerInfo: boolean = true;
 
   getServerUrl(): string {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelperInterface.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelperInterface.ts
@@ -3,7 +3,7 @@ import { EventContext as ExtentContextDirectusTypes } from '@directus/types';
 import { ItemsServiceHelper } from './ItemsServiceHelper';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { ServerInfo } from './ItemsServiceCreator';
-import { createDirectus, rest, serverInfo } from '@directus/sdk';
+import { createDirectus, DirectusClient, rest, RestClient, serverInfo } from '@directus/sdk';
 
 export interface MyDatabaseTestableHelperInterface {
   getServerInfo(): Promise<ServerInfo>;
@@ -14,7 +14,7 @@ export interface MyDatabaseTestableHelperInterface {
 
 export class MyDatabaseTestableHelper implements MyDatabaseTestableHelperInterface {
   private cachedServerInfo: ServerInfo | undefined = undefined;
-  private cachedClient: any = undefined;
+  private cachedClient: (DirectusClient<DatabaseTypes.CustomDirectusTypes> & RestClient<DatabaseTypes.CustomDirectusTypes>) | undefined = undefined;
   public useOfflineServerInfo: boolean = true;
 
   getServerUrl(): string {
@@ -55,7 +55,9 @@ export class MyDatabaseTestableHelper implements MyDatabaseTestableHelperInterfa
   }
 
   async downloadServerInfo(): Promise<ServerInfo> {
-    return await this.getPublicClient().request(serverInfo());
+    // The SDK's ServerInfoOutput type does not declare all fields (e.g. project_color)
+    // which the Directus server actually returns and our local ServerInfo type expects.
+    return (await this.getPublicClient().request(serverInfo())) as unknown as ServerInfo;
   }
 
   async getAdminBearerToken(): Promise<string | undefined> {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/RedirectWhitelistHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/RedirectWhitelistHelper.ts
@@ -5,9 +5,8 @@ const WILDCARD_REPLACEMENT = 'WILDCARD_REPLACEMENT';
 
 export class RedirectWhitelistHelper {
   static isRedirectUrlAllowedForWhitelistEntriesWithSimpleWildcards(redirect_whitelist_entries: string[], redirect_url: URL) {
-    for (let i = 0; i < redirect_whitelist_entries.length; i++) {
+    for (const redirect_whitelist_entry of redirect_whitelist_entries) {
       // iterate over the whitelist as long as we haven't found a valid redirect
-      let redirect_whitelist_entry = redirect_whitelist_entries[i];
       try {
         if (RedirectWhitelistHelper.isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry, redirect_url)) {
           return true;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/form/FormHelper.ts
@@ -169,8 +169,7 @@ export class FormHelper {
 
     let sizes = [200, 400, 800, 1600];
     let images: string[] = [];
-    for (let i = 0; i < sizes.length; i++) {
-      let size = sizes[i];
+    for (const size of sizes) {
       let imageUrl = `https://picsum.photos/${size}/${size}`;
       images.push(imageUrl);
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/osnabrueck/StudentenwerkOsnabrueckNews_Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/osnabrueck/StudentenwerkOsnabrueckNews_Parser.ts
@@ -28,8 +28,7 @@ export class StudentenwerkOsnabrueckNews_Parser implements NewsParserInterface {
 
       let news: NewsTypeForParser[] = [];
 
-      for (let i = 0; i < articles.length; i++) {
-        let article = articles[i];
+      for (const article of articles.toArray()) {
         let imageElement = $(article).find('img');
         let imageUrl = imageElement.length ? StudentenwerkOsnabrueckNews_Parser.baseUrl + imageElement.attr('src') : '';
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/push-notification-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/push-notification-hook/index.ts
@@ -33,8 +33,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
       throw new Error('No keys provided for update');
     }
 
-    for (let i = 0; i < keys.length; i++) {
-      let key = keys[i];
+    for (const key of keys) {
       const currentItemId = key; // Assuming only one item is being updated
       const currentItems = await itemService.readByQuery({
         filter: { id: currentItemId },
@@ -106,7 +105,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
       body = payload.message_body;
     }
 
-    let data: any | undefined = undefined; // can't be null, otherwise it will result in an error from expo
+    let data: any = undefined; // can't be null, otherwise it will result in an error from expo
     if (payload.message_data) {
       // check if message_data is set
       data = payload.message_data;
@@ -115,7 +114,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
     // Every token should be: "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]" (with the ExponentPushToken prefix and square brackets)
 
     // https://github.com/expo/expo/discussions/27980
-    let richContent: any | undefined = undefined; // https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format
+    let richContent: any = undefined; // https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format
 
     let payload_image_url = payload.image_url;
     if (payload_image_url) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/osnabrueck/StudentenwerkOsnabrueckWashingmachineParser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/osnabrueck/StudentenwerkOsnabrueckWashingmachineParser.ts
@@ -23,8 +23,7 @@ export class StudentenwerkOsnabrueckWashingmachineParser implements Washingmachi
   async getWashingmachines(simulated_now?: Date): Promise<WashingmachinesTypeForParser[]> {
     let answer: WashingmachinesTypeForParser[] = [];
     let intercardWashers = await StudentenwerkOsnabrueckWashingmachineParser.getAllTerminalFromIntercard();
-    for (let i = 0; i < intercardWashers.length; i++) {
-      let washer = intercardWashers[i];
+    for (const washer of intercardWashers) {
       if (washer) {
         let external_identifier = StudentenwerkOsnabrueckWashingmachineParser.getWasherExternalIdentifier(washer.terminalNr, washer.automateNr);
         let date_finished: string | null = null;
@@ -60,8 +59,7 @@ export class StudentenwerkOsnabrueckWashingmachineParser implements Washingmachi
   filterDuplicateWashingmachines(washingmachines: WashingmachinesTypeForParser[]): WashingmachinesTypeForParser[] {
     let answer: WashingmachinesTypeForParser[] = [];
     let map: Map<string, WashingmachinesTypeForParser> = new Map<string, WashingmachinesTypeForParser>();
-    for (let i = 0; i < washingmachines.length; i++) {
-      let washingmachine = washingmachines[i];
+    for (const washingmachine of washingmachines) {
       if (washingmachine) {
         let external_identifier = washingmachine.basicData.external_identifier;
         let existing = map.get(external_identifier);

--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -24,7 +24,7 @@ const EventsScreen = () => {
     const kioskMode = useKioskMode();
     const { popupEvents } = useAppSelector((state) => state.food);
     const { primaryColor } = useAppSelector((state) => state.settings);
-	const [selectedEvent, setSelectedEvent] = useState<any | null>(null);
+	const [selectedEvent, setSelectedEvent] = useState<any>(null);
 	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 	const handleClose = useCallback(() => {
 		setSelectedEvent(null);

--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { DatabaseTypes } from 'repo-depkit-common';
 import { SafeAreaView, ScrollView } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { useAppSelector } from '@/redux/hooks';
@@ -24,7 +25,7 @@ const EventsScreen = () => {
     const kioskMode = useKioskMode();
     const { popupEvents } = useAppSelector((state) => state.food);
     const { primaryColor } = useAppSelector((state) => state.settings);
-	const [selectedEvent, setSelectedEvent] = useState<any>(null);
+	const [selectedEvent, setSelectedEvent] = useState<Partial<DatabaseTypes.PopupEvents> | null>(null);
 	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 	const handleClose = useCallback(() => {
 		setSelectedEvent(null);

--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -36,7 +36,7 @@ const FeedbackScreen = () => {
 	const contrastColor = myContrastColor(primaryColor, theme, mode === 'dark');
 	const [loading, setLoading] = useState(false);
 	const [inputValues, setInputValues] = useState<{
-		[key: string]: string | boolean | number | any;
+		[key: string]: any;
 	}>({});
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [errorJson, setErrorJson] = useState<string | null>(null);

--- a/apps/frontend/app/app/(app)/map/index.tsx
+++ b/apps/frontend/app/app/(app)/map/index.tsx
@@ -1279,7 +1279,8 @@ const OsmVectorMapScreen: React.FC = () => {
 			const coords = (building?.coordinates as BuildingCoordinates)?.coordinates;
 			const lat = coords ? Number(coords[1]).toFixed(5) : null;
 			const lng = coords ? Number(coords[0]).toFixed(5) : null;
-			addLog(`Marker clicked: ${title}${lat !== null ? ` (${lat}, ${lng})` : ''}`);
+			const coordsText = lat !== null ? ` (${lat}, ${lng})` : '';
+			addLog(`Marker clicked: ${title}${coordsText}`);
 
 			if (coords?.length === 2) {
 				setMapCenterOverride({ lat: Number(coords[1]), lng: Number(coords[0]) });

--- a/apps/frontend/app/app/index.tsx
+++ b/apps/frontend/app/app/index.tsx
@@ -16,7 +16,7 @@ const extractRawExpoToken = (token: string | null) => {
 	return m ? m[1] : token;
 };
 
-async function savePushTokenToAPI(opts: { token: string | null; profile: DatabaseTypes.Profiles | any; dispatch: any }) {
+async function savePushTokenToAPI(opts: { token: string | null; profile: any; dispatch: any }) {
 	const { token, profile, dispatch } = opts;
 	if (!token) {
 		return;

--- a/apps/frontend/app/app/index.tsx
+++ b/apps/frontend/app/app/index.tsx
@@ -16,7 +16,7 @@ const extractRawExpoToken = (token: string | null) => {
 	return m ? m[1] : token;
 };
 
-async function savePushTokenToAPI(opts: { token: string | null; profile: any; dispatch: any }) {
+async function savePushTokenToAPI(opts: { token: string | null; profile: Partial<DatabaseTypes.Profiles>; dispatch: any }) {
 	const { token, profile, dispatch } = opts;
 	if (!token) {
 		return;

--- a/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -37,7 +37,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 		name: 'Mon',
 	});
 	const [windowWidth, setWindowWidth] = useState<number>(Dimensions.get('window').width);
-	const [selectedItem, setSelectedItem] = useState<any | null>(null);
+	const [selectedItem, setSelectedItem] = useState<any>(null);
 	const [data, setData] = useState<any[]>(timeTableData);
 	const [inputValue, setInputValue] = useState<string>('');
 	const [selectedColor, setSelectedColor] = useState<string>('');

--- a/apps/frontend/app/components/Login/Header.tsx
+++ b/apps/frontend/app/components/Login/Header.tsx
@@ -26,8 +26,7 @@ const LoginHeader = () => {
 	function useDeviceLocaleCodesWithoutRegionCode(): string[] {
 		let localeCodes: string[] = [];
 
-		for (let i = 0; i < locales.length; i++) {
-			let locale = locales[i];
+		for (const locale of locales) {
 			localeCodes.push(locale.languageTag);
 		}
 

--- a/apps/frontend/app/constants/AsyncStorageHelper.ts
+++ b/apps/frontend/app/constants/AsyncStorageHelper.ts
@@ -25,9 +25,9 @@ export const setValue = async (key: string, value: any): Promise<void> => {
  * Retrieve a value from storage (sqlite on native, AsyncStorage on web).
  *
  * @param {string} key - The key of the value to retrieve.
- * @returns {Promise<any | null>} - The parsed value, or null if not found or an error occurred.
+ * @returns {Promise<any>} - The parsed value, or null if not found or an error occurred.
  */
-export const getValue = async (key: string): Promise<any | null> => {
+export const getValue = async (key: string): Promise<any> => {
 	try {
 		const jsonValue = await sqliteKeyValueStorage.getItem(key);
 		return jsonValue != null ? JSON.parse(jsonValue) : null;

--- a/apps/frontend/app/helper/DeviceHelper.ts
+++ b/apps/frontend/app/helper/DeviceHelper.ts
@@ -82,8 +82,7 @@ export function useBreakPointValue<T>(breakPoints: BreakPointsDictionary<T>): T 
 
 	const breakPointOrder = getSmallestToLargestBreakPointList().reverse(); // From largest to smallest for iteration.
 
-	for (let i = 0; i < breakPointOrder.length; i++) {
-		const breakPoint = breakPointOrder[i];
+	for (const breakPoint of breakPointOrder) {
 		const width: number | undefined = widthBreakPoints[breakPoint];
 		if (width && widthUnscaled >= width) {
 			const valueOfBreakPoint = breakPoints[breakPoint];

--- a/apps/frontend/app/helper/collectionHelper.ts
+++ b/apps/frontend/app/helper/collectionHelper.ts
@@ -8,7 +8,7 @@ export type FilterOperator = 'eq' | 'neq' | 'lt' | 'lte' | 'gt' | 'gte' | 'in' |
 export type Query<CollectionScheme> = {
 	fields?: (keyof CollectionScheme | string)[] | null;
 	sort?: (keyof CollectionScheme | string)[] | null;
-	filter?: any;
+	filter?: Record<string, any> | null;
 	deep?: Record<string, Query<CollectionScheme>> | null;
 	limit?: number | null;
 	offset?: number | null;

--- a/apps/frontend/app/helper/collectionHelper.ts
+++ b/apps/frontend/app/helper/collectionHelper.ts
@@ -8,7 +8,7 @@ export type FilterOperator = 'eq' | 'neq' | 'lt' | 'lte' | 'gt' | 'gte' | 'in' |
 export type Query<CollectionScheme> = {
 	fields?: (keyof CollectionScheme | string)[] | null;
 	sort?: (keyof CollectionScheme | string)[] | null;
-	filter?: any | null;
+	filter?: any;
 	deep?: Record<string, Query<CollectionScheme>> | null;
 	limit?: number | null;
 	offset?: number | null;

--- a/apps/frontend/app/helper/resourceHelper.tsx
+++ b/apps/frontend/app/helper/resourceHelper.tsx
@@ -26,17 +26,17 @@ const getIconComponent = (iconString: string, iconColor: string): JSX.Element | 
 };
 
 interface Translation {
-	languages_code: string;
-	text?: string;
-	name?: string;
-	content?: string;
-	description?: string;
-	title?: string;
+	languages_code: string | DatabaseTypes.Languages | null;
+	text?: string | null;
+	name?: string | null;
+	content?: string | null;
+	description?: string | null;
+	title?: string | null;
 }
 
-const getTextFromTranslation = (translations: Array<any>, languageCode: string): string => {
+const getTextFromTranslation = (translations: Array<Partial<Translation>> | null | undefined, languageCode: string): string => {
 	if (!translations || translations.length === 0) return '';
-	const translation = translations.find(t => t.languages_code?.split('-')[0] === languageCode);
+	const translation = translations.find(t => (t.languages_code as string)?.split('-')[0] === languageCode);
 	return translation?.text || translation?.name || translation?.content || '';
 };
 
@@ -58,9 +58,9 @@ export const getFromCategoryTranslation = (translations: Array<DatabaseTypes.For
 	return translation?.name || '';
 };
 
-export const getFoodAttributesTranslation = (translations: Array<any>, languageCode: string): string => {
+export const getFoodAttributesTranslation = (translations: Array<Partial<DatabaseTypes.FoodsAttributesTranslations> | Partial<Translation>> | null | undefined, languageCode: string): string => {
 	if (!translations || translations.length === 0) return '';
-	const translation = translations.find(t => t.languages_code?.split('-')[0] === languageCode);
+	const translation = translations.find(t => (t.languages_code as string)?.split('-')[0] === languageCode);
 	return translation?.name || '';
 };
 

--- a/apps/frontend/app/helper/resourceHelper.tsx
+++ b/apps/frontend/app/helper/resourceHelper.tsx
@@ -34,7 +34,7 @@ interface Translation {
 	title?: string;
 }
 
-const getTextFromTranslation = (translations: Array<Translation | any>, languageCode: string): string => {
+const getTextFromTranslation = (translations: Array<any>, languageCode: string): string => {
 	if (!translations || translations.length === 0) return '';
 	const translation = translations.find(t => t.languages_code?.split('-')[0] === languageCode);
 	return translation?.text || translation?.name || translation?.content || '';
@@ -58,7 +58,7 @@ export const getFromCategoryTranslation = (translations: Array<DatabaseTypes.For
 	return translation?.name || '';
 };
 
-export const getFoodAttributesTranslation = (translations: Array<DatabaseTypes.FoodsAttributesTranslations | Translation | any>, languageCode: string): string => {
+export const getFoodAttributesTranslation = (translations: Array<any>, languageCode: string): string => {
 	if (!translations || translations.length === 0) return '';
 	const translation = translations.find(t => t.languages_code?.split('-')[0] === languageCode);
 	return translation?.name || '';

--- a/apps/frontend/app/hooks/usePopupEventModal.tsx
+++ b/apps/frontend/app/hooks/usePopupEventModal.tsx
@@ -6,6 +6,7 @@ import { useAppSelector } from '@/redux/hooks';
 import { SET_POPUP_EVENTS } from '@/redux/Types/types';
 import useKioskMode from '@/hooks/useKioskMode';
 import type { ModalCloseReason } from 'repo-depkit-common-ui';
+import { DatabaseTypes } from 'repo-depkit-common';
 
 const usePopupEventModal = () => {
 	const dispatch = useDispatch();
@@ -13,7 +14,7 @@ const usePopupEventModal = () => {
 	const popupEvents = useAppSelector((state) => state.food.popupEvents, shallowEqual);
 	const { showAndDiscardOthers: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 	const popupEventShownIdRef = useRef<string | null>(null);
-	const [currentPopupEvent, setCurrentPopupEvent] = useState<any>(null);
+	const [currentPopupEvent, setCurrentPopupEvent] = useState<Partial<DatabaseTypes.PopupEvents> | null>(null);
 
 	// Events the user closed only via the header X button, backdrop tap or swipe-down
 	// in THIS app session. Those closes are deliberately NOT persisted as "seen"

--- a/apps/frontend/app/hooks/usePopupEventModal.tsx
+++ b/apps/frontend/app/hooks/usePopupEventModal.tsx
@@ -13,7 +13,7 @@ const usePopupEventModal = () => {
 	const popupEvents = useAppSelector((state) => state.food.popupEvents, shallowEqual);
 	const { showAndDiscardOthers: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 	const popupEventShownIdRef = useRef<string | null>(null);
-	const [currentPopupEvent, setCurrentPopupEvent] = useState<any | null>(null);
+	const [currentPopupEvent, setCurrentPopupEvent] = useState<any>(null);
 
 	// Events the user closed only via the header X button, backdrop tap or swipe-down
 	// in THIS app session. Those closes are deliberately NOT persisted as "seen"

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -1106,9 +1106,10 @@ export default function RouteDetailScreen() {
 		}
 
 		const count = routeActivities.length;
+		const activitiesText = count === 1 ? 'existiert noch eine Aktivität' : `existieren noch ${count} Aktivitäten`;
 		showAlert(
 			'Route löschen',
-			`Für diese Route ${count === 1 ? 'existiert noch eine Aktivität' : `existieren noch ${count} Aktivitäten`}. Was soll damit passieren?`,
+			`Für diese Route ${activitiesText}. Was soll damit passieren?`,
 			[
 				{ text: 'Abbrechen', style: 'cancel' },
 				{ text: 'Anderer Route zuordnen', onPress: handleOpenReassignPicker },

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -545,9 +545,9 @@ export function synthesizeManualActivityRoutePoints(
 	//     gridPathCells so the synthetic route points follow the actual red-line
 	//     grid instead of jumping from h10 centre to h10 centre.
 	const redLinePath: string[] = [];
-	for (let i = 0; i < hexTilesOrdered.length; i++) {
+	for (const hexTile of hexTilesOrdered) {
 		try {
-			const redLineCell = cellToCenterChild(hexTilesOrdered[i], RED_LINE_GRID_RESOLUTION) || hexTilesOrdered[i];
+			const redLineCell = cellToCenterChild(hexTile, RED_LINE_GRID_RESOLUTION) || hexTile;
 			if (redLinePath.length === 0) {
 				redLinePath.push(redLineCell);
 			} else {

--- a/apps/geonexia/frontend/helpers/TTSHelper.ts
+++ b/apps/geonexia/frontend/helpers/TTSHelper.ts
@@ -104,19 +104,19 @@ export function buildKmAnnouncement(
 
 	switch (langCode) {
 		case 'de':
-			return `${km} Kilometer${buildSpeedParts('Tempo', `Minuten {sec} Sekunden pro Kilometer`, 'Kilometer pro Stunde')}`;
+			return `${km} Kilometer${buildSpeedParts('Tempo', 'Minuten {sec} Sekunden pro Kilometer', 'Kilometer pro Stunde')}`;
 		case 'fr':
-			return `${km} kilomètre${km > 1 ? 's' : ''}${buildSpeedParts('allure', `minutes {sec} secondes par kilomètre`, 'kilomètres par heure')}`;
+			return `${km} kilomètre${km > 1 ? 's' : ''}${buildSpeedParts('allure', 'minutes {sec} secondes par kilomètre', 'kilomètres par heure')}`;
 		case 'es':
-			return `${km} kilómetro${km > 1 ? 's' : ''}${buildSpeedParts('ritmo', `minutos {sec} segundos por kilómetro`, 'kilómetros por hora')}`;
+			return `${km} kilómetro${km > 1 ? 's' : ''}${buildSpeedParts('ritmo', 'minutos {sec} segundos por kilómetro', 'kilómetros por hora')}`;
 		case 'it':
-			return `${km} chilometro${km > 1 ? 'i' : ''}${buildSpeedParts('passo', `minuti {sec} secondi al chilometro`, 'chilometri all\'ora')}`;
+			return `${km} chilometro${km > 1 ? 'i' : ''}${buildSpeedParts('passo', 'minuti {sec} secondi al chilometro', "chilometri all'ora")}`;
 		case 'pt':
-			return `${km} quilômetro${km > 1 ? 's' : ''}${buildSpeedParts('ritmo', `minutos {sec} segundos por quilômetro`, 'quilômetros por hora')}`;
+			return `${km} quilômetro${km > 1 ? 's' : ''}${buildSpeedParts('ritmo', 'minutos {sec} segundos por quilômetro', 'quilômetros por hora')}`;
 		case 'nl':
-			return `${km} kilometer${buildSpeedParts('tempo', `minuten {sec} seconden per kilometer`, 'kilometer per uur')}`;
+			return `${km} kilometer${buildSpeedParts('tempo', 'minuten {sec} seconden per kilometer', 'kilometer per uur')}`;
 		default:
-			return `${km} kilometer${km > 1 ? 's' : ''}${buildSpeedParts('pace', `minutes {sec} seconds per kilometer`, 'kilometers per hour')}`;
+			return `${km} kilometer${km > 1 ? 's' : ''}${buildSpeedParts('pace', 'minutes {sec} seconds per kilometer', 'kilometers per hour')}`;
 	}
 }
 

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -125,7 +125,8 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
   const result = await ascRequest(token, 'GET', `/apps/${appId}/appStoreVersions?${query}`);
   const versions = asArray(result.data);
 
-  console.log(`   Vorhandene App Store Versions (${versions.length}): ${versions.map(v => `${v.attributes?.versionString}=${v.attributes?.appStoreState}`).join(', ') || '(keine)'}`);
+  const versionsSummary = versions.map(v => `${v.attributes?.versionString}=${v.attributes?.appStoreState}`).join(', ') || '(keine)';
+  console.log(`   Vorhandene App Store Versions (${versions.length}): ${versionsSummary}`);
 
   const exactMatch = versions.find(v => v.attributes?.versionString === versionString);
   if (exactMatch) {

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -71,6 +71,9 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Prefer using nullish coalescing operator (`??=` / `??`). | 18 von 18 (Codemod mit Zeilenverifikation; alle Ziel-Typen `X \| null` bzw. `boolean \| undefined`) | – |
 | 2026-07-20 | Redirect this error message to stderr (>&2). | 14 von 14 (nur Shell-Skripte, `bash -n` geprüft) | – |
 | 2026-07-20 | 'If' statement should not be the only statement in 'else' block. | 10 von 10 (`else { if }` → `else if`) | – |
+| 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | – |
+| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | – |
+| 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | – |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 
@@ -79,7 +82,7 @@ Neu abgearbeitete Typen bitte hier ergänzen.
 component" (97x), „Array index in keys" (60x, braucht stabile IDs), TODO-Kommentare
 (39x), Funktions-Verschachtelung (35x), Exception-Handling (23x), „Default parameters
 should be last" (20x, ändert Aufrufer), „Add an explicit return" (20x),
-`await` auf Non-Promise (16x), Parameter-Reihenfolge (16x), for-of (12x).
+`await` auf Non-Promise (16x), Parameter-Reihenfolge (16x).
 Diese Typen in kleinen, thematisch gruppierten PRs separat angehen.
 
 ## Hinweise

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -72,7 +72,7 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Redirect this error message to stderr (>&2). | 14 von 14 (nur Shell-Skripte, `bash -n` geprüft) | – |
 | 2026-07-20 | 'If' statement should not be the only statement in 'else' block. | 10 von 10 (`else { if }` → `else if`) | – |
 | 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | #3953 |
-| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | #3953 |
+| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (wo möglich sprechende Typen wie `Partial<...>` statt `any`; sonst redundante Union-Member entfernt) | #3953 |
 | 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
 
 Neu abgearbeitete Typen bitte hier ergänzen.

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -71,9 +71,9 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Prefer using nullish coalescing operator (`??=` / `??`). | 18 von 18 (Codemod mit Zeilenverifikation; alle Ziel-Typen `X \| null` bzw. `boolean \| undefined`) | – |
 | 2026-07-20 | Redirect this error message to stderr (>&2). | 14 von 14 (nur Shell-Skripte, `bash -n` geprüft) | – |
 | 2026-07-20 | 'If' statement should not be the only statement in 'else' block. | 10 von 10 (`else { if }` → `else if`) | – |
-| 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | – |
-| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | – |
-| 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | – |
+| 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | #3953 |
+| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | #3953 |
+| 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 

--- a/packages/common/src/DateHelper.ts
+++ b/packages/common/src/DateHelper.ts
@@ -88,8 +88,7 @@ export class DateHelper {
   static getWeekdayByIndex(weekdayNumber: number): Weekday {
     const modulo = weekdayNumber % 7;
     const enumValues = DateHelper.getWeekdayEnumsValues();
-    for (let i = 0; i < enumValues.length; i++) {
-      const weekdayEnum = enumValues[i];
+    for (const weekdayEnum of enumValues) {
       if (weekdayEnum) {
         const weekdayIndex = DateHelper.getWeekdayIndex(weekdayEnum);
         if (weekdayIndex === modulo) {
@@ -167,8 +166,7 @@ export class DateHelper {
     const weekdayIndex = date.getDay();
     const weekdayEnums = DateHelper.getWeekdayEnumsValues();
     const indexToWeekdayEnum: { [index: number]: Weekday } = {};
-    for (let i = 0; i < weekdayEnums.length; i++) {
-      const weekdayEnum = weekdayEnums[i];
+    for (const weekdayEnum of weekdayEnums) {
       if (weekdayEnum) {
         const weekdayEnumIndex = DateHelper.getWeekdayIndex(weekdayEnum);
         indexToWeekdayEnum[weekdayEnumIndex] = weekdayEnum;


### PR DESCRIPTION
## Zusammenfassung

Nächste Runde des SonarCloud-Maintainability-Workflows (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`). Die verbliebenen Top-10-Typen sind laut Workflow-Doku bewusst zurückgestellte, größere Einzel-Refactorings — daher wurden hier die drei nächsten halb-mechanischen Typen (Plätze 11–13) vollständig abgearbeitet: **34 Fixes**, bewusst klein gehalten, damit der Review überschaubar bleibt.

### Behobene Issue-Typen

| Issue-Typ | Fixes | Vorgehen |
|---|---|---|
| Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 | Index-Loops über Arrays auf `for-of` umgestellt; das Cheerio-Objekt im News-Parser wird über `.toArray()` iteriert. |
| 'any' overrides all other types in this union type. | 12 von 12 | Wo möglich sprechende Typen statt `any` (siehe unten); an den übrigen Stellen redundante Union-Member entfernt (`any \| null` → `any`). |
| Refactor this code to not use nested template literals. | 10 von 10 | Innere Template-Literale ohne Interpolation zu normalen Strings gemacht (TTSHelper, 7x); die übrigen 3 in benannte Variablen extrahiert. |

### `any`-Stellen: sprechende Typen statt blankem `any`

Wo ein konkreter Typ die Absicht dokumentiert und mit allen Aufrufern kompiliert, wurde er verwendet:

- `helper/resourceHelper.tsx`: `getTextFromTranslation` und `getFoodAttributesTranslation` nehmen jetzt `Array<Partial<Translation>>` (bzw. `... | Partial<DatabaseTypes.FoodsAttributesTranslations>`); das lokale `Translation`-Interface wurde an die generierten Directus-Typen angeglichen (`languages_code: string | Languages | null`, Felder `| null`). **Nebeneffekt:** behebt einen vorbestehenden Typfehler in `SettingsListMarkingLabelFast.tsx`.
- `app/index.tsx`: `savePushTokenToAPI` nimmt `profile: Partial<DatabaseTypes.Profiles>`.
- `hooks/usePopupEventModal.tsx` + `app/(app)/events/index.tsx`: `useState<Partial<DatabaseTypes.PopupEvents> | null>` statt `useState<any>`.
- `helper/collectionHelper.ts`: `Query.filter` ist jetzt `Record<string, any> | null` (dokumentiert „Objekt", Operator-Struktur bleibt offen).
- Backend `MyDatabaseHelperInterface.ts`: `cachedClient` als typisierter Directus-REST-Client. Dabei kam eine vom `any` versteckte Diskrepanz zwischen SDK-`ServerInfoOutput` und lokalem `ServerInfo` ans Licht — in `downloadServerInfo` per kommentiertem Cast dokumentiert.

Bewusst bei `any` belassen (kein sinnvoller konkreter Typ möglich):

- `push-notification-hook/index.ts` `data`/`richContent`: Quelle ist `message_data?: unknown | null` bzw. heterogene Quellen inkl. `JSON.parse`.
- `constants/AsyncStorageHelper.ts` `getValue`: `JSON.parse`-Ergebnis ist tatsächlich beliebig.
- `feedback-support/index.tsx` `inputValues`: beliebige Formularwerte.
- `CourseTimeTable/CourseBottomSheet.tsx` `selectedItem`: lokale, untypisierte Timetable-Zeilen ohne benannten Typ.

### Verifikation

- `directus-extension-rocket-meals-bundle`: `yarn typecheck` ohne Fehler.
- `packages/common`: `yarn test` — 38 Tests grün (inkl. `DateHelper`).
- `apps/frontend/app` und `apps/geonexia/frontend`: `tsc --noEmit` vor/nach der Änderung verglichen — keine neuen Fehler; ein vorbestehender Fehler wurde behoben (s. o.).
- `apps/scripts`: `tsc --noEmit` zeigt nur den vorbestehenden `replaceAll`-/`lib`-Fehler in Zeile 26 (nicht angefasst).

### Aktuelle Top 10 (nach diesem PR verbleibend)

1. 109x Refactor this function to reduce its Cognitive Complexity
2. 97x Move this component definition out of the parent component
3. 60x Do not use Array index in keys
4. 39x Complete the task associated to this "TODO" comment
5. 35x Refactor this code to not nest functions more than N levels deep
6. 23x Handle this exception or don't catch it at all
7. 20x Default parameters should be last
8. 20x Add an explicit return statement at the end of the function
9. 16x Unexpected `await` of a non-Promise value
10. 16x Arguments have the same names but not the same order as the function parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKX8i3BHprhykPRWVjZr3R