### PR TITLE
fix(sonar): add explicit return statements to shell functions

### DIFF
--- a/apps/backend/backupRestore.sh
+++ b/apps/backend/backupRestore.sh
@@ -15,6 +15,8 @@ get_docker_compose_cmd() {
         echo "Neither docker-compose nor docker compose is available. Please install one of them."
         exit 1
     fi
+
+    return $?
 }
 
 DOCKER_COMPOSE_CMD=$(get_docker_compose_cmd)
@@ -63,6 +65,8 @@ select_backup() {
             echo "Invalid selection. Please try again."
         fi
     done
+
+    return $?
 }
 
 # Main entry point

--- a/apps/backend/genSSO_Apple.sh
+++ b/apps/backend/genSSO_Apple.sh
@@ -4,6 +4,8 @@
 function show_help() {
     echo "Usage: ./genSSO_Apple.sh --team_id <team_id> --client_id <client_id> --key_id <key_id> --key_file_path <path_to_key_file>"
     echo "or:    ./genSSO_Apple.sh --team_id <team_id> --client_id <client_id> --key_id <key_id> --key_file_content '<key_file_content>'"
+
+    return $?
 }
 
 # Initialize variables for parameters
@@ -103,6 +105,8 @@ CLAIMS=$(printf '{"iss":"%s","iat":%d,"exp":%d,"aud":"https://appleid.apple.com"
 # Base64 URL encode function
 base64_url_encode() {
     openssl enc -base64 -A | tr '+/' '-_' | tr -d '='
+
+    return $?
 }
 
 # Create JWT token
@@ -127,6 +131,8 @@ function convert_ec {
 
     echo -n $R | xxd -r -p
     echo -n $S | xxd -r -p
+
+    return $?
 }
 SIGNATURE=$(echo -n "$JWT_HEADER_BASE64.$JWT_CLAIMS_BASE64" | openssl dgst -binary -sha256 -sign <(echo "$ECDSA_KEY") | convert_ec | openssl base64 -e -A | tr '+/' '-_' | tr -d '\n=')
 

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -84,14 +84,14 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 
-**Übersprungen (Stand 2026-07-21, individuelle Refactorings statt mechanischer Fixes):**
+**Noch offen (Stand 2026-07-21, brauchen individuelle Refactorings statt mechanischer Fixes):**
 „Cognitive Complexity" (109x), „Move this component definition out of the parent
 component" (97x), „Array index in keys" (60x, braucht stabile IDs), TODO-Kommentare
 (39x), Funktions-Verschachtelung (35x), Exception-Handling (23x), „Default parameters
 should be last" (20x, ändert Aufrufer), `await` auf Non-Promise (16x, Prüfung pro
 Stelle nötig), Parameter-Reihenfolge (16x, ausschließlich `hashHelper.ts` — Reihenfolge
 könnte algorithmisch beabsichtigt sein, braucht manuelle Prüfung).
-Diese Typen in kleinen, thematisch gruppierten PRs separat angehen.
+Diese Typen in kleinen, thematisch gruppierten PRs angehen.
 
 ## Hinweise
 

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -80,15 +80,17 @@ Maintainability-Issues weiter", ist genau dieser Ablauf gemeint.
 | 2026-07-20 | Refactor this code to not use nested template literals. | 10 von 10 (innere Literale ohne Interpolation → normale Strings; sonst in Variable extrahiert) | #3953 |
 | 2026-07-20 | Remove this useless assignment to variable "X". | 97 von 97 (ungenutzte useState-Werte per Array-Elision, tote Deklarationen/Handler samt ungenutzt gewordener Imports entfernt; Seiteneffekt-Aufrufe als nacktes `await` behalten) | #3958 |
 | 2026-07-20 | useState call is not destructured into value + setter pair | 18 von 18 (10x Array-Elision aus #3958 zurück zu benanntem `[x, setX]`-Paar mit `NOSONAR`-Kommentar — Kommentar entfernen, sobald die Variable genutzt wird; 8x Setter-Umbenennung: 6x Tippfehler `setAmimationJson` → `setAnimationJson`, 2x `set...State`-Suffix in `useLanguage.ts`) | – |
+| 2026-07-21 | Add an explicit return statement at the end of the function. | 20 von 20 (nur Shell-Skripte; `return $?` als letzte Anweisung ergänzt, damit der bisherige implizite Exit-Code jeder Funktion unverändert bleibt — keine Semantikänderung) | – |
 
 Neu abgearbeitete Typen bitte hier ergänzen.
 
-**Übersprungen (Stand 2026-07-20, individuelle Refactorings statt mechanischer Fixes):**
-„Cognitive Complexity" (113x), „Move this component definition out of the parent
+**Übersprungen (Stand 2026-07-21, individuelle Refactorings statt mechanischer Fixes):**
+„Cognitive Complexity" (109x), „Move this component definition out of the parent
 component" (97x), „Array index in keys" (60x, braucht stabile IDs), TODO-Kommentare
 (39x), Funktions-Verschachtelung (35x), Exception-Handling (23x), „Default parameters
-should be last" (20x, ändert Aufrufer), „Add an explicit return" (20x),
-`await` auf Non-Promise (16x), Parameter-Reihenfolge (16x).
+should be last" (20x, ändert Aufrufer), `await` auf Non-Promise (16x, Prüfung pro
+Stelle nötig), Parameter-Reihenfolge (16x, ausschließlich `hashHelper.ts` — Reihenfolge
+könnte algorithmisch beabsichtigt sein, braucht manuelle Prüfung).
 Diese Typen in kleinen, thematisch gruppierten PRs separat angehen.
 
 ## Hinweise

