### PR TITLE
refactor: fix 36 SonarCloud maintainability issues (explicit shell returns, redundant awaits)

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -271,7 +271,7 @@ export class ParseSchedule {
   }
 
   async getFoodsService() {
-    return await this.context.myDatabaseHelper.getFoodsHelper();
+    return this.context.myDatabaseHelper.getFoodsHelper();
   }
 
   getFoodofferDatesFromRawFoodofferJSONList(foodoffersForParser: FoodoffersTypeForParser[]): FoodofferDateType[] {
@@ -288,7 +288,7 @@ export class ParseSchedule {
   static readonly DELETE_BATCH_SIZE = 250;
 
   async deleteFoodOffers(foodoffers: DatabaseTypes.Foodoffers[], notice: string) {
-    let itemService = await this.context.myDatabaseHelper.getFoodoffersHelper();
+    let itemService = this.context.myDatabaseHelper.getFoodoffersHelper();
     let idsToDelete = foodoffers.map(item => item.id);
 
     if (idsToDelete.length > 0) {
@@ -362,7 +362,7 @@ export class ParseSchedule {
       if (!canteen) continue;
 
       const canteenFoodoffers = foodoffersForParserGroupedByCanteen[canteenExternalIdentifier] || [];
-      const foodoffersHelper = await this.context.myDatabaseHelper.getFoodoffersHelper();
+      const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
 
       if (canteen.foodoffers_import_without_date) {
         // Import-without-date canteen: all offers have date=null, process as a single group.
@@ -512,7 +512,7 @@ export class ParseSchedule {
       await this.context.logger.appendLog('Sync: checking all canteens for missing report data (oldest report date: ' + globalOldestDateString + ')');
       const canteensHelper = this.context.myDatabaseHelper.getCanteensHelper();
       const allCanteens = await canteensHelper.readAllItems();
-      const foodoffersHelper = await this.context.myDatabaseHelper.getFoodoffersHelper();
+      const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
 
       for (const canteen of allCanteens) {
         const externalIdentifier = canteen.external_identifier;
@@ -1097,7 +1097,7 @@ export class ParseSchedule {
 
     const batchSize = 10;
 
-    const myFoodOffersService = await this.context.myDatabaseHelper.getFoodoffersHelper();
+    const myFoodOffersService = this.context.myDatabaseHelper.getFoodoffersHelper();
 
     const myTimer = new MyTimer(SCHEDULE_NAME + ' - Create Food Offers (' + canteenInfo + ', ' + dateInfo + ')');
     await this.context.logger.appendLog('Amount of food offers to create: ' + foodoffersToCreate.length)
@@ -1138,7 +1138,7 @@ export class ParseSchedule {
   }
 
   async updateMarkings(markingsJSONList: MarkingsTypeForParser[]) {
-    let itemService = await this.context.myDatabaseHelper.getMarkingsHelper();
+    let itemService = this.context.myDatabaseHelper.getMarkingsHelper();
 
     markingsJSONList = ListHelper.removeDuplicatesFromJsonList(markingsJSONList, 'external_identifier'); // Remove duplicates https://github.com/rocket-meals/rocket-meals/issues/151
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
@@ -128,7 +128,7 @@ export class MaxManagerConnector implements FoodParserInterface, MarkingParserIn
     private async getHtml(canteenId: string, fetchDate: Date, initialHtml: string): Promise<string | undefined> {
         if(this.config.fileContentReader){
             const fileContentReader = this.config.fileContentReader;
-            let fileContent = await fileContentReader.getContent();
+            let fileContent = fileContentReader.getContent();
             return fileContent;
         }
         if(this.config.url){

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/customers/hannover/FormHousingContractsWorkflowHannover.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/customers/hannover/FormHousingContractsWorkflowHannover.ts
@@ -26,7 +26,7 @@ export class FormHousingContractsWorkflowHannover extends FormImportSyncWorkflow
   }
 
   async getCurrentResultHash(): Promise<WorkflowResultHash> {
-    let hash = await this.reader.getResultHash(this.contracts);
+    let hash = this.reader.getResultHash(this.contracts);
     return new WorkflowResultHash(hash);
   }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/AvatarHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/AvatarHelper.ts
@@ -10,7 +10,7 @@ export class AvatarHelper {
     const database = myDatabaseHelper?.eventContext?.database || myDatabaseHelper?.apiContext.database;
     // TODO: check if we can use instead of database the userService to handle/manipulate users
 
-    const filesService = await myDatabaseHelper.getFilesHelper();
+    const filesService = myDatabaseHelper.getFilesHelper();
     if (!userId) {
       throw new Error('deleteAvatarOfUser: No userId provided: ');
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelper.ts
@@ -52,7 +52,7 @@ export class MyDatabaseHelper implements MyDatabaseHelperInterface {
   }
 
   async getAdminBearerToken(): Promise<string | undefined> {
-    let usersHelper = await this.getUsersHelper();
+    let usersHelper = this.getUsersHelper();
     let adminEmail = EnvVariableHelper.getAdminEmail();
     let adminUser = await usersHelper.findFirstItem({
       email: adminEmail,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ShareServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ShareServiceHelper.ts
@@ -52,7 +52,7 @@ export class ShareServiceHelper implements ShareDirectusFileMethod {
   }
 
   async createShareLink(options: CreateShareLinkOptions): Promise<string | null> {
-    let usersHelper = await this.myDatabaseHelper.getUsersHelper();
+    let usersHelper = this.myDatabaseHelper.getUsersHelper();
     let adminEmail = EnvVariableHelper.getAdminEmail();
     let adminUser = await usersHelper.findFirstItem({
       email: adminEmail,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -87,7 +87,7 @@ export class TranslationHelper {
     config: TranslationUpdateConfig<E>
   ) {
     const { translationsFromParsing, items_primary_field_in_translation_table, itemsTablename, myDatabaseHelper } = config;
-    const specificItemServiceReader = await myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
+    const specificItemServiceReader = myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
     if (itemWithTranslations) {
       const { updateObject: updateObject, updateNeeded: updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations(itemWithTranslations, itemWithTranslations, translationsFromParsing, items_primary_field_in_translation_table);
 
@@ -136,7 +136,7 @@ export class TranslationHelper {
     config: TranslationUpdateConfig<E>
   ) {
     const { itemsTablename, myDatabaseHelper } = config;
-    const specificItemServiceReader = await myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
+    const specificItemServiceReader = myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
     let itemWithTranslations = await specificItemServiceReader.readOne(item?.id, {
       ...TranslationHelper.QUERY_FIELDS_FOR_ALL_FIELDS_AND_FOR_TRANSLATION_FETCHING,
     }); // Bottleneck HERE. Takes on average 1.0s

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/NewsParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/NewsParseSchedule.ts
@@ -59,7 +59,7 @@ export class NewsParseSchedule {
   }
 
   async findOrCreateSingleNews(newsJSON: NewsTypeForParser) {
-    let itemService = await this.context.myDatabaseHelper.getNewsHelper();
+    let itemService = this.context.myDatabaseHelper.getNewsHelper();
 
     const searchJson = {
       external_identifier: newsJSON?.basicNews.external_identifier,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
@@ -188,7 +188,7 @@ async function modifyInputForCreateOrUpdateWorkflowRunToRunning(
           throw new Error('-- No WorkflowRunJobInterface found for workflowId: ' + workflowId);
         } else {
           console.log('Handling workflow_runs for workflowId: ' + workflowId);
-          let result = await workflowRunJobInterface.handleWorkflowRunsWantToRun(input, workflowRuns, alreadyRunningWorkflowRuns);
+          let result = workflowRunJobInterface.handleWorkflowRunsWantToRun(input, workflowRuns, alreadyRunningWorkflowRuns);
           if (result.errorMessage) {
             console.error('Error while setting workflow_runs to running: ' + result.errorMessage);
             throw new Error('Error while setting workflow_runs to running: ' + result.errorMessage);

--- a/apps/backend/backupRestore.sh
+++ b/apps/backend/backupRestore.sh
@@ -15,6 +15,7 @@ get_docker_compose_cmd() {
         echo "Neither docker-compose nor docker compose is available. Please install one of them."
         exit 1
     fi
+    return 0
 }
 
 DOCKER_COMPOSE_CMD=$(get_docker_compose_cmd)
@@ -63,6 +64,7 @@ select_backup() {
             echo "Invalid selection. Please try again."
         fi
     done
+    return 0
 }
 
 # Main entry point

--- a/apps/backend/genSSO_Apple.sh
+++ b/apps/backend/genSSO_Apple.sh
@@ -4,6 +4,7 @@
 function show_help() {
     echo "Usage: ./genSSO_Apple.sh --team_id <team_id> --client_id <client_id> --key_id <key_id> --key_file_path <path_to_key_file>"
     echo "or:    ./genSSO_Apple.sh --team_id <team_id> --client_id <client_id> --key_id <key_id> --key_file_content '<key_file_content>'"
+    return 0
 }
 
 # Initialize variables for parameters
@@ -103,6 +104,7 @@ CLAIMS=$(printf '{"iss":"%s","iat":%d,"exp":%d,"aud":"https://appleid.apple.com"
 # Base64 URL encode function
 base64_url_encode() {
     openssl enc -base64 -A | tr '+/' '-_' | tr -d '='
+    return 0
 }
 
 # Create JWT token
@@ -127,6 +129,7 @@ function convert_ec {
 
     echo -n $R | xxd -r -p
     echo -n $S | xxd -r -p
+    return 0
 }
 SIGNATURE=$(echo -n "$JWT_HEADER_BASE64.$JWT_CLAIMS_BASE64" | openssl dgst -binary -sha256 -sign <(echo "$ECDSA_KEY") | convert_ec | openssl base64 -e -A | tr '+/' '-_' | tr -d '\n=')
 

--- a/apps/frontend/app/helper/SystemActionHelper.ts
+++ b/apps/frontend/app/helper/SystemActionHelper.ts
@@ -29,7 +29,7 @@ export class CommonSystemActionHelper {
 			if (newWindow) {
 				target = '_blank';
 			}
-			await window.open(url, target);
+			window.open(url, target);
 		}
 	}
 

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -72,7 +72,7 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Redirect this error message to stderr (>&2). | 14 von 14 (nur Shell-Skripte, `bash -n` geprüft) | – |
 | 2026-07-20 | 'If' statement should not be the only statement in 'else' block. | 10 von 10 (`else { if }` → `else if`) | – |
 | 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | #3953 |
-| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | #3953 |
+| 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (wo möglich sprechende Typen wie `Partial<...>` statt `any`; sonst redundante Union-Member entfernt) | #3953 |
 | 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
 | 2026-07-20 | Add an explicit return statement at the end of the function. | 20 von 20 (nur Shell-Skripte, `return 0` am Funktionsende; kein Aufrufer wertet den Exit-Status aus, `bash -n` geprüft) | #3954 |
 | 2026-07-20 | Unexpected `await` of a non-Promise (non-"Thenable") value. | 16 von 16 (`await` entfernt; alle Zielmethoden verifiziert synchron, z. B. MyDatabaseHelper-Getter, `window.open`) | #3954 |

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -74,6 +74,8 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | #3953 |
 | 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | #3953 |
 | 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
+| 2026-07-20 | Add an explicit return statement at the end of the function. | 20 von 20 (nur Shell-Skripte, `return 0` am Funktionsende; kein Aufrufer wertet den Exit-Status aus, `bash -n` geprüft) | – |
+| 2026-07-20 | Unexpected `await` of a non-Promise (non-"Thenable") value. | 16 von 16 (`await` entfernt; alle Zielmethoden verifiziert synchron, z. B. MyDatabaseHelper-Getter, `window.open`) | – |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 
@@ -81,8 +83,7 @@ Neu abgearbeitete Typen bitte hier ergänzen.
 „Cognitive Complexity" (113x), „Move this component definition out of the parent
 component" (97x), „Array index in keys" (60x, braucht stabile IDs), TODO-Kommentare
 (39x), Funktions-Verschachtelung (35x), Exception-Handling (23x), „Default parameters
-should be last" (20x, ändert Aufrufer), „Add an explicit return" (20x),
-`await` auf Non-Promise (16x), Parameter-Reihenfolge (16x).
+should be last" (20x, ändert Aufrufer), Parameter-Reihenfolge (16x).
 Diese Typen in kleinen, thematisch gruppierten PRs separat angehen.
 
 ## Hinweise

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -74,8 +74,8 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | #3953 |
 | 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (redundante Union-Member entfernt, `any` beibehalten — keine Typ-Semantik geändert) | #3953 |
 | 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
-| 2026-07-20 | Add an explicit return statement at the end of the function. | 20 von 20 (nur Shell-Skripte, `return 0` am Funktionsende; kein Aufrufer wertet den Exit-Status aus, `bash -n` geprüft) | – |
-| 2026-07-20 | Unexpected `await` of a non-Promise (non-"Thenable") value. | 16 von 16 (`await` entfernt; alle Zielmethoden verifiziert synchron, z. B. MyDatabaseHelper-Getter, `window.open`) | – |
+| 2026-07-20 | Add an explicit return statement at the end of the function. | 20 von 20 (nur Shell-Skripte, `return 0` am Funktionsende; kein Aufrufer wertet den Exit-Status aus, `bash -n` geprüft) | #3954 |
+| 2026-07-20 | Unexpected `await` of a non-Promise (non-"Thenable") value. | 16 von 16 (`await` entfernt; alle Zielmethoden verifiziert synchron, z. B. MyDatabaseHelper-Getter, `window.open`) | #3954 |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 

--- a/generate_basic_auth_traefik.sh
+++ b/generate_basic_auth_traefik.sh
@@ -5,6 +5,7 @@ generate_basic_auth() {
   local username=$1
   local password=$2
   echo -n "$username:$password" | base64
+  return 0
 }
 
 # Function to update .env file
@@ -27,12 +28,14 @@ update_env_file() {
     echo "BASIC_AUTH=${basic_auth_value}" >> .env
     echo "BASIC_AUTH value added to .env file."
   fi
+  return 0
 }
 
 # Function to get username
 get_username() {
   read -p "Enter username: " username
   echo "$username"
+  return 0
 }
 
 # Function to get password with confirmation
@@ -50,6 +53,7 @@ get_password() {
       echo "Passwords do not match. Please try again."
     fi
   done
+  return 0
 }
 
 # Main script

--- a/scripts/generateIcons.sh
+++ b/scripts/generateIcons.sh
@@ -13,6 +13,7 @@ check_imagemagick() {
             exit 1
         fi
     fi
+    return 0
 }
 
 # Function to install ImageMagick
@@ -40,6 +41,7 @@ install_imagemagick() {
         echo "Unsupported operating system. Please install ImageMagick manually."
         exit 1
     fi
+    return 0
 }
 
 # Function to print usage help
@@ -51,6 +53,7 @@ print_usage() {
     echo "  <path_to_company_logo> Path to the company logo file"
     echo "  [output_folder]        Optional: Path to the output folder. Default is ./app/assets/images/"
     echo "  --project-dir <dir>    Optional: Path to the project directory. Output folder will be <dir>/assets/"
+    return 0
 }
 
 # Define default output folder
@@ -68,6 +71,7 @@ SPLASH_SIZE="1155x2500"
 calculate_splash_logo_width() {
     local splash_width=$(echo $SPLASH_SIZE | cut -dx -f1)
     SPLASH_LOGO_WIDTH=$(echo "$splash_width * 0.9" | bc)
+    return 0
 }
 
 ## Converts transparent pixels in a PNG from black-transparent (0,0,0,0) to
@@ -93,6 +97,7 @@ convert_transparent_to_white() {
         -delete 0 -compose CopyOpacity -composite \
         -colorspace sRGB \
         PNG32:"$output_path"
+    return 0
 }
 
 generate_splash_icon() {
@@ -122,6 +127,7 @@ generate_splash_icon() {
 
     # Also generate splash.png (used by expo-splash-screen)
     cp "$splash_icon_path" "$OUTPUT_FOLDER/splash.png"
+    return 0
 }
 
 generate_adaptive_icon() {
@@ -134,6 +140,7 @@ generate_adaptive_icon() {
 
     convert "$icon_path" -resize ${icon_size}x${icon_size} \
         -gravity center -background none -extent $ADAPTIVE_ICON_SIZE "$output_path"
+    return 0
 }
 
 generate_adaptive_icon_background() {
@@ -141,6 +148,7 @@ generate_adaptive_icon_background() {
 
     # Erzeuge weißes (nicht transparentes) Bild
     convert -size $ADAPTIVE_ICON_SIZE xc:white "$output_path"
+    return 0
 }
 
 # Function to compute SHA-256 hash of a file
@@ -154,6 +162,7 @@ compute_file_hash() {
         echo "ERROR: No SHA-256 hash tool found" >&2
         exit 1
     fi
+    return 0
 }
 
 # Function to write hash JSON file for source tracking
@@ -178,6 +187,7 @@ write_hash_file() {
 EOF
 
     echo "Hash file written to $hash_file"
+    return 0
 }
 
 # Function to generate images
@@ -212,6 +222,7 @@ generate_images() {
 
     # Write hash file for source tracking
     write_hash_file "$icon_path" "$logo_path"
+    return 0
 }
 
 # Main script execution


### PR DESCRIPTION
## Zusammenfassung

Zweite Runde des SonarCloud-Maintainability-Workflows (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`): die zwei nächsten mechanisch prüfbaren Typen mit vielen Vorkommen — **36 Fixes**, jeder Fix ist eine Ein-Zeilen-Änderung.

> **Hinweis (gestapelter PR):** Basiert auf #3953, damit die Workflow-Doku-Tabelle nicht konfligiert. Base ist der Branch von #3953; nach dessen Merge bitte zuerst prüfen, dass GitHub die Base automatisch auf `master` umgestellt hat (passiert beim Merge mit Branch-Löschung automatisch). Der Diff hier zeigt nur die 36 neuen Fixes.

### Behobene Issue-Typen

| Issue-Typ | Fixes | Vorgehen |
|---|---|---|
| Add an explicit return statement at the end of the function. | 20 von 20 | Ausschließlich Shell-Funktionen (`backupRestore.sh`, `genSSO_Apple.sh`, `generate_basic_auth_traefik.sh`, `generateIcons.sh`): `return 0` am Funktionsende ergänzt. Verifiziert: Kein Aufrufer wertet den Exit-Status dieser Funktionen aus (keine `if func`/`&&`/`set -e`/`pipefail`-Konstrukte), die Semantik bleibt also unverändert. `bash -n` für alle 4 Skripte grün. |
| Unexpected `await` of a non-Promise (non-"Thenable") value. | 16 von 16 | Redundantes `await` vor synchronen Aufrufen entfernt. Jede Zielmethode wurde geprüft und ist synchron: die `MyDatabaseHelper`-Getter (`getFoodsHelper`, `getFoodoffersHelper`, `getMarkingsHelper`, `getNewsHelper`, `getUsersHelper`, `getFilesHelper`, `getItemsServiceHelper`), `MaxManagerFileContentReader.getContent(): string`, `HannoverTL1HousingFileReader.getResultHash(): string`, `handleWorkflowRunsWantToRun(): ResultHandleWorkflowRunsWantToRun` sowie `window.open` im Frontend. Die umgebenden Funktionen bleiben `async`. |

### Ausgelassene Stellen

Keine — alle 36 gemeldeten Vorkommen der beiden Typen wurden behoben.

### Verifikation

- Shell: `bash -n` für alle 4 geänderten Skripte ohne Fehler.
- `directus-extension-rocket-meals-bundle`: `yarn typecheck` ohne Fehler.
- `apps/frontend/app`: `tsc --noEmit` vor/nach der Änderung verglichen — Fehlerliste identisch (keine neuen Fehler).

### Aktuelle Top 10 (nach diesem PR verbleibend)

1. 109x Refactor this function to reduce its Cognitive Complexity
2. 97x Move this component definition out of the parent component
3. 60x Do not use Array index in keys
4. 39x Complete the task associated to this "TODO" comment
5. 35x Refactor this code to not nest functions more than N levels deep
6. 23x Handle this exception or don't catch it at all
7. 20x Default parameters should be last (ändert Aufrufer)
8. 16x Arguments have the same names but not the same order as the function parameters
9. 12x Expected a `for-of` loop (in #3953 behoben, wartet auf nächsten Scan)
10. 12x 'any' overrides all other types in this union type (in #3953 behoben, wartet auf nächsten Scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKX8i3BHprhykPRWVjZr3R

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKX8i3BHprhykPRWVjZr3R)_