### PR TITLE
fix(sonar): reduce function nesting depth below the 4-level threshold (35x)

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/onboarding/index.tsx
@@ -239,6 +239,28 @@ const OnboardingScreen = () => {
 		loadProfileAvatars();
 	}, []);
 
+	// Fades a slot out, swaps in the avatar at poolIdx, fades back in, then calls onComplete.
+	const performAvatarSwap = useCallback((slot: number, poolIdx: number, onComplete: () => void) => {
+		Animated.timing(slotOpacities[slot], {
+			toValue: 0,
+			duration: AVATAR_FADE_DURATION,
+			useNativeDriver: true,
+		}).start(() => {
+			setSlotAvatars(prev => {
+				const next = [...prev];
+				next[slot] = avatarPoolRef.current[poolIdx];
+				return next;
+			});
+			nextPoolIndexRef.current += 1;
+			nextSlotRef.current += 1;
+			Animated.timing(slotOpacities[slot], {
+				toValue: 1,
+				duration: AVATAR_FADE_DURATION,
+				useNativeDriver: true,
+			}).start(onComplete);
+		});
+	}, [slotOpacities]);
+
 	// Avatar carousel: one slot swaps at a time, every AVATAR_SLOT_INTERVAL ms.
 	// Only starts once server avatars are available. Stops when all server avatars
 	// have been shown (wraps around only if the pool is larger than AVATARS_TOTAL).
@@ -254,33 +276,16 @@ const OnboardingScreen = () => {
 			const slot = nextSlotRef.current % AVATARS_TOTAL;
 			const poolIdx = nextPoolIndexRef.current;
 
-			Animated.timing(slotOpacities[slot], {
-				toValue: 0,
-				duration: AVATAR_FADE_DURATION,
-				useNativeDriver: true,
-			}).start(() => {
-				setSlotAvatars(prev => {
-					const next = [...prev];
-					next[slot] = pool[poolIdx];
-					return next;
-				});
-				nextPoolIndexRef.current += 1;
-				nextSlotRef.current += 1;
-				Animated.timing(slotOpacities[slot], {
-					toValue: 1,
-					duration: AVATAR_FADE_DURATION,
-					useNativeDriver: true,
-				}).start(() => {
-					// Only schedule next swap if there are more server avatars to show
-					if (nextPoolIndexRef.current < avatarPoolRef.current.length) {
-						timer = setTimeout(swapNext, AVATAR_SLOT_INTERVAL);
-					}
-				});
+			performAvatarSwap(slot, poolIdx, () => {
+				// Only schedule next swap if there are more server avatars to show
+				if (nextPoolIndexRef.current < avatarPoolRef.current.length) {
+					timer = setTimeout(swapNext, AVATAR_SLOT_INTERVAL);
+				}
 			});
 		};
 		timer = setTimeout(swapNext, AVATAR_SLOT_INTERVAL);
 		return () => clearTimeout(timer);
-	}, [hasServerAvatars, slotOpacities]);
+	}, [hasServerAvatars, performAvatarSwap]);
 
 	// ── User count animation ──────────────────────────────────────────────────
 	// Smoothly animates to a new target value: fast approach, slow last 5 units.

