### PR TITLE
fix(sonar): hoist nested render-prop/header components out of parents (45x)

### DIFF
--- a/apps/frontend/app/app/(app)/campus/components/CampusHeader.tsx
+++ b/apps/frontend/app/app/(app)/campus/components/CampusHeader.tsx
@@ -16,6 +16,22 @@ interface CampusHeaderProps {
     drawerPosition: 'left' | 'right' | 'system' | undefined; // Added 'system'
 }
 
+const HeaderIconButton = ({
+    triggerProps,
+    onPress,
+    nativeID,
+    children,
+}: {
+    triggerProps: object;
+    onPress: () => void;
+    nativeID?: string;
+    children: React.ReactNode;
+}) => (
+    <IconButton {...triggerProps} onPress={onPress} style={{ padding: 10 }} nativeID={nativeID}>
+        {children}
+    </IconButton>
+);
+
 const CampusHeader: React.FC<CampusHeaderProps> = ({
     theme,
     translate,
@@ -34,9 +50,9 @@ const CampusHeader: React.FC<CampusHeaderProps> = ({
                     <CustomTooltip
                         placement="top"
                         trigger={triggerProps => (
-                            <IconButton {...triggerProps} onPress={onToggleDrawer} style={{ padding: 10 }} nativeID={ComponentIds.OPEN_DRAWER}>
+                            <HeaderIconButton triggerProps={triggerProps} onPress={onToggleDrawer} nativeID={ComponentIds.OPEN_DRAWER}>
                                 <Ionicons name="menu" size={24} color={theme.header.text} />
-                            </IconButton>
+                            </HeaderIconButton>
                         )}
                     >
                         <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -53,9 +69,9 @@ const CampusHeader: React.FC<CampusHeaderProps> = ({
                     <CustomTooltip
                         placement="top"
                         trigger={triggerProps => (
-                            <IconButton {...triggerProps} onPress={onSort} style={{ padding: 10 }}>
+                            <HeaderIconButton triggerProps={triggerProps} onPress={onSort}>
                                 <MaterialIcons name="sort" size={24} color={theme.header.text} />
-                            </IconButton>
+                            </HeaderIconButton>
                         )}
                     >
                         <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/campus/details/components/DetailsHeader.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/components/DetailsHeader.tsx
@@ -14,6 +14,22 @@ interface DetailsHeaderProps {
     onOpenNavigation: () => void;
 }
 
+const NavigationTriggerButton = ({
+    triggerProps,
+    onPress,
+    backgroundColor,
+    iconColor,
+}: {
+    triggerProps: object;
+    onPress: () => void;
+    backgroundColor: string;
+    iconColor: string;
+}) => (
+    <IconButton {...triggerProps} onPress={onPress} style={{ ...styles.navigationButton, backgroundColor }}>
+        <MaterialCommunityIcons name="navigation-variant" size={24} color={iconColor} />
+    </IconButton>
+);
+
 const DetailsHeader: React.FC<DetailsHeaderProps> = ({
     alias,
     screenWidth,
@@ -36,13 +52,7 @@ const DetailsHeader: React.FC<DetailsHeaderProps> = ({
                 <CustomTooltip
                     placement="top"
                     trigger={triggerProps => (
-                        <IconButton
-                            {...triggerProps}
-                            onPress={onOpenNavigation}
-                            style={{ ...styles.navigationButton, backgroundColor: theme.screen.iconBg }}
-                        >
-                            <MaterialCommunityIcons name="navigation-variant" size={24} color={theme.screen.icon} />
-                        </IconButton>
+                        <NavigationTriggerButton triggerProps={triggerProps} onPress={onOpenNavigation} backgroundColor={theme.screen.iconBg} iconColor={theme.screen.icon} />
                     )}
                 >
                     <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/campus/details/components/DetailsTabs.tsx
+++ b/apps/frontend/app/app/(app)/campus/details/components/DetailsTabs.tsx
@@ -15,6 +15,26 @@ interface DetailsTabsProps extends TabsStyleProps {
     children: React.ReactNode;
 }
 
+const TabIconButton = ({
+    triggerProps,
+    onPress,
+    isActive,
+    activeStyle,
+    inactiveStyle,
+    children,
+}: {
+    triggerProps: object;
+    onPress: () => void;
+    isActive: boolean;
+    activeStyle: any;
+    inactiveStyle: any;
+    children: React.ReactNode;
+}) => (
+    <IconButton {...triggerProps} onPress={onPress} style={[styles.tab, isActive ? activeStyle : inactiveStyle]}>
+        {children}
+    </IconButton>
+);
+
 const DetailsTabs: React.FC<DetailsTabsProps> = ({
     activeTab,
     setActiveTab,
@@ -31,20 +51,19 @@ const DetailsTabs: React.FC<DetailsTabsProps> = ({
                 <CustomTooltip
                     placement="top"
                     trigger={triggerProps => (
-                        <IconButton
-                            {...triggerProps}
+                        <TabIconButton
+                            triggerProps={triggerProps}
                             onPress={() => setActiveTab(CampusDetailTab.INFORMATION)}
-                            style={[
-                                styles.tab,
-                                activeTab === CampusDetailTab.INFORMATION ? themeStyles : { backgroundColor: theme.screen.iconBg }
-                            ]}
+                            isActive={activeTab === CampusDetailTab.INFORMATION}
+                            activeStyle={themeStyles}
+                            inactiveStyle={{ backgroundColor: theme.screen.iconBg }}
                         >
                             <Foundation
                                 name="info"
                                 size={26}
                                 color={activeTab === CampusDetailTab.INFORMATION ? contrastColor : theme.screen.icon}
                             />
-                        </IconButton>
+                        </TabIconButton>
                     )}
                 >
                     <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -57,20 +76,19 @@ const DetailsTabs: React.FC<DetailsTabsProps> = ({
                 <CustomTooltip
                     placement="top"
                     trigger={triggerProps => (
-                        <IconButton
-                            {...triggerProps}
-                            style={[
-                                styles.tab,
-                                activeTab === CampusDetailTab.DESCRIPTION ? themeStyles : { backgroundColor: theme.screen.iconBg }
-                            ]}
+                        <TabIconButton
+                            triggerProps={triggerProps}
                             onPress={() => setActiveTab(CampusDetailTab.DESCRIPTION)}
+                            isActive={activeTab === CampusDetailTab.DESCRIPTION}
+                            activeStyle={themeStyles}
+                            inactiveStyle={{ backgroundColor: theme.screen.iconBg }}
                         >
                             <MaterialCommunityIcons
                                 name="sort-variant"
                                 size={26}
                                 color={activeTab === CampusDetailTab.DESCRIPTION ? contrastColor : theme.screen.icon}
                             />
-                        </IconButton>
+                        </TabIconButton>
                     )}
                 >
                     <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/foodoffers/components/BalanceQuickAccessButton.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/BalanceQuickAccessButton.tsx
@@ -27,6 +27,27 @@ interface BalanceQuickAccessButtonProps {
  * (e.g. in Expo Go) so the modal's "Simulate X€" debug actions remain
  * reachable to exercise the flow without physical hardware.
  */
+const BalanceTriggerButton = ({
+	triggerProps,
+	onPress,
+	style,
+	color,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	style?: any;
+	color: string;
+}) => (
+	<IconButton
+		{...triggerProps}
+		onPress={onPress}
+		style={style}
+		nativeID={AppComponentIds.FOODOFFERS_BALANCE_QUICK_ACCESS}
+	>
+		<Octicons name="credit-card" size={24} color={color} />
+	</IconButton>
+);
+
 const BalanceQuickAccessButton: React.FC<BalanceQuickAccessButtonProps> = ({ style }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
@@ -80,14 +101,7 @@ const BalanceQuickAccessButton: React.FC<BalanceQuickAccessButtonProps> = ({ sty
 		<CustomTooltip
 			placement="top"
 			trigger={triggerProps => (
-				<IconButton
-					{...triggerProps}
-					onPress={() => openAccountBalanceModal(isNfcSupported && isNfcEnabled)}
-					style={style}
-					nativeID={AppComponentIds.FOODOFFERS_BALANCE_QUICK_ACCESS}
-				>
-					<Octicons name="credit-card" size={24} color={theme.header.text} />
-				</IconButton>
+				<BalanceTriggerButton triggerProps={triggerProps} onPress={() => openAccountBalanceModal(isNfcSupported && isNfcEnabled)} style={style} color={theme.header.text} />
 			)}
 		>
 			<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersHeader.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/components/FoodOffersHeader.tsx
@@ -23,6 +23,24 @@ interface FoodOffersHeaderProps {
     openOptionsModal: () => void;
 }
 
+const HeaderIconButton = ({
+    triggerProps,
+    onPress,
+    style,
+    nativeID,
+    children,
+}: {
+    triggerProps: object;
+    onPress: () => void;
+    style?: any;
+    nativeID?: string;
+    children: React.ReactNode;
+}) => (
+    <IconButton {...triggerProps} onPress={onPress} style={style} nativeID={nativeID}>
+        {children}
+    </IconButton>
+);
+
 const FoodOffersHeader: React.FC<FoodOffersHeaderProps> = ({
     drawerPosition,
     hasUnreadChats,
@@ -52,7 +70,7 @@ const FoodOffersHeader: React.FC<FoodOffersHeaderProps> = ({
                     <CustomTooltip
                         placement="top"
                         trigger={triggerProps => (
-                            <IconButton {...triggerProps} onPress={() => drawerNavigation.toggleDrawer()} style={iconPaddingStyle} nativeID={ComponentIds.OPEN_DRAWER}>
+                            <HeaderIconButton triggerProps={triggerProps} onPress={() => drawerNavigation.toggleDrawer()} style={iconPaddingStyle} nativeID={ComponentIds.OPEN_DRAWER}>
                                 <Ionicons name="menu" size={24} color={theme.header.text} />
                                 {hasUnreadChats ? (
                                     <View
@@ -65,7 +83,7 @@ const FoodOffersHeader: React.FC<FoodOffersHeaderProps> = ({
                                         ]}
                                     />
                                 ) : null}
-                            </IconButton>
+                            </HeaderIconButton>
                         )}
                     >
                         <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -92,9 +110,9 @@ const FoodOffersHeader: React.FC<FoodOffersHeaderProps> = ({
                     <CustomTooltip
                         placement="top"
                         trigger={triggerProps => (
-                            <IconButton {...triggerProps} onPress={openOptionsModal} style={iconPaddingStyle}>
+                            <HeaderIconButton triggerProps={triggerProps} onPress={openOptionsModal} style={iconPaddingStyle}>
                                 <Entypo name="dots-three-vertical" size={22} color={theme.header.text} />
-                            </IconButton>
+                            </HeaderIconButton>
                         )}
                     >
                         <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/foodoffers/details/components/FoodHeader.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/components/FoodHeader.tsx
@@ -22,6 +22,22 @@ interface FoodHeaderProps extends FoodDetailsSectionBaseProps {
     initialImageRemoteUrl?: string | null;
 }
 
+const StarRatingIconButton = ({
+    triggerProps,
+    onPress,
+    filled,
+    color,
+}: {
+    triggerProps: object;
+    onPress: () => void;
+    filled: boolean;
+    color: string;
+}) => (
+    <IconButton {...triggerProps} onPress={onPress} style={styles.paddingSmall}>
+        <MaterialIcons name={filled ? 'star' : 'star-border'} size={22} color={color} />
+    </IconButton>
+);
+
 const FoodHeader = ({
     foodDetails,
     screenWidth,
@@ -56,13 +72,7 @@ const FoodHeader = ({
                 <CustomTooltip
                     placement="top"
                     trigger={(triggerProps) => (
-                        <IconButton {...triggerProps} onPress={() => rateFood(index + 1)} style={styles.paddingSmall}>
-                            <MaterialIcons
-                                name={previousFeedback?.rating > index ? 'star' : 'star-border'}
-                                size={22}
-                                color={foodsAreaColor}
-                            />
-                        </IconButton>
+                        <StarRatingIconButton triggerProps={triggerProps} onPress={() => rateFood(index + 1)} filled={previousFeedback?.rating > index} color={foodsAreaColor} />
                     )}
                 >
                     <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/foodoffers/details/components/TabController.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/components/TabController.tsx
@@ -17,6 +17,35 @@ interface TabControllerProps extends FoodAreaDisplayProps {
     containerWidth: string | number;
 }
 
+const TabTriggerButton = ({
+    triggerProps,
+    style,
+    iconName,
+    iconColor,
+    onSelect,
+}: {
+    triggerProps: any;
+    style: any;
+    iconName: any;
+    iconColor: string;
+    onSelect: () => void;
+}) => (
+    <IconButton
+        {...triggerProps}
+        style={style}
+        activeOpacity={1}
+        onPress={(e: any) => {
+            onSelect();
+            if (triggerProps.onPress) {
+                triggerProps.onPress(e);
+            }
+        }}
+        padding={10}
+    >
+        <MaterialCommunityIcons name={iconName} size={26} color={iconColor} />
+    </IconButton>
+);
+
 const TabController = ({
     activeTab,
     setActiveTab,
@@ -37,24 +66,13 @@ const TabController = ({
         <CustomTooltip
             placement="top"
             trigger={(triggerProps) => (
-                <IconButton
-                    {...triggerProps}
+                <TabTriggerButton
+                    triggerProps={triggerProps}
                     style={getTabStyle(tabName)}
-                    activeOpacity={1}
-                    onPress={(e: any) => {
-                        setActiveTab(tabName);
-                        if (triggerProps.onPress) {
-                            triggerProps.onPress(e);
-                        }
-                    }}
-                    padding={10}
-                >
-                    <MaterialCommunityIcons
-                        name={iconName}
-                        size={26}
-                        color={activeTab === tabName ? contrastColor : theme.screen.icon}
-                    />
-                </IconButton>
+                    iconName={iconName}
+                    iconColor={activeTab === tabName ? contrastColor : theme.screen.icon}
+                    onSelect={() => setActiveTab(tabName)}
+                />
             )}
         >
             <TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/housing/components/HousingHeader.tsx
+++ b/apps/frontend/app/app/(app)/housing/components/HousingHeader.tsx
@@ -19,6 +19,22 @@ interface HousingHeaderProps {
 	openHousingSortingModal: () => void;
 }
 
+const HeaderIconButton = ({
+	triggerProps,
+	onPress,
+	nativeID,
+	children,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	nativeID?: string;
+	children: React.ReactNode;
+}) => (
+	<IconButton {...triggerProps} onPress={onPress} style={{ padding: 10 }} nativeID={nativeID}>
+		{children}
+	</IconButton>
+);
+
 const HousingHeader: React.FC<HousingHeaderProps> = ({
 	theme,
 	translate,
@@ -56,14 +72,9 @@ const HousingHeader: React.FC<HousingHeaderProps> = ({
 					<CustomTooltip
 						placement="top"
 						trigger={(triggerProps) => (
-							<IconButton
-								{...triggerProps}
-								onPress={() => navigation.toggleDrawer()}
-								style={{ padding: 10 }}
-								nativeID={ComponentIds.OPEN_DRAWER}
-							>
+							<HeaderIconButton triggerProps={triggerProps} onPress={() => navigation.toggleDrawer()} nativeID={ComponentIds.OPEN_DRAWER}>
 								<Ionicons name="menu" size={24} color={theme.header.text} />
-							</IconButton>
+							</HeaderIconButton>
 						)}
 					>
 						<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -81,13 +92,9 @@ const HousingHeader: React.FC<HousingHeaderProps> = ({
 					<CustomTooltip
 						placement="top"
 						trigger={(triggerProps) => (
-							<IconButton
-								{...triggerProps}
-								onPress={openHousingSortingModal}
-								style={{ padding: 10 }}
-							>
+							<HeaderIconButton triggerProps={triggerProps} onPress={openHousingSortingModal}>
 								<MaterialIcons name="sort" size={24} color={theme.header.text} />
-							</IconButton>
+							</HeaderIconButton>
 						)}
 					>
 						<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/housing/details/components/HousingDetailsHeader.tsx
+++ b/apps/frontend/app/app/(app)/housing/details/components/HousingDetailsHeader.tsx
@@ -16,6 +16,22 @@ interface HousingDetailsHeaderProps {
 	onOpenNavigation: () => void;
 }
 
+const NavigationTriggerButton = ({
+	triggerProps,
+	onPress,
+	backgroundColor,
+	iconColor,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	backgroundColor: string;
+	iconColor: string;
+}) => (
+	<IconButton {...triggerProps} style={[styles.navigationButton, { backgroundColor }]} onPress={onPress}>
+		<MaterialCommunityIcons name="navigation-variant" size={24} color={iconColor} />
+	</IconButton>
+);
+
 const HousingDetailsHeader: React.FC<HousingDetailsHeaderProps> = ({
 	apartmentDetails,
 	theme,
@@ -41,20 +57,7 @@ const HousingDetailsHeader: React.FC<HousingDetailsHeaderProps> = ({
 				<CustomTooltip
 					placement="top"
 					trigger={(triggerProps) => (
-						<IconButton
-							{...triggerProps}
-							style={[
-								styles.navigationButton,
-								{ backgroundColor: theme.screen.iconBg },
-							]}
-							onPress={onOpenNavigation}
-						>
-							<MaterialCommunityIcons
-								name="navigation-variant"
-								size={24}
-								color={theme.screen.icon}
-							/>
-						</IconButton>
+						<NavigationTriggerButton triggerProps={triggerProps} onPress={onOpenNavigation} backgroundColor={theme.screen.iconBg} iconColor={theme.screen.icon} />
 					)}
 				>
 					<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/housing/details/components/HousingDetailsTabs.tsx
+++ b/apps/frontend/app/app/(app)/housing/details/components/HousingDetailsTabs.tsx
@@ -17,6 +17,26 @@ interface HousingDetailsTabsProps extends TabsStyleProps {
 	apartmentDetails: DatabaseTypes.Apartments | null;
 }
 
+const TabIconButton = ({
+	triggerProps,
+	onPress,
+	isActive,
+	activeStyle,
+	inactiveStyle,
+	children,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	isActive: boolean;
+	activeStyle: any;
+	inactiveStyle: any;
+	children: React.ReactNode;
+}) => (
+	<IconButton {...triggerProps} style={[styles.tab, isActive ? activeStyle : inactiveStyle]} onPress={onPress}>
+		{children}
+	</IconButton>
+);
+
 const HousingDetailsTabs: React.FC<HousingDetailsTabsProps> = ({
 	activeTab,
 	setActiveTab,
@@ -36,16 +56,15 @@ const HousingDetailsTabs: React.FC<HousingDetailsTabsProps> = ({
 			key={key}
 			placement="top"
 			trigger={(triggerProps) => (
-				<IconButton
-					{...triggerProps}
-					style={[
-						styles.tab,
-						activeTab === key ? themeStyles : { backgroundColor: theme.screen.iconBg },
-					]}
+				<TabIconButton
+					triggerProps={triggerProps}
 					onPress={() => setActiveTab(key)}
+					isActive={activeTab === key}
+					activeStyle={themeStyles}
+					inactiveStyle={{ backgroundColor: theme.screen.iconBg }}
 				>
 					{icon}
-				</IconButton>
+				</TabIconButton>
 			)}
 		>
 			<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/map/components/MapHeader.tsx
+++ b/apps/frontend/app/app/(app)/map/components/MapHeader.tsx
@@ -22,6 +22,22 @@ interface MapHeaderProps {
 	isFilterActive?: boolean;
 }
 
+const HeaderIconButton = ({
+	triggerProps,
+	onPress,
+	nativeID,
+	children,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	nativeID?: string;
+	children: React.ReactNode;
+}) => (
+	<IconButton {...triggerProps} onPress={onPress} style={styles.iconButton} nativeID={nativeID}>
+		{children}
+	</IconButton>
+);
+
 const MapHeader: React.FC<MapHeaderProps> = ({
 	drawerPosition,
 	query,
@@ -44,14 +60,9 @@ const MapHeader: React.FC<MapHeaderProps> = ({
 				<CustomTooltip
 					placement="bottom"
 					trigger={triggerProps => (
-						<IconButton
-							{...triggerProps}
-							onPress={() => drawerNavigation.toggleDrawer()}
-							style={styles.iconButton}
-							nativeID={ComponentIds.OPEN_DRAWER}
-						>
+						<HeaderIconButton triggerProps={triggerProps} onPress={() => drawerNavigation.toggleDrawer()} nativeID={ComponentIds.OPEN_DRAWER}>
 							<Ionicons name="menu" size={24} color={theme.header.text} />
-						</IconButton>
+						</HeaderIconButton>
 					)}
 				>
 					<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -89,16 +100,12 @@ const MapHeader: React.FC<MapHeaderProps> = ({
 				<CustomTooltip
 					placement="bottom"
 					trigger={triggerProps => (
-						<IconButton
-							{...triggerProps}
-							onPress={() => onFilterPress?.()}
-							style={styles.iconButton}
-						>
+						<HeaderIconButton triggerProps={triggerProps} onPress={() => onFilterPress?.()}>
 							<View style={styles.filterIconWrapper}>
 								<FontAwesome name="filter" size={24} color={theme.header.text} />
 								{isFilterActive && <View style={styles.filterBadge} />}
 							</View>
-						</IconButton>
+						</HeaderIconButton>
 					)}
 				>
 					<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -112,13 +119,9 @@ const MapHeader: React.FC<MapHeaderProps> = ({
 				<CustomTooltip
 					placement="bottom"
 					trigger={triggerProps => (
-						<IconButton
-							{...triggerProps}
-							onPress={() => onSettingsPress?.()}
-							style={styles.iconButton}
-						>
+						<HeaderIconButton triggerProps={triggerProps} onPress={() => onSettingsPress?.()}>
 							<Ionicons name="settings-outline" size={24} color={theme.header.text} />
-						</IconButton>
+						</HeaderIconButton>
 					)}
 				>
 					<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/app/(app)/settings/index.tsx
+++ b/apps/frontend/app/app/(app)/settings/index.tsx
@@ -62,6 +62,8 @@ import FoodoffersAverageRatingToggle from '@/components/FoodoffersAverageRatingT
 
 type CollectibleItemSize = 'small' | 'medium' | 'large';
 
+const ListItemSeparator = () => <View style={{ height: 10 }} />;
+
 const Settings = () => {
         useSetPageTitle(TranslationKeys.settings);
         const { theme, setThemeMode } = useTheme();
@@ -1066,7 +1068,7 @@ const Settings = () => {
 					paddingVertical: 40,
 					backgroundColor: theme.screen.background,
 				}}
-				ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
+				ItemSeparatorComponent={ListItemSeparator}
 			/>
 		</SafeAreaView>
 	);

--- a/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
+++ b/apps/frontend/app/components/BuildingItem/BuildingItem.tsx
@@ -38,6 +38,26 @@ export interface BuildingItemPropsOptimized extends CardLayoutProps {
 	isLastOpened?: boolean;
 }
 
+const NavigationTriggerButton = ({
+	triggerProps,
+	onPress,
+	backgroundColor,
+	iconColor,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	backgroundColor: string;
+	iconColor: string;
+}) => (
+	<IconButton
+		{...triggerProps}
+		style={[styles.navigationButton, { backgroundColor }]}
+		onPress={onPress}
+	>
+		<MaterialCommunityIcons name="navigation-variant" size={20} color={iconColor} />
+	</IconButton>
+);
+
 const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({ 
 	campus, 
 	onEditImage, 
@@ -138,16 +158,7 @@ const BuildingItem: React.FC<BuildingItemPropsOptimized> = ({
 						<CustomTooltip
 							placement="top"
 							trigger={innerTriggerProps => (
-								<IconButton
-									{...innerTriggerProps}
-									style={[
-										styles.navigationButton,
-										{ backgroundColor: campus_area_color },
-									]}
-									onPress={handleOpenNavigation}
-								>
-									<MaterialCommunityIcons name="navigation-variant" size={20} color={contrastColor} />
-								</IconButton>
+								<NavigationTriggerButton triggerProps={innerTriggerProps} onPress={handleOpenNavigation} backgroundColor={campus_area_color} iconColor={contrastColor} />
 							)}
 						>
 							<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -18,6 +18,22 @@ import { TranslationKeys } from '@/locales/keys';
 import SettingsList from '@/components/SettingsList';
 import SettingsListLikeDislike from '@/components/SettingsListLikeDislike';
 
+const HoverIconTrigger = ({
+	triggerProps,
+	onHoverIn,
+	onHoverOut,
+	children,
+}: {
+	triggerProps: object;
+	onHoverIn: () => void;
+	onHoverOut: () => void;
+	children: React.ReactNode;
+}) => (
+	<Pressable style={{ cursor: 'default' } as any} {...triggerProps} onHoverIn={onHoverIn} onHoverOut={onHoverOut}>
+		{children}
+	</Pressable>
+);
+
 const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({ label, date, groupPosition, isAccountRequired }) => {
 	const { theme } = useTheme();
 	const dispatch = useDispatch();
@@ -94,7 +110,7 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({ label, dat
 				placement="top"
 				isOpen={showTooltip}
 				trigger={triggerProps => (
-					<Pressable style={{ cursor: 'default' } as any} {...triggerProps} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)}>
+					<HoverIconTrigger triggerProps={triggerProps} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)}>
 						{label?.image_remote_url || label?.image ? (
 							<Image
 								source={{
@@ -105,7 +121,7 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({ label, dat
 						) : (
 							label?.icon && getIconComponent(label?.icon, theme.screen.icon)
 						)}
-					</Pressable>
+					</HoverIconTrigger>
 				)}
 			>
 				<TooltipContent

--- a/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
@@ -11,6 +11,42 @@ import { CustomTooltip, TooltipContent, TooltipText } from '@/components/CustomT
 import { TranslationKeys } from '@/locales/keys';
 import { useAppSelector } from '@/redux/hooks';
 
+const TimetableEventTrigger = ({
+	triggerProps,
+	color,
+	height,
+	top,
+	width,
+	left,
+	title,
+	onPress,
+}: {
+	triggerProps: object;
+	color: string;
+	height: number;
+	top: number;
+	width: number;
+	left: number;
+	title: string;
+	onPress: () => void;
+}) => (
+	<TouchableOpacity
+		{...triggerProps}
+		style={{
+			...styles.slotEvent,
+			backgroundColor: color,
+			borderColor: color,
+			height,
+			top,
+			width,
+			left,
+		}}
+		onPress={onPress}
+	>
+		<Text style={styles.eventText}>{title}</Text>
+	</TouchableOpacity>
+);
+
 const CourseTimetable: React.FC<CourseTimetableProps> = ({ events, openSheet, setIsUpdate, setTimeTableData, setSelectedEventId }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
@@ -164,21 +200,16 @@ const CourseTimetable: React.FC<CourseTimetableProps> = ({ events, openSheet, se
 				key={event.id}
 				placement="top"
 				trigger={triggerProps => (
-					<TouchableOpacity
-						{...triggerProps}
-						style={{
-							...styles.slotEvent,
-							backgroundColor: event.color,
-							borderColor: event.color,
-							height: calculateHeight(event.startTime, event.endTime),
-							top: calculateTopPosition(event.startTime),
-							width: eventWidth - 4, // Add some spacing
-							left: horizontalPosition,
-						}}
+					<TimetableEventTrigger
+						triggerProps={triggerProps}
+						color={event.color}
+						height={calculateHeight(event.startTime, event.endTime)}
+						top={calculateTopPosition(event.startTime)}
+						width={eventWidth - 4} // Add some spacing
+						left={horizontalPosition}
+						title={event.title}
 						onPress={() => handleUpdateEvent(event)}
-					>
-						<Text style={styles.eventText}>{event.title}</Text>
-					</TouchableOpacity>
+					/>
 				)}
 			>
 				<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -159,6 +159,102 @@ const processMarkdownContent = (lines: string[]) => {
 	return result;
 };
 
+const calculateMarginLeft = (level: number, indent = 0) => level * 16 + indent * 4;
+
+// Component for rendering text with proper formatting
+const TextContent = ({ text, level, indent, textColor }: { text: string; level: number; indent: number; textColor: string }) => (
+	<Text
+		style={{
+			fontSize: 16,
+			fontFamily: 'Poppins_400Regular',
+			color: textColor,
+			marginLeft: calculateMarginLeft(level, indent),
+			lineHeight: 24,
+		}}
+	>
+		{text}
+	</Text>
+);
+
+// Component for rendering images
+const ImageContent = ({
+	url,
+	altText,
+	level,
+	indent,
+	textColor,
+	imageWidth,
+	imageHeight,
+}: {
+	url: string;
+	altText: string;
+	level: number;
+	indent: number;
+	textColor: string;
+	imageWidth?: string | number;
+	imageHeight?: string | number;
+}) => {
+	const [error, setError] = useState(false);
+
+	return (
+		<View
+			style={{
+				width: '100%',
+				alignItems: 'center',
+				marginLeft: calculateMarginLeft(level, indent),
+				marginVertical: 10,
+				borderRadius: 8,
+				overflow: 'hidden',
+				marginTop: 20,
+			}}
+		>
+			{error ? (
+				<View
+					style={{
+						borderWidth: 1,
+						borderColor: textColor,
+						justifyContent: 'center',
+						alignItems: 'center',
+						padding: 10,
+					}}
+				>
+					<Text
+						style={{
+							fontSize: 12,
+							color: textColor,
+							fontFamily: 'Poppins_400Regular',
+							textAlign: 'center',
+							fontStyle: 'italic',
+						}}
+					>
+						{altText}
+					</Text>
+				</View>
+			) : (
+				<View
+					style={{
+						width: (imageWidth || '100%') as DimensionValue,
+						height: (imageHeight || 400) as DimensionValue,
+						justifyContent: 'center',
+						alignItems: 'center',
+						padding: 10,
+					}}
+				>
+					<Image
+						source={{ uri: url }}
+						style={{
+							width: (imageWidth || '100%') as DimensionValue,
+							height: (imageHeight || 400) as DimensionValue,
+							resizeMode: 'cover',
+						}}
+						onError={() => setError(true)}
+					/>
+				</View>
+			)}
+		</View>
+	);
+};
+
 const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColor, imageWidth, imageHeight }) => {
 	const { theme } = useTheme();
 	const { primaryColor, selectedTheme: mode } = useAppSelector((state) => state.settings);
@@ -169,86 +265,6 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 			const lines = rawText.split('\n');
 
 			const contrastColor = myContrastColor(backgroundColor || primaryColor, theme, mode === 'dark');
-
-			const calculateMarginLeft = (level: number, indent = 0) => level * 16 + indent * 4;
-
-			// Component for rendering text with proper formatting
-			const TextContent = ({ text, level, indent }: { text: string; level: number; indent: number }) => (
-				<Text
-					style={{
-						fontSize: 16,
-						fontFamily: 'Poppins_400Regular',
-						color: theme.screen.text,
-						marginLeft: calculateMarginLeft(level, indent),
-						lineHeight: 24,
-					}}
-				>
-					{text}
-				</Text>
-			);
-
-			// Component for rendering images
-			const ImageContent = ({ url, altText, level, indent }: { url: string; altText: string; level: number; indent: number }) => {
-				const [error, setError] = useState(false);
-
-				return (
-					<View
-						style={{
-							width: '100%',
-							alignItems: 'center',
-							marginLeft: calculateMarginLeft(level, indent),
-							marginVertical: 10,
-							borderRadius: 8,
-							overflow: 'hidden',
-							marginTop: 20,
-						}}
-					>
-						{error ? (
-							<View
-								style={{
-									borderWidth: 1,
-									borderColor: theme.screen.text,
-									justifyContent: 'center',
-									alignItems: 'center',
-									padding: 10,
-								}}
-							>
-								<Text
-									style={{
-										fontSize: 12,
-										color: theme.screen.text,
-										fontFamily: 'Poppins_400Regular',
-										textAlign: 'center',
-										fontStyle: 'italic',
-									}}
-								>
-									{altText}
-								</Text>
-							</View>
-						) : (
-							<View
-								style={{
-									width: (imageWidth || '100%') as DimensionValue,
-									height: (imageHeight || 400) as DimensionValue,
-									justifyContent: 'center',
-									alignItems: 'center',
-									padding: 10,
-								}}
-							>
-								<Image
-									source={{ uri: url }}
-									style={{
-										width: (imageWidth || '100%') as DimensionValue,
-										height: (imageHeight || 400) as DimensionValue,
-										resizeMode: 'cover',
-									}}
-									onError={() => setError(true)}
-								/>
-							</View>
-						)}
-					</View>
-				);
-			};
 
 			// Main renderer for content items
 			const renderContentItem = (item: any, level: number, index: number) => {
@@ -274,7 +290,7 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 						return <View key={`empty-${level}-${index}`} style={{ height: 16 }} />;
 
 					case 'text':
-						return <TextContent key={`text-${level}-${index}`} text={item.content} level={level} indent={item.indent || 0} />;
+						return <TextContent key={`text-${level}-${index}`} text={item.content} level={level} indent={item.indent || 0} textColor={theme.screen.text} />;
 
 					case 'email':
 						return (
@@ -300,7 +316,7 @@ const CustomMarkdown: React.FC<CustomMarkdownProps> = ({ content, backgroundColo
 					}
 
 					case 'image':
-						return <ImageContent key={`image-${level}-${index}`} url={item.url} altText={item.altText} level={level} indent={item.indent || 0} />;
+						return <ImageContent key={`image-${level}-${index}`} url={item.url} altText={item.altText} level={level} indent={item.indent || 0} textColor={theme.screen.text} imageWidth={imageWidth} imageHeight={imageHeight} />;
 
 					case 'collapsible':
 						return (

--- a/apps/frontend/app/components/CustomMenuHeader/CustomMenuHeader.tsx
+++ b/apps/frontend/app/components/CustomMenuHeader/CustomMenuHeader.tsx
@@ -15,6 +15,44 @@ import { ComponentIds } from '@/constants/ComponentIds';
 import useChatUnreadStatus from '@/hooks/useChatUnreadStatus';
 import useActiveCollectibleEvent from '@/hooks/useActiveCollectibleEvent';
 
+const MenuTriggerButton = ({
+	triggerProps,
+	onPress,
+	color,
+	backgroundColor,
+	accentColor,
+	showNotificationDot,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	color: string;
+	backgroundColor: string;
+	accentColor: string;
+	showNotificationDot: boolean;
+}) => (
+	<TouchableOpacity
+		{...triggerProps}
+		onPress={onPress}
+		style={styles.menuButton}
+		nativeID={ComponentIds.OPEN_DRAWER}
+	>
+		<View style={styles.menuIconWrapper}>
+			<Ionicons name="menu" size={24} color={color} />
+			{showNotificationDot ? (
+				<View
+					style={[
+						styles.notificationDot,
+						{
+							backgroundColor: accentColor,
+							borderColor: backgroundColor,
+						},
+					]}
+				/>
+			) : null}
+		</View>
+	</TouchableOpacity>
+);
+
 const CustomMenuHeader: React.FC<CustomMenuHeaderProps> = ({ label }) => {
 	const { theme } = useTheme();
         const { translate } = useLanguage();
@@ -48,27 +86,14 @@ const CustomMenuHeader: React.FC<CustomMenuHeaderProps> = ({ label }) => {
 					<CustomTooltip
 						placement="top"
 						trigger={triggerProps => (
-                                                        <TouchableOpacity
-                                                                {...triggerProps}
+                                                        <MenuTriggerButton
+                                                                triggerProps={triggerProps}
                                                                 onPress={() => navigation.toggleDrawer()}
-                                                                style={styles.menuButton}
-                                                                nativeID={ComponentIds.OPEN_DRAWER}
-                                                        >
-                                                                <View style={styles.menuIconWrapper}>
-                                                                        <Ionicons name="menu" size={24} color={theme.header.text} />
-                                                                        {showNotificationDot ? (
-                                                                                <View
-                                                                                        style={[
-                                                                                                styles.notificationDot,
-                                                                                                {
-                                                                                                        backgroundColor: theme.accent,
-                                                                                                        borderColor: theme.header.background,
-                                                                                                },
-                                                                                        ]}
-                                                                                />
-                                                                        ) : null}
-                                                                </View>
-                                                        </TouchableOpacity>
+                                                                color={theme.header.text}
+                                                                backgroundColor={theme.header.background}
+                                                                accentColor={theme.accent}
+                                                                showNotificationDot={showNotificationDot}
+                                                        />
                                                 )}
                                         >
 						<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
+++ b/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
@@ -14,6 +14,12 @@ import { TranslationKeys } from '@/locales/keys';
 
 import { AppScreens } from 'repo-depkit-common';
 
+const BackTriggerButton = ({ triggerProps, onPress, color }: { triggerProps: object; onPress: () => void; color: string }) => (
+	<TouchableOpacity activeOpacity={0.4} {...triggerProps} onPress={onPress} style={{ padding: 10 }}>
+		<Ionicons name="arrow-back" size={26} color={color} />
+	</TouchableOpacity>
+);
+
 const CustomStackHeader: React.FC<CustomStackHeaderProps> = ({ label, rightElement }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
@@ -87,11 +93,7 @@ const CustomStackHeader: React.FC<CustomStackHeaderProps> = ({ label, rightEleme
                                 <View style={styles.col1}>
 					<CustomTooltip
 						placement="top"
-						trigger={triggerProps => (
-							<TouchableOpacity activeOpacity={0.4} {...triggerProps} onPress={handleGoback} style={{ padding: 10 }}>
-								<Ionicons name="arrow-back" size={26} color={theme.header.text} />
-							</TouchableOpacity>
-						)}
+						trigger={triggerProps => <BackTriggerButton triggerProps={triggerProps} onPress={handleGoback} color={theme.header.text} />}
 					>
 						<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
 							<TooltipText fontSize="$sm" color={theme.tooltip.text}>

--- a/apps/frontend/app/components/FeedbackLabel/index.tsx
+++ b/apps/frontend/app/components/FeedbackLabel/index.tsx
@@ -17,6 +17,22 @@ import SettingsList from '@/components/SettingsList';
 import SettingsListLikeDislike from '@/components/SettingsListLikeDislike';
 import useAppRatingScore from '@/hooks/useAppRatingScore';
 
+const HoverIconTrigger = ({
+	triggerProps,
+	onHoverIn,
+	onHoverOut,
+	children,
+}: {
+	triggerProps: object;
+	onHoverIn: () => void;
+	onHoverOut: () => void;
+	children: React.ReactNode;
+}) => (
+	<Pressable {...triggerProps} onHoverIn={onHoverIn} onHoverOut={onHoverOut} style={{ cursor: 'default' } as any}>
+		{children}
+	</Pressable>
+);
+
 const FeedbackLabel: React.FC<FeedbackLabelProps> = ({ label, icon, imageUrl, labelEntries, foodId, offerId, groupPosition, isAccountRequired }) => {
 	const { theme } = useTheme();
 	const dispatch = useDispatch();
@@ -69,10 +85,10 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({ label, icon, imageUrl, la
 				placement="top"
 				isOpen={showTooltip}
 				trigger={triggerProps => (
-					<Pressable {...triggerProps} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)} style={{ cursor: 'default' } as any}>
+					<HoverIconTrigger triggerProps={triggerProps} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)}>
 						{imageUrl && <Image source={{ uri: imageUrl }} style={styles.icon} />}
 						{icon && getIconComponent(icon, theme.screen.icon)}
-					</Pressable>
+					</HoverIconTrigger>
 				)}
 			>
 				<TooltipContent

--- a/apps/frontend/app/components/FeedbackSupport/FeedbackSupport.tsx
+++ b/apps/frontend/app/components/FeedbackSupport/FeedbackSupport.tsx
@@ -19,29 +19,29 @@ type FeedbackItemProps = {
 	setInputValues?: any;
 };
 
+const FeedbackIconSelector: React.FC<{
+	name: any;
+	size: number;
+	color: string;
+	style?: object;
+}> = ({ name, size, color, style }) => {
+	if (name === 'feed') {
+		return <MaterialIcons name={name} size={size} color={color} style={style} />;
+	} else if (name === 'like1' || name === 'dislike1') {
+		return <AntDesign name={name} size={size} color={color} style={style} />;
+	} else {
+		return <MaterialCommunityIcons name={name} size={size} color={color} style={style} />;
+	}
+};
+
 const FeedbackItem: React.FC<FeedbackItemProps> = ({ icon, title, value, extraIcons = [], theme, windowWidth, onPress, inputValues, setInputValues }) => {
 	const { translate } = useLanguage();
 	const { primaryColor } = useAppSelector((state) => state.settings);
 
-	const IconSelector: React.FC<{
-		name: any;
-		size: number;
-		color: string;
-		style?: object;
-	}> = ({ name, size, color, style }) => {
-		if (name === 'feed') {
-			return <MaterialIcons name={name} size={size} color={color} style={style} />;
-		} else if (name === 'like1' || name === 'dislike1') {
-			return <AntDesign name={name} size={size} color={color} style={style} />;
-		} else {
-			return <MaterialCommunityIcons name={name} size={size} color={color} style={style} />;
-		}
-	};
-
 	return (
 		<TouchableOpacity style={[styles.container, { backgroundColor: theme.screen.iconBg }]} disabled={title === 'like_status'} onPress={title !== 'like_status' ? onPress : undefined}>
 			<View style={styles.iconTextContainer}>
-				{icon && <IconSelector name={icon} size={20} color={theme.screen.icon} style={{ marginRight: 10 }} />}
+				{icon && <FeedbackIconSelector name={icon} size={20} color={theme.screen.icon} style={{ marginRight: 10 }} />}
 				<Text
 					style={{
 						color: theme.screen.text,

--- a/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -19,6 +19,89 @@ import { TranslationKeys } from '@/locales/keys';
 import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { UserHelper } from '@/helper/UserHelper';
 
+const MarkingIconTrigger = ({
+	triggerProps,
+	onPress,
+	onHoverIn,
+	onHoverOut,
+	marking,
+	size,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	onHoverIn: () => void;
+	onHoverOut: () => void;
+	marking: any;
+	size: number;
+}) => (
+	<Pressable {...triggerProps} onPress={onPress} onHoverIn={onHoverIn} onHoverOut={onHoverOut}>
+		<MarkingIcon marking={marking} size={size} />
+	</Pressable>
+);
+
+const MarkingLabelTextTrigger = ({
+	triggerProps,
+	onHoverIn,
+	onHoverOut,
+	text,
+	textColor,
+}: {
+	triggerProps: object;
+	onHoverIn: () => void;
+	onHoverOut: () => void;
+	text: string;
+	textColor: string;
+}) => (
+	<Pressable {...triggerProps} onHoverIn={onHoverIn} onHoverOut={onHoverOut} style={styles.labelContainer}>
+		<Text
+			style={{
+				...styles.label,
+				color: textColor,
+				fontSize: isWeb ? 18 : 14,
+				textAlignVertical: 'center',
+			}}
+		>
+			{text}
+		</Text>
+	</Pressable>
+);
+
+const MarkingReactionTrigger = ({
+	triggerProps,
+	onPress,
+	onHoverIn,
+	onHoverOut,
+	buttonStyle,
+	loading,
+	active,
+	activeIconName,
+	inactiveIconName,
+	iconSize,
+	activeColor,
+	inactiveColor,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	onHoverIn: () => void;
+	onHoverOut: () => void;
+	buttonStyle: any;
+	loading: boolean;
+	active: boolean;
+	activeIconName: any;
+	inactiveIconName: any;
+	iconSize: number;
+	activeColor: string;
+	inactiveColor: string;
+}) => (
+	<Pressable onHoverIn={onHoverIn} onHoverOut={onHoverOut} style={buttonStyle} {...triggerProps} onPress={onPress}>
+		{loading ? (
+			<ActivityIndicator size={25} color={activeColor} />
+		) : (
+			<MaterialCommunityIcons name={active ? activeIconName : inactiveIconName} size={iconSize} color={active ? activeColor : inactiveColor} />
+		)}
+	</Pressable>
+);
+
 const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet, size = 30 }) => {
 	const { theme } = useTheme();
 	const dispatch = useDispatch();
@@ -175,9 +258,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 					<CustomTooltip
 						placement="top"
 						trigger={triggerProps => (
-							<Pressable {...triggerProps} onPress={() => openMarkingLabel(marking)} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)}>
-								<MarkingIcon marking={marking} size={size} />
-							</Pressable>
+							<MarkingIconTrigger triggerProps={triggerProps} onPress={() => openMarkingLabel(marking)} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)} marking={marking} size={size} />
 						)}
 					>
 						<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -193,18 +274,7 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 					placement="top"
 					isOpen={showTooltip}
 					trigger={triggerProps => (
-						<Pressable {...triggerProps} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)} style={styles.labelContainer}>
-							<Text
-								style={{
-									...styles.label,
-									color: theme.screen.text,
-									fontSize: isWeb ? 18 : 14,
-									textAlignVertical: 'center',
-								}}
-							>
-								{markingText}
-							</Text>
-						</Pressable>
+						<MarkingLabelTextTrigger triggerProps={triggerProps} onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)} text={markingText} textColor={theme.screen.text} />
 					)}
 				>
 					<TooltipContent
@@ -226,9 +296,20 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 				<CustomTooltip
 					placement="top"
 					trigger={triggerProps => (
-						<Pressable onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)} style={styles.likeButton} {...triggerProps} onPress={() => handleUpdateMarking(true)}>
-							{likeLoading ? <ActivityIndicator size={25} color={foods_area_color} /> : <MaterialCommunityIcons name={ownMarking?.like ? 'thumb-up' : 'thumb-up-outline'} size={iconSize} color={ownMarking?.like ? foods_area_color : theme.screen.icon} />}
-						</Pressable>
+						<MarkingReactionTrigger
+							triggerProps={triggerProps}
+							onPress={() => handleUpdateMarking(true)}
+							onHoverIn={() => setShowTooltip(true)}
+							onHoverOut={() => setShowTooltip(false)}
+							buttonStyle={styles.likeButton}
+							loading={likeLoading}
+							active={!!ownMarking?.like}
+							activeIconName="thumb-up"
+							inactiveIconName="thumb-up-outline"
+							iconSize={iconSize}
+							activeColor={foods_area_color}
+							inactiveColor={theme.screen.icon}
+						/>
 					)}
 				>
 					<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
@@ -240,9 +321,20 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 				<CustomTooltip
 					placement="top"
 					trigger={triggerProps => (
-						<Pressable onHoverIn={() => setShowTooltip(true)} onHoverOut={() => setShowTooltip(false)} {...triggerProps} style={styles.dislikeButton} {...triggerProps} onPress={() => handleUpdateMarking(false)}>
-							{dislikeLoading ? <ActivityIndicator size={25} color={foods_area_color} /> : <MaterialCommunityIcons name={ownMarking?.like === false ? 'thumb-down' : 'thumb-down-outline'} size={iconSize} color={ownMarking?.like === false ? foods_area_color : theme.screen.icon} />}
-						</Pressable>
+						<MarkingReactionTrigger
+							triggerProps={triggerProps}
+							onPress={() => handleUpdateMarking(false)}
+							onHoverIn={() => setShowTooltip(true)}
+							onHoverOut={() => setShowTooltip(false)}
+							buttonStyle={styles.dislikeButton}
+							loading={dislikeLoading}
+							active={ownMarking?.like === false}
+							activeIconName="thumb-down"
+							inactiveIconName="thumb-down-outline"
+							iconSize={iconSize}
+							activeColor={foods_area_color}
+							inactiveColor={theme.screen.icon}
+						/>
 					)}
 				>
 					<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
+++ b/apps/frontend/app/components/MyMarkdown/MyMarkdown.tsx
@@ -46,6 +46,68 @@ export const replaceLinebreaks = (sourceContent: string) => {
 	return sourceContent;
 };
 
+function makeLinkRenderer(contrastColor: string): CustomBlockRenderer {
+	return (props: any) => {
+		const { href } = props.tnode.attributes;
+		const { data } = props.tnode;
+		const text = data || props.children[0]?.data;
+
+		const hrefLower = href?.toLowerCase() ?? '';
+		const isLatLonLink = hrefLower.startsWith('latlon:');
+		const isLocationLink = isLatLonLink || hrefLower.startsWith(UriScheme.GEO) || hrefLower.startsWith(UriScheme.MAPS);
+
+		let finalHref = href;
+		if (isLatLonLink) {
+			const coordinateString = href.slice('latlon:'.length);
+			const [latitudeRaw, longitudeRaw] = coordinateString.split(',');
+
+			const latitude = Number.parseFloat(latitudeRaw?.trim() ?? '');
+			const longitude = Number.parseFloat(longitudeRaw?.trim() ?? '');
+
+			if (!Number.isNaN(latitude) && !Number.isNaN(longitude)) {
+				finalHref = CommonSystemActionHelper.getGoogleMapsUrl(latitude, longitude);
+			}
+		} else if (isLocationLink) {
+			const { resolvedHref } = resolveLocationHref(href);
+			finalHref = resolvedHref ?? href;
+		}
+
+		const handlePress = () => {
+			if (finalHref) {
+				openLinkSafely(finalHref);
+			}
+		};
+
+		let iconLeft = <FontAwesome6 name="arrow-up-right-from-square" size={20} color={contrastColor} />;
+
+		if (finalHref?.startsWith('tel:')) {
+			iconLeft = <FontAwesome6 name="phone" size={20} color={contrastColor} />;
+		} else if (finalHref?.startsWith('mailto:')) {
+			iconLeft = <MaterialCommunityIcons name="email" size={24} color={contrastColor} />;
+		} else if (isLocationLink) {
+			iconLeft = <Ionicons name="navigate" size={24} color={contrastColor} />;
+		}
+
+		return <ProjectButton text={text} onPress={handlePress} iconLeft={iconLeft} />;
+	};
+}
+
+function makeSubRenderer(fontSize: number, textColor: string): CustomTextualRenderer {
+	return (props: any) => {
+		const { data } = props.tnode;
+		const text = data || props.children[0]?.data;
+		return <Text style={{ fontSize: fontSize * 0.8, lineHeight: fontSize, textAlignVertical: 'bottom', color: textColor }}>{text}</Text>;
+	};
+}
+
+function makeSupRenderer(fontSize: number, textColor: string): CustomTextualRenderer {
+	return (props: any) => {
+		const { data } = props.tnode;
+		const text = data || props.children[0]?.data;
+		return <Text style={{ fontSize: fontSize * 0.8, lineHeight: fontSize * 1.5, textAlignVertical: 'top', color: textColor }}>{text}</Text>;
+	};
+}
+
 const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorProp }) => {
 	const { primaryColor, selectedTheme } = useAppSelector((state) => state.settings);
 
@@ -104,62 +166,12 @@ const MyMarkdown: React.FC<MyMarkdownProps> = ({ content, textColor: textColorPr
 
 	const customRenderers = React.useMemo(() => {
 		const renderers: Record<string, CustomBlockRenderer | CustomTextualRenderer | CustomMixedRenderer> = {
-		a: (props: any) => {
-			const { href } = props.tnode.attributes;
-			const { data } = props.tnode;
-			const text = data || props.children[0]?.data;
-
-			const hrefLower = href?.toLowerCase() ?? '';
-			const isLatLonLink = hrefLower.startsWith('latlon:');
-			const isLocationLink = isLatLonLink || hrefLower.startsWith(UriScheme.GEO) || hrefLower.startsWith(UriScheme.MAPS);
-
-			let finalHref = href;
-			if (isLatLonLink) {
-				const coordinateString = href.slice('latlon:'.length);
-				const [latitudeRaw, longitudeRaw] = coordinateString.split(',');
-
-				const latitude = Number.parseFloat(latitudeRaw?.trim() ?? '');
-				const longitude = Number.parseFloat(longitudeRaw?.trim() ?? '');
-
-				if (!Number.isNaN(latitude) && !Number.isNaN(longitude)) {
-					finalHref = CommonSystemActionHelper.getGoogleMapsUrl(latitude, longitude);
-				}
-			} else if (isLocationLink) {
-				const { resolvedHref } = resolveLocationHref(href);
-				finalHref = resolvedHref ?? href;
-			}
-
-			const handlePress = () => {
-				if (finalHref) {
-					openLinkSafely(finalHref);
-				}
-			};
-
-			let iconLeft = <FontAwesome6 name="arrow-up-right-from-square" size={20} color={contrastColor} />;
-
-			if (finalHref?.startsWith('tel:')) {
-				iconLeft = <FontAwesome6 name="phone" size={20} color={contrastColor} />;
-			} else if (finalHref?.startsWith('mailto:')) {
-				iconLeft = <MaterialCommunityIcons name="email" size={24} color={contrastColor} />;
-			} else if (isLocationLink) {
-				iconLeft = <Ionicons name="navigate" size={24} color={contrastColor} />;
-			}
-
-			return <ProjectButton text={text} onPress={handlePress} iconLeft={iconLeft} />;
-		},
-		sub: (props: any) => {
-			const { data } = props.tnode;
-			const text = data || props.children[0]?.data;
-			return <Text style={{ fontSize: fontSize * 0.8, lineHeight: fontSize, textAlignVertical: 'bottom', color: textColor }}>{text}</Text>;
-		},
-		sup: (props: any) => {
-			const { data } = props.tnode;
-			const text = data || props.children[0]?.data;
-			return <Text style={{ fontSize: fontSize * 0.8, lineHeight: fontSize * 1.5, textAlignVertical: 'top', color: textColor }}>{text}</Text>;
-		},
-	};
-	return renderers;
-}, [textColor, fontSize, contrastColor]);
+			a: makeLinkRenderer(contrastColor),
+			sub: makeSubRenderer(fontSize, textColor),
+			sup: makeSupRenderer(fontSize, textColor),
+		};
+		return renderers;
+	}, [textColor, fontSize, contrastColor]);
 
 	return (
 		<View>

--- a/apps/frontend/app/components/NewsItem/NewsItem.tsx
+++ b/apps/frontend/app/components/NewsItem/NewsItem.tsx
@@ -12,6 +12,35 @@ import { myContrastColor } from '@/helper/ColorHelper';
 import { CustomTooltip, TooltipContent, TooltipText } from '@/components/CustomTooltip';
 import { TranslationKeys } from '@/locales/keys';
 
+const ReadMoreTriggerButton = ({
+	triggerProps,
+	onPress,
+	backgroundColor,
+	textColor,
+	width,
+	label,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	backgroundColor: string;
+	textColor: string;
+	width: number | string;
+	label: string;
+}) => (
+	<TouchableOpacity
+		{...triggerProps}
+		style={{
+			...styles.readMoreButton,
+			backgroundColor,
+			width,
+		}}
+		onPress={onPress}
+	>
+		<Text style={{ ...styles.readMore, color: textColor }}>{label}</Text>
+		<FontAwesome6 name="arrow-up-right-from-square" size={20} color={textColor} />
+	</TouchableOpacity>
+);
+
 const NewsItem: React.FC<any> = ({ news }) => {
 	const { theme } = useTheme();
 	const toast = useToast();
@@ -130,18 +159,14 @@ const NewsItem: React.FC<any> = ({ news }) => {
 					<CustomTooltip
 						placement="top"
 						trigger={triggerProps => (
-							<TouchableOpacity
-								{...triggerProps}
-								style={{
-									...styles.readMoreButton,
-									backgroundColor: news_area_color,
-									width: screenWidth > 768 ? 210 : '100%',
-								}}
+							<ReadMoreTriggerButton
+								triggerProps={triggerProps}
 								onPress={handleNewsDetails}
-							>
-								<Text style={{ ...styles.readMore, color: contrastColor }}>{translate(TranslationKeys.read_more)}</Text>
-								<FontAwesome6 name="arrow-up-right-from-square" size={20} color={contrastColor} />
-							</TouchableOpacity>
+								backgroundColor={news_area_color}
+								textColor={contrastColor}
+								width={screenWidth > 768 ? 210 : '100%'}
+								label={translate(TranslationKeys.read_more)}
+							/>
 						)}
 					>
 						<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">

--- a/apps/frontend/app/components/SettingsListLikeDislike/SettingsListLikeDislike.tsx
+++ b/apps/frontend/app/components/SettingsListLikeDislike/SettingsListLikeDislike.tsx
@@ -8,6 +8,58 @@ import { myContrastColor } from '@/helper/ColorHelper';
 import { isWeb } from '@/constants/Constants';
 import { SettingsListLikeDislikeProps } from './types';
 
+const LikeDislikeTriggerButton = ({
+	triggerProps,
+	onPress,
+	buttonStyle,
+	active,
+	loading,
+	inactiveIconName,
+	activeIconName,
+	iconSize,
+	backgroundColor,
+	contrastColor,
+	inactiveIconColor,
+	inactiveTextColor,
+	count,
+}: {
+	triggerProps: object;
+	onPress: () => void;
+	buttonStyle: any;
+	active: boolean;
+	loading: boolean;
+	inactiveIconName: any;
+	activeIconName: any;
+	iconSize: number;
+	backgroundColor: string;
+	contrastColor: string;
+	inactiveIconColor: string;
+	inactiveTextColor: string;
+	count: number | null | undefined;
+}) => (
+	<Pressable
+		{...triggerProps}
+		style={{
+			...buttonStyle,
+			backgroundColor: active ? backgroundColor : undefined,
+		}}
+		onPress={onPress}
+	>
+		{loading ? (
+			<ActivityIndicator size={iconSize} color={backgroundColor} />
+		) : (
+			<MaterialCommunityIcons
+				name={active ? activeIconName : inactiveIconName}
+				size={iconSize}
+				color={active ? contrastColor : inactiveIconColor}
+			/>
+		)}
+		{count != null && count > 0 && (
+			<Text style={[styles.count, { color: active ? contrastColor : inactiveTextColor }]}>{count}</Text>
+		)}
+	</Pressable>
+);
+
 const SettingsListLikeDislike: React.FC<SettingsListLikeDislikeProps> = ({
 	like,
 	onPressLike,
@@ -30,27 +82,21 @@ const SettingsListLikeDislike: React.FC<SettingsListLikeDislikeProps> = ({
 			<CustomTooltip
 				placement="top"
 				trigger={triggerProps => (
-					<Pressable
-						{...triggerProps}
-						style={{
-							...styles.likeButton,
-							backgroundColor: like ? foods_area_color : undefined,
-						}}
+					<LikeDislikeTriggerButton
+						triggerProps={triggerProps}
 						onPress={onPressLike}
-					>
-						{likeLoading ? (
-							<ActivityIndicator size={iconSize} color={foods_area_color} />
-						) : (
-							<MaterialCommunityIcons
-								name={like ? 'thumb-up' : 'thumb-up-outline'}
-								size={iconSize}
-								color={like ? contrastColor : theme.screen.icon}
-							/>
-						)}
-						{likeCount != null && likeCount > 0 && (
-							<Text style={[styles.count, { color: like ? contrastColor : theme.screen.text }]}>{likeCount}</Text>
-						)}
-					</Pressable>
+						buttonStyle={styles.likeButton}
+						active={like === true}
+						loading={likeLoading}
+						inactiveIconName="thumb-up-outline"
+						activeIconName="thumb-up"
+						iconSize={iconSize}
+						backgroundColor={foods_area_color}
+						contrastColor={contrastColor}
+						inactiveIconColor={theme.screen.icon}
+						inactiveTextColor={theme.screen.text}
+						count={likeCount}
+					/>
 				)}
 			>
 				{likeTooltipText ? (
@@ -65,27 +111,21 @@ const SettingsListLikeDislike: React.FC<SettingsListLikeDislikeProps> = ({
 			<CustomTooltip
 				placement="top"
 				trigger={triggerProps => (
-					<Pressable
-						{...triggerProps}
-						style={{
-							...styles.dislikeButton,
-							backgroundColor: like === false ? foods_area_color : undefined,
-						}}
+					<LikeDislikeTriggerButton
+						triggerProps={triggerProps}
 						onPress={onPressDislike}
-					>
-						{dislikeLoading ? (
-							<ActivityIndicator size={iconSize} color={foods_area_color} />
-						) : (
-							<MaterialCommunityIcons
-								name={like === false ? 'thumb-down' : 'thumb-down-outline'}
-								size={iconSize}
-								color={like === false ? contrastColor : theme.screen.icon}
-							/>
-						)}
-						{dislikeCount != null && dislikeCount > 0 && (
-							<Text style={[styles.count, { color: like === false ? contrastColor : theme.screen.text }]}>{dislikeCount}</Text>
-						)}
-					</Pressable>
+						buttonStyle={styles.dislikeButton}
+						active={like === false}
+						loading={dislikeLoading}
+						inactiveIconName="thumb-down-outline"
+						activeIconName="thumb-down"
+						iconSize={iconSize}
+						backgroundColor={foods_area_color}
+						contrastColor={contrastColor}
+						inactiveIconColor={theme.screen.icon}
+						inactiveTextColor={theme.screen.text}
+						count={dislikeCount}
+					/>
 				)}
 			>
 				{dislikeTooltipText ? (

--- a/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
+++ b/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
@@ -21,6 +21,26 @@ export interface SettingsListMarkingLabelProps extends MarkingLabelProps {}
 // All props are defined in MarkingLabelProps; this named export is kept for
 // backwards compatibility and as the canonical type for this component.
 
+const MarkingLabelTrigger = ({
+	triggerProps,
+	onPress,
+	onHoverIn,
+	onHoverOut,
+	marking,
+	size,
+}: {
+	triggerProps: object;
+	onPress?: () => void;
+	onHoverIn: () => void;
+	onHoverOut: () => void;
+	marking: any;
+	size: number;
+}) => (
+	<Pressable {...triggerProps} onPress={onPress} onHoverIn={onHoverIn} onHoverOut={onHoverOut}>
+		<MarkingIcon marking={marking} size={size} />
+	</Pressable>
+);
+
 const SettingsListMarkingLabel: React.FC<SettingsListMarkingLabelProps> = ({
 	markingId,
 	handleMenuSheet,
@@ -163,26 +183,16 @@ const SettingsListMarkingLabel: React.FC<SettingsListMarkingLabelProps> = ({
 		<View style={styles.leftIconWrapper}>
 			<CustomTooltip
 				placement="top"
-				trigger={triggerProps =>
-					handleMenuSheet ? (
-						<Pressable
-							{...triggerProps}
-							onPress={() => openMarkingLabel(marking)}
-							onHoverIn={() => setShowTooltip(true)}
-							onHoverOut={() => setShowTooltip(false)}
-						>
-							<MarkingIcon marking={marking} size={size} />
-						</Pressable>
-					) : (
-						<Pressable
-							{...triggerProps}
-							onHoverIn={() => setShowTooltip(true)}
-							onHoverOut={() => setShowTooltip(false)}
-						>
-							<MarkingIcon marking={marking} size={size} />
-						</Pressable>
-					)
-				}
+				trigger={triggerProps => (
+					<MarkingLabelTrigger
+						triggerProps={triggerProps}
+						onPress={handleMenuSheet ? () => openMarkingLabel(marking) : undefined}
+						onHoverIn={() => setShowTooltip(true)}
+						onHoverOut={() => setShowTooltip(false)}
+						marking={marking}
+						size={size}
+					/>
+				)}
 			>
 				<TooltipContent bg={theme.tooltip.background} py="$1" px="$2">
 					<TooltipText fontSize="$sm" color={theme.tooltip.text}>

--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -652,6 +652,18 @@ function buildActivityHexGeoJson(
 	};
 }
 
+function ActivityDetailBackHeaderButton({ color, onPress }: { color: string; onPress: () => void }) {
+	return (
+		<TouchableOpacity
+			onPress={onPress}
+			style={styles.headerBackButton}
+			activeOpacity={0.7}
+		>
+			<MaterialIcons name="arrow-back" size={24} color={color} />
+		</TouchableOpacity>
+	);
+}
+
 export default function ActivityDetailScreen() {
 	const { id } = useLocalSearchParams<{ id: string }>();
 	const { theme } = useTheme();
@@ -756,15 +768,7 @@ export default function ActivityDetailScreen() {
 		navigation.setOptions({
 			headerStyle: { backgroundColor: theme.header.background },
 			headerTintColor: theme.header.text,
-			headerLeft: () => (
-				<TouchableOpacity
-					onPress={() => router.navigate('/activities')}
-					style={styles.headerBackButton}
-					activeOpacity={0.7}
-				>
-					<MaterialIcons name="arrow-back" size={24} color={theme.header.text} />
-				</TouchableOpacity>
-			),
+			headerLeft: () => <ActivityDetailBackHeaderButton color={theme.header.text} onPress={() => router.navigate('/activities')} />,
 		});
 	}, [navigation, router, theme.header.background, theme.header.text]);
 

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -382,6 +382,22 @@ async function applyForestBillboardsForUncachedTiles(records: Record<string, any
 	}
 }
 
+function ActivitiesHeaderRight({ onRebuild, onExport, onImport }: { onRebuild: () => void; onExport: () => void; onImport: () => void }) {
+	return (
+		<View style={styles.headerButtons}>
+			<TouchableOpacity onPress={onRebuild} style={styles.headerImportButton} activeOpacity={0.7}>
+				<MaterialIcons name="refresh" size={24} color={PRIMARY_COLOR} />
+			</TouchableOpacity>
+			<TouchableOpacity onPress={onExport} style={styles.headerImportButton} activeOpacity={0.7}>
+				<MaterialIcons name="file-upload" size={24} color={PRIMARY_COLOR} />
+			</TouchableOpacity>
+			<TouchableOpacity onPress={onImport} style={styles.headerImportButton} activeOpacity={0.7}>
+				<MaterialIcons name="file-download" size={24} color={PRIMARY_COLOR} />
+			</TouchableOpacity>
+		</View>
+	);
+}
+
 // ─── Activities Screen ────────────────────────────────────────────────────────
 
 export default function ActivitiesScreen() {
@@ -761,19 +777,7 @@ export default function ActivitiesScreen() {
 	// Show import, export, and rebuild buttons in the header
 	useLayoutEffect(() => {
 		navigation.setOptions({
-			headerRight: () => (
-				<View style={styles.headerButtons}>
-					<TouchableOpacity onPress={handleRebuildMap} style={styles.headerImportButton} activeOpacity={0.7}>
-						<MaterialIcons name="refresh" size={24} color={PRIMARY_COLOR} />
-					</TouchableOpacity>
-					<TouchableOpacity onPress={handleExportAll} style={styles.headerImportButton} activeOpacity={0.7}>
-						<MaterialIcons name="file-upload" size={24} color={PRIMARY_COLOR} />
-					</TouchableOpacity>
-					<TouchableOpacity onPress={openImportModal} style={styles.headerImportButton} activeOpacity={0.7}>
-						<MaterialIcons name="file-download" size={24} color={PRIMARY_COLOR} />
-					</TouchableOpacity>
-				</View>
-			),
+			headerRight: () => <ActivitiesHeaderRight onRebuild={handleRebuildMap} onExport={handleExportAll} onImport={openImportModal} />,
 		});
 	}, [navigation, openImportModal, handleExportAll, handleRebuildMap]);
 

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -306,6 +306,18 @@ function ReassignRouteContent({
 	);
 }
 
+function RouteBackHeaderButton({ color, onPress }: { color: string; onPress: () => void }) {
+	return (
+		<TouchableOpacity
+			onPress={onPress}
+			style={styles.headerBackButton}
+			activeOpacity={0.7}
+		>
+			<MaterialIcons name="arrow-back" size={24} color={color} />
+		</TouchableOpacity>
+	);
+}
+
 export default function RouteDetailScreen() {
 	const { id } = useLocalSearchParams<{ id: string }>();
 	const { theme } = useTheme();
@@ -404,15 +416,7 @@ export default function RouteDetailScreen() {
 			headerStyle: { backgroundColor: theme.header.background },
 			headerTintColor: theme.header.text,
 			title: route?.name ?? '',
-			headerLeft: () => (
-				<TouchableOpacity
-					onPress={() => router.navigate('/routes')}
-					style={styles.headerBackButton}
-					activeOpacity={0.7}
-				>
-					<MaterialIcons name="arrow-back" size={24} color={theme.header.text} />
-				</TouchableOpacity>
-			),
+			headerLeft: () => <RouteBackHeaderButton color={theme.header.text} onPress={() => router.navigate('/routes')} />,
 		});
 	}, [navigation, router, theme.header.background, theme.header.text, route?.name]);
 

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -226,6 +226,18 @@ function MatchParticipants({ players }: Readonly<{ players: GameHistoryPlayerEnt
 	);
 }
 
+function GameDetailBackButton({ color }: { color: string }) {
+	return (
+		<TouchableOpacity
+			nativeID={ComponentIds.GAME_DETAIL_BACK_BUTTON}
+			onPress={() => router.replace('/games')}
+			style={styles.headerBackButton}
+		>
+			<Ionicons name="arrow-back" size={24} color={color} />
+		</TouchableOpacity>
+	);
+}
+
 // ─── Game detail screen ───────────────────────────────────────────────────────
 
 export default function GameTypeDetailScreen() {
@@ -246,15 +258,7 @@ export default function GameTypeDetailScreen() {
 	useLayoutEffect(() => {
 		navigation.setOptions({
 			title: gameType ? `${gameType.icon} ${gameType.name}` : 'Spiel',
-			headerLeft: () => (
-				<TouchableOpacity
-					nativeID={ComponentIds.GAME_DETAIL_BACK_BUTTON}
-					onPress={() => router.replace('/games')}
-					style={styles.headerBackButton}
-				>
-					<Ionicons name="arrow-back" size={24} color={theme.header.text} />
-				</TouchableOpacity>
-			),
+			headerLeft: () => <GameDetailBackButton color={theme.header.text} />,
 		});
 	}, [navigation, theme.header.text, gameType]);
 

--- a/apps/score-tracker/frontend/app/games/index.tsx
+++ b/apps/score-tracker/frontend/app/games/index.tsx
@@ -20,6 +20,27 @@ function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bot
 	return 'middle';
 }
 
+function GamesHeaderRight({ color, onImport, onAdd }: { color: string; onImport: () => void; onAdd: () => void }) {
+	return (
+		<View style={styles.headerButtons}>
+			<TouchableOpacity
+				nativeID={ComponentIds.GAMES_SCREEN_IMPORT_BUTTON}
+				onPress={onImport}
+				style={styles.headerButton}
+			>
+				<Ionicons name="cloud-download-outline" size={22} color={color} />
+			</TouchableOpacity>
+			<TouchableOpacity
+				nativeID={ComponentIds.GAMES_SCREEN_ADD_BUTTON}
+				onPress={onAdd}
+				style={styles.headerButton}
+			>
+				<Ionicons name="add-circle-outline" size={24} color={color} />
+			</TouchableOpacity>
+		</View>
+	);
+}
+
 export default function GamesScreen() {
 	const { theme } = useTheme();
 	const insets = useSafeAreaInsets();
@@ -108,24 +129,7 @@ export default function GamesScreen() {
 
 	React.useLayoutEffect(() => {
 		navigation.setOptions({
-			headerRight: () => (
-				<View style={styles.headerButtons}>
-					<TouchableOpacity
-						nativeID={ComponentIds.GAMES_SCREEN_IMPORT_BUTTON}
-						onPress={handleOpenImportModal}
-						style={styles.headerButton}
-					>
-						<Ionicons name="cloud-download-outline" size={22} color={theme.header.text} />
-					</TouchableOpacity>
-					<TouchableOpacity
-						nativeID={ComponentIds.GAMES_SCREEN_ADD_BUTTON}
-						onPress={handleAddGameType}
-						style={styles.headerButton}
-					>
-						<Ionicons name="add-circle-outline" size={24} color={theme.header.text} />
-					</TouchableOpacity>
-				</View>
-			),
+			headerRight: () => <GamesHeaderRight color={theme.header.text} onImport={handleOpenImportModal} onAdd={handleAddGameType} />,
 		});
 	}, [navigation, theme.header.text, handleAddGameType, handleOpenImportModal]);
 

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -581,6 +581,45 @@ function GameTypeSelectSection({ onDone }: Readonly<{ onDone: () => void }>) {
 
 // ─── Game Screen ──────────────────────────────────────────────────────────────
 
+function GameHeaderRight({
+	color,
+	isActive,
+	isEditingPlayers,
+	onToggleEditingPlayers,
+	onOpenSettings,
+}: {
+	color: string;
+	isActive: boolean;
+	isEditingPlayers: boolean;
+	onToggleEditingPlayers: () => void;
+	onOpenSettings: () => void;
+}) {
+	return (
+		<View style={styles.headerButtons}>
+			{isActive && (
+				<TouchableOpacity
+					nativeID={ComponentIds.GAME_HEADER_EDIT_PLAYERS_BUTTON}
+					onPress={onToggleEditingPlayers}
+					style={styles.headerButton}
+				>
+					<Ionicons
+						name={isEditingPlayers ? 'checkmark-circle-outline' : 'people-outline'}
+						size={22}
+						color={color}
+					/>
+				</TouchableOpacity>
+			)}
+			<TouchableOpacity
+				nativeID={ComponentIds.GAME_HEADER_SETTINGS_BUTTON}
+				onPress={onOpenSettings}
+				style={styles.headerButton}
+			>
+				<Ionicons name="settings-outline" size={22} color={color} />
+			</TouchableOpacity>
+		</View>
+	);
+}
+
 export default function GameScreen() {
 	const { theme } = useTheme();
 	const insets = useSafeAreaInsets();
@@ -834,28 +873,13 @@ export default function GameScreen() {
 			// Show which game is being played right in the header
 			title: selectedGameType ? `${selectedGameType.icon} ${selectedGameType.name}` : 'Game',
 			headerRight: () => (
-				<View style={styles.headerButtons}>
-					{status === 'active' && (
-						<TouchableOpacity
-							nativeID={ComponentIds.GAME_HEADER_EDIT_PLAYERS_BUTTON}
-							onPress={toggleEditingPlayers}
-							style={styles.headerButton}
-						>
-							<Ionicons
-								name={isEditingPlayers ? 'checkmark-circle-outline' : 'people-outline'}
-								size={22}
-								color={theme.header.text}
-							/>
-						</TouchableOpacity>
-					)}
-					<TouchableOpacity
-						nativeID={ComponentIds.GAME_HEADER_SETTINGS_BUTTON}
-						onPress={handleOpenSettingsModal}
-						style={styles.headerButton}
-					>
-						<Ionicons name="settings-outline" size={22} color={theme.header.text} />
-					</TouchableOpacity>
-				</View>
+				<GameHeaderRight
+					color={theme.header.text}
+					isActive={status === 'active'}
+					isEditingPlayers={isEditingPlayers}
+					onToggleEditingPlayers={toggleEditingPlayers}
+					onOpenSettings={handleOpenSettingsModal}
+				/>
 			),
 		});
 	}, [navigation, theme.header.text, status, isEditingPlayers, handleOpenSettingsModal, selectedGameType]);

--- a/apps/score-tracker/frontend/app/players/index.tsx
+++ b/apps/score-tracker/frontend/app/players/index.tsx
@@ -277,6 +277,18 @@ function FriendEditContent({ friendId, onClose }: Readonly<{ friendId: string; o
 
 // ─── Players (friends) screen ─────────────────────────────────────────────────
 
+function PlayersHeaderRight({ color, onPress }: { color: string; onPress: () => void }) {
+	return (
+		<TouchableOpacity
+			nativeID={ComponentIds.PLAYERS_SCREEN_OPTIONS_BUTTON}
+			onPress={onPress}
+			style={styles.headerButton}
+		>
+			<Ionicons name="settings-outline" size={22} color={color} />
+		</TouchableOpacity>
+	);
+}
+
 export default function PlayersScreen() {
 	const { theme } = useTheme();
 	const insets = useSafeAreaInsets();
@@ -329,15 +341,7 @@ export default function PlayersScreen() {
 
 	React.useLayoutEffect(() => {
 		navigation.setOptions({
-			headerRight: () => (
-				<TouchableOpacity
-					nativeID={ComponentIds.PLAYERS_SCREEN_OPTIONS_BUTTON}
-					onPress={handleOpenOptionsModal}
-					style={styles.headerButton}
-				>
-					<Ionicons name="settings-outline" size={22} color={theme.header.text} />
-				</TouchableOpacity>
-			),
+			headerRight: () => <PlayersHeaderRight color={theme.header.text} onPress={handleOpenOptionsModal} />,
 		});
 	}, [navigation, theme.header.text, handleOpenOptionsModal]);
 

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -61,8 +61,7 @@ bzw. dem nächsten SonarCloud-Scan. Details zu bereits gefixten Typen stehen in
 der Git-/PR-Historie.
 
 **Brauchen individuelle Refactorings statt mechanischer Fixes (Stand 2026-07-21):**
-„Cognitive Complexity" (109x), „Move this component definition out of the parent
-component" (97x), TODO-Kommentare (39x).
+„Cognitive Complexity" (109x), TODO-Kommentare (39x).
 Diese Typen in kleinen, thematisch gruppierten PRs angehen.
 
 „Exception-Handling" (23x) ist als erster dieser schweren Fälle abgearbeitet: alle
@@ -103,6 +102,44 @@ Markdown-Zeilen (`DataAccess.tsx`, `course-timetable/index.tsx`) sowie die
 URL-Liste in `rss-feed-config/index.tsx` (nur Anhängen/Editieren, kein
 Löschen/Umsortieren vorhanden — vor einer Restrukturierung zu ID-Objekten
 erst klären, ob Löschen/Umsortieren tatsächlich nie kommen soll).
+
+„Move this component definition out of the parent component" (97x) wurde
+teilweise abgearbeitet: 45 der 46 Vorkommen außerhalb von `_layout.tsx`-Dateien
+wurden gefixt, indem die jeweilige verschachtelte Funktion (meist ein
+`CustomTooltip`-`trigger={triggerProps => (...)}`-Block oder ein
+`navigation.setOptions({ headerLeft/headerRight: () => (...) })`) auf Modul-
+oder Dateiebene als eigene benannte Komponente extrahiert wurde; Closures
+wurden als explizite Props durchgereicht. Bei `MyMarkdown.tsx` (drei
+`react-native-render-html`-Renderer) wurden bewusst Factory-Funktionen
+(`makeLinkRenderer`, `makeSubRenderer`, `makeSupRenderer`) statt parameterloser
+Komponenten verwendet, da die Renderer `contrastColor`/`textColor`/`fontSize`
+aus dem `useMemo` weiterhin benötigen.
+
+**Zwei Dinge bewusst offengelassen:**
+- `FoodItem.tsx:324` — der `CustomTooltip`-Trigger dort schließt über ~20
+  Werte (Styles, Handler, Item-Daten), was ihn zum größten und riskantesten
+  Kandidaten in diesem Batch macht; da `CustomTooltip` den Trigger ohnehin nur
+  als Funktion aufruft (kein JSX-Tag, also kein echtes Remount-Risiko), ist der
+  Nutzen einer sofortigen Extraktion gering gegenüber dem Risiko, beim
+  Durchreichen der vielen Closures etwas zu vertauschen. Für eine eigene,
+  ruhigere Änderung vormerken.
+- Alle 51 Vorkommen in `_layout.tsx`-Dateien (`apps/frontend/app/app/(app)/_layout.tsx`
+  20x, `apps/geonexia/frontend/app/_layout.tsx` 12x,
+  `apps/score-tracker/frontend/app/_layout.tsx` 7x, plus 12x in kleineren
+  `_layout.tsx`-Dateien) — bewusst für einen eigenen, fokussierten PR
+  aufgehoben, da es sich um die zentralen Navigationskonfigurationen der drei
+  Apps handelt und Fehler dort app-weite Auswirkungen hätten.
+
+Anmerkung zur Sonar-Regel: Ein Großteil der gefixten Stellen sind
+Render-Prop-Funktionen (`trigger`, `headerLeft`/`headerRight`), die von ihrem
+Aufrufer direkt als Funktion aufgerufen werden, nicht als JSX-Tag instanziiert
+— es gibt dort also keinen echten Remount-Bug (React vergibt nur beim
+JSX-Tag `<Foo/>` eine Komponentenidentität). Sonar meldet sie trotzdem, weil
+es rein syntaktisch auf „Funktion gibt JSX zurück, verschachtelt im
+Elternkomponenten-Body" prüft. Echte Remount-Bugs mit sichtbarem Impact waren
+nur `CustomMarkdown.tsx` (`TextContent`/`ImageContent`, als JSX-Tags gerendert
+— Bild-Ladefehler-State ist vorher bei jedem Re-Render von `CustomMarkdown`
+verloren gegangen) und `FeedbackSupport.tsx` (`IconSelector`).
 
 ## Hinweise
 


### PR DESCRIPTION
## Summary

Following `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`, this tackles the fourth "harder" issue type: **"Move this component definition out of the parent component and pass data as props"** (SonarCloud rule S6478, 97 reported occurrences). This PR fixes **45 of the 46 occurrences outside `_layout.tsx` files** — the `_layout.tsx` navigation-config files (51 occurrences) are deliberately deferred to their own PR (see below).

### What the rule flags and what it actually means here

The rule targets a real React anti-pattern: defining a component function *inside* another component's render body. If that inner function is instantiated as a JSX tag (`<Foo/>`), every parent re-render creates a new function identity, so React fully unmounts+remounts it — losing local state, resetting animations, causing visible flicker.

Most of the 45 fixed sites here are **`CustomTooltip` `trigger={triggerProps => (...)}` blocks and `navigation.setOptions({ headerLeft/headerRight: () => (...) })`** — these are called directly as plain functions by their consumer, never JSX-tagged, so there's no real remount bug; SonarCloud flags the syntactic pattern regardless (a function nested in a component body that returns JSX). Still fixed for the Sonar pass and general hygiene, but no visible behavior change to test for.

Two sites were **genuine bugs with visible impact**, prioritized first:
- `CustomMarkdown.tsx`'s `TextContent`/`ImageContent` — rendered as real JSX tags in a mapped list, so `ImageContent`'s own image-load-error `useState` was reset on every unrelated re-render of the parent (images would visibly flash/reload).
- `FeedbackSupport.tsx`'s `IconSelector` — trivial to hoist, captured nothing from its parent.

### Approach

Each nested function was extracted to a named component at module (or file) scope, with everything it used to close over threaded through as explicit props. Where multiple near-identical blocks existed in one file, they share a single hoisted component instead of duplicating it: `SettingsListLikeDislike`'s like/dislike buttons, `MarkingLabels`' four trigger blocks, and the repeated `CustomTooltip` icon-button shape across `MapHeader`/`CampusHeader`/`FoodOffersHeader`/`HousingHeader`/`DetailsTabs`/`HousingDetailsTabs`.

`MyMarkdown.tsx`'s three `react-native-render-html` renderers use factory functions (`makeLinkRenderer`/`makeSubRenderer`/`makeSupRenderer`) instead of bare parameterless components, since they still need `contrastColor`/`textColor`/`fontSize` threaded in from the existing `useMemo` — a naive no-args hoist would have been wrong here.

### Deliberately left for follow-up (documented in the doc)

- **`FoodItem.tsx:324`** — its trigger closes over ~20 values (styles, handlers, item data). Since it's a render-prop with no real remount risk, the effort/risk of threading that many props in one pass wasn't worth it here; flagged for its own careful pass.
- **All 51 `_layout.tsx` occurrences** (20 in `apps/frontend/app/app/(app)/_layout.tsx`, 12 in `apps/geonexia/frontend/app/_layout.tsx`, 7 in `apps/score-tracker/frontend/app/_layout.tsx`, 12 across smaller nested layouts) — these are each app's central navigation configuration; kept out of this PR to keep the diff reviewable and the blast radius small, matching the workflow doc's "small, thematically grouped PRs" guidance.

`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` is updated with what's done and what's still open.

## Test plan

- [x] Manually reviewed each of the 46 reported locations against `reports/sonarCloud/report_maintainability.csv` — no line drift found
- [x] Verified every extraction preserves the exact original closure values and behavior (styles, colors, handlers) — no behavior changes intended anywhere except the two genuine-bug fixes noted above
- [x] Syntax-checked every edited file with `tsc --noEmit --noResolve` (isolated per-file, `node_modules` not installed in this sandbox) — no syntax or undefined-reference errors
- [ ] Full `tsc --noEmit` / lint / build could not be run in this sandbox (no `node_modules` installed) — CI should confirm


---
_Generated by [Claude Code](https://claude.ai/code/session_018XmRF7FMaQ8HUPi81rr8Bn)_