--- a/generate_basic_auth_traefik.sh
+++ b/generate_basic_auth_traefik.sh
@@ -5,6 +5,8 @@ generate_basic_auth() {
   local username=$1
   local password=$2
   echo -n "$username:$password" | base64
+
+  return $?
 }
 
 # Function to update .env file
@@ -27,12 +29,16 @@ update_env_file() {
     echo "BASIC_AUTH=${basic_auth_value}" >> .env
     echo "BASIC_AUTH value added to .env file."
   fi
+
+  return $?
 }
 
 # Function to get username
 get_username() {
   read -p "Enter username: " username
   echo "$username"
+
+  return $?
 }
 
 # Function to get password with confirmation
@@ -50,6 +56,8 @@ get_password() {
       echo "Passwords do not match. Please try again."
     fi
   done
+
+  return $?
 }
 
 # Main script

--- a/scripts/generateIcons.sh
+++ b/scripts/generateIcons.sh
@@ -13,6 +13,8 @@ check_imagemagick() {
             exit 1
         fi
     fi
+
+    return $?
 }
 
 # Function to install ImageMagick
@@ -40,6 +42,8 @@ install_imagemagick() {
         echo "Unsupported operating system. Please install ImageMagick manually."
         exit 1
     fi
+
+    return $?
 }
 
 # Function to print usage help
@@ -51,6 +55,8 @@ print_usage() {
     echo "  <path_to_company_logo> Path to the company logo file"
     echo "  [output_folder]        Optional: Path to the output folder. Default is ./app/assets/images/"
     echo "  --project-dir <dir>    Optional: Path to the project directory. Output folder will be <dir>/assets/"
+
+    return $?
 }
 
 # Define default output folder
@@ -68,6 +74,8 @@ SPLASH_SIZE="1155x2500"
 calculate_splash_logo_width() {
     local splash_width=$(echo $SPLASH_SIZE | cut -dx -f1)
     SPLASH_LOGO_WIDTH=$(echo "$splash_width * 0.9" | bc)
+
+    return $?
 }
 
 ## Converts transparent pixels in a PNG from black-transparent (0,0,0,0) to
@@ -93,6 +101,8 @@ convert_transparent_to_white() {
         -delete 0 -compose CopyOpacity -composite \
         -colorspace sRGB \
         PNG32:"$output_path"
+
+    return $?
 }
 
 generate_splash_icon() {
@@ -122,6 +132,8 @@ generate_splash_icon() {
 
     # Also generate splash.png (used by expo-splash-screen)
     cp "$splash_icon_path" "$OUTPUT_FOLDER/splash.png"
+
+    return $?
 }
 
 generate_adaptive_icon() {
@@ -134,6 +146,8 @@ generate_adaptive_icon() {
 
     convert "$icon_path" -resize ${icon_size}x${icon_size} \
         -gravity center -background none -extent $ADAPTIVE_ICON_SIZE "$output_path"
+
+    return $?
 }
 
 generate_adaptive_icon_background() {
@@ -141,6 +155,8 @@ generate_adaptive_icon_background() {
 
     # Erzeuge weißes (nicht transparentes) Bild
     convert -size $ADAPTIVE_ICON_SIZE xc:white "$output_path"
+
+    return $?
 }
 
 # Function to compute SHA-256 hash of a file
@@ -154,6 +170,8 @@ compute_file_hash() {
         echo "ERROR: No SHA-256 hash tool found" >&2
         exit 1
     fi
+
+    return $?
 }
 
 # Function to write hash JSON file for source tracking
@@ -178,6 +196,8 @@ write_hash_file() {
 EOF
 
     echo "Hash file written to $hash_file"
+
+    return $?
 }
 
 # Function to generate images
@@ -212,6 +232,8 @@ generate_images() {
 
     # Write hash file for source tracking
     write_hash_file "$icon_path" "$logo_path"
+
+    return $?
 }
 
 # Main script execution


### PR DESCRIPTION
## Summary

Continues the SonarCloud Maintainability workflow (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`) and tackles one of the previously skipped "harder" issue types.

- Fixed **"Add an explicit return statement at the end of the function."** — 20 von 20 Vorkommen, ausschließlich in Shell-Skripten:
  - `scripts/generateIcons.sh` (11)
  - `apps/backend/backupRestore.sh` (2)
  - `apps/backend/genSSO_Apple.sh` (3)
  - `generate_basic_auth_traefik.sh` (4)
- Fix: jede betroffene Funktion endet nun mit `return $?` — das übernimmt exakt den bisherigen impliziten Exit-Code des letzten Kommandos, ändert also keine Semantik, macht den Rückgabewert aber explizit (Sonar-konform).
- Doku aktualisiert: Typ in der Tabelle "Bereits abgearbeitete Typen" ergänzt, verbleibende Top-10 in "Übersprungen" auf den aktuellen Stand gebracht (inkl. kurzer Begründung, warum "Parameter-Reihenfolge" und "await auf Non-Promise" weiterhin manuelle Prüfung brauchen).

## Test plan

- [x] `bash -n` auf alle 4 geänderten Skripte (Syntaxcheck, alle OK)
- [x] `node scripts/count-sonar-maintainability-issues.js` erneut ausgeführt, um die aktuelle Top-10-Liste zu bestätigen
- [ ] Nächster SonarCloud-Scan bestätigt, dass der Typ vollständig behoben ist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpCUXE5RJD5mSpXNT4a8y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpCUXE5RJD5mSpXNT4a8y6)_