--- a/apps/frontend/app/app/(app)/foodoffers/details/components/FoodHeader.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/components/FoodHeader.tsx
@@ -50,42 +50,44 @@ const FoodHeader = ({
     const imageRemoteUrl = useMemo(() => foodDetails?.image_remote_url || initialImageRemoteUrl, [foodDetails?.image_remote_url, initialImageRemoteUrl]);
     const imageAssetId = useMemo(() => foodDetails?.image || initialImageAssetId, [foodDetails?.image, initialImageAssetId]);
 
-    const renderRatingStars = useCallback(() => (
-        <View style={isWeb ? styles.stars : styles.mobileStars}>
-            {Array.from({ length: 5 }).map((_, index) => (
-                <React.Fragment key={index}>
-                    {isWeb ? (
-                        <CustomTooltip
-                            placement="top"
-                            trigger={(triggerProps) => (
-                                <IconButton {...triggerProps} onPress={() => rateFood(index + 1)} style={styles.paddingSmall}>
-                                    <MaterialIcons
-                                        name={previousFeedback?.rating > index ? 'star' : 'star-border'}
-                                        size={22}
-                                        color={foodsAreaColor}
-                                    />
-                                </IconButton>
-                            )}
-                        >
-                            <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
-                                <TooltipText fontSize="$sm" color={theme.tooltip.text}>
-                                    {`${translate(TranslationKeys.set_rating_to)} ${index + 1}`}
-                                </TooltipText>
-                            </TooltipContent>
-                        </CustomTooltip>
-                    ) : (
-                        <TouchableOpacity onPress={() => rateFood(index + 1)}>
+    const renderStarItem = useCallback((index: number) => (
+        <React.Fragment key={index}>
+            {isWeb ? (
+                <CustomTooltip
+                    placement="top"
+                    trigger={(triggerProps) => (
+                        <IconButton {...triggerProps} onPress={() => rateFood(index + 1)} style={styles.paddingSmall}>
                             <MaterialIcons
                                 name={previousFeedback?.rating > index ? 'star' : 'star-border'}
-                                size={20}
+                                size={22}
                                 color={foodsAreaColor}
                             />
-                        </TouchableOpacity>
+                        </IconButton>
                     )}
-                </React.Fragment>
-            ))}
+                >
+                    <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
+                        <TooltipText fontSize="$sm" color={theme.tooltip.text}>
+                            {`${translate(TranslationKeys.set_rating_to)} ${index + 1}`}
+                        </TooltipText>
+                    </TooltipContent>
+                </CustomTooltip>
+            ) : (
+                <TouchableOpacity onPress={() => rateFood(index + 1)}>
+                    <MaterialIcons
+                        name={previousFeedback?.rating > index ? 'star' : 'star-border'}
+                        size={20}
+                        color={foodsAreaColor}
+                    />
+                </TouchableOpacity>
+            )}
+        </React.Fragment>
+    ), [previousFeedback?.rating, foodsAreaColor, rateFood, theme, translate]);
+
+    const renderRatingStars = useCallback(() => (
+        <View style={isWeb ? styles.stars : styles.mobileStars}>
+            {Array.from({ length: 5 }).map((_, index) => renderStarItem(index))}
         </View>
-    ), [isWeb, previousFeedback?.rating, foodsAreaColor, rateFood, theme, translate]);
+    ), [renderStarItem]);
 
     if (isWeb) {
         return (

--- a/apps/frontend/app/app/(app)/foodoffers/hooks.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/hooks.ts
@@ -116,6 +116,24 @@ export const useFoodOffersData = (
         return prefetchedFoodOffers[getCacheKey(canteenId, date)];
     }, [prefetchedFoodOffers]);
 
+    const prefetchNextDay = useCallback((canteenId: string, date: string) => {
+        const nextCacheKey = getCacheKey(canteenId, date);
+
+        // Check if already fetched or in progress to prevent duplicate calls
+        if (prefetchedKeys.current.has(nextCacheKey) || prefetchedFoodOffers[nextCacheKey]) return;
+
+        prefetchedKeys.current.add(nextCacheKey);
+        fetchFoodOffersByCanteen(canteenId, date)
+            .then(res => {
+                const offers = res?.data || [];
+                setPrefetchedFoodOffers(p => ({ ...p, [nextCacheKey]: offers }));
+            })
+            .catch(e => {
+                console.error('Error prefetching Food Offers:', e);
+                prefetchedKeys.current.delete(nextCacheKey); // Allow retry on error
+            });
+    }, [prefetchedFoodOffers]);
+
     const updateSort = useCallback((id: FoodSortOption, foodOffers: DatabaseTypes.Foodoffers[]) => {
         const { profile, languageCode } = stateRef.current;
         const state = store.getState() as RootState;
@@ -173,24 +191,10 @@ export const useFoodOffersData = (
         runAfterInteractions(() => {
             for (let i = 1; i <= 2; i++) {
                 const date = format(addDays(parseDateOnly(selectedDate), i), 'yyyy-MM-dd');
-                const nextCacheKey = getCacheKey(canteenId, date);
-                
-                // Check if already fetched or in progress to prevent duplicate calls
-                if (!prefetchedKeys.current.has(nextCacheKey) && !prefetchedFoodOffers[nextCacheKey]) {
-                    prefetchedKeys.current.add(nextCacheKey);
-                    fetchFoodOffersByCanteen(canteenId, date)
-                        .then(res => {
-                            const offers = res?.data || [];
-                            setPrefetchedFoodOffers(p => ({ ...p, [nextCacheKey]: offers }));
-                        })
-                        .catch(e => {
-                            console.error('Error prefetching Food Offers:', e);
-                            prefetchedKeys.current.delete(nextCacheKey); // Allow retry on error
-                        });
-                }
+                prefetchNextDay(canteenId, date);
             }
         });
-    }, [selectedCanteen, selectedDate, getCachedOffers, prefetchedFoodOffers, updateSort, sortBy, dispatch, currentFoodOffers]);
+    }, [selectedCanteen, selectedDate, getCachedOffers, prefetchNextDay, updateSort, sortBy, dispatch, currentFoodOffers]);
 
     const fetchCanteenLabels = useCallback(async () => {
         try {

--- a/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -24,6 +24,85 @@ import { PriceGroupKey } from '@/app/(app)/settings/types';
 
 const fontSize = 10;
 
+const buildFoodMarkingEntry = (food: any, markings: any[] | undefined, markingGroups: any, theme: any, mode: string) => {
+	// Extract marking IDs properly
+	const markingIds = food?.markings?.map((mark: any) => mark.markings_id) || [];
+
+	// Find matching marking objects from `markings` array
+	let filteredMarkings = markings?.filter((mark: any) => markingIds.includes(mark.id)) || [];
+
+	// Sort the filtered markings using sortMarkingsByGroup
+	filteredMarkings = sortMarkingsByGroup(filteredMarkings, markingGroups as any);
+
+	return filteredMarkings.map((item: any) => ({
+		image: item?.image_remote_url ? { uri: item.image_remote_url } : { uri: getImageUrl(item.image) },
+		bgColor: item?.background_color,
+		color: myContrastColor(item?.background_color, theme, mode === 'dark'),
+		shortCode: item?.short_code,
+		icon: item?.icon,
+	}));
+};
+
+const renderMarkingIcon = (marking: any, idx: number) => {
+	const iconParts = marking?.icon?.split(':') || [];
+	const [library, name] = iconParts;
+	const Icon = library && iconLibraries[library];
+	if (marking?.icon) {
+		return (
+			<View
+				key={idx}
+				style={{
+					...styles.iconMarking,
+					backgroundColor: marking?.bgColor,
+					marginRight: 5,
+					borderRadius: 5,
+				}}
+			>
+				<Icon name={name} size={14} color={marking.color} />
+			</View>
+		);
+	}
+	if (!marking?.image?.uri && marking?.shortCode) {
+		return (
+			<View
+				key={idx}
+				style={{
+					...styles.shortCode,
+					backgroundColor: marking?.bgColor,
+					marginRight: 5,
+					padding: 2,
+					borderRadius: 5,
+				}}
+			>
+				<Text
+					style={{
+						color: marking.color,
+						fontSize: fontSize,
+					}}
+				>
+					{marking?.shortCode}
+				</Text>
+			</View>
+		);
+	}
+	if (marking?.image?.uri) {
+		return (
+			<Image
+				key={idx}
+				source={marking.image.uri}
+				style={{
+					backgroundColor: marking?.bgColor,
+					width: 15,
+					height: 15,
+					marginRight: 2,
+					borderRadius: 5,
+				}}
+			/>
+		);
+	}
+	return null;
+};
+
 const Index = () => {
 	const printRef = useRef<any>(null);
 	const { translate } = useLanguage();
@@ -238,25 +317,7 @@ const Index = () => {
 			Object.entries(foodData).forEach(([day, dayFoods]) => {
 				dayFoods.forEach((food: any) => {
 					if (!food?.id) return; // Skip if food has no ID
-
-					// Extract marking IDs properly
-					const markingIds = food?.markings?.map((mark: any) => mark.markings_id) || [];
-
-					// Find matching marking objects from `markings` array
-					let filteredMarkings = markings?.filter((mark: any) => markingIds.includes(mark.id)) || [];
-
-					// Sort the filtered markings using sortMarkingsByGroup
-					filteredMarkings = sortMarkingsByGroup(filteredMarkings, markingGroups as any);
-
-					const dummyMarkings = filteredMarkings.map((item: any) => ({
-						image: item?.image_remote_url ? { uri: item.image_remote_url } : { uri: getImageUrl(item.image) },
-						bgColor: item?.background_color,
-						color: myContrastColor(item?.background_color, theme, mode === 'dark'),
-						shortCode: item?.short_code,
-						icon: item?.icon,
-					}));
-
-					newMarkings[food.id] = dummyMarkings; // Store by food ID
+					newMarkings[food.id] = buildFoodMarkingEntry(food, markings, markingGroups, theme, mode); // Store by food ID
 				});
 			});
 			setMarkingsState(newMarkings);
@@ -508,65 +569,7 @@ const Index = () => {
 																				padding: 2,
 																			}}
 																		>
-																			{foodMarkings[filteredFood.id]?.map((marking: any, idx: number) => {
-																					const iconParts = marking?.icon?.split(':') || [];
-																					const [library, name] = iconParts;
-																					const Icon = library && iconLibraries[library];
-																					if (marking?.icon) {
-																						return (
-																							<View
-																								key={idx}
-																								style={{
-																									...styles.iconMarking,
-																									backgroundColor: marking?.bgColor,
-																									marginRight: 5,
-																									borderRadius: 5,
-																								}}
-																							>
-																								<Icon name={name} size={14} color={marking.color} />
-																							</View>
-																						);
-																					}
-																					if (!marking?.image?.uri && marking?.shortCode) {
-																						return (
-																							<View
-																								key={idx}
-																								style={{
-																									...styles.shortCode,
-																									backgroundColor: marking?.bgColor,
-																									marginRight: 5,
-																									padding: 2,
-																									borderRadius: 5,
-																								}}
-																							>
-																								<Text
-																									style={{
-																										color: marking.color,
-																										fontSize: fontSize,
-																									}}
-																								>
-																									{marking?.shortCode}
-																								</Text>
-																							</View>
-																						);
-																					}
-																					if (marking?.image?.uri) {
-																						return (
-																							<Image
-																								key={idx}
-																								source={marking.image.uri}
-																								style={{
-																									backgroundColor: marking?.bgColor,
-																									width: 15,
-																									height: 15,
-																									marginRight: 2,
-																									borderRadius: 5,
-																								}}
-																							/>
-																						);
-																					}
-																					return null;
-																				})}
+																			{foodMarkings[filteredFood.id]?.map(renderMarkingIcon)}
 																		</View>
 																	)}
 																</View>

--- a/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
@@ -150,6 +150,46 @@ const CourseTimetable: React.FC<CourseTimetableProps> = ({ events, openSheet, se
 		openSheet();
 	};
 
+	const renderDayEvent = (event: EventTypes, eventIndex: number, dayEvents: EventTypes[]) => {
+		// Find overlapping events
+		const overlappingEvents = dayEvents.filter((e, i) => i !== eventIndex && new Date(`1970-01-01T${e.startTime}:00Z`).getTime() < new Date(`1970-01-01T${event.endTime}:00Z`).getTime() && new Date(`1970-01-01T${e.endTime}:00Z`).getTime() > new Date(`1970-01-01T${event.startTime}:00Z`).getTime());
+
+		// Calculate horizontal position and width
+		const overlapCount = overlappingEvents.length + 1; // Include the current event
+		const eventWidth = getColumnWidth() / overlapCount; // Divide width equally
+		const horizontalPosition = (eventIndex % overlapCount) * eventWidth; // Position side by side
+
+		return (
+			<CustomTooltip
+				key={event.id}
+				placement="top"
+				trigger={triggerProps => (
+					<TouchableOpacity
+						{...triggerProps}
+						style={{
+							...styles.slotEvent,
+							backgroundColor: event.color,
+							borderColor: event.color,
+							height: calculateHeight(event.startTime, event.endTime),
+							top: calculateTopPosition(event.startTime),
+							width: eventWidth - 4, // Add some spacing
+							left: horizontalPosition,
+						}}
+						onPress={() => handleUpdateEvent(event)}
+					>
+						<Text style={styles.eventText}>{event.title}</Text>
+					</TouchableOpacity>
+				)}
+			>
+				<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
+					<TooltipText fontSize="$sm" color={theme.tooltip.text}>
+						{`${translate(TranslationKeys.event)}: ${translate(TranslationKeys.edit)}`}
+					</TooltipText>
+				</TooltipContent>
+			</CustomTooltip>
+		);
+	};
+
 	const reorderedDays = useMemo(() => {
 		if (!days) return [];
 		const firstDayIndex = days.findIndex(day => day.id.toLocaleLowerCase() === firstDayOfTheWeek.id);
@@ -240,45 +280,7 @@ const CourseTimetable: React.FC<CourseTimetableProps> = ({ events, openSheet, se
 								{events
 										?.filter(event => event?.day?.toLocaleLowerCase() === day.id) // Filter events for the current day
 										.sort((a, b) => new Date(`1970-01-01T${a.startTime}:00Z`).getTime() - new Date(`1970-01-01T${b.startTime}:00Z`).getTime()) // Sort events by start time
-										.map((event, eventIndex, dayEvents) => {
-											// Find overlapping events
-											const overlappingEvents = dayEvents.filter((e, i) => i !== eventIndex && new Date(`1970-01-01T${e.startTime}:00Z`).getTime() < new Date(`1970-01-01T${event.endTime}:00Z`).getTime() && new Date(`1970-01-01T${e.endTime}:00Z`).getTime() > new Date(`1970-01-01T${event.startTime}:00Z`).getTime());
-
-											// Calculate horizontal position and width
-											const overlapCount = overlappingEvents.length + 1; // Include the current event
-											const eventWidth = getColumnWidth() / overlapCount; // Divide width equally
-											const horizontalPosition = (eventIndex % overlapCount) * eventWidth; // Position side by side
-
-											return (
-												<CustomTooltip
-													key={event.id}
-													placement="top"
-													trigger={triggerProps => (
-														<TouchableOpacity
-															{...triggerProps}
-															style={{
-																...styles.slotEvent,
-																backgroundColor: event.color,
-																borderColor: event.color,
-																height: calculateHeight(event.startTime, event.endTime),
-																top: calculateTopPosition(event.startTime),
-																width: eventWidth - 4, // Add some spacing
-																left: horizontalPosition,
-															}}
-															onPress={() => handleUpdateEvent(event)}
-														>
-															<Text style={styles.eventText}>{event.title}</Text>
-														</TouchableOpacity>
-													)}
-												>
-													<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
-														<TooltipText fontSize="$sm" color={theme.tooltip.text}>
-															{`${translate(TranslationKeys.event)}: ${translate(TranslationKeys.edit)}`}
-														</TooltipText>
-													</TooltipContent>
-												</CustomTooltip>
-											);
-										})}
+										.map(renderDayEvent)}
 							</View>
 						))}
 					</View>

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -10,164 +10,165 @@ import { useTheme } from '@/hooks/useTheme';
 import { StringHelper } from 'repo-depkit-common';
 import { resolveLocationHref } from '@/helper/MarkdownLinkHelper';
 
+// Regex patterns for different content types
+const CONTENT_PATTERNS = {
+	email: /\[([^\]]+)]\((mailto:[^)]+)\)/,
+	location: /\[([^\]]+)]\(((?:geo|maps):[^)]+)\)/i,
+	link: /\[([^\]]+)]\((https?:\/\/[^)]+)\)/,
+	image: /!\[([^\]]*)]\(([^)]+)\)/,
+	heading: /^#{1,3}\s*(.*)$/,
+};
+
+// Process markdown content into a structured format
+const processMarkdownContent = (lines: string[]) => {
+	const result: any[] = [];
+	const stack: Array<{ level: number; items: any[] }> = [{ level: 0, items: result }];
+	let currentParagraph: Array<{ text: string; indent: number }> = [];
+
+	const flushTextContent = () => {
+		if (currentParagraph.length) {
+			const minIndent = Math.min(...currentParagraph.map(item => item.indent));
+			const textContent = currentParagraph.map(item => item.text).join('\n');
+			stack.at(-1)!.items.push({
+				type: 'text',
+				content: textContent,
+				indent: Number.isFinite(minIndent) ? minIndent : 0,
+			});
+			currentParagraph = [];
+		}
+	};
+
+	for (let i = 0; i < lines.length; i += 1) {
+		const line = lines[i];
+		const normalizedLine = StringHelper.replaceAllLiteralWithOptions({ str: line, find: '\t', replace: '    ' });
+		const indentLength = normalizedLine.match(/^\s*/)?.[0].length ?? 0;
+		const trimmedLine = line.trim();
+
+		const headingMatch = CONTENT_PATTERNS.heading.exec(trimmedLine);
+		if (headingMatch) {
+			flushTextContent();
+
+			const level = headingMatch[0].match(/#/g)?.length || 1;
+			const headerText = headingMatch[1].trim();
+
+			if (level === 1) {
+				while (stack.length > 1) {
+					stack.pop();
+				}
+
+				stack.at(-1)!.items.push({
+					type: 'heading',
+					content: headerText,
+					level,
+				});
+				continue;
+			}
+
+			while (stack.length > 1 && stack.at(-1)!.level >= level) {
+				stack.pop();
+			}
+
+			let startCollapsed = false;
+			for (let lookahead = i + 1; lookahead < lines.length; lookahead += 1) {
+				const lookLine = lines[lookahead];
+				if (lookLine.trim() === '') {
+					continue;
+				}
+				const lookNormalized = StringHelper.replaceAllLiteralWithOptions({ str: lookLine, find: '\t', replace: '    ' });
+				const lookIndent = lookNormalized.match(/^\s*/)?.[0].length ?? 0;
+				startCollapsed = lookIndent > 0;
+				break;
+			}
+
+			const newSection = {
+				type: 'collapsible',
+				header: headerText,
+				items: [],
+				level,
+				startCollapsed,
+			};
+
+			stack.at(-1)!.items.push(newSection);
+			stack.push({ level, items: newSection.items });
+			continue;
+		}
+
+		if (trimmedLine === '') {
+			flushTextContent();
+			stack.at(-1)!.items.push({ type: 'emptyLine' });
+			continue;
+		}
+
+		const trimmedForMatch = trimmedLine;
+
+		if (CONTENT_PATTERNS.image.test(trimmedForMatch)) {
+			flushTextContent();
+			const match = CONTENT_PATTERNS.image.exec(trimmedForMatch);
+			stack.at(-1)!.items.push({
+				type: 'image',
+				altText: match?.[1] || '',
+				url: match?.[2] || '',
+				indent: indentLength,
+			});
+			continue;
+		}
+
+		if (CONTENT_PATTERNS.email.test(trimmedForMatch)) {
+			flushTextContent();
+			const match = CONTENT_PATTERNS.email.exec(trimmedForMatch);
+			stack.at(-1)!.items.push({
+				type: 'email',
+				displayText: match?.[1],
+				email: match?.[2],
+				indent: indentLength,
+			});
+			continue;
+		}
+
+		if (CONTENT_PATTERNS.location.test(trimmedForMatch)) {
+			flushTextContent();
+			const match = CONTENT_PATTERNS.location.exec(trimmedForMatch);
+			stack.at(-1)!.items.push({
+				type: 'location',
+				displayText: match?.[1],
+				url: match?.[2],
+				indent: indentLength,
+			});
+			continue;
+		}
+
+		if (CONTENT_PATTERNS.link.test(trimmedForMatch)) {
+			flushTextContent();
+			const match = CONTENT_PATTERNS.link.exec(trimmedForMatch);
+			stack.at(-1)!.items.push({
+				type: 'link',
+				displayText: match?.[1],
+				url: match?.[2],
+				indent: indentLength,
+			});
+			continue;
+		}
+
+		currentParagraph.push({
+			text: trimmedLine,
+			indent: indentLength,
+		});
+	}
+
+	flushTextContent();
+	return result;
+};
+
 const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColor, imageWidth, imageHeight }) => {
 	const { theme } = useTheme();
 	const { primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
 
 	const getContent = () => {
-		// Regex patterns for different content types
-		const contentPatterns = {
-			email: /\[([^\]]+)]\((mailto:[^)]+)\)/,
-			location: /\[([^\]]+)]\(((?:geo|maps):[^)]+)\)/i,
-			link: /\[([^\]]+)]\((https?:\/\/[^)]+)\)/,
-			image: /!\[([^\]]*)]\(([^)]+)\)/,
-			heading: /^#{1,3}\s*(.*)$/,
-		};
-
 		if (content) {
 			const rawText = content;
 			const lines = rawText.split('\n');
 
 			const contrastColor = myContrastColor(backgroundColor || primaryColor, theme, mode === 'dark');
-			// Process content into a structured format
-			const processContent = (lines: string[]) => {
-				const result: any[] = [];
-				const stack: Array<{ level: number; items: any[] }> = [{ level: 0, items: result }];
-				let currentParagraph: Array<{ text: string; indent: number }> = [];
-
-				const flushTextContent = () => {
-					if (currentParagraph.length) {
-						const minIndent = Math.min(...currentParagraph.map(item => item.indent));
-						const textContent = currentParagraph.map(item => item.text).join('\n');
-						stack.at(-1)!.items.push({
-							type: 'text',
-							content: textContent,
-							indent: Number.isFinite(minIndent) ? minIndent : 0,
-						});
-						currentParagraph = [];
-					}
-				};
-
-				for (let i = 0; i < lines.length; i += 1) {
-					const line = lines[i];
-					const normalizedLine = StringHelper.replaceAllLiteralWithOptions({ str: line, find: '\t', replace: '    ' });
-					const indentLength = normalizedLine.match(/^\s*/)?.[0].length ?? 0;
-					const trimmedLine = line.trim();
-
-					const headingMatch = contentPatterns.heading.exec(trimmedLine);
-					if (headingMatch) {
-						flushTextContent();
-
-						const level = headingMatch[0].match(/#/g)?.length || 1;
-						const headerText = headingMatch[1].trim();
-
-						if (level === 1) {
-							while (stack.length > 1) {
-								stack.pop();
-							}
-
-							stack.at(-1)!.items.push({
-								type: 'heading',
-								content: headerText,
-								level,
-							});
-							continue;
-						}
-
-						while (stack.length > 1 && stack.at(-1)!.level >= level) {
-							stack.pop();
-						}
-
-						let startCollapsed = false;
-						for (let lookahead = i + 1; lookahead < lines.length; lookahead += 1) {
-							const lookLine = lines[lookahead];
-							if (lookLine.trim() === '') {
-								continue;
-							}
-							const lookNormalized = StringHelper.replaceAllLiteralWithOptions({ str: lookLine, find: '\t', replace: '    ' });
-							const lookIndent = lookNormalized.match(/^\s*/)?.[0].length ?? 0;
-							startCollapsed = lookIndent > 0;
-							break;
-						}
-
-						const newSection = {
-							type: 'collapsible',
-							header: headerText,
-							items: [],
-							level,
-							startCollapsed,
-						};
-
-						stack.at(-1)!.items.push(newSection);
-						stack.push({ level, items: newSection.items });
-						continue;
-					}
-
-					if (trimmedLine === '') {
-						flushTextContent();
-						stack.at(-1)!.items.push({ type: 'emptyLine' });
-						continue;
-					}
-
-					const trimmedForMatch = trimmedLine;
-
-					if (contentPatterns.image.test(trimmedForMatch)) {
-						flushTextContent();
-						const match = contentPatterns.image.exec(trimmedForMatch);
-						stack.at(-1)!.items.push({
-							type: 'image',
-							altText: match?.[1] || '',
-							url: match?.[2] || '',
-							indent: indentLength,
-						});
-						continue;
-					}
-
-					if (contentPatterns.email.test(trimmedForMatch)) {
-						flushTextContent();
-						const match = contentPatterns.email.exec(trimmedForMatch);
-						stack.at(-1)!.items.push({
-							type: 'email',
-							displayText: match?.[1],
-							email: match?.[2],
-							indent: indentLength,
-						});
-						continue;
-					}
-
-					if (contentPatterns.location.test(trimmedForMatch)) {
-						flushTextContent();
-						const match = contentPatterns.location.exec(trimmedForMatch);
-						stack.at(-1)!.items.push({
-							type: 'location',
-							displayText: match?.[1],
-							url: match?.[2],
-							indent: indentLength,
-						});
-						continue;
-					}
-
-					if (contentPatterns.link.test(trimmedForMatch)) {
-						flushTextContent();
-						const match = contentPatterns.link.exec(trimmedForMatch);
-						stack.at(-1)!.items.push({
-							type: 'link',
-							displayText: match?.[1],
-							url: match?.[2],
-							indent: indentLength,
-						});
-						continue;
-					}
-
-					currentParagraph.push({
-						text: trimmedLine,
-						indent: indentLength,
-					});
-				}
-
-				flushTextContent();
-				return result;
-			};
 
 			const calculateMarginLeft = (level: number, indent = 0) => level * 16 + indent * 4;
 
@@ -320,7 +321,7 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 				return items.map((item, index) => renderContentItem(item, level, index));
 			};
 
-			const hierarchicalContent = processContent(lines);
+			const hierarchicalContent = processMarkdownContent(lines);
 			return <View style={{ paddingBottom: 20 }}>{renderContent(hierarchicalContent)}</View>;
 		}
 

