### PR TITLE
fix(sonar): remove 97 useless variable assignments; group quoted identifiers in issue counting

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/file-cleanup-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/file-cleanup-hook/index.ts
@@ -207,7 +207,7 @@ export class FileCleanupWorkflow extends SingleWorkflowRun {
       diskSpaceDict: FileDiskSpaceDict;
     }
   ): Promise<string[]> {
-    const { context, filesHelper, dict, diskSpaceDict } = params;
+    const { filesHelper, dict, diskSpaceDict } = params;
     const unreferencedFiles: string[] = [];
     for (const fileId in dict) {
       const file = await filesHelper.readOne(fileId);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-notify-schedule-hook/NotifySchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-notify-schedule-hook/NotifySchedule.ts
@@ -170,7 +170,7 @@ export class NotifySchedule {
       date: Date;
     }
   ) {
-    const { expoPushToken, foodOffer, foodWithTranslations, language, aboutMealsInDays, date } = params;
+    const { expoPushToken, foodWithTranslations, language, aboutMealsInDays, date } = params;
     // Create a new push_notification entry in the database
     let pushNotificationService = this.context.myDatabaseHelper.getPushNotificationsHelper();
     /**

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/MarkingTL1Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/MarkingTL1Parser.ts
@@ -41,7 +41,6 @@ export class MarkingTL1Parser implements MarkingParserInterface {
   private static getMarkingJSONFromRawMarking(rawMarking: { [p: string]: string }): MarkingsTypeForParser | null {
     let id = rawMarking['ID'];
     let name = rawMarking['BESCHREIBUNG'];
-    let hint = rawMarking['HINWEISE'];
     let short = rawMarking['KUERZEL'];
 
     let external_identifier = MarkingTL1Parser.getMarkingExternalIdentifier(id, short);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -14,7 +14,7 @@ import {CollectionNames, DatabaseTypes, DateHelper, DirectusItemStatus} from 're
 import {MarkingParserInterface, MarkingsTypeForParser} from './MarkingParserInterface';
 import {ListHelper} from '../helpers/ListHelper';
 import {DictMarkingsExclusions, MarkingFilterHelper} from '../helpers/MarkingFilterHelper';
-import {MyTimer, MyTimers} from '../helpers/MyTimer';
+import {MyTimer} from '../helpers/MyTimer';
 import {HashHelper} from '../helpers/HashHelper';
 import {WORKFLOW_RUN_STATE} from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 import {WorkflowResultHash} from '../helpers/itemServiceHelpers/WorkflowsRunHelper';
@@ -1101,7 +1101,6 @@ export class ParseSchedule {
 
     const myTimer = new MyTimer(SCHEDULE_NAME + ' - Create Food Offers (' + canteenInfo + ', ' + dateInfo + ')');
     await this.context.logger.appendLog('Amount of food offers to create: ' + foodoffersToCreate.length)
-    const myTimersEmitEvents = new MyTimers('disableEventEmit_TRUE', 'disableEventEmit_FALSE');
 
     let batchIndex = 1;
     const amountOfBatches = Math.ceil(foodoffersToCreate.length / batchSize);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/FilesServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/FilesServiceHelper.ts
@@ -59,8 +59,6 @@ export class FilesServiceHelper extends ItemsServiceHelper<DatabaseTypes.Directu
    * @returns The id of the created file
    */
   async uploadOneFromBuffer(buffer: Buffer, filename: string, fileType: MyFileTypes, myDatabaseHelper: MyDatabaseHelperInterface, directus_folder_id?: string): Promise<PrimaryKey> {
-    const filesHelper = new FilesServiceHelper(myDatabaseHelper);
-
     // Convert Buffer to a Readable Stream
     const stream = new Readable();
     stream.push(buffer);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceHelper.ts
@@ -61,7 +61,7 @@ export class ItemsServiceHelper<T> implements ItemsService<T> {
 
   // async updateOneItemWithoutHookTrigger(item: TypeWithId<Partial<T>>, update: Partial<T>, optsCustom?: OptsCustomType): Promise<void> {
   async updateOneWithoutHookTrigger(data: UpdateOneProps<T>): Promise<void> {
-    let { primary_key, update, optsCustom } = data;
+    let { primary_key, update } = data;
     let database = this.apiContext.database;
     //console.log("Updating item without hook trigger - post");
     await database(this.tablename).update(update).where('id', primary_key);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ai/image/ImageRawGeneratorChatGpt.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ai/image/ImageRawGeneratorChatGpt.ts
@@ -96,11 +96,7 @@ export class ImageRawGeneratorChatGpt implements ImageRawGeneratorInterface{
     });
     //console.log("Received image generation response.");
 
-    let usage = result.usage;
-    let input_tokens = usage?.input_tokens || 0;
-    let output_tokens = usage?.output_tokens || 0;
-    let total_tokens = usage?.total_tokens || 0;
-    //console.log(`Image generation token usage - Input: ${input_tokens}, Output: ${output_tokens}, Total: ${total_tokens}`);
+    //console.log(`Image generation token usage - Input: ${result.usage?.input_tokens}, Output: ${result.usage?.output_tokens}, Total: ${result.usage?.total_tokens}`);
 
 // Save the image to a file
     const resultData = result?.data?.[0];

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/proof-key-code-exchange-endpoint/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/proof-key-code-exchange-endpoint/index.ts
@@ -267,14 +267,12 @@ function checkIfProviderRegistered(provider: string) {
 
 function generateAuthorizationCode(amountBytes?: number) {
   const bytesMinAmount = 32;
-  const bytesMaxAmount = 96;
   const usedAmountBytes = amountBytes || bytesMinAmount;
   const authorization_code = crypto.randomBytes(usedAmountBytes).toString('hex');
   return authorization_code;
 }
 
 function generateStateCode() {
-  const bytesMinAmount = 16;
   const bytesDefaultAmount = 32;
   return crypto.randomBytes(bytesDefaultAmount).toString('hex');
 }
@@ -282,7 +280,7 @@ function generateStateCode() {
 export default defineEndpoint({
   id: EndpointTopName,
   handler: (router, apiContext) => {
-    const { services, database, getSchema, env, logger } = apiContext;
+    const { database, env } = apiContext;
 
     const redisUrl = env?.['REDIS'];
     let validRedisUrl: string | null = null;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/push-notification-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/push-notification-hook/index.ts
@@ -148,7 +148,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
     console.log(messages);
 
     try {
-      let answer = await axios.post('https://exp.host/--/api/v2/push/send', messages);
+      await axios.post('https://exp.host/--/api/v2/push/send', messages);
       input.status_log = 'success';
     } catch (e: any) {
       console.log(`Failed to send notification: ${e.message}`);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/redirect-with-token-endpoint/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/redirect-with-token-endpoint/index.ts
@@ -177,7 +177,7 @@ export default defineEndpoint({
       }
       // REFERER: https://accounts.google.com/
 
-      const { services, database, getSchema, env, logger } = apiContext;
+      const { database, env } = apiContext;
 
       const myDatabaseHelper = new MyDatabaseHelper(apiContext);
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
@@ -114,7 +114,7 @@ class WashingmachinesWorkflow extends SingleWorkflowRun {
 }
 
 export default MyDefineHook.defineHookWithAllTablesExisting(HOOK_NAME,async (registerFunctions: RegisterFunctions, apiContext) => {
-  const { action, filter, schedule } = registerFunctions;
+  const { schedule } = registerFunctions;
 
   registerWashingmachinesFilterUpdate(apiContext, registerFunctions);
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
@@ -310,7 +310,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
         id: workflowId,
         alias: workflowId,
       };
-      let workflow = await myDatabaseHelper.getWorkflowsHelper().upsertOne(searchAndUpdate);
+      await myDatabaseHelper.getWorkflowsHelper().upsertOne(searchAndUpdate);
     }
   });
 

--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -101,7 +101,7 @@ export default function Layout() {
 	useEffect(() => {
 		loggedInRef.current = loggedIn;
 	}, [loggedIn]);
-	const { canteens, selectedCanteen: persistedCanteen } = useAppSelector((state) => state.canteenReducer);
+	const { selectedCanteen: persistedCanteen } = useAppSelector((state) => state.canteenReducer);
 	const selectedCanteen = useSelectedCanteen();
 
 	useEffect(() => {

--- a/apps/frontend/app/app/(app)/account-balance/index.tsx
+++ b/apps/frontend/app/app/(app)/account-balance/index.tsx
@@ -59,7 +59,7 @@ const AccountBalanceScreen: React.FC<AccountBalanceScreenProps> = ({ autoStartNf
 	const { translate } = useLanguage();
 	const dispatch = useDispatch();
 	const debugMode = useDebugMode();
-	const { profile, isDevMode } = useAppSelector((state) => state.authReducer);
+	const { profile } = useAppSelector((state) => state.authReducer);
 	const { appSettings, language, primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
 	const balance_area_color = appSettings?.balance_area_color ? appSettings?.balance_area_color : primaryColor;
 	const [isNfcSupported, setIsNfcSupported] = useState(false);

--- a/apps/frontend/app/app/(app)/campus/index.tsx
+++ b/apps/frontend/app/app/(app)/campus/index.tsx
@@ -54,9 +54,9 @@ const Index: React.FC = () => {
 	// Local State
 	const [query, setQuery] = useState<string>('');
 	const [refreshing, setRefreshing] = useState(false);
-	const [hasLoaded, setHasLoaded] = useState(false);
+	const [, setHasLoaded] = useState(false);
 	const [loading, setLoading] = useState(true);
-	const [campusesDispatched, setCampusesDispatched] = useState(false);
+	const [, setCampusesDispatched] = useState(false);
 	const [selectedBuilding, setSelectedBuilding] = useState<DatabaseTypes.Buildings | null>(null);
 	const [listWidth, setListWidth] = useState<number>(windowWidth);
 	const [distanceModalVisible, setDistanceModalVisible] = useState(false);

--- a/apps/frontend/app/app/(app)/course-timetable/index.tsx
+++ b/apps/frontend/app/app/(app)/course-timetable/index.tsx
@@ -58,11 +58,6 @@ const TimetableScreen = () => {
 		});
 	}, [showScrollViewModal, closeScrollViewModal, timeTableData, isUpdate, selectedEventId]);
 
-	const closeSheet = () => {
-		closeScrollViewModal();
-		setIsUpdate(false);
-	};
-
 	const capitalizeFirstLetter = (string: string) => {
 		return string?.charAt(0)?.toUpperCase() + string?.slice(1)?.toLowerCase();
 	};

--- a/apps/frontend/app/app/(app)/events/index.tsx
+++ b/apps/frontend/app/app/(app)/events/index.tsx
@@ -25,7 +25,7 @@ const EventsScreen = () => {
     const kioskMode = useKioskMode();
     const { popupEvents } = useAppSelector((state) => state.food);
     const { primaryColor } = useAppSelector((state) => state.settings);
-	const [selectedEvent, setSelectedEvent] = useState<Partial<DatabaseTypes.PopupEvents> | null>(null);
+	const [, setSelectedEvent] = useState<Partial<DatabaseTypes.PopupEvents> | null>(null);
 	const { show: showScrollViewModal, close: closeScrollViewModal } = useMyScrollViewModal();
 	const handleClose = useCallback(() => {
 		setSelectedEvent(null);

--- a/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/settings-list-components/index.tsx
@@ -22,7 +22,6 @@ const SettingsListComponents = () => {
 	const [dateValue, setDateValue] = useState('01.01.2024');
 	const [dateError, setDateError] = useState('');
 	const [inputValue, setInputValue] = useState('Beispieltext');
-	const [nickname, setNickname] = useState('Tester');
 	const [boolValue, setBoolValue] = useState(true);
 	const [likeValue, setLikeValue] = useState<boolean | null>(null);
 

--- a/apps/frontend/app/app/(app)/feedback-support/index.tsx
+++ b/apps/frontend/app/app/(app)/feedback-support/index.tsx
@@ -80,22 +80,10 @@ const FeedbackScreen = () => {
 		}, [app_feedbacks_id, profile?.id])
 	);
 
-	function getIsLandScape(): boolean {
-		const windowWidth = Dimensions.get('screen').width;
-		const windowHeight = Dimensions.get('screen').height;
-		let isLandscape = windowWidth > windowHeight;
-		if (Platform.OS === 'web') {
-			isLandscape = windowWidth > windowHeight;
-		}
-		return isLandscape;
-	}
-
 	const fetchDeviceInfo = async () => {
 		const windowWidth = Dimensions.get('screen').width;
 		const windowHeight = Dimensions.get('screen').height;
 		const windowScale = Dimensions.get('screen').scale;
-		const isSimulator = !DeviceInfo.isDevice;
-		const isTablet = DeviceInfo.deviceType === DeviceInfo.DeviceType.TABLET;
 		const brand = DeviceInfo.brand;
 		let platform: string;
 		if (Platform.OS === 'web') {
@@ -106,7 +94,6 @@ const FeedbackScreen = () => {
 			platform = 'Android';
 		}
 		const systemVersion = DeviceInfo.osVersion;
-		let isLandscape = getIsLandScape();
 
 		setInputValues({
 			title: '',

--- a/apps/frontend/app/app/(app)/foodoffers/hooks.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/hooks.ts
@@ -262,7 +262,7 @@ export const useSheetHandling = (
     const [selectedSheet, setSelectedSheet] = useState<string | null>(null);
     const [sheetProps, setSheetProps] = useState<Record<string, any>>({});
     // Optimization: Keep sheet active to prevent unmount/remount on navigation
-    const [isActive, setIsActive] = useState(true);
+    const [isActive] = useState(true);
 
     const openSheet = useCallback((sheet: 'menu' | 'sort' | string, props = {}) => {
         if (sheet === 'sort') {

--- a/apps/frontend/app/app/(app)/foodoffers/index.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/index.tsx
@@ -8,7 +8,6 @@ import { DrawerContentComponentProps } from '@react-navigation/drawer';
 import { useDispatch, shallowEqual } from 'react-redux';
 import { useAppSelector } from '@/redux/hooks';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
-import useKioskMode from '@/hooks/useKioskMode';
 import {
 	SET_BUSINESS_HOURS,
 	SET_SELECTED_CANTEEN,
@@ -55,7 +54,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 
-	const appSettings = useAppSelector((state) => state.settings.appSettings, shallowEqual);
 	const drawerPosition = useAppSelector((state) => state.settings.drawerPosition);
 
 	const selectedDate = useAppSelector((state) => state.food.selectedDate);
@@ -66,7 +64,6 @@ const Index: React.FC<DrawerContentComponentProps> = () => {
 
 	const selectedCanteen = useSelectedCanteen();
 	useFoodOffersDefaultDate();
-	const kioskMode = useKioskMode();
 	const { hasUnreadChats } = useChatUnreadStatus();
 	const { openActiveModal, activePopupEvent } = usePopupEventModal();
 	const { openFoodofferSortingModal } = useFoodofferSortingModal();

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -252,18 +252,10 @@ const Index = () => {
 		});
 	};
 
-	const closeEditSheet = () => {
-		closeScrollViewModal();
-	};
-
 	const openWarningSheet = () => {
 		showScrollViewModal({
 			children: <SubmissionWarningSheet id={String(form_submission_id)} closeSheet={closeScrollViewModal} />,
 		});
-	};
-
-	const closeWarningSheet = () => {
-		closeScrollViewModal();
 	};
 
 	const getDirectusFilesData = async (data: any) => {
@@ -390,8 +382,7 @@ const Index = () => {
 			const fieldPromises = sortedResult.map(async answer => {
 				const fieldId = String(answer?.id);
 				const fieldType = (answer?.form_field as DatabaseTypes.FormFields)?.field_type || '';
-				const prefix = (answer?.form_field as DatabaseTypes.FormFields)?.value_prefix || '-';
-				const [custom_type, ...idParts] = fieldType.split('-');
+				const [custom_type] = fieldType.split('-');
 				const defaultValue = (answer as any)[custom_type];
 				let value;
 
@@ -688,7 +679,6 @@ const Index = () => {
 				const formDataEntry = formData[String(fieldId)];
 				const value = formDataEntry?.value;
 				const fieldType = (answer?.form_field as DatabaseTypes.FormFields)?.field_type || '';
-				const prefix = (answer?.form_field as DatabaseTypes.FormFields)?.value_prefix || '-';
 				const custom_id = fieldType?.split('-')[1];
 
 				const { custom_type } = formDataEntry;
@@ -838,8 +828,6 @@ const Index = () => {
 		if (formAnswers) {
 			formAnswers.forEach(answer => {
 				const fieldType = (answer?.form_field as DatabaseTypes.FormFields)?.field_type || '';
-				const prefix = (answer?.form_field as DatabaseTypes.FormFields)?.value_prefix || '-';
-
 				const parts = fieldType.split('-');
 				if (parts) {
 					const collection = parts?.length > 2 ? parts.slice(2).join('-') : '';

--- a/apps/frontend/app/app/(app)/forms/index.tsx
+++ b/apps/frontend/app/app/(app)/forms/index.tsx
@@ -12,7 +12,6 @@ import { iconLibraries } from '@/components/Drawer/CustomDrawerContent';
 import { FormsHelper } from '@/redux/actions/Forms/Forms';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
-import { useLanguage } from '@/hooks/useLanguage';
 import { SET_CACHED_FORMS } from '@/redux/Types/types';
 
 const CACHED_COLOR = '#22c55e';
@@ -20,10 +19,9 @@ const CACHED_COLOR = '#22c55e';
 const Index = () => {
 useSetPageTitle(TranslationKeys.select_a_form);
 const { theme } = useTheme();
-const { translate } = useLanguage();
 const dispatch = useDispatch();
 const [loading, setLoading] = useState(false);
-const [isShowingCachedData, setIsShowingCachedData] = useState(false);
+const [, setIsShowingCachedData] = useState(false);
     const { category_id } = useLocalSearchParams();
     const { language } = useAppSelector((state) => state.settings);
     const [forms, setForms] = useState<DatabaseTypes.Forms[]>([]);

--- a/apps/frontend/app/app/(app)/map/index.tsx
+++ b/apps/frontend/app/app/(app)/map/index.tsx
@@ -1167,14 +1167,6 @@ const OsmVectorMapScreen: React.FC = () => {
 		setAutoRotateSpeed((s) => s + AUTO_ROTATE_SPEED_STEP);
 	}, []);
 
-	const handleManualRotateLeft1 = useCallback(() => {
-		sendToMapRef.current({ bearingDelta: -1, easeAnimation: true, easeDuration: 200 });
-	}, []);
-
-	const handleManualRotateRight1 = useCallback(() => {
-		sendToMapRef.current({ bearingDelta: 1, easeAnimation: true, easeDuration: 200 });
-	}, []);
-
 	const handleToggleFullscreen = useCallback(() => {
 		setIsFullscreen((prev) => !prev);
 	}, []);

--- a/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanList/index.tsx
@@ -103,10 +103,6 @@ const Index = () => {
 		openSelectFoodPlanCanteenModal(option);
 	};
 
-	const closeIntervalSheet = () => {
-		closeScrollViewModal();
-	};
-
 	const openIntervalSheet = (intervalKey: string, intervalLabel: string) => {
 		const foodIntervalValue = foodPlan?.nextFoodInterval ? String(foodPlan.nextFoodInterval) : '';
 		const refreshIntervalValue = foodPlan?.refreshInterval ? String(foodPlan.refreshInterval) : '';

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -43,7 +43,7 @@ const Index = () => {
 	const [optionalFoods, setOptionalFoods] = useState([]);
 	const [foodMarkings, setFoodMarkings] = useState<any>({});
 	const [foodCategories, setFoodCategories] = useState<DatabaseTypes.FoodsCategories[]>([]);
-	const [foodOfferCategories, setFoodOfferCategories] = useState<DatabaseTypes.FoodoffersCategories[]>([]);
+	const [, setFoodOfferCategories] = useState<DatabaseTypes.FoodoffersCategories[]>([]);
 	const [optionalFoodMarkings, setOptionalFoodMarkings] = useState<any>({});
 	const [mainFoodCategories, setMainFoodCategories] = useState<any>({});
 	const [optionalFoodCategories, setOptionalFoodCategories] = useState<any>({});
@@ -952,9 +952,7 @@ const Index = () => {
 						{chunkedMarkings?.map((chunk, chunkIndex) => (
 								<View key={chunkIndex} style={styles.mainContainer}>
 									{chunk.map((marking: any, index: any) => {
-										const markingImage = marking?.image_remote_url ? { uri: marking?.image_remote_url } : { uri: getImageUrl(marking?.image) };
 										const markingText = getTextFromTranslation(marking?.translations, language);
-										const MarkingBackgroundColor = marking?.background_color;
 										const MarkingColor = myContrastColor(marking?.background_color, theme, mode === 'dark');
 										return (
 											<View key={index} style={styles.iconText}>

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -97,10 +97,6 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 		});
 	}, [campus, openLinkCoordinateModal, translate]);
 
-	const cardWidth = useMemo(() => {
-		return amountColumnsForcard === 0 ? CardDimensionHelper.getCardDimension(screenWidth) : CardDimensionHelper.getCardWidth(screenWidth, amountColumnsForcard);
-	}, [amountColumnsForcard, screenWidth]);
-
 	const imageSource = useMemo(() => {
 		if (campus?.image || campus?.image_remote_url) {
 			return { uri: campus?.image_remote_url || getImageUrl(campus?.image) };

--- a/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
+++ b/apps/frontend/app/components/CanteenSelectionSheet/CanteenSelectionSheet.tsx
@@ -23,10 +23,7 @@ const CanteenSelectionSheet: React.FC<CanteenSelectionSheetProps> = ({ closeShee
 	const dispatch = useDispatch();
 	const canteenHelper = new CanteenHelper();
 	const buildingsHelper = new BuildingsHelper();
-	const { serverInfo, appSettings, primaryColor } = useAppSelector((state) => state.settings);
 	const { isManagement } = useAppSelector((state) => state.authReducer);
-	const defaultImage = getImageUrl(serverInfo?.info?.project?.project_logo);
-	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
 
 	const handleSelectCanteen = (canteen: DatabaseTypes.Canteens) => {
 		dispatch({ type: SET_SELECTED_CANTEEN, payload: canteen });

--- a/apps/frontend/app/components/CanteenVisitsDateRow/index.tsx
+++ b/apps/frontend/app/components/CanteenVisitsDateRow/index.tsx
@@ -54,7 +54,7 @@ export const CanteenVisitDetailsModalContent: React.FC<CanteenVisitDetailsModalC
 	const [toggling, setToggling] = useState(false);
 	const { checkAndShowAppRating } = useCheckAppRateAsking();
 
-	const { counts, ownVisit, setOwnVisit, fetchData } = useCanteenVisitData({
+	const { counts, ownVisit, fetchData } = useCanteenVisitData({
 		canteenId,
 		date,
 		profileId,

--- a/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -40,7 +40,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 	const [selectedItem, setSelectedItem] = useState<any>(null);
 	const [data, setData] = useState<any[]>(timeTableData);
 	const [inputValue, setInputValue] = useState<string>('');
-	const [selectedColor, setSelectedColor] = useState<string>('');
+	const [, setSelectedColor] = useState<string>('');
 
 	useEffect(() => {
 		if (isUpdate && timeTableData) {
@@ -61,11 +61,6 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 
 	const course_timetable_area_color = appSettings?.course_timetable_area_color ? appSettings?.course_timetable_area_color : primaryColor;
 	const contrastColor = myContrastColor(course_timetable_area_color, theme, mode === 'dark');
-	const SheetClose = () => {
-		closeSheet();
-		setSelectedItem(null);
-	};
-
 	const cancleSheet = () => {
 		setSelectedItem(null);
 	};

--- a/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
+++ b/apps/frontend/app/components/DropdownInput/DropdownInput.tsx
@@ -7,7 +7,6 @@ import { TranslationKeys } from '@/locales/keys';
 import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewModal';
 import DropdownSheet from './DropdownSheet';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useAppSelector } from '@/redux/hooks';
 import type { FormInputBaseProps } from './types';
 
 const ensureStringArray = (options: string[]): string[] => {
@@ -32,7 +31,6 @@ type DropdownInputProps = Omit<FormInputBaseProps, 'isDisabled'> & {
 const DropdownInput = ({ id, value, onChange, error, isDisabled, custom_type, options = [], prefix, suffix, allowCustomValues = true, onOpenSheet, onCloseSheet }: DropdownInputProps) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
-	const { primaryColor } = useAppSelector(state => state.settings);
 
 	const normalizedOptions = useMemo(() => ensureStringArray(options), [options]);
 

--- a/apps/frontend/app/components/Feedbacks/index.tsx
+++ b/apps/frontend/app/components/Feedbacks/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { AntDesign, Ionicons, MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
@@ -13,7 +13,6 @@ import { FoodFeedbackHelper } from '@/redux/actions/FoodFeedbacks/FoodFeedbacks'
 import useToast from '@/hooks/useToast';
 import { DELETE_FOOD_FEEDBACK_LOCAL, UPDATE_FOOD_FEEDBACK_LOCAL } from '@/redux/Types/types';
 import { useLanguage } from '@/hooks/useLanguage';
-import { myContrastColor } from '@/helper/ColorHelper';
 import SettingsList from '@/components/SettingsList';
 import SettingsListTextInput from '@/components/SettingsListTextInput';
 import { TranslationKeys } from '@/locales/keys';
@@ -44,13 +43,11 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId, 
 	const { translate } = useLanguage();
 	const dispatch = useDispatch();
 	const foodOfferCanteenId = canteenId;
-	const { width: screenWidth } = useWindowDimensions();
 	
 	const user = useAppSelector((state) => state.authReducer.user, shallowEqual);
 	const profile = useAppSelector((state) => state.authReducer.profile, shallowEqual);
 	const primaryColor = useAppSelector((state) => state.settings.primaryColor);
 	const appSettings = useAppSelector((state) => state.settings.appSettings, shallowEqual);
-	const mode = useAppSelector((state) => state.settings.selectedTheme);
 
 	const [commentType, setCommentType] = useState('');
 	const [loading, setLoading] = useState(loadingState);
@@ -70,7 +67,6 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId, 
 	}, [ownFoodFeedbacks, foodId]);
 
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
-	const contrastColor = myContrastColor(foods_area_color, theme, mode === 'dark');
 
 	useEffect(() => {
 		if (appSettings?.foods_feedbacks_comments_type) {
@@ -135,21 +131,6 @@ const Feedbacks: React.FC<FeedbacksProps> = ({ foodDetails, offerId, canteenId, 
 		}
 	}, [previousFeedback]);
 
-	const handleTextChange = (text: string) => {
-		if (!user?.id) {
-			openAccountRequiredModal();
-			return;
-		}
-
-		if (text.length > 120) {
-			toast('Comment should be less than 500 characters', 'error');
-			return;
-		}
-		setComment(text);
-	};
-
-	const resp = screenWidth > 800;
-	
     const ratingSummaryItems = useMemo(() => {
         const rating = foodDetails?.rating_average ?? foodDetails?.rating_average_legacy;
         const ratingAmount = foodDetails?.rating_amount ?? foodDetails?.rating_amount_legacy;

--- a/apps/frontend/app/components/FoodOfferDetailsContent/FoodOfferDetailsContent.tsx
+++ b/apps/frontend/app/components/FoodOfferDetailsContent/FoodOfferDetailsContent.tsx
@@ -79,7 +79,7 @@ const FoodOfferDetailsContent: React.FC<FoodOfferDetailsContentProps> = ({ offer
 
     const profileHelper = useMemo(() => new ProfileHelper(), []);
     const foodfeedbackHelper = useMemo(() => new FoodFeedbackHelper(), []);
-    const [notificationGranted, pushTokenObj, _, requestDeviceNotificationPermission] = NotificationHelper.useNotificationPermission(profile);
+    const [, pushTokenObj, _, requestDeviceNotificationPermission] = NotificationHelper.useNotificationPermission(profile);
 
     const { foodDetails, foodAttributes, loading: foodAttributesLoading } = useFoodDetails({ offerId, initialFoodId });
     const { groupedAttributes } = useFoodAttributes({ foodAttributes, foodDetails });
@@ -256,8 +256,6 @@ const FoodOfferDetailsContent: React.FC<FoodOfferDetailsContentProps> = ({ offer
             } else {
                 containerWidth = '80%';
             }
-        } else {
-            containerWidth = '100%';
         }
         return containerWidth;
     }, [screenWidth]);

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -56,7 +56,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 	const { canteenFeedbackLabels, canteens } = useAppSelector((state) => state.canteenReducer);
 	const { sortBy, language, amountColumnsForcard, appSettings, primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
 	const { ownFoodFeedbacks, foodCategories, foodOfferCategories, foodOffersInfoItems } = useAppSelector((state) => state.food);
-	const { profile, user, isDevMode } = useAppSelector((state) => state.authReducer);
+	const { profile, user } = useAppSelector((state) => state.authReducer);
 	const { appElements } = useAppSelector((state) => state.appElements);
 	
 	const selectedCanteen = canteens?.find(c => c.id === canteenId) as DatabaseTypes.Canteens | undefined;

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -200,23 +200,15 @@ export const HoursSheetContent: React.FC = () => {
 							if (currentRange?.time_start == null || currentRange.time_end == null) {
 								currentRange = { time_start, time_end };
 							} else {
-								let isSame = false;
-								let isBetween = false;
-								let isExtending = false;
-								let isOutside = false;
 								if (time_start === currentRange.time_start && time_end === currentRange.time_end) {
-									isSame = true;
 									// do nothing
 								} else if (time_start === null || time_end === null) {
 									// do nothing
 								} else if (time_start >= currentRange.time_start && time_end <= currentRange.time_end) {
-									isBetween = true;
 									// do nothing
 								} else if (time_start < currentRange.time_end && time_end > currentRange.time_end) {
-									isExtending = true;
 									currentRange.time_end = time_end;
 								} else if (time_start > currentRange.time_end) {
-									isOutside = true;
 									consecutiveRanges.push(currentRange); // push the current range to the consecutive ranges
 									currentRange = { time_start, time_end }; // start a new range
 								}

--- a/apps/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
+++ b/apps/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
@@ -28,7 +28,6 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const MAX_IMAGE_DIMENSION = 6000;
 	const { foodCollection } = useAppSelector((state) => state.food);
-	const [selectedImage, setSelectedImage] = useState<string | undefined>(undefined);
 
 
 	const getFolder = () => {
@@ -110,8 +109,6 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 			if (fileName === 'foods') {
 				storage = getFolder();
 			}
-			let fileSizes: number | undefined = undefined;
-
 			if (Platform.OS === 'web') {
 				const blob: Blob = await new Promise((resolve, reject) => {
 					const xhr = new XMLHttpRequest();
@@ -127,7 +124,6 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 					xhr.send(null);
 				});
 
-				fileSizes = blob.size;
 				if (storage) {
 					formData.append('folder', storage);
 				}
@@ -146,10 +142,6 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 					formData.append('folder', storage);
 				}
 				formData.append('image', file, file_name);
-
-				const response = await fetch(finalUri);
-				const blob = await response.blob();
-				fileSizes = blob.size;
 			}
 
 			const client = ServerAPI.getClient();
@@ -160,7 +152,7 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 			const file_id = resultFileUpload.id;
 
 			const collectionHelper = new CollectionHelper(fileName);
-                        let resultImageLinked = await collectionHelper.updateItem(selectedFoodId, {
+                        await collectionHelper.updateItem(selectedFoodId, {
                                 image: file_id,
                                 image_generated: false,
                         });
@@ -177,7 +169,7 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 		try {
 			const collectionHelper = new CollectionHelper(fileName);
 			setLoading({ ...loading, delete: true });
-                        let result = await collectionHelper.updateItem(selectedFoodId, {
+                        await collectionHelper.updateItem(selectedFoodId, {
                                 image: null,
                                 image_remote_url: null,
                                 image_generated: false,

--- a/apps/frontend/app/components/ImageUpload/ImageUpload.tsx
+++ b/apps/frontend/app/components/ImageUpload/ImageUpload.tsx
@@ -18,7 +18,7 @@ const ImageUpload = ({ id, value, onChange, error, isDisabled, custom_type, offl
 	const { translate } = useLanguage();
 	const { theme } = useTheme();
 	const formAnswersHelper = new FormAnswersHelper();
-	const { primaryColor, appSettings, selectedTheme: mode } = useAppSelector((state) => state.settings);
+	const { primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
 	const [authToken, setAuthToken] = useState<string | null | undefined>(undefined);
 
 	useEffect(() => {

--- a/apps/frontend/app/components/Labels/index.tsx
+++ b/apps/frontend/app/components/Labels/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Linking, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useTheme } from '@/hooks/useTheme';
 import styles from './styles';
@@ -45,12 +45,6 @@ const Labels: React.FC<LabelsProps> = ({ foodDetails, offerId, foodOfferDetails,
 	const showSeparatedMarkingsBreakdown = seperatedMarkingsReduxValue ?? customerConfigSeperate;
 
 	const foods_area_color = appSettings?.foods_area_color ? appSettings?.foods_area_color : primaryColor;
-
-	let food_responsible_organization_name = appSettings?.food_responsible_organization_name || 'Verantwortliche Organisation';
-	let food_responsible_organization_link = appSettings?.food_responsible_organization_link || 'https://www.studentenwerk-osnabrueck.de/';
-	const handleRedirect = () => {
-		Linking.openURL(food_responsible_organization_link).catch(err => console.error('Failed to open URL:', err));
-	};
 
 	const markings = useSelector(selectMarkings);
 	const markingGroups = useSelector(selectMarkingGroups);

--- a/apps/frontend/app/components/ListWeekHeader/ListWeekHeader.tsx
+++ b/apps/frontend/app/components/ListWeekHeader/ListWeekHeader.tsx
@@ -3,14 +3,10 @@ import { useTheme } from '@/hooks/useTheme';
 import { Ionicons, MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
 import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useAppSelector } from '@/redux/hooks';
-import { useLanguage } from '@/hooks/useLanguage';
 import { isWeb } from '@/constants/Constants';
 
 const FoodPlanHeader = ({ handlePrint }: any) => {
 	const { theme } = useTheme();
-	const { translate } = useLanguage();
-	const { weekPlan } = useAppSelector((state) => state.management);
 	const [headerVisible, setHeaderVisible] = useState(true);
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
 	const isMobile = screenWidth < 800;
@@ -19,10 +15,6 @@ const FoodPlanHeader = ({ handlePrint }: any) => {
 
 	const handleScanHelpClick = () => {
 		setHeaderVisible(false);
-	};
-
-	const handleSecondaryClick = () => {
-		setHeaderVisible(true);
 	};
 
 	useEffect(() => {

--- a/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
+++ b/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
@@ -31,7 +31,7 @@ const SettingsListMarkingLabel: React.FC<SettingsListMarkingLabelProps> = ({
 	const dispatch = useDispatch();
 	const { translate } = useLanguage();
 	const [warning, setWarning] = useState(false);
-	const [showTooltip, setShowTooltip] = useState(false);
+	const [, setShowTooltip] = useState(false);
 	const language = useAppSelector(state => state.settings.language);
 	const user = useAppSelector(state => state.authReducer.user);
 	const profile = useAppSelector(state => state.authReducer.profile);

--- a/apps/frontend/app/components/SettingsListMarkingLabelFast/SettingsListMarkingLabelFast.tsx
+++ b/apps/frontend/app/components/SettingsListMarkingLabelFast/SettingsListMarkingLabelFast.tsx
@@ -11,7 +11,6 @@ import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { UserHelper } from '@/helper/UserHelper';
 import SettingsList from '@/components/SettingsList';
 import SettingsListLikeDislikeFast from '@/components/SettingsListLikeDislikeFast';
-import { useLanguage } from '@/hooks/useLanguage';
 import { createSelector } from 'reselect';
 import { RootState } from '@/redux/reducer';
 import { MarkingLabelProps } from '@/components/MarkingLabels/types';
@@ -39,7 +38,6 @@ const SettingsListMarkingLabelFast: React.FC<SettingsListMarkingLabelFastProps> 
 	groupPosition,
 }) => {
 	const dispatch = useDispatch();
-	const { translate } = useLanguage();
 	const [warning, setWarning] = useState(false);
 	const language = useAppSelector(state => state.settings.language);
 	const user = useAppSelector(state => state.authReducer.user);

--- a/apps/frontend/app/components/SettingsListNickname/SettingsListNickname.tsx
+++ b/apps/frontend/app/components/SettingsListNickname/SettingsListNickname.tsx
@@ -37,11 +37,6 @@ const SettingsListNickname: React.FC<SettingsListNicknameProps> = ({ groupPositi
 
         const trimmedValue = useMemo(() => value?.trim?.() ?? '', [value]);
 
-        const disableSave = useMemo(
-                () => trimmedValue === (currentNickname?.trim?.() ?? ''),
-                [currentNickname, trimmedValue]
-        );
-
         const handleSave = useCallback(async (savedValue: string) => {
                 const nextNickname = savedValue?.trim?.() ?? trimmedValue;
                 if (isRegisteredUser) {

--- a/apps/frontend/app/components/SingleLineInput/SingleLineInput.tsx
+++ b/apps/frontend/app/components/SingleLineInput/SingleLineInput.tsx
@@ -11,7 +11,6 @@ import { TranslationKeys } from '@/locales/keys';
 const SingleLineInput = ({ id, value, onChange, error, isDisabled, custom_type, prefix, suffix, autoFocus, insideBottomSheet }: { id: string; value: string; onChange: (id: string, value: string, custom_type: string) => void; error: string; isDisabled: boolean; custom_type: string; prefix: string | null | undefined; suffix: string | null | undefined; autoFocus?: boolean; insideBottomSheet?: boolean }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
-	const flag = !suffix && !prefix;
 	// Inside bottom-sheet content the input must be BottomSheetTextInput, otherwise
 	// the sheet's keyboard tracking cannot see it and the keyboard covers the field.
 	// BottomSheetTextInput throws outside a sheet, so it must stay opt-in.

--- a/apps/frontend/app/components/UI/IconButton.tsx
+++ b/apps/frontend/app/components/UI/IconButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { TouchableOpacity, TouchableOpacityProps } from 'react-native';
-import { useTheme } from '@/hooks/useTheme';
 
 type IconButtonProps = TouchableOpacityProps & {
   padding?: number;
@@ -8,7 +7,6 @@ type IconButtonProps = TouchableOpacityProps & {
 };
 
 const IconButton: React.FC<IconButtonProps> = ({ children, padding = 5, style, ...rest }) => {
-  const { theme } = useTheme();
   return (
     <TouchableOpacity
       {...(rest as TouchableOpacityProps)}

--- a/apps/frontend/app/components/WashingMachines/index.tsx
+++ b/apps/frontend/app/components/WashingMachines/index.tsx
@@ -91,7 +91,7 @@ const WashingMachines: React.FC<any> = ({ campusDetails }) => {
 		const now = new Date();
 
 		for (const machine of washingMachines) {
-			const { date_finished, alias, id } = machine;
+			const { date_finished, alias } = machine;
 
 			if (date_finished) {
 				const finishDate = new Date(date_finished);

--- a/apps/frontend/app/constants/HelperFunctions.ts
+++ b/apps/frontend/app/constants/HelperFunctions.ts
@@ -9,7 +9,6 @@ import { PriceGroupKey } from '@/app/(app)/settings/types';
 
 export const generateCodeVerifier = async () => {
 	const bytesMinAmount = 32;
-	const bytesMaxAmount = 96;
 	const bytesAmount = bytesMinAmount;
 	const printableAsciiStart = 33; // ASCII value of '!'
 	const printableAsciiEnd = 126; // ASCII value of '~'

--- a/apps/frontend/app/helper/ColorHelper.tsx
+++ b/apps/frontend/app/helper/ColorHelper.tsx
@@ -60,7 +60,6 @@ function useLighterOrDarkerColorByContrastWithOptions(color: string | undefined,
 		}
 
 		const backgroundColor = Color(color);
-		const isDark = backgroundColor.isDark();
 		let modifiedColor = backgroundColor.clone();
 		const step = 1; // Adjust step to be more precise
 		let currentContrastRatio = getContrastRatio(modifiedColor.toHexString(), color);

--- a/apps/frontend/app/helper/DeviceHelper.ts
+++ b/apps/frontend/app/helper/DeviceHelper.ts
@@ -74,9 +74,7 @@ function getSmallestToLargestBreakPointList(): BreakPoint[] {
  */
 export function useBreakPointValue<T>(breakPoints: BreakPointsDictionary<T>): T {
 	const dimensions = useWindowDimensions();
-	const scale = dimensions.scale;
 	const widthUnscaled = dimensions.width; // the unscaled width is our reference how "big" the screen is, for fingers size
-	const widthScaled = widthUnscaled * scale; // the scaled width is how fine and detailed the screen is to the eye
 
 	const widthBreakPoints: BreakPointsDictionary<number> = getDimensionWidthBreakPoints();
 

--- a/apps/frontend/app/helper/nfcCardReaderHelper/CardReader.ts
+++ b/apps/frontend/app/helper/nfcCardReaderHelper/CardReader.ts
@@ -35,7 +35,7 @@ export default class CardReader {
 		message ??= 'Hold your phone near the card';
 		let cardInformations;
 		try {
-			const result = await this.NfcManager.start();
+			await this.NfcManager.start();
 			cardInformations = await MensaCardReaderHelper.readMensaCardInformations(this, message);
 		} catch (err) {
 			console.warn(err);

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -2749,7 +2749,7 @@ export default function RecordScreen() {
 	const [isRecording, setIsRecording] = useState(false);
 	const [elapsedSeconds, setElapsedSeconds] = useState(0);
 	const [liveDistanceKm, setLiveDistanceKm] = useState(0);
-	const [liveSpeedKmh, setLiveSpeedKmh] = useState<number | null>(null);
+	const [, setLiveSpeedKmh] = useState<number | null>(null);
 	// Incrementally accumulated route distance (km) of the current recording.
 	// Kept in a ref so each GPS fix only adds the latest segment instead of
 	// re-summing the whole route, and so the value stays available while the
@@ -2762,7 +2762,6 @@ export default function RecordScreen() {
 	const measureWaypointsRef = useRef<Array<{ lat: number; lng: number }>>([]);
 
 	// Magnify mode (debug only): show detailed map info when tapping a hex tile
-	const [isMagnifyMode, setIsMagnifyMode] = useState(false);
 	const isMagnifyModeRef = useRef(false);
 
 	// Search highlight (debug only): track viewport cells and cached features for red-border overlay
@@ -2838,9 +2837,9 @@ export default function RecordScreen() {
 
 	// H3 grid settings (refs for synchronous access in callbacks)
 	const showGridAlwaysRef = useRef(false);
-	const [showGridAlways, setShowGridAlways] = useState(false);
+	const [, setShowGridAlways] = useState(false);
 	const h3ResolutionRef = useRef(H3_DEFAULT_RESOLUTION);
-	const [h3Resolution, setH3Resolution] = useState(H3_DEFAULT_RESOLUTION);
+	const [, setH3Resolution] = useState(H3_DEFAULT_RESOLUTION);
 	const h3MinZoomRef = useRef(H3_MIN_ZOOM_DEFAULT);
 
 	// Heading mode: when active during recording, the map rotates to face the
@@ -3789,18 +3788,6 @@ export default function RecordScreen() {
 		setIsMeasureMode(false);
 		measureWaypointsRef.current = [];
 		mapRef.current?.sendToMap({ measureMode: false });
-	}, []);
-
-	// ── Magnify mode (debug only) ───────────────────────────────────────────────
-
-	const startMagnifyMode = useCallback(() => {
-		isMagnifyModeRef.current = true;
-		setIsMagnifyMode(true);
-	}, []);
-
-	const cancelMagnifyMode = useCallback(() => {
-		isMagnifyModeRef.current = false;
-		setIsMagnifyMode(false);
 	}, []);
 
 	const openSearchModal = useCallback(async () => {

--- a/apps/geonexia/frontend/app/settings/index.tsx
+++ b/apps/geonexia/frontend/app/settings/index.tsx
@@ -36,7 +36,6 @@ import { queryTileFeaturesForHexCell } from '../../helpers/TileFeatureHelper';
 import { setThemeMode } from '../../store/themeSlice';
 import type { ThemeMode } from '../../store/themeSlice';
 import { setGpsIntervalSeconds } from '../../store/gpsIntervalSlice';
-import { setTTSEnabled } from '../../store/ttsSlice';
 import SpeechSettingsContent from '../../components/SpeechSettingsModal';
 import AdvancedSettingsContent from '../../components/AdvancedSettingsContent';
 import type { RouteSmoothingLevel } from '../../helpers/RouteSmootherHelper';
@@ -274,7 +273,6 @@ export default function SettingsScreen() {
 	const dispatch = useDispatch<AppDispatch>();
 	const selectedTheme = useSelector((state: RootState) => state.theme.selectedMode);
 	const selectedGpsInterval = useSelector((state: RootState) => state.gpsInterval.intervalSeconds);
-	const isTTSEnabled = useSelector((state: RootState) => state.tts.ttsEnabled);
 	const speechEnabled = useSelector((state: RootState) => state.speechSettings.enabled);
 	const isDebugMode = useSelector((state: RootState) => state.hexTiles.isDebugMode);
 	const isDevMode = useSelector((state: RootState) => state.hexTiles.isDevMode);
@@ -353,10 +351,6 @@ export default function SettingsScreen() {
 		dispatch(setDebugMode(next));
 		saveDebugModeFlag(next);
 	}, [dispatch, isDebugMode]);
-
-	const handleToggleTTS = useCallback(() => {
-		dispatch(setTTSEnabled(!isTTSEnabled));
-	}, [dispatch, isTTSEnabled]);
 
 	const handleOpenSpeechSettings = useCallback(() => {
 		showSpeechModal({

--- a/apps/geonexia/frontend/store/store.ts
+++ b/apps/geonexia/frontend/store/store.ts
@@ -94,7 +94,7 @@ let _lastSavedPlayerInformation: PlayerInformation | null = null;
 store.subscribe(() => {
 	const state = store.getState();
 
-	const { records, isDevMode } = state.hexTiles;
+	const { records } = state.hexTiles;
 	if (records !== _lastSavedRecords) {
 		_lastSavedRecords = records;
 		if (_saveTimer) clearTimeout(_saveTimer);

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -13,8 +13,12 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
    ```
 
    Das Script liest `reports/sonarCloud/report_maintainability.csv`, gruppiert die
-   Issues nach Meldungstyp (Zahlen in Meldungen werden normalisiert) und gibt die
-   Top 10 mit Anzahl aus.
+   Issues nach Meldungstyp und gibt die Top 10 mit Anzahl aus. Zur Gruppierung
+   werden Zahlen sowie zitierte Bezeichner in den Meldungen normalisiert (z. B.
+   zählt `Remove this useless assignment to variable "setNickname"` als
+   `... to variable "X"`). Keyword-Zitate, die die Regel selbst ausmachen (z. B.
+   `` `Set` ``, `` `.some(…)` ``, `` `readonly` ``), bleiben erhalten — Liste
+   `KEYWORD_QUOTES` im Script bei Bedarf ergänzen.
 
 2. **Top 10 dem Nutzer nennen** — immer mit Anzahl pro Typ.
 

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -78,6 +78,7 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Expected a `for-of` loop instead of a `for` loop with this simple iteration. | 12 von 12 (Cheerio-Objekt per `.toArray()` iteriert) | #3953 |
 | 2026-07-20 | 'any' overrides all other types in this union type. | 12 von 12 (wo möglich sprechende Typen wie `Partial<...>` statt `any`; sonst redundante Union-Member entfernt) | #3953 |
 | 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
+| 2026-07-20 | Remove this useless assignment to variable "X". | 97 von 97 (ungenutzte useState-Werte per Array-Elision, tote Deklarationen/Handler samt ungenutzt gewordener Imports entfernt; Seiteneffekt-Aufrufe als nacktes `await` behalten) | #3958 |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -1386,8 +1386,6 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 		...visibleAttributeKeys,
 	];
 
-	const diceButtonBg = accentColor ?? theme.screen.text;
-	const diceIconColor = myContrastColor(diceButtonBg, theme, isDark);
 	const hasHiddenProps = !!(hiddenProps && Object.keys(hiddenProps).length > 0);
 
 	return (

--- a/scripts/count-sonar-maintainability-issues.js
+++ b/scripts/count-sonar-maintainability-issues.js
@@ -3,6 +3,9 @@
  * Counts SonarCloud maintainability issues grouped by message type.
  * Numbers in messages are stripped so that issues of the same kind
  * (e.g. "Reduce ... from 21 to 15" vs "... from 18 to 15") are grouped together.
+ * Quoted identifiers (e.g. `Remove this useless assignment to variable "setNickname"`)
+ * are replaced with a placeholder so all occurrences count as one type — except
+ * keyword-like tokens (e.g. `Set`, `.some(…)`, `readonly`) that define the rule itself.
  *
  * Usage: node scripts/count-sonar-maintainability-issues.js [path/to/report.csv] [topN]
  */
@@ -42,8 +45,49 @@ function parseCsvLine(line) {
     return fields;
 }
 
+// Quoted tokens that are part of the rule itself (keywords/APIs), not
+// occurrence-specific identifiers. These are kept verbatim so that different
+// rules are not merged into one type.
+const KEYWORD_QUOTES = new Set([
+    'Set',
+    '.some(…)',
+    '.find(…)',
+    '.filter(…)',
+    'readonly',
+    'TODO',
+    'await',
+    'Thenable',
+    'sort',
+    'toSorted',
+    'switch',
+    'if',
+    'void',
+    'default',
+    'boolean',
+    'Boolean',
+    'string',
+    'export…from',
+    'String#codePointAt()',
+    'String#charCodeAt()',
+    'Object.hasOwn()',
+    'Object.prototype.hasOwnProperty.call()',
+    'Math.max()',
+    '[object Object]',
+    'node:buffer',
+    'buffer',
+]);
+
 function normalizeMessage(message) {
-    return message.replace(/\d+/g, 'N');
+    return message
+        // Single quotes only count as quoting when not preceded by a word
+        // character, so apostrophes ("Object's", "don't") are left alone.
+        .replace(/"([^"]*)"|`([^`]*)`|(?<![\w'])'([^']*)'/g, (match, dq, bq, sq) => {
+            const inner = dq ?? bq ?? sq;
+            if (KEYWORD_QUOTES.has(inner)) return match;
+            const quote = match[0];
+            return `${quote}X${quote}`;
+        })
+        .replace(/\d+/g, 'N');
 }
 
 const content = fs.readFileSync(csvPath, 'utf8');


### PR DESCRIPTION
## Zusammenfassung

Docs-Maintenance-Workflow (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`): Zähl-Script verbessert und den damit sichtbar gewordenen nächsten mechanischen Issue-Typ vollständig abgearbeitet.

### 1. Zähl-Script: zitierte Bezeichner normalisieren

`scripts/count-sonar-maintainability-issues.js` ersetzt jetzt zusätzlich zu Zahlen auch zitierte Bezeichner durch einen Platzhalter, z. B. zählt `Remove this useless assignment to variable "setNickname"` als `... to variable "X"`. Ausnahmen: Keyword-Zitate, die die Regel selbst ausmachen (`` `Set` ``, `` `.some(…)` ``, `` `.find(…)` ``, `` `readonly` ``, `"TODO"`, `"switch"`, …) bleiben über die `KEYWORD_QUOTES`-Liste erhalten. Apostrophe („Object's", „don't") werden nicht als Zitatanfang gewertet.

Ergebnis: 211 → 80 unterschiedliche Issue-Typen; `Remove this useless assignment to variable "X"` wird als nächster Top-Typ sichtbar (97x).

### 2. Behobener Issue-Typ: `Remove this useless assignment to variable "X"` — 97 von 97

Alle Fixes sind reine Dead-Code-Entfernungen ohne Verhaltensänderung, nach Bereichen in einzelne Commits aufgeteilt (leicht einzeln zu reviewen):

| Commit | Bereich | Stellen |
|---|---|---|
| Backend-Extensions (`directus-extension-rocket-meals-bundle`) | 12 Dateien | 21 |
| Frontend-Screens (`apps/frontend/app/app`) | 14 Dateien | 28 |
| Frontend-Komponenten/Helper (`apps/frontend/app/components`, `constants`, `helper`) | 23 Dateien | 39 |
| Geonexia + common-ui | 4 Dateien | 9 |

Verwendete Muster:
- Ungenutzte `useState`-Werte, deren Setter gebraucht wird → Array-Elision `const [, setX] = useState(...)`; komplett ungenutzte Paare → Zeile entfernt.
- Ungenutzte Destructuring-Keys entfernt (übrige Keys geprüft und erhalten).
- Tote Funktions-/`useCallback`-Deklarationen entfernt, inkl. dadurch ungenutzt gewordener Imports/Selectors.
- Zuweisungen mit nötigem Seiteneffekt (`axios.post`, `collectionHelper.updateItem`, `NfcManager.start`) als nacktes `await ...` behalten, nur die Zuweisung entfernt.
- Redundante Reassignments entfernt (z. B. `else { containerWidth = '100%' }` bei Initialwert `'100%'`).

### Verifikation

- Backend: `yarn typecheck` (tsc --noEmit) im Extension-Workspace läuft grün.
- Frontend: per `tsc --noEmit` geprüft, dass keine neuen Namensauflösungs-Fehler entstehen (vorbestehende, unabhängige Theme-Typ-Fehler unverändert).
- Keine visuellen Änderungen (nur Dead-Code-Entfernung), daher kein Screenshot nötig.

### Aktuelle Top 10 (nach diesem PR verbleibend)

```
 1.  109x  Refactor this function to reduce its Cognitive Complexity from N to the N allowed.
 2.   97x  Move this component definition out of the parent component and pass data as props.
 3.   60x  Do not use Array index in keys
 4.   39x  Complete the task associated to this "TODO" comment.
 5.   35x  Refactor this code to not nest functions more than N levels deep.
 6.   23x  Handle this exception or don't catch it at all.
 7.   20x  Default parameters should be last.
 8.   20x  Add an explicit return statement at the end of the function.
 9.   16x  Unexpected `await` of a non-Promise (non-"Thenable") value.
10.   16x  Arguments 'X' and 'X' have the same names but not the same order as the function parameters.
```
(1–10 stehen auf der Übersprungen-Liste des Workflows — individuelle Refactorings; nächste mechanische Kandidaten: `'X' is deprecated.` 12x, `This pattern can be replaced with 'X'.` 10x, `Review this redundant assignment` 10x.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiFdrRz4ChcpqN2dz9kVSU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiFdrRz4ChcpqN2dz9kVSU)_