--- a/apps/frontend/app/components/ExpoUpdateLoader/ExpoUpdateLoader.tsx
+++ b/apps/frontend/app/components/ExpoUpdateLoader/ExpoUpdateLoader.tsx
@@ -13,6 +13,10 @@ interface ExpoUpdateLoaderProps {
 
 const TIMEOUT_MS = 10000; // 10 Sekunden
 
+function createTimeoutPromise(ms: number): Promise<null> {
+	return new Promise<null>(resolve => setTimeout(() => resolve(null), ms));
+}
+
 const ExpoUpdateLoader: React.FC<ExpoUpdateLoaderProps> = ({ children }) => {
 	const { isSmartPhone } = usePlatformHelper();
 	const { translate } = useLanguage();
@@ -28,7 +32,7 @@ const ExpoUpdateLoader: React.FC<ExpoUpdateLoaderProps> = ({ children }) => {
 				return;
 			}
 
-			const timeoutPromise = new Promise<null>(resolve => setTimeout(() => resolve(null), TIMEOUT_MS));
+			const timeoutPromise = createTimeoutPromise(TIMEOUT_MS);
 
 			try {
 				setStatus(TranslationKeys.CHECK_FOR_APP_UPDATES);

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -35,6 +35,208 @@ const getSortedBusinessHoursGroups = (groups: { id: string; sort?: number | null
 	});
 };
 
+const buildDayStartAndEndTimeDict = (
+	hoursList: any[],
+	sortedDayKeys: string[]
+): Record<string, { day: string; time_start: number | null; time_end: number | null }[]> => {
+	const dayStartAndEndTimeDict: Record<string, { day: string; time_start: number | null; time_end: number | null }[]> = {};
+
+	hoursList.forEach((entry: any) => {
+		sortedDayKeys.forEach(day => {
+			if (entry[day]) {
+				let timesForDay = dayStartAndEndTimeDict[day] || [];
+
+				let time_start_as_string = entry.time_start; // "08:00:00"
+				let time_end_as_string = entry.time_end; // "20:00:00"
+				if (!time_start_as_string || !time_end_as_string) {
+					timesForDay.push({
+						day,
+						time_start: null,
+						time_end: null,
+					});
+				} else {
+					let time_start_as_seconds = Number.parseInt(time_start_as_string.split(':')[0]) * 3600 + Number.parseInt(time_start_as_string.split(':')[1]) * 60;
+					let time_end_as_seconds = Number.parseInt(time_end_as_string.split(':')[0]) * 3600 + Number.parseInt(time_end_as_string.split(':')[1]) * 60;
+
+					timesForDay.push({
+						day,
+						time_start: time_start_as_seconds,
+						time_end: time_end_as_seconds,
+					});
+				}
+				dayStartAndEndTimeDict[day] = timesForDay;
+			}
+		});
+	});
+
+	return dayStartAndEndTimeDict;
+};
+
+// Group by same time_start and time_end
+// e.g. Monday: 08:00-12:00, 11:00-14:00, 14:00-20:00 ==> 08:00-20:00
+const computeConsecutiveRangesByDay = (
+	sortedDayKeys: string[],
+	dayStartAndEndTimeDict: Record<string, { day: string; time_start: number | null; time_end: number | null }[]>
+): Record<string, { time_start: number | null; time_end: number | null }[]> => {
+	const dayConsecutiveRanges: Record<string, { time_start: number | null; time_end: number | null }[]> = {};
+	// Iterate over each day and its corresponding time ranges
+	sortedDayKeys.forEach(day => {
+		const timeRanges = dayStartAndEndTimeDict[day];
+		if (!timeRanges || timeRanges.length === 0) {
+		} else {
+			// sorting the time ranges by time_start
+			timeRanges.sort((a, b) => {
+				if (a.time_start === null || b.time_start === null) {
+					// null will be at the end
+					return a.time_start === null ? 1 : -1;
+				}
+				return a.time_start - b.time_start;
+			});
+			let consecutiveRanges: {
+				time_start: number | null;
+				time_end: number | null;
+			}[] = [];
+			// we now want to find overlapping time ranges for each day
+			let currentRange: {
+				time_start: number | null;
+				time_end: number | null;
+			} | null = null;
+			timeRanges.forEach(timeRange => {
+				const { time_start, time_end } = timeRange;
+				if (currentRange?.time_start == null || currentRange.time_end == null) {
+					currentRange = { time_start, time_end };
+				} else {
+					if (time_start === currentRange.time_start && time_end === currentRange.time_end) {
+						// do nothing
+					} else if (time_start === null || time_end === null) {
+						// do nothing
+					} else if (time_start >= currentRange.time_start && time_end <= currentRange.time_end) {
+						// do nothing
+					} else if (time_start < currentRange.time_end && time_end > currentRange.time_end) {
+						currentRange.time_end = time_end;
+					} else if (time_start > currentRange.time_end) {
+						consecutiveRanges.push(currentRange); // push the current range to the consecutive ranges
+						currentRange = { time_start, time_end }; // start a new range
+					}
+				}
+			});
+			if (currentRange) {
+				consecutiveRanges.push(currentRange); // push the last range to the consecutive ranges
+			}
+
+			dayConsecutiveRanges[day] = consecutiveRanges;
+		}
+	});
+	return dayConsecutiveRanges;
+};
+
+const mergeDaysWithSameTimeRanges = (
+	sortedDayKeys: string[],
+	dayConsecutiveRanges: Record<string, { time_start: number | null; time_end: number | null }[]>
+): { day: string[]; time_start: string | null; time_end: string | null }[] => {
+	const groupedTimes: {
+		day: string[];
+		time_start: string | null;
+		time_end: string | null;
+	}[] = [];
+
+	let previousSavedTimeRanges: {
+		time_start: number | null;
+		time_end: number | null;
+	}[] = [];
+	let previousDaysForTimeRange: string[] = [];
+	for (let i = 0; i < sortedDayKeys.length; i++) {
+		let currentDay = sortedDayKeys[i];
+		let currentTimeRanges = dayConsecutiveRanges[currentDay];
+		if (!currentTimeRanges || currentTimeRanges.length === 0) {
+			// if we have no time ranges for this day, we can skip it
+			// but we need to check if we have a previous day with time ranges and if so, we need to add it to the groupedTimes
+			if (previousDaysForTimeRange.length > 0 && previousSavedTimeRanges.length > 0) {
+				// we have a previous day with time ranges
+				previousSavedTimeRanges.forEach(timeRange => {
+					groupedTimes.push({
+						day: previousDaysForTimeRange,
+						time_start: timeRange.time_start === null ? null : timeRange.time_start.toString(),
+						time_end: timeRange.time_end === null ? null : timeRange.time_end.toString(),
+					});
+				});
+				previousSavedTimeRanges = [];
+				previousDaysForTimeRange = [];
+			} else {
+				// Do nothing as previous day has handled the time ranges
+			}
+		} else {
+			// So we have previous time ranges and now we want to check if the current time ranges are the same as the previous time ranges
+			let isLastDay = i === sortedDayKeys.length - 1;
+
+			let isSameTimeRange = false;
+
+			if (currentTimeRanges.length === previousSavedTimeRanges.length) {
+				currentTimeRanges.forEach(timeRange => {
+					previousSavedTimeRanges.forEach(previousTimeRange => {
+						if (timeRange.time_start === previousTimeRange.time_start && timeRange.time_end === previousTimeRange.time_end) {
+							isSameTimeRange = true;
+						}
+					});
+				});
+			}
+
+			if (isSameTimeRange) {
+				// we have a same time range, so we can add the current day to the previous days
+				previousDaysForTimeRange.push(currentDay);
+			} else {
+				// we have a different time range, so we need to save the previous time ranges and add the current day to the grouped times
+				previousSavedTimeRanges.forEach(timeRange => {
+					groupedTimes.push({
+						day: previousDaysForTimeRange,
+						time_start: timeRange.time_start === null ? null : timeRange.time_start.toString(),
+						time_end: timeRange.time_end === null ? null : timeRange.time_end.toString(),
+					});
+				});
+				previousDaysForTimeRange = [currentDay];
+				previousSavedTimeRanges = currentTimeRanges;
+			}
+
+			// if we are at the last day, we need to add the previous time ranges to the grouped times
+			if (isLastDay) {
+				previousSavedTimeRanges.forEach(timeRange => {
+					groupedTimes.push({
+						day: previousDaysForTimeRange,
+						time_start: timeRange.time_start === null ? null : timeRange.time_start.toString(),
+						time_end: timeRange.time_end === null ? null : timeRange.time_end.toString(),
+					});
+				});
+			}
+		}
+	}
+
+	return groupedTimes;
+};
+
+// Format time_start and time_end from seconds back to HH:mm:ss
+const formatGroupedTimesInPlace = (groupedTimes: { time_start: string | null; time_end: string | null }[]) => {
+	groupedTimes.forEach(timeRange => {
+		if (timeRange.time_start === null || timeRange.time_end === null) {
+			// do nothing if value is null
+			return;
+		}
+
+		let time_start_in_seconds = Number.parseInt(timeRange.time_start);
+		let time_end_in_seconds = Number.parseInt(timeRange.time_end);
+		let time_start_hours = Math.floor(time_start_in_seconds / 3600);
+		let time_start_minutes = Math.floor((time_start_in_seconds % 3600) / 60);
+		let time_start_seconds = time_start_in_seconds % 60;
+		let time_end_hours = Math.floor(time_end_in_seconds / 3600);
+		let time_end_minutes = Math.floor((time_end_in_seconds % 3600) / 60);
+		let time_end_seconds = time_end_in_seconds % 60;
+		timeRange.time_start = `${String(time_start_hours).padStart(2, '0')}:${String(time_start_minutes).padStart(2, '0')}:${String(time_start_seconds).padStart(2, '0')}`;
+		timeRange.time_end = `${String(time_end_hours).padStart(2, '0')}:${String(time_end_minutes).padStart(2, '0')}:${String(time_end_seconds).padStart(2, '0')}`;
+
+		timeRange.time_start = `${String(time_start_hours).padStart(2, '0')}:${String(time_start_minutes).padStart(2, '0')}:${String(time_start_seconds).padStart(2, '0')}`;
+		timeRange.time_end = `${String(time_end_hours).padStart(2, '0')}:${String(time_end_minutes).padStart(2, '0')}:${String(time_end_seconds).padStart(2, '0')}`;
+	});
+};
+
 export const HoursSheetContent: React.FC = () => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
@@ -140,186 +342,11 @@ export const HoursSheetContent: React.FC = () => {
 
 			Object.entries(groupedByGroupName).forEach(([groupId, groupData]) => {
 				const { name: groupName, hours: hoursList } = groupData;
-				const dayStartAndEndTimeDict: Record<string, { day: string; time_start: number | null; time_end: number | null }[]> = {};
+				const dayStartAndEndTimeDict = buildDayStartAndEndTimeDict(hoursList, sortedDayKeys);
+				const dayConsecutiveRanges = computeConsecutiveRangesByDay(sortedDayKeys, dayStartAndEndTimeDict);
+				const groupedTimes = mergeDaysWithSameTimeRanges(sortedDayKeys, dayConsecutiveRanges);
+				formatGroupedTimesInPlace(groupedTimes);
 
-				hoursList.forEach((entry: any) => {
-					sortedDayKeys.forEach(day => {
-						if (entry[day]) {
-							let timesForDay = dayStartAndEndTimeDict[day] || [];
-
-							let time_start_as_string = entry.time_start; // "08:00:00"
-							let time_end_as_string = entry.time_end; // "20:00:00"
-							if (!time_start_as_string || !time_end_as_string) {
-								timesForDay.push({
-									day,
-									time_start: null,
-									time_end: null,
-								});
-							} else {
-								let time_start_as_seconds = Number.parseInt(time_start_as_string.split(':')[0]) * 3600 + Number.parseInt(time_start_as_string.split(':')[1]) * 60;
-								let time_end_as_seconds = Number.parseInt(time_end_as_string.split(':')[0]) * 3600 + Number.parseInt(time_end_as_string.split(':')[1]) * 60;
-
-								timesForDay.push({
-									day,
-									time_start: time_start_as_seconds,
-									time_end: time_end_as_seconds,
-								});
-							}
-							dayStartAndEndTimeDict[day] = timesForDay;
-						}
-					});
-				});
-
-				// Step 2: Group by same time_start and time_end
-				// e.g. Monday: 08:00-12:00, 11:00-14:00, 14:00-20:00 ==> 08:00-20:00
-				const dayConsecutiveRanges: Record<string, { time_start: number | null; time_end: number | null }[]> = {};
-				// Iterate over each day and its corresponding time ranges
-				sortedDayKeys.forEach(day => {
-					const timeRanges = dayStartAndEndTimeDict[day];
-					if (!timeRanges || timeRanges.length === 0) {
-					} else {
-						// sorting the time ranges by time_start
-						timeRanges.sort((a, b) => {
-							if (a.time_start === null || b.time_start === null) {
-								// null will be at the end
-								return a.time_start === null ? 1 : -1;
-							}
-							return a.time_start - b.time_start;
-						});
-						let consecutiveRanges: {
-							time_start: number | null;
-							time_end: number | null;
-						}[] = [];
-						// we now want to find overlapping time ranges for each day
-						let currentRange: {
-							time_start: number | null;
-							time_end: number | null;
-						} | null = null;
-						timeRanges.forEach(timeRange => {
-							const { time_start, time_end } = timeRange;
-							if (currentRange?.time_start == null || currentRange.time_end == null) {
-								currentRange = { time_start, time_end };
-							} else {
-								if (time_start === currentRange.time_start && time_end === currentRange.time_end) {
-									// do nothing
-								} else if (time_start === null || time_end === null) {
-									// do nothing
-								} else if (time_start >= currentRange.time_start && time_end <= currentRange.time_end) {
-									// do nothing
-								} else if (time_start < currentRange.time_end && time_end > currentRange.time_end) {
-									currentRange.time_end = time_end;
-								} else if (time_start > currentRange.time_end) {
-									consecutiveRanges.push(currentRange); // push the current range to the consecutive ranges
-									currentRange = { time_start, time_end }; // start a new range
-								}
-							}
-						});
-						if (currentRange) {
-							consecutiveRanges.push(currentRange); // push the last range to the consecutive ranges
-						}
-
-						dayConsecutiveRanges[day] = consecutiveRanges;
-					}
-				});
-				const groupedTimes: {
-					day: string[];
-					time_start: string | null;
-					time_end: string | null;
-				}[] = [];
-
-				let previousSavedTimeRanges: {
-					time_start: number | null;
-					time_end: number | null;
-				}[] = [];
-				let previousDaysForTimeRange: string[] = [];
-				for (let i = 0; i < sortedDayKeys.length; i++) {
-					let currentDay = sortedDayKeys[i];
-					let currentTimeRanges = dayConsecutiveRanges[currentDay];
-					if (!currentTimeRanges || currentTimeRanges.length === 0) {
-						// if we have no time ranges for this day, we can skip it
-						// but we need to check if we have a previous day with time ranges and if so, we need to add it to the groupedTimes
-						if (previousDaysForTimeRange.length > 0 && previousSavedTimeRanges.length > 0) {
-							// we have a previous day with time ranges
-							previousSavedTimeRanges.forEach(timeRange => {
-								groupedTimes.push({
-									day: previousDaysForTimeRange,
-									time_start: timeRange.time_start === null ? null : timeRange.time_start.toString(),
-									time_end: timeRange.time_end === null ? null : timeRange.time_end.toString(),
-								});
-							});
-							previousSavedTimeRanges = [];
-							previousDaysForTimeRange = [];
-						} else {
-							// Do nothing as previous day has handled the time ranges
-						}
-					} else {
-						// So we have previous time ranges and now we want to check if the current time ranges are the same as the previous time ranges
-						let isLastDay = i === sortedDayKeys.length - 1;
-
-						let isSameTimeRange = false;
-
-						if (currentTimeRanges.length === previousSavedTimeRanges.length) {
-							currentTimeRanges.forEach(timeRange => {
-								previousSavedTimeRanges.forEach(previousTimeRange => {
-									if (timeRange.time_start === previousTimeRange.time_start && timeRange.time_end === previousTimeRange.time_end) {
-										isSameTimeRange = true;
-									}
-								});
-							});
-						}
-
-						if (isSameTimeRange) {
-							// we have a same time range, so we can add the current day to the previous days
-							previousDaysForTimeRange.push(currentDay);
-						} else {
-							// we have a different time range, so we need to save the previous time ranges and add the current day to the grouped times
-							previousSavedTimeRanges.forEach(timeRange => {
-								groupedTimes.push({
-									day: previousDaysForTimeRange,
-									time_start: timeRange.time_start === null ? null : timeRange.time_start.toString(),
-									time_end: timeRange.time_end === null ? null : timeRange.time_end.toString(),
-								});
-							});
-							previousDaysForTimeRange = [currentDay];
-							previousSavedTimeRanges = currentTimeRanges;
-						}
-
-						// if we are at the last day, we need to add the previous time ranges to the grouped times
-						if (isLastDay) {
-							previousSavedTimeRanges.forEach(timeRange => {
-								groupedTimes.push({
-									day: previousDaysForTimeRange,
-									time_start: timeRange.time_start === null ? null : timeRange.time_start.toString(),
-									time_end: timeRange.time_end === null ? null : timeRange.time_end.toString(),
-								});
-							});
-						}
-					}
-				}
-
-				// Step 4: Format time_start and time_end from seconds back to HH:mm:ss
-				groupedTimes.forEach(timeRange => {
-					if (timeRange.time_start === null || timeRange.time_end === null) {
-						// do nothing if value is null
-						return;
-					}
-
-					let time_start_in_seconds = Number.parseInt(timeRange.time_start);
-					let time_end_in_seconds = Number.parseInt(timeRange.time_end);
-					let time_start_hours = Math.floor(time_start_in_seconds / 3600);
-					let time_start_minutes = Math.floor((time_start_in_seconds % 3600) / 60);
-					let time_start_seconds = time_start_in_seconds % 60;
-					let time_end_hours = Math.floor(time_end_in_seconds / 3600);
-					let time_end_minutes = Math.floor((time_end_in_seconds % 3600) / 60);
-					let time_end_seconds = time_end_in_seconds % 60;
-					timeRange.time_start = `${String(time_start_hours).padStart(2, '0')}:${String(time_start_minutes).padStart(2, '0')}:${String(time_start_seconds).padStart(2, '0')}`;
-					timeRange.time_end = `${String(time_end_hours).padStart(2, '0')}:${String(time_end_minutes).padStart(2, '0')}:${String(time_end_seconds).padStart(2, '0')}`;
-
-					timeRange.time_start = `${String(time_start_hours).padStart(2, '0')}:${String(time_start_minutes).padStart(2, '0')}:${String(time_start_seconds).padStart(2, '0')}`;
-					timeRange.time_end = `${String(time_end_hours).padStart(2, '0')}:${String(time_end_minutes).padStart(2, '0')}:${String(time_end_seconds).padStart(2, '0')}`;
-				});
-
-				// Step 3: Convert grouped object back to array
 				dayWiseGroupedByGroupName[groupId] = {
 					name: groupName,
 					entries: groupedTimes,

--- a/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -27,6 +27,10 @@ const LOCATION_LINK_DESTINATION_PATTERN = new RegExp(String.raw`\((${UriScheme.G
 export const sanitizeLocationLinkWhitespace = (sourceContent: string) =>
 	sourceContent.replace(LOCATION_LINK_DESTINATION_PATTERN, (_match, scheme, coordinates) => `(${scheme}${coordinates.replace(/\s+/g, '')})`);
 
+function openLinkSafely(url: string) {
+	Linking.openURL(url).catch(err => console.error('Failed to open URL:', err));
+}
+
 export const replaceLinebreaks = (sourceContent: string) => {
 	const option_find_linebreaks = true;
 	if (option_find_linebreaks) {
@@ -127,7 +131,7 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 
 			const handlePress = () => {
 				if (finalHref) {
-					Linking.openURL(finalHref).catch(err => console.error('Failed to open URL:', err));
+					openLinkSafely(finalHref);
 				}
 			};
 

--- a/apps/geonexia/frontend/app/_layout.tsx
+++ b/apps/geonexia/frontend/app/_layout.tsx
@@ -378,6 +378,47 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
 	);
 }
 
+// Fire-and-forget: fetch features for enclosed tiles that are not yet in the
+// feature cache, then apply forest trees.
+async function applyForestBillboardsForUncachedTiles(records: Record<string, any>, hexTileFeatureCache: HexTileFeatureCache) {
+	try {
+		const tilesWithoutCache = Object.entries(records)
+			.filter(([hexId, rec]) =>
+				rec.enclosedCount > 0 &&
+				!rec.walkedOn &&
+				!hexTileFeatureCache[hexId],
+			)
+			.map(([hexId]) => hexId);
+		if (tilesWithoutCache.length === 0) return;
+		const newEntries: HexTileFeatureCache = {};
+		for (const hexId of tilesWithoutCache) {
+			try {
+				const features = await queryTileFeaturesForHexCell(hexId);
+				newEntries[hexId] = features;
+				if (hasForestFeature(features)) {
+					store.dispatch(setBillboardAtAnchor({
+						h3Index: hexId,
+						anchorColor: BillboardAnchorPosition.CENTER,
+						billboard: BILLBOARD_PINE_TREE_LARGE,
+					}));
+					// Also place the small tree at a MIDDLE ring position,
+					// matching the full checkAndApplyForest behaviour.
+					store.dispatch(setBillboardAtAnchor({
+						h3Index: hexId,
+						anchorColor: getSmallTreeAnchorForHexId(hexId),
+						billboard: BILLBOARD_PINE_TREE_SMALL,
+					}));
+				}
+			} catch {
+				// ignore per-cell errors
+			}
+		}
+		await mergeHexTileFeatureCache(newEntries);
+	} catch (err) {
+		console.warn('[Layout] Feature cache update after rebuild failed:', err);
+	}
+}
+
 export default function Layout() {
 	useEffect(() => {
 		(async () => {
@@ -415,44 +456,7 @@ export default function Layout() {
 						store.dispatch(setDevMode({ isDevMode, records: rebuiltRecords, walkedEdges: rebuiltEdges, walkedEdgesRedLine: rebuiltEdgesRedLine }));
 						// Fire-and-forget: fetch features for enclosed tiles
 						// that are not yet in the feature cache, then apply forest trees.
-						void (async () => {
-							try {
-								const tilesWithoutCache = Object.entries(rebuiltRecords)
-									.filter(([hexId, rec]) =>
-										rec.enclosedCount > 0 &&
-										!rec.walkedOn &&
-										!hexTileFeatureCache[hexId],
-									)
-									.map(([hexId]) => hexId);
-								if (tilesWithoutCache.length === 0) return;
-								const newEntries: HexTileFeatureCache = {};
-								for (const hexId of tilesWithoutCache) {
-									try {
-										const features = await queryTileFeaturesForHexCell(hexId);
-										newEntries[hexId] = features;
-										if (hasForestFeature(features)) {
-											store.dispatch(setBillboardAtAnchor({
-												h3Index: hexId,
-												anchorColor: BillboardAnchorPosition.CENTER,
-												billboard: BILLBOARD_PINE_TREE_LARGE,
-											}));
-											// Also place the small tree at a MIDDLE ring position,
-											// matching the full checkAndApplyForest behaviour.
-											store.dispatch(setBillboardAtAnchor({
-												h3Index: hexId,
-												anchorColor: getSmallTreeAnchorForHexId(hexId),
-												billboard: BILLBOARD_PINE_TREE_SMALL,
-											}));
-										}
-									} catch {
-										// ignore per-cell errors
-									}
-								}
-								await mergeHexTileFeatureCache(newEntries);
-							} catch (err) {
-								console.warn('[Layout] Feature cache update after rebuild failed:', err);
-							}
-						})();
+						void applyForestBillboardsForUncachedTiles(rebuiltRecords, hexTileFeatureCache);
 						return;
 					}
 				} catch (err) {

--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -679,6 +679,21 @@ export default function ActivityDetailScreen() {
 	const dispatch = useDispatch<AppDispatch>();
 	const routeModalShownRef = useRef(false);
 	const [savedRoutes, setSavedRoutes] = useState<SavedRoute[]>([]);
+
+	// Shared onDone handler for RouteAssignmentModalContent: applies the user's route
+	// choice, refreshes the assigned-route display and the saved-routes list, then closes.
+	const handleRouteAssignmentDone = useCallback((updated: SavedActivity) => {
+		setActivity(updated);
+		if (typeof updated.routeId === 'string') {
+			loadRoute(updated.routeId).then(setAssignedRoute).catch(() => setAssignedRoute(null));
+		} else {
+			setAssignedRoute(updated.routeId === null ? null : undefined);
+		}
+		loadRoutes().then(setSavedRoutes).catch(() => {});
+		closeRouteModal();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	const isDebugMode = useDebugMode();
 	const { showAlert } = useGeonexiaAlert();
 	const { show: showDebugModal } = useMyScrollViewModal();
@@ -815,16 +830,7 @@ export default function ActivityDetailScreen() {
 								activity={a}
 								savedRoutes={routes}
 								bestMatch={bestMatch}
-								onDone={(updated) => {
-									setActivity(updated);
-									if (typeof updated.routeId === 'string') {
-										loadRoute(updated.routeId).then(setAssignedRoute).catch(() => setAssignedRoute(null));
-									} else {
-										setAssignedRoute(updated.routeId === null ? null : undefined);
-									}
-									loadRoutes().then(setSavedRoutes).catch(() => {});
-									closeRouteModal();
-								}}
+								onDone={handleRouteAssignmentDone}
 								theme={theme}
 							/>
 						),
@@ -1298,22 +1304,13 @@ export default function ActivityDetailScreen() {
 						activity={activity}
 						savedRoutes={routes}
 						bestMatch={bestMatch}
-						onDone={(updated) => {
-							setActivity(updated);
-							if (typeof updated.routeId === 'string') {
-								loadRoute(updated.routeId).then(setAssignedRoute).catch(() => setAssignedRoute(null));
-							} else {
-								setAssignedRoute(updated.routeId === null ? null : undefined);
-							}
-							loadRoutes().then(setSavedRoutes).catch(() => {});
-							closeRouteModal();
-						}}
+						onDone={handleRouteAssignmentDone}
 						theme={theme}
 					/>
 				),
 			});
 		}).catch(() => {});
-	}, [activity, showRouteModal, closeRouteModal, theme]);
+	}, [activity, showRouteModal, closeRouteModal, theme, handleRouteAssignmentDone]);
 
 	const handleFilterUnrealisticPoints = useCallback(() => {
 		if (!activity) return;

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -349,6 +349,39 @@ function RouteSelectionContent({
 	);
 }
 
+// Fire-and-forget: fetch map features for enclosed-only tiles that have no
+// cached feature data yet, so the pine tree billboard can be applied even
+// when the feature cache was empty or incomplete.
+async function applyForestBillboardsForUncachedTiles(records: Record<string, any>, hexTileFeatureCache: HexTileFeatureCache, dispatch: AppDispatch) {
+	try {
+		const enclosedWithoutCache = Object.entries(records)
+			.filter(([hexId, rec]) => rec.enclosedCount > 0 && !rec.walkedOn && !hexTileFeatureCache[hexId])
+			.map(([hexId]) => hexId);
+
+		if (enclosedWithoutCache.length === 0) return;
+
+		const newEntries: HexTileFeatureCache = {};
+		for (const hexId of enclosedWithoutCache) {
+			try {
+				const features = await queryTileFeaturesForHexCell(hexId);
+				newEntries[hexId] = features;
+				if (hasForestFeature(features)) {
+					dispatch(setBillboardAtAnchor({
+						h3Index: hexId,
+						anchorColor: BillboardAnchorPosition.CENTER,
+						billboard: BILLBOARD_PINE_TREE_LARGE,
+					}));
+				}
+			} catch {
+				// ignore per-cell errors
+			}
+		}
+		await mergeHexTileFeatureCache(newEntries);
+	} catch (err) {
+		console.warn('[Rebuild] Feature cache update failed:', err);
+	}
+}
+
 // ─── Activities Screen ────────────────────────────────────────────────────────
 
 export default function ActivitiesScreen() {
@@ -619,38 +652,7 @@ export default function ActivitiesScreen() {
 						dispatch(loadWalkedEdgesState(walkedEdges));
 						dispatch(loadWalkedEdgesRedLineState(walkedEdgesRedLine));
 
-						// Fire-and-forget: fetch map features for enclosed-only tiles that
-						// have no cached feature data yet, so the pine tree billboard can be
-						// applied even when the feature cache was empty or incomplete.
-						void (async () => {
-							try {
-								const enclosedWithoutCache = Object.entries(records)
-									.filter(([hexId, rec]) => rec.enclosedCount > 0 && !rec.walkedOn && !hexTileFeatureCache[hexId])
-									.map(([hexId]) => hexId);
-
-								if (enclosedWithoutCache.length === 0) return;
-
-								const newEntries: HexTileFeatureCache = {};
-								for (const hexId of enclosedWithoutCache) {
-									try {
-										const features = await queryTileFeaturesForHexCell(hexId);
-										newEntries[hexId] = features;
-										if (hasForestFeature(features)) {
-											dispatch(setBillboardAtAnchor({
-												h3Index: hexId,
-												anchorColor: BillboardAnchorPosition.CENTER,
-												billboard: BILLBOARD_PINE_TREE_LARGE,
-											}));
-										}
-									} catch {
-										// ignore per-cell errors
-									}
-								}
-								await mergeHexTileFeatureCache(newEntries);
-							} catch (err) {
-								console.warn('[Rebuild] Feature cache update failed:', err);
-							}
-						})();
+						void applyForestBillboardsForUncachedTiles(records, hexTileFeatureCache, dispatch);
 
 						const count = allActivities.length;
 						showAlert('Map Rebuilt', `Map rebuilt from ${count} ${count === 1 ? 'activity' : 'activities'}.`);
@@ -687,6 +689,42 @@ export default function ActivitiesScreen() {
 		});
 	}, [showImportModal, handleImport, handleImportFromFile, closeImportModal, theme]);
 
+	// Persists a manually-entered activity, links it to its route, applies its
+	// hex tiles/edges to the in-memory map state, then closes the modal and navigates to it.
+	const handleManualActivitySave = useCallback((activity: SavedActivity, selectedRoute: SavedRoute) => {
+		saveActivity(activity);
+		// Add activity ID to route.activityIds
+		const updatedIds = [...new Set([...(selectedRoute.activityIds ?? []), activity.id])];
+		const updatedRoute = { ...selectedRoute, activityIds: updatedIds };
+		saveRoute(updatedRoute);
+		setRoutes((prev) => prev.map((r) => r.id === updatedRoute.id ? updatedRoute : r));
+		setActivities((prev) => [activity, ...prev]);
+		// Apply the route's hex tiles and edges to the in-memory map state
+		if (isH3Available() && selectedRoute.hexTiles.length > 0) {
+			dispatch(startRun());
+			dispatch(markVisited({ h3Indices: selectedRoute.hexTiles, timestamp: activity.startedAt }));
+			// Apply enclosed tiles so the map rebuild produces the correct terrain
+			const enclosed = activity.computed?.enclosedHexTiles ?? activity.enclosedHexTiles ?? [];
+			if (enclosed.length > 0) {
+				dispatch(markEnclosed({ h3Indices: enclosed, timestamp: activity.startedAt }));
+			}
+			// Record hex-to-hex transitions so walk path spokes are drawn
+			const hexTilesOrdered = activity.hexTilesOrdered ?? selectedRoute.hexTiles;
+			const edges = computeEdgesFromHexTiles(hexTilesOrdered);
+			if (edges.length > 0) {
+				dispatch(addWalkedEdges(edges));
+			}
+			// Record red-line edges using the activity's already-computed
+			// red-line route points (synthesized in handleSave).
+			const edgesRedLine = computeEdgesFromRoutePoints(activity.routePoints, RED_LINE_GRID_RESOLUTION);
+			if (edgesRedLine.length > 0) {
+				dispatch(addWalkedEdgesRedLine(edgesRedLine));
+			}
+		}
+		closeManualModal();
+		router.push(`/activities/${activity.id}`);
+	}, [dispatch, router, closeManualModal]);
+
 	const openManualActivityModal = useCallback(() => {
 		if (routes.length === 0) {
 			showAlert('Keine Routen', 'Erstelle zuerst eine Route, bevor du eine manuelle Aktivität hinzufügen kannst.');
@@ -706,39 +744,7 @@ export default function ActivitiesScreen() {
 							children: (
 								<ManualActivityDurationContent
 									route={selectedRoute}
-									onSave={(activity) => {
-										saveActivity(activity);
-										// Add activity ID to route.activityIds
-										const updatedIds = [...new Set([...(selectedRoute.activityIds ?? []), activity.id])];
-										const updatedRoute = { ...selectedRoute, activityIds: updatedIds };
-										saveRoute(updatedRoute);
-										setRoutes((prev) => prev.map((r) => r.id === updatedRoute.id ? updatedRoute : r));
-										setActivities((prev) => [activity, ...prev]);
-										// Apply the route's hex tiles and edges to the in-memory map state
-										if (isH3Available() && selectedRoute.hexTiles.length > 0) {
-											dispatch(startRun());
-											dispatch(markVisited({ h3Indices: selectedRoute.hexTiles, timestamp: activity.startedAt }));
-											// Apply enclosed tiles so the map rebuild produces the correct terrain
-											const enclosed = activity.computed?.enclosedHexTiles ?? activity.enclosedHexTiles ?? [];
-											if (enclosed.length > 0) {
-												dispatch(markEnclosed({ h3Indices: enclosed, timestamp: activity.startedAt }));
-											}
-											// Record hex-to-hex transitions so walk path spokes are drawn
-											const hexTilesOrdered = activity.hexTilesOrdered ?? selectedRoute.hexTiles;
-											const edges = computeEdgesFromHexTiles(hexTilesOrdered);
-											if (edges.length > 0) {
-												dispatch(addWalkedEdges(edges));
-											}
-											// Record red-line edges using the activity's already-computed
-											// red-line route points (synthesized in handleSave).
-											const edgesRedLine = computeEdgesFromRoutePoints(activity.routePoints, RED_LINE_GRID_RESOLUTION);
-											if (edgesRedLine.length > 0) {
-												dispatch(addWalkedEdgesRedLine(edgesRedLine));
-											}
-										}
-										closeManualModal();
-										router.push(`/activities/${activity.id}`);
-									}}
+									onSave={(activity) => handleManualActivitySave(activity, selectedRoute)}
 									onClose={closeManualModal}
 									theme={theme}
 								/>

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -24,7 +24,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { MapLocationButton, MyMap, MyMapHandle, QrCode, useTheme, useMyScrollViewModal, SettingsListSelectOptionSingle, SettingsListGroupTitle, SettingsList, SettingsListTextInput, SettingsListBoolean, SettingsListNumberInput, MapStyleKey } from 'repo-depkit-common-ui';
 
 import { HEX_TILE_SCRIPT } from '../assets/hexTileScript';
-import { TERRAIN_ASSETS, TERRAIN_CATEGORIES } from '../assets/terrainAssets';
+import { TERRAIN_ASSETS, TERRAIN_CATEGORIES, TerrainAssetEntry } from '../assets/terrainAssets';
 import { MapLoadingOverlay } from '../components/MapLoadingOverlay';
 import { isAvailable as isH3Available, latLngToCell, cellToLatLng, gridDisk, gridDistance, areNeighborCells, cellToBoundary, gridPathCells, cellToChildren, cellToCenterChild, cellToParent, gridRingUnsafe, getResolution, isValidCell, computeRouteLengthKm, formatDistanceKm, getPentagons } from '../helpers/H3Helper';
 import { queryTileFeaturesForHexCell } from '../helpers/TileFeatureHelper';
@@ -122,6 +122,27 @@ function getListGroupPosition(index: number, length: number): 'top' | 'middle' |
 	if (index === 0) return 'top';
 	if (index === length - 1) return 'bottom';
 	return 'middle';
+}
+
+/**
+ * Renders the shared "terrain category -> entries" grid used by both the tile-image
+ * and tile-color pickers; each caller supplies its own per-entry row (selection state
+ * and onPress differ between the two pickers).
+ */
+function renderTerrainCategoryList(renderEntry: (entry: TerrainAssetEntry, position: 'top' | 'middle' | 'bottom' | 'single') => React.ReactNode) {
+	return (
+		<View style={{ paddingBottom: 20 }}>
+			{TERRAIN_CATEGORIES.map((cat) => {
+				const entries = TERRAIN_ASSETS[cat];
+				return (
+					<View key={cat}>
+						<SettingsListGroupTitle title={cat} />
+						{entries.map((entry, i) => renderEntry(entry, getListGroupPosition(i, entries.length)))}
+					</View>
+				);
+			})}
+		</View>
+	);
 }
 
 /** Locale-independent code unit comparison for deterministic string sorting. */
@@ -1933,38 +1954,23 @@ function HexTileInfoContent({ h3Index }: Readonly<{ h3Index: string }>) {
 		showModal({
 			title: '🌿 Select Tile Image',
 			onClose: closeModal,
-			children: (
-				<View style={{ paddingBottom: 20 }}>
-					{TERRAIN_CATEGORIES.map((cat) => {
-						const entries = TERRAIN_ASSETS[cat];
-						return (
-							<View key={cat}>
-								<SettingsListGroupTitle title={cat} />
-								{entries.map((entry, i) => {
-									const position = getListGroupPosition(i, entries.length);
-									return (
-										<SettingsListHexTile
-											key={entry.key}
-											tileImageKey={entry.key}
-											title={entry.key.split('/').pop() ?? entry.key}
-											isSelected={currentTileImage === entry.key}
-											selectionColor={PRIMARY_COLOR}
-											onPress={() => {
-												dispatch(setHexTileCustomization({
-													h3Index,
-													tileImage: currentTileImage === entry.key ? null : entry.key,
-												}));
-												closeModal();
-											}}
-											groupPosition={position}
-										/>
-									);
-								})}
-							</View>
-						);
-					})}
-				</View>
-			),
+			children: renderTerrainCategoryList((entry, position) => (
+				<SettingsListHexTile
+					key={entry.key}
+					tileImageKey={entry.key}
+					title={entry.key.split('/').pop() ?? entry.key}
+					isSelected={currentTileImage === entry.key}
+					selectionColor={PRIMARY_COLOR}
+					onPress={() => {
+						dispatch(setHexTileCustomization({
+							h3Index,
+							tileImage: currentTileImage === entry.key ? null : entry.key,
+						}));
+						closeModal();
+					}}
+					groupPosition={position}
+				/>
+			)),
 		});
 	}, [showModal, closeModal, currentTileImage, h3Index, dispatch]);
 
@@ -2408,6 +2414,11 @@ const magnifyStyles = StyleSheet.create({
  * Converts a MapFeatureInfo into a display key used for search filtering.
  * Format: "class/subclass" when both are present, otherwise whichever is non-null.
  */
+function cellHasEnabledFeature(cell: string, cache: Map<string, MapFeatureInfo[]>, enabledKeys: string[]): boolean {
+	const features = cache.get(cell) ?? [];
+	return features.some((f) => enabledKeys.includes(featureToSearchKey(f)));
+}
+
 function featureToSearchKey(f: { class: string | null; subclass: string | null; layerId: string | null }): string {
 	const parts = [f.class, f.subclass].filter((v): v is string => v !== null && v.length > 0);
 	if (parts.length > 0) return parts.join('/');
@@ -3413,10 +3424,7 @@ export default function RecordScreen() {
 					}
 				}),
 			);
-			const matchingCells = cells.filter((cell) => {
-				const features = cache.get(cell) ?? [];
-				return features.some((f) => enabledKeys.includes(featureToSearchKey(f)));
-			});
+			const matchingCells = cells.filter((cell) => cellHasEnabledFeature(cell, cache, enabledKeys));
 			const highlightFeatures = matchingCells.map((h3Index) => {
 				const boundary = cellToBoundary(h3Index, H3_GEOJSON_ORDER);
 				return {
@@ -3956,35 +3964,20 @@ export default function RecordScreen() {
 				}
 				closeColoringModal();
 			},
-			children: (
-				<View style={{ paddingBottom: 20 }}>
-					{TERRAIN_CATEGORIES.map((cat) => {
-						const entries = TERRAIN_ASSETS[cat];
-						return (
-							<View key={cat}>
-								<SettingsListGroupTitle title={cat} />
-								{entries.map((entry, i) => {
-									const position = getListGroupPosition(i, entries.length);
-									return (
-										<SettingsListSelectOptionSingle
-											key={entry.key}
-											label={entry.key.split('/').pop() ?? entry.key}
-											isSelected={coloringTileImageRef.current === entry.key}
-											selectionColor={PRIMARY_COLOR}
-											onPress={() => {
-												coloringSelectionMadeRef.current = true;
-												setColoringTileImage(entry.key);
-												closeColoringModal();
-											}}
-											groupPosition={position}
-										/>
-									);
-								})}
-							</View>
-						);
-					})}
-				</View>
-			),
+			children: renderTerrainCategoryList((entry, position) => (
+				<SettingsListSelectOptionSingle
+					key={entry.key}
+					label={entry.key.split('/').pop() ?? entry.key}
+					isSelected={coloringTileImageRef.current === entry.key}
+					selectionColor={PRIMARY_COLOR}
+					onPress={() => {
+						coloringSelectionMadeRef.current = true;
+						setColoringTileImage(entry.key);
+						closeColoringModal();
+					}}
+					groupPosition={position}
+				/>
+			)),
 		});
 	}, [showColoringModal, closeColoringModal]);
 

--- a/apps/geonexia/frontend/app/settings/index.tsx
+++ b/apps/geonexia/frontend/app/settings/index.tsx
@@ -264,6 +264,47 @@ function TTSLogContent({
 	);
 }
 
+// Fire-and-forget: fetch features for enclosed tiles that are not yet in the
+// feature cache, then apply forest trees.
+async function applyForestBillboardsForUncachedTiles(records: Record<string, any>, hexTileFeatureCache: HexTileFeatureCache, dispatch: AppDispatch) {
+	try {
+		const tilesWithoutCache = Object.entries(records)
+			.filter(([hexId, rec]) =>
+				rec.enclosedCount > 0 &&
+				!rec.walkedOn &&
+				!hexTileFeatureCache[hexId],
+			)
+			.map(([hexId]) => hexId);
+		if (tilesWithoutCache.length === 0) return;
+		const newEntries: HexTileFeatureCache = {};
+		for (const hexId of tilesWithoutCache) {
+			try {
+				const features = await queryTileFeaturesForHexCell(hexId);
+				newEntries[hexId] = features;
+				if (hasForestFeature(features)) {
+					dispatch(setBillboardAtAnchor({
+						h3Index: hexId,
+						anchorColor: BillboardAnchorPosition.CENTER,
+						billboard: BILLBOARD_PINE_TREE_LARGE,
+					}));
+					// Also place the small tree at a MIDDLE ring position,
+					// matching the full checkAndApplyForest behaviour.
+					dispatch(setBillboardAtAnchor({
+						h3Index: hexId,
+						anchorColor: getSmallTreeAnchorForHexId(hexId),
+						billboard: BILLBOARD_PINE_TREE_SMALL,
+					}));
+				}
+			} catch {
+				// ignore per-cell errors
+			}
+		}
+		await mergeHexTileFeatureCache(newEntries);
+	} catch (err) {
+		console.warn('[Rebuild] Feature cache update failed:', err);
+	}
+}
+
 // ─── Settings Screen ──────────────────────────────────────────────────────────
 
 export default function SettingsScreen() {
@@ -554,44 +595,7 @@ export default function SettingsScreen() {
 						dispatch(loadWalkedEdgesState(walkedEdges));
 						dispatch(loadWalkedEdgesRedLineState(walkedEdgesRedLine));
 
-						void (async () => {
-							try {
-								const tilesWithoutCache = Object.entries(records)
-									.filter(([hexId, rec]) =>
-										rec.enclosedCount > 0 &&
-										!rec.walkedOn &&
-										!hexTileFeatureCache[hexId],
-									)
-									.map(([hexId]) => hexId);
-								if (tilesWithoutCache.length === 0) return;
-								const newEntries: HexTileFeatureCache = {};
-								for (const hexId of tilesWithoutCache) {
-									try {
-										const features = await queryTileFeaturesForHexCell(hexId);
-										newEntries[hexId] = features;
-										if (hasForestFeature(features)) {
-											dispatch(setBillboardAtAnchor({
-												h3Index: hexId,
-												anchorColor: BillboardAnchorPosition.CENTER,
-												billboard: BILLBOARD_PINE_TREE_LARGE,
-											}));
-											// Also place the small tree at a MIDDLE ring position,
-											// matching the full checkAndApplyForest behaviour.
-											dispatch(setBillboardAtAnchor({
-												h3Index: hexId,
-												anchorColor: getSmallTreeAnchorForHexId(hexId),
-												billboard: BILLBOARD_PINE_TREE_SMALL,
-											}));
-										}
-									} catch {
-										// ignore per-cell errors
-									}
-								}
-								await mergeHexTileFeatureCache(newEntries);
-							} catch (err) {
-								console.warn('[Rebuild] Feature cache update failed:', err);
-							}
-						})();
+						void applyForestBillboardsForUncachedTiles(records, hexTileFeatureCache, dispatch);
 
 						const count = allActivities.length;
 						showAlert('Welt neu aufgebaut', `Karte aus ${count} ${count === 1 ? 'Aktivität' : 'Aktivitäten'} neu aufgebaut.`);

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -605,6 +605,7 @@ export default function GameScreen() {
 	const navigation = useNavigation();
 
 	const [isEditingPlayers, setIsEditingPlayers] = useState(false);
+	const toggleEditingPlayers = useCallback(() => setIsEditingPlayers(v => !v), []);
 
 	// Leaving the setup phase always drops back into the scoreboard view.
 	const prevStatusRef = useRef(status);
@@ -837,7 +838,7 @@ export default function GameScreen() {
 					{status === 'active' && (
 						<TouchableOpacity
 							nativeID={ComponentIds.GAME_HEADER_EDIT_PLAYERS_BUTTON}
-							onPress={() => setIsEditingPlayers((v) => !v)}
+							onPress={toggleEditingPlayers}
 							style={styles.headerButton}
 						>
 							<Ionicons

--- a/apps/score-tracker/frontend/components/ExpoUpdateLoader.tsx
+++ b/apps/score-tracker/frontend/components/ExpoUpdateLoader.tsx
@@ -10,6 +10,10 @@ interface ExpoUpdateLoaderProps {
 const TIMEOUT_MS = 10000;
 const IS_SMARTPHONE = Platform.OS === 'ios' || Platform.OS === 'android';
 
+function createTimeoutPromise(ms: number): Promise<null> {
+	return new Promise<null>(resolve => setTimeout(() => resolve(null), ms));
+}
+
 /**
  * Blocks the very first render behind a branded loading screen while checking
  * for (and applying) an OTA update, so a cold app start always runs the latest
@@ -31,7 +35,7 @@ const ExpoUpdateLoader: React.FC<ExpoUpdateLoaderProps> = ({ children }) => {
 				return;
 			}
 
-			const timeoutPromise = new Promise<null>((resolve) => setTimeout(() => resolve(null), TIMEOUT_MS));
+			const timeoutPromise = createTimeoutPromise(TIMEOUT_MS);
 
 			try {
 				setStatus('Suche nach Updates...');

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -63,13 +63,27 @@ der Git-/PR-Historie.
 **Brauchen individuelle Refactorings statt mechanischer Fixes (Stand 2026-07-21):**
 „Cognitive Complexity" (109x), „Move this component definition out of the parent
 component" (97x), „Array index in keys" (60x, braucht stabile IDs), TODO-Kommentare
-(39x), Funktions-Verschachtelung (35x).
+(39x).
 Diese Typen in kleinen, thematisch gruppierten PRs angehen.
 
 „Exception-Handling" (23x) ist als erster dieser schweren Fälle abgearbeitet: alle
 gemeldeten Catch-Blöcke (leer, nur Kommentar, oder Rethrow ohne Original-Error)
 protokollieren jetzt den tatsächlichen Fehler bzw. reichen ihn in der Fehlermeldung
 weiter, ohne das bestehende Fallback-/Swallow-Verhalten zu ändern.
+
+„Funktions-Verschachtelung" (35x, „not nest functions more than 4 levels deep")
+ist als zweiter Fall abgearbeitet: die jeweils innerste verschachtelte Funktion
+wurde in eine benannte Funktion auf Modul- oder Komponentenebene extrahiert
+(Closures als explizite Parameter), ohne die Logik zu verändern. Wo mehrere
+Stellen im selben oder in Schwesterdateien exakt denselben Block dupliziert
+hatten (`ExpoUpdateLoader`, das Forst-Billboard-Fire-and-forget in
+`apps/geonexia/frontend/app/{_layout,activities/index,settings/index}.tsx`, der
+`onDone`-Handler in `activities/[id].tsx`, der Terrain-Kategorie-Picker in
+`apps/geonexia/frontend/app/index.tsx`), wurde je ein gemeinsamer Helper
+extrahiert — außer bei den Forst-Billboard-Blöcken, die sich in einem Detail
+unterscheiden (der kleine Baum an der `MIDDLE`-Ankerposition wird nur in
+`_layout.tsx` und `settings/index.tsx` gesetzt, nicht in `activities/index.tsx`);
+dieser Unterschied wurde unverändert beibehalten, kein Verhalten angeglichen.
 
 ## Hinweise
 

--- a/packages/common-ui/src/components/FeatureWishesScreen/FeatureWishesScreen.tsx
+++ b/packages/common-ui/src/components/FeatureWishesScreen/FeatureWishesScreen.tsx
@@ -74,6 +74,29 @@ const DEFAULT_ITEMS: FeatureWishItem[] = [
 ];
 
 const STATUS_PUBLISHED = 'published';
+
+function applyLikeToggle(
+	id: string,
+	setLikedIds: React.Dispatch<React.SetStateAction<Set<string>>>,
+	setItems: React.Dispatch<React.SetStateAction<FeatureWishItem[]>>
+) {
+	setLikedIds(prev => {
+		const wasLiked = prev.has(id);
+		const next = new Set(prev);
+		if (wasLiked) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		setItems(prevItems =>
+			prevItems.map(item => {
+				if (item.id !== id) return item;
+				return { ...item, likes: (item.likes ?? 0) + (wasLiked ? -1 : 1) };
+			})
+		);
+		return next;
+	});
+}
 const STATUS_DRAFT = 'draft';
 
 const FeatureWishesScreen: React.FC<FeatureWishesScreenProps> = ({
@@ -123,22 +146,7 @@ const FeatureWishesScreen: React.FC<FeatureWishesScreenProps> = ({
 	}, [items, activeFilter, searchText]);
 
 	const handleLike = useCallback((id: string) => {
-		setLikedIds((prev) => {
-			const wasLiked = prev.has(id);
-			const next = new Set(prev);
-			if (wasLiked) {
-				next.delete(id);
-			} else {
-				next.add(id);
-			}
-			setItems((prevItems) =>
-				prevItems.map((item) => {
-					if (item.id !== id) return item;
-					return { ...item, likes: (item.likes ?? 0) + (wasLiked ? -1 : 1) };
-				})
-			);
-			return next;
-		});
+		applyLikeToggle(id, setLikedIds, setItems);
 	}, []);
 
 	const handleApprove = useCallback(


### PR DESCRIPTION
## Summary

Following `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`, this tackles the second of the issue types listed as needing individual judgment rather than a mechanical codemod: **"Refactor this code to not nest functions more than 4 levels deep"** (SonarCloud rule S2004, 35 occurrences across 17 files in `apps/frontend`, `apps/geonexia`, `apps/score-tracker`, and `packages/common-ui`).

Each site's innermost nested function was extracted into a named function at module or component scope, with closures passed through as explicit parameters — no logic changes, just moving the same code to a shallower lexical position. Where multiple sites duplicated the exact same block, one shared helper now serves all of them instead of fixing each copy separately:

- **`ExpoUpdateLoader`** (score-tracker + frontend copies) — shared `createTimeoutPromise(ms)` module helper.
- **Forest-billboard fire-and-forget block** in `apps/geonexia/frontend/app/{_layout,activities/index,settings/index}.tsx` — extracted **per file** rather than merged into one cross-file helper, because `activities/index.tsx`'s version intentionally omits the small tree at the `MIDDLE` anchor position that the other two set. That existing behavioral difference is preserved unchanged.
- **`onDone` route-assignment handler**, duplicated twice within `apps/geonexia/frontend/app/activities/[id].tsx` — one shared `handleRouteAssignmentDone` callback.
- **Terrain-category picker grid**, duplicated between `openTileSelection` and `openColoringModal` in `apps/geonexia/frontend/app/index.tsx` — one shared `renderTerrainCategoryList(renderEntry)` helper; each caller still supplies its own row renderer since the two pickers use different list components and selection state.
- Everywhere else (single-site violations) — the innermost function was hoisted to module/component scope: `FeatureWishesScreen.tsx`, `FoodHeader.tsx`, `CourseTimetable.tsx` (same `CustomTooltip`-trigger shape as `FoodHeader`), `foodoffers/hooks.ts`, `MyMarkdown.tsx`, `CustomMarkdown.tsx` (hoisted the whole markdown-parsing algorithm to module scope, since it doesn't touch component state), `HoursSheet.tsx` (extracted the business-hours grouping algorithm into 4 pure module functions), `list-week-screen/details/index.tsx`, `experimentell/onboarding/index.tsx` (avatar swap animation), `score-tracker/app/index.tsx`, and `geonexia/index.tsx`'s `refreshSearchHighlight`.

No occurrences were skipped — all 35 reported locations matched the current code (no line drift) and were fixable without behavior changes.

`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` is updated to record this type as done.

## Test plan

- [x] Manually reviewed each of the 35 sites against `reports/sonarCloud/report_maintainability.csv` — no line drift found
- [x] Verified every extraction preserves the exact original logic (same closures, same control flow, same conditionals) — no behavior changes
- [x] Syntax-checked every edited file with `tsc --noEmit --noResolve` (isolated per-file, since `node_modules` isn't installed in this sandbox) — no syntax errors; remaining diagnostics are pre-existing missing-module/implicit-any noise from checking files without the full project's dependency graph
- [ ] Full `tsc --noEmit` / lint / build could not be run in this sandbox (no `node_modules` installed) — CI should confirm


---
_Generated by [Claude Code](https://claude.ai/code/session_018XmRF7FMaQ8HUPi81rr8Bn)_