### PR TITLE
fix(sonar): mechanical maintainability batch + move TODOs to tracking issue

### DIFF
--- a/apps/accessibilityTester/src/report.ts
+++ b/apps/accessibilityTester/src/report.ts
@@ -104,7 +104,7 @@ function impactEmoji(impact: ImpactLevel): string {
 }
 
 function escapeMarkdownTableCell(text: string): string {
-  return text.replaceAll(/\|/g, String.raw`\|`).replaceAll(/\n/g, ' ');
+  return text.replaceAll('|', String.raw`\|`).replaceAll('\n', ' ');
 }
 
 export function generateMarkdownReport(report: AccessibilityReport): string {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/base64-file-upload-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/base64-file-upload-hook/index.ts
@@ -12,7 +12,7 @@ const DIRECTUS_COLLECTION_PREFIX = 'directus_';
  * Special field types in Directus that hold a reference to a single file or
  * a many-to-many files relationship.
  */
-const FILE_FIELD_SPECIALS = ['file', 'files'];
+const FILE_FIELD_SPECIALS = new Set(['file', 'files']);
 
 /**
  * Register filter hooks that convert base64 data-URI values into uploaded
@@ -65,7 +65,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(
 
       for (const field of fields) {
         const special: string[] = field?.meta?.special ?? [];
-        const hasFileSpecial = special.some(s => FILE_FIELD_SPECIALS.includes(s));
+        const hasFileSpecial = special.some(s => FILE_FIELD_SPECIALS.has(s));
         if (hasFileSpecial) {
           registerBase64FilterHook(registerFunctions, apiContext, collectionName, field.field);
         }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -1177,7 +1177,9 @@ export class ParseSchedule {
   }
 
   async updateMarkingTranslations(marking: DatabaseTypes.Markings, markingJSON: MarkingsTypeForParser) {
-    await TranslationHelper.updateItemTranslations<DatabaseTypes.Markings, DatabaseTypes.MarkingsTranslations>(marking, {
+    let itemService = this.context.myDatabaseHelper.getMarkingsHelper();
+    let markingWithTranslations = await itemService.readOneWithTranslations(marking.id);
+    await TranslationHelper.updateItemTranslationsForItemWithTranslationsFetched<DatabaseTypes.Markings, DatabaseTypes.MarkingsTranslations>(markingWithTranslations, {
       translationsFromParsing: markingJSON.translations,
       items_primary_field_in_translation_table: 'markings_id',
       itemsTablename: CollectionNames.MARKINGS,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -218,8 +218,6 @@ export class ParseSchedule {
         external_identifier: categoryExternalIdentifier,
       };
       await this.context.myDatabaseHelper.getFoodsCategoriesHelper().findOrCreateItem(searchJSON, createJSON);
-
-      // TODO: Update translations for food categories here, similar to markings
     }
   }
 
@@ -253,8 +251,6 @@ export class ParseSchedule {
         external_identifier: categoryExternalIdentifier,
       };
       await this.context.myDatabaseHelper.getFoodofferCategoriesHelper().findOrCreateItem(searchJSON, createJSON);
-
-      // TODO: Update translations for foodoffer categories here, similar to markings
     }
   }
 
@@ -842,7 +838,7 @@ export class ParseSchedule {
         await this.assignMarkingsToFood(markings, foundFoodWithTranslations, helperObject.dictMarkingsExclusions);
         await this.assignFoodCategoryToFood(foundFoodWithTranslations, foodsInformationForParser, helperObject.foodCategoryExternalIdentifiersToFoodCategoriesDict);
 
-        await this.updateFoodBasicFields(basicFoodData); // TODO: Remove in the future
+        await this.updateFoodBasicFields(basicFoodData);
         await this.updateFoodsAttributesValues(foundFoodWithTranslations, foodsInformationForParser.attribute_values, helperObject.dictExternalIdentifierToFoodAttributes);
 
         await this.updateFoodTranslations(foundFoodWithTranslations, foodsInformationForParser);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
@@ -146,7 +146,6 @@ export type FormExtractRelevantInformationSingle = {
 export type FormExtractRelevantInformation = FormExtractRelevantInformationSingle[];
 
 function registerHookSendMailAfterFormSubmissionStateSyncing(registerFunctions: RegisterFunctions, apiContext: ApiContext) {
-  // TODO: Move this into a workflow instead of a hook
   registerFunctions.action(CollectionNames.FORM_SUBMISSIONS + '.items.update', async (meta, context) => {
     console.log('Send mail after form submission state syncing');
     let myDatabaseHelper = new MyDatabaseHelper(apiContext, context);
@@ -387,7 +386,6 @@ async function sendFormExtractMail(form: DatabaseTypes.Forms, formExtract: Datab
 
   let internalMyDatabaseHelper = myDatabaseHelper.cloneWithInternalServerMode();
   // we need the internal server mode to generate the pdf, as traefik does not route the request correctly
-  // TODO: Fix traefik configuration or add server to extra_hosts in docker-compose
   let pdfBuffer = await FormHelper.generatePdfFromForm({
     form,
     formExtractRelevantInformation,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/AvatarHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/AvatarHelper.ts
@@ -8,7 +8,6 @@ export class AvatarHelper {
    */
   static async deleteAvatarOfUser(myDatabaseHelper: MyDatabaseHelper, userId: string) {
     const database = myDatabaseHelper?.eventContext?.database || myDatabaseHelper?.apiContext.database;
-    // TODO: check if we can use instead of database the userService to handle/manipulate users
 
     const filesService = myDatabaseHelper.getFilesHelper();
     if (!userId) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/DirectusFieldsServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/DirectusFieldsServiceHelper.ts
@@ -17,7 +17,7 @@ export class DirectusFieldsServiceHelper {
     // @ts-ignore - workaround for typescript error
     return new FieldsService({
       accountability: null, //this makes us admin
-      knex: database, //TODO: i think this is not neccessary
+      knex: database,
       schema: schema,
     });
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceCreator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceCreator.ts
@@ -40,7 +40,7 @@ export interface AbstractService<Item> {
 }
 
 // https://github.com/directus/directus/blob/main/api/src/types/items.ts
-export type MutationOptions = any; // TODO: check if we ever need this
+export type MutationOptions = any;
 
 // https://github.com/directus/directus/blob/main/api/src/services/items.ts#L35
 export type QueryOptions = {
@@ -103,7 +103,7 @@ export class ItemsServiceCreator extends GetItemsService {
     let database = this.eventContext?.database || this.apiContext.database; // https://github.com/directus/directus/discussions/11051#discussioncomment-2014806
     return new ItemsService(tablename, {
       accountability: null, //this makes us admin
-      knex: database, //TODO: i think this is not neccessary
+      knex: database,
       schema: schema,
     });
   }
@@ -140,7 +140,7 @@ export class FileServiceCreator extends GetItemsService {
 
     return new FilesService({
       accountability: accountability, //this makes us admin
-      knex: database, //TODO: i think this is not neccessary
+      knex: database,
       schema: schema,
     });
   }
@@ -164,7 +164,7 @@ export class ActivityServiceCreator extends GetItemsService {
     const database = this.apiContext.database;
     return new ActivityService({
       accountability: null, //this makes us admin
-      knex: database, //TODO: i think this is not neccessary
+      knex: database,
       schema: schema,
     });
   }
@@ -200,7 +200,7 @@ export class ServerServiceCreator extends GetItemsService {
     const database = this.apiContext.database;
     return new ServerService({
       accountability: null, //this makes us admin
-      knex: database, //TODO: i think this is not neccessary
+      knex: database,
       schema: schema,
     });
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyDatabaseHelper.ts
@@ -107,7 +107,6 @@ export class MyDatabaseHelper implements MyDatabaseHelperInterface {
   getServerUrl(): string {
     let defaultServerUrl = 'http://127.0.0.1'; // https://github.com/directus/directus/blob/9bd3b2615bb6bc5089ffcf14d141406e7776dd0e/docs/self-hosted/quickstart.md?plain=1#L97
     // could be also: http://rocket-meals-directus:8055/server/info but we stick to the default localhost
-    // TODO: Fix traefik and use the public url support
 
     let defaultServerPort = this.getServerPort();
     if (defaultServerPort) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyServiceClassHelpers.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MyServiceClassHelpers.ts
@@ -2,7 +2,7 @@ import {
     AssetsService as DirectusAssetsService,
     SharesService as DirectusShareService,
     FieldsService as DirectusFieldsService
-} from '@directus/api/dist/services'; // TODO: Check for future
+} from '@directus/api/dist/services';
 
 export class AssetsService extends DirectusAssetsService {}
 export class SharesService extends DirectusShareService {}

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ShareServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ShareServiceHelper.ts
@@ -87,7 +87,6 @@ export class ShareServiceHelper implements ShareDirectusFileMethod {
     let accountability: Accountability = {
       role: role_admin_id,
       user: adminUser.id,
-      // TODO: Test if this works without the roles array
       // @ts-ignore
       roles: [role_admin_id],
       admin: true,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -3,8 +3,8 @@ import { CollectionNames, DatabaseTypes, LanguageCodes, LanguageCodesType } from
 
 import { MyDatabaseHelper } from './MyDatabaseHelper';
 
-const FIELD_TRANSLATION_LANGUAGE_CODE = 'languages_code'; // TODO Import from directus-extension-auto-translation package the field name
-const FIELD_LANGUAGE_ID = 'code'; // TODO Import from directus-extension-auto-translation package the field name
+const FIELD_TRANSLATION_LANGUAGE_CODE = 'languages_code';
+const FIELD_LANGUAGE_ID = 'code';
 
 export type ExistingTranslation = {
   be_source_for_translations?: boolean | null;
@@ -233,7 +233,6 @@ export class TranslationHelper {
         }
       } else {
         //the parser dont provide a translation, we should delete it?
-        //TODO check if translation was generated or manually typed
         delete remaining_translationsFromParsing[existingLanguageCode]; // dont create a new translation for this language
       }
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ai/image/ImageRawGeneratorChatGpt.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ai/image/ImageRawGeneratorChatGpt.ts
@@ -54,7 +54,6 @@ enum ChatGptImage_MODEL_DallE3_GenerationOptionImageSize {
 
 
 /**
- * TODO: Check prompt with: https://platform.openai.com/docs/guides/moderation omni-moderation model
  * Coole idee eigentlich
  */
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/housing-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/housing-sync-hook/index.ts
@@ -41,13 +41,11 @@ export default MyDefineHook.defineHookWithAllTablesExisting(HOOK_NAME,async ({ a
   let usedParser: ApartmentParserInterface | null = null;
   switch (EnvVariableHelper.getSyncForCustomer()) {
     case SyncForCustomerEnum.TEST:
-      usedParser = null;
       break;
     case SyncForCustomerEnum.HANNOVER:
       usedParser = new StudentenwerkHannoverApartments_Parser();
       break;
     case SyncForCustomerEnum.OSNABRUECK:
-      usedParser = null;
       break;
   }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/mails-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/mails-hook/index.ts
@@ -54,7 +54,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
     const schema = await getSchema();
     let mailService: MailServiceType = new MailService({
       accountability: null, //this makes us admin
-      knex: database, //TODO: i think this is not neccessary
+      knex: database,
       schema: schema,
     });
     return await mailService.send(options);
@@ -70,7 +70,6 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
 
   // filter all update actions where from value running to start want to change, since this is not allowed
   filter<Partial<DatabaseTypes.Mails>>(CollectionNames.MAILS + '.items.create', async (input: Partial<DatabaseTypes.Mails>, meta, eventContext) => {
-    // TODO: Maybe outsource this into a workflow instead of a filter
     let myDatabaseHelper = new MyDatabaseHelper(apiContext, eventContext);
     const mailsHelper = myDatabaseHelper.getMailsHelper();
 
@@ -180,7 +179,6 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
             let name = direcuts_file.filename_disk || direcuts_file.filename_download || 'file';
             let shareLink = await filesHelper.createDirectusFilesShareLink({
               directus_files_id: directus_files_id,
-              // TODO: hier noch die Mail_id mitgeben, geht aber nur nach dem erstellen der mail oder im workflow
               name: name,
             });
             if (shareLink) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/NewsParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/NewsParseSchedule.ts
@@ -7,7 +7,6 @@ import { HashHelper } from '../helpers/HashHelper';
 import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 
 export class NewsParseSchedule {
-  //TODO stringfiy and cache results to reduce dublicate removing from foodOffers and Meals ...
   private readonly context: WorkflowRunContext;
   private readonly parser: NewsParserInterface;
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/NewsParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/news-sync-hook/NewsParseSchedule.ts
@@ -68,7 +68,9 @@ export class NewsParseSchedule {
   }
 
   async updateNewsTranslations(item: DatabaseTypes.News, newsJSON: NewsTypeForParser) {
-    await TranslationHelper.updateItemTranslations(item, {
+    let itemService = this.context.myDatabaseHelper.getNewsHelper();
+    let itemWithTranslations = await itemService.readOneWithTranslations(item.id);
+    await TranslationHelper.updateItemTranslationsForItemWithTranslationsFetched(itemWithTranslations, {
       translationsFromParsing: newsJSON.translations,
       items_primary_field_in_translation_table: 'news_id',
       itemsTablename: CollectionNames.NEWS,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/proof-key-code-exchange-endpoint/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/proof-key-code-exchange-endpoint/index.ts
@@ -384,7 +384,7 @@ export default defineEndpoint({
       await myStorage.setCodeChallenge(authorization_code, {
         code_challenge: code_challenge_app,
         code_challenge_method: code_challenge_method_app,
-        //directus_session_token: null, // TODO: can be removed, as we dont want to share the directus session token.
+        //directus_session_token: null,
         directus_refresh_token: null, // currently we have not saved the directus_refresh_token. After the OAuth2 Flow we will add it there
       });
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/utilization-canteen-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/utilization-canteen-hook/ParseSchedule.ts
@@ -247,7 +247,6 @@ export class ParseSchedule {
 
   /**
    * Simple prediction for the utilization of a canteen, assuming the same utilization as last week
-   * TODO: Implement a more sophisticated prediction
    * @param utilization_group
    * @param cashregisters
    * @param canteen

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
@@ -124,7 +124,6 @@ export default MyDefineHook.defineHookWithAllTablesExisting(HOOK_NAME,async (reg
       usedParser = new DemoWashingmachineParser();
       break;
     case SyncForCustomerEnum.HANNOVER:
-      usedParser = null;
       break;
     case SyncForCustomerEnum.OSNABRUECK:
       usedParser = new StudentenwerkOsnabrueckWashingmachineParser();

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/osnabrueck/StudentenwerkOsnabrueckWashingmachineParser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/osnabrueck/StudentenwerkOsnabrueckWashingmachineParser.ts
@@ -33,8 +33,6 @@ export class StudentenwerkOsnabrueckWashingmachineParser implements Washingmachi
           date.setMinutes(date.getMinutes() + washer.expectedFreeTimeInMinutes);
           date_finished = DateHelper.formatDateToIso8601WithoutTimezone(date);
           //console.log("Washer " + washer.terminalNr + " " + washer.automateNr + " expected free time: " + washer.expectedFreeTimeInMinutes + " Date finished: " + date_finished);
-        } else {
-          date_finished = null;
         }
 
         let washingmachine: WashingmachinesTypeForParserOmmited = {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
@@ -320,7 +320,6 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
     console.log('WorkflowRun created');
     if (input.state === undefined) {
       // default state is "running"
-      // TODO: Fetch database schema and look what the default value is
       input.state = WORKFLOW_RUN_STATE.RUNNING;
     }
 

--- a/apps/backend/sync/importSchema.js
+++ b/apps/backend/sync/importSchema.js
@@ -19,8 +19,8 @@ const httpsAgent = new https.Agent({
 /**
  * Configuration for collections and modules
  */
-const requiredModules = ['flow-manager', 'schema-management-module', 'generate-types'];
-const collectionsToSkip = ['2-wikis.json'];
+const requiredModules = new Set(['flow-manager', 'schema-management-module', 'generate-types']);
+const collectionsToSkip = new Set(['2-wikis.json']);
 
 // Load directus .env file
 const currentPackageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, './package.json'), 'utf8'));
@@ -248,7 +248,7 @@ const enableRequiredSettings = async headers => {
     // module.id comes from the Directus API response; strip control/newline characters
     // before logging so it can't be used to forge fake log lines (log injection).
     const safeModuleId = String(module.id).replace(/[\r\n\t\x00-\x1f]/g, '');
-    if (requiredModules.includes(module.id)) {
+    if (requiredModules.has(module.id)) {
       if (!module.enabled) {
         console.log(` -  Enabling ${safeModuleId}`);
         modules[moduleIndex].enabled = true;
@@ -479,7 +479,7 @@ const saveCollections = async headers => {
   collections = collections.filter(file => !file.endsWith('.DS_Store'));
 
   for (const collection of collections) {
-    if (collectionsToSkip.includes(collection)) {
+    if (collectionsToSkip.has(collection)) {
       console.log(` -  Skipping ignored collection: ${collection}`);
       continue;
     }

--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -48,7 +48,6 @@ import { format } from 'date-fns';
 import { CanteenHelper } from '@/redux/actions/Canteens/Canteens';
 import { BuildingsHelper, BuildingsOrganizationsHelper } from '@/redux/actions/Buildings/Buildings';
 import { OrganizationsHelper } from '@/redux/actions/Organizations/Organizations';
-// TODO: replace HashHelper with expo-crypto once packages can be installed
 import { HashHelper } from '@/helper/hashHelper';
 import { CollectionKeys } from '@/constants/collectionKeys';
 import { loadChatReadStatus } from '@/helper/chatReadStatus';

--- a/apps/frontend/app/app/(app)/experimentell/debug-logout/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/debug-logout/index.tsx
@@ -93,9 +93,9 @@ const DebugLogout = () => {
 	];
 
 	const myTestLogout = async () => {
-		const exclude = ['CLEAR_ANONYMOUSLY', 'ON_LOGOUT', 'RESET_STORE'];
+		const exclude = new Set(['CLEAR_ANONYMOUSLY', 'ON_LOGOUT', 'RESET_STORE']);
 		for (const step of steps) {
-			if (exclude.includes(step.label)) continue;
+			if (exclude.has(step.label)) continue;
 			const result = step.action() as any;
 			if (result && typeof result === 'object' && typeof result.then === 'function') {
 				await result;

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -750,12 +750,12 @@ const Index = () => {
 				} else if (custom_type === 'value_files') {
 					if (Array.isArray(value) && value.length > 0) {
 						const newFiles = value.filter((file: any) => !file?.edit);
-						const existingFileIds = value.filter((file: any) => file?.edit).map((file: any) => file.directus_files_id).filter(Boolean);
+						const existingFileIds = new Set(value.filter((file: any) => file?.edit).map((file: any) => file.directus_files_id).filter(Boolean));
 
 						// Detect deleted relations by comparing current files with original answer files
 						const originalValueFiles: any[] = (answer as any).value_files || [];
 						const deletedRelationIds = originalValueFiles
-							.filter((orig: any) => orig?.directus_files_id && !existingFileIds.includes(orig.directus_files_id))
+							.filter((orig: any) => orig?.directus_files_id && !existingFileIds.has(orig.directus_files_id))
 							.map((orig: any) => orig.id)
 							.filter(Boolean);
 

--- a/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-day-screen/index.tsx
@@ -466,8 +466,8 @@ const Index = () => {
 			foodList.forEach((food: any) => {
 				// Deduplicate marking IDs to prevent the same marking appearing twice
 				const markingIdsRaw = food?.markings?.map((mark: any) => mark.markings_id) || [];
-				const markingIds = [...new Set(markingIdsRaw)];
-				let filteredMarkings = markings?.filter((mark: any) => markingIds.includes(mark.id)) || [];
+				const markingIds = new Set(markingIdsRaw);
+				let filteredMarkings = markings?.filter((mark: any) => markingIds.has(mark.id)) || [];
 
 				// Sort the filtered markings using sortMarkingsByGroup
 				filteredMarkings = sortMarkingsByGroup(filteredMarkings, markingGroups as any);

--- a/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
+++ b/apps/frontend/app/components/CanteenFeedbackLabels/CanteenFeedbackLabels.tsx
@@ -61,9 +61,9 @@ const CanteenFeedbackLabels: React.FC<CanteenFeedbackLabelProps> = ({ label, dat
 		if (!selectedCanteen?.id) return;
 		let likeStats = null;
 		if (isLike === true && labelData?.like === true) {
-			likeStats = null;
+			// likeStats already null
 		} else if (isLike === false && labelData?.like === false) {
-			likeStats = null;
+			// likeStats already null
 		} else {
 			likeStats = isLike;
 		}

--- a/apps/frontend/app/components/FeedbackLabel/index.tsx
+++ b/apps/frontend/app/components/FeedbackLabel/index.tsx
@@ -58,9 +58,9 @@ const FeedbackLabel: React.FC<FeedbackLabelProps> = ({ label, icon, imageUrl, la
 		}
 		let likeStats = null;
 		if (isLike === true && like === true) {
-			likeStats = null;
+			// likeStats already null
 		} else if (isLike === false && like === false) {
-			likeStats = null;
+			// likeStats already null
 		} else {
 			likeStats = isLike;
 		}

--- a/apps/frontend/app/constants/HelperFunctions.ts
+++ b/apps/frontend/app/constants/HelperFunctions.ts
@@ -42,7 +42,6 @@ export function isOnGithubPages() {
 	return false;
 }
 
-// TODO: Workaround Expo Issue: https://github.com/expo/expo/issues/29274
 export function reloadAndRemoveParamsForGithubPages() {
 	window.location.replace(window.location.origin + window.location.pathname);
 }

--- a/apps/frontend/app/constants/UrlHelper.ts
+++ b/apps/frontend/app/constants/UrlHelper.ts
@@ -5,10 +5,9 @@ import { EnvHelper } from './EnvHelper';
 
 export class UrlHelper {
 	static createLocalURL(path: string) {
-		const isProduction = EnvHelper.isProduction(); // TODO: Check if issue: https://github.com/rocket-meals/rocket-meals/issues/15 is fixed
+		const isProduction = EnvHelper.isProduction();
 
 		if (isProduction) {
-			// TODO: Check if issue: https://github.com/rocket-meals/rocket-meals/issues/15 is fixed
 			const urlWithoutBaseUrl = createURL(path); // createUrl creates a url but without the base url which seems to be a bug
 			// example: path = "/login"
 			// example: urlWithoutBaseUrl = "https://localhost:3000/login"
@@ -23,7 +22,7 @@ export class UrlHelper {
 			return url;
 		} else {
 			const url = createURL(path);
-			// example: url = "localhost:19006/login" TODO: Url does not seem to have the baseUrl but it works in development. Seems to be a bug.
+			// example: url = "localhost:19006/login"
 			return url;
 		}
 	}

--- a/apps/frontend/app/helper/ColorHelper.tsx
+++ b/apps/frontend/app/helper/ColorHelper.tsx
@@ -2,7 +2,6 @@ import Color from 'tinycolor2';
 import { useMemo } from 'react';
 import { Theme } from '@/context/ThemeContext';
 
-// TODO: memorize this function to reduce computation load and improve performance
 /**
  * Calculates the contrast ratio between two colors based on their luminance.
  * The function uses the WCAG formula for contrast ratio, which is (L1 + 0.05) / (L2 + 0.05),

--- a/apps/frontend/app/helper/hashHelper.ts
+++ b/apps/frontend/app/helper/hashHelper.ts
@@ -68,7 +68,7 @@ export class HashHelper {
 			for (let lCount = 0; lCount <= 3; lCount++) {
 				const lByte = (lValue >>> (lCount * 8)) & 255;
 				wordToHexValue_temp = '0' + lByte.toString(16);
-				wordToHexValue += wordToHexValue_temp.substr(wordToHexValue_temp.length - 2, 2);
+				wordToHexValue += wordToHexValue_temp.slice(wordToHexValue_temp.length - 2, wordToHexValue_temp.length);
 			}
 			return wordToHexValue;
 		};

--- a/apps/frontend/app/helper/hashHelper.ts
+++ b/apps/frontend/app/helper/hashHelper.ts
@@ -2,7 +2,6 @@ export class HashHelper {
 	/**
 	 * Compute an MD5 hash for a string. This implementation is minimal and should
 	 * be replaced with expo-crypto when package installation is possible.
-	 * TODO: Replace with expo-crypto MD5 implementation
 	 */
 	static md5(str: string): string {
 		let xl: number;

--- a/apps/frontend/app/redux/actions/User/User.ts
+++ b/apps/frontend/app/redux/actions/User/User.ts
@@ -24,7 +24,6 @@ export type CachedUserInformation = DatabaseTypes.DirectusUsers | undefined;
 // export function useCurrentUserRaw(): [CachedUserInformation | null | undefined, (newValue: CachedUserInformation) => void] {
 // 	const [cachedUser, setCachedUser] = useCachedUserRaw()
 // 	const [currentUser, setCurrentUser] = useSyncState<CachedUserInformation>(NonPersistentStore.currentUser)
-// 	// TODO: Update cached user
 // 	const setUserWithCache = (newValue: any) => {
 // 		setCurrentUser((currentValue) => {
 // 			return newValue
@@ -57,14 +56,12 @@ export function useIsCurrentUserAnonymous() {
 
 export function getAnonymousUser(): any {
 	return {
-		// TODO: Add some default values
 		id: null,
 	};
 }
 
 // export function useCurrentUser(): [DatabaseTypes.DirectusUsers | undefined, (newValue: any) => void] {
 // 	const [currentUserRaw, setCurrentUserRaw] = useCurrentUserRaw()
-// 	// TODO: Update cached user
 // 	const setUserWithCache = (newValue: any) => {
 // 		setCurrentUserRaw(
 // 			{

--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -652,7 +652,7 @@ function buildActivityHexGeoJson(
 	};
 }
 
-function ActivityDetailBackHeaderButton({ color, onPress }: { color: string; onPress: () => void }) {
+function ActivityDetailBackHeaderButton({ color, onPress }: Readonly<{ color: string; onPress: () => void }>) {
 	return (
 		<TouchableOpacity
 			onPress={onPress}

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -382,7 +382,7 @@ async function applyForestBillboardsForUncachedTiles(records: Record<string, any
 	}
 }
 
-function ActivitiesHeaderRight({ onRebuild, onExport, onImport }: { onRebuild: () => void; onExport: () => void; onImport: () => void }) {
+function ActivitiesHeaderRight({ onRebuild, onExport, onImport }: Readonly<{ onRebuild: () => void; onExport: () => void; onImport: () => void }>) {
 	return (
 		<View style={styles.headerButtons}>
 			<TouchableOpacity onPress={onRebuild} style={styles.headerImportButton} activeOpacity={0.7}>

--- a/apps/geonexia/frontend/app/billboard-config/index.tsx
+++ b/apps/geonexia/frontend/app/billboard-config/index.tsx
@@ -111,7 +111,7 @@ function SpriteThumbnailIcon({ spriteIndex }: Readonly<{ spriteIndex: number }>)
 
 	return (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={modalStyles.thumb}
 			originWhitelist={['*']}
 			scrollEnabled={false}
@@ -484,7 +484,7 @@ export default function BillboardConfigScreen() {
 								<View style={[styles.previewContainer, { backgroundColor: theme.screen.text + '08' }]}>
 									{svgUri ? (
 										<WebView
-											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll(/"/g, '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
+											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
 											style={[styles.previewImage, { backgroundColor: 'transparent' }]}
 											originWhitelist={['*']}
 											scrollEnabled={false}

--- a/apps/geonexia/frontend/app/hex-texture-config/index.tsx
+++ b/apps/geonexia/frontend/app/hex-texture-config/index.tsx
@@ -105,7 +105,7 @@ function TerrainThumbnailIcon({ terrainEntry }: Readonly<{ terrainEntry: Terrain
 
 	return (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${imgUri.replaceAll(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${MODAL_THUMB_SIZE}px;height:${MODAL_THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${imgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={modalStyles.thumb}
 			originWhitelist={['*']}
 			scrollEnabled={false}
@@ -507,7 +507,7 @@ export default function HexTextureConfigScreen() {
 								<View style={[styles.previewContainer, { backgroundColor: theme.screen.text + '08' }]}>
 									{imgUri ? (
 										<WebView
-											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${imgUri.replaceAll(/"/g, '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
+											source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${PREVIEW_HEIGHT}px;height:${PREVIEW_HEIGHT}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${imgUri.replaceAll('"', '&quot;')}" onload="window.ReactNativeWebView&&window.ReactNativeWebView.postMessage(this.naturalWidth+','+this.naturalHeight)"/></body></html>` }}
 											style={[styles.previewImage, { backgroundColor: 'transparent' }]}
 											originWhitelist={['*']}
 											scrollEnabled={false}

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -306,7 +306,7 @@ function ReassignRouteContent({
 	);
 }
 
-function RouteBackHeaderButton({ color, onPress }: { color: string; onPress: () => void }) {
+function RouteBackHeaderButton({ color, onPress }: Readonly<{ color: string; onPress: () => void }>) {
 	return (
 		<TouchableOpacity
 			onPress={onPress}

--- a/apps/geonexia/frontend/app/settings/index.tsx
+++ b/apps/geonexia/frontend/app/settings/index.tsx
@@ -87,7 +87,7 @@ const THEME_OPTIONS: { id: ThemeMode; label: string; icon: React.ReactNode }[] =
 	{ id: 'systematic', label: 'System', icon: <MaterialCommunityIcons name="theme-light-dark" size={22} color="#ffffff" /> },
 ];
 
-const GPS_PRESET_SECONDS = [1, 5, 15];
+const GPS_PRESET_SECONDS = new Set([1, 5, 15]);
 
 const GPS_PRESET_OPTIONS: { id: number; label: string; icon: React.ReactNode }[] = [
 	{ id: 1, label: '1s', icon: <MaterialCommunityIcons name="crosshairs-gps" size={22} color="#ffffff" /> },
@@ -96,7 +96,7 @@ const GPS_PRESET_OPTIONS: { id: number; label: string; icon: React.ReactNode }[]
 ];
 
 function gpsIntervalLabel(seconds: number): string {
-	if (GPS_PRESET_SECONDS.includes(seconds)) return `${seconds}s`;
+	if (GPS_PRESET_SECONDS.has(seconds)) return `${seconds}s`;
 	return `Custom (${seconds}s)`;
 }
 
@@ -125,7 +125,7 @@ function GpsIntervalContent({
 	selectedSeconds: number;
 	onSelect: (seconds: number) => void;
 }>) {
-	const isPreset = GPS_PRESET_SECONDS.includes(selectedSeconds);
+	const isPreset = GPS_PRESET_SECONDS.has(selectedSeconds);
 
 	return (
 		<>

--- a/apps/geonexia/frontend/components/SettingsListBillboard/index.tsx
+++ b/apps/geonexia/frontend/components/SettingsListBillboard/index.tsx
@@ -61,7 +61,7 @@ const SettingsListBillboard: React.FC<Props> = ({
 
 	const thumbnail = svgUri ? (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:contain}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={[styles.thumb, { backgroundColor: 'transparent' }]}
 			originWhitelist={['*']}
 			scrollEnabled={false}

--- a/apps/geonexia/frontend/components/SettingsListHexTile/index.tsx
+++ b/apps/geonexia/frontend/components/SettingsListHexTile/index.tsx
@@ -73,7 +73,7 @@ const SettingsListHexTile: React.FC<Props> = ({
 
 	const thumbnail = svgUri ? (
 		<WebView
-			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${svgUri.replaceAll(/"/g, '&quot;')}"/></body></html>` }}
+			source={{ html: `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{margin:0;padding:0}html,body{width:${THUMB_SIZE}px;height:${THUMB_SIZE}px;overflow:hidden;background:transparent}img{width:100%;height:100%;object-fit:cover}</style></head><body><img src="${svgUri.replaceAll('"', '&quot;')}"/></body></html>` }}
 			style={[styles.thumb, { backgroundColor: 'transparent' }]}
 			originWhitelist={['*']}
 			scrollEnabled={false}

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -226,7 +226,7 @@ function MatchParticipants({ players }: Readonly<{ players: GameHistoryPlayerEnt
 	);
 }
 
-function GameDetailBackButton({ color }: { color: string }) {
+function GameDetailBackButton({ color }: Readonly<{ color: string }>) {
 	return (
 		<TouchableOpacity
 			nativeID={ComponentIds.GAME_DETAIL_BACK_BUTTON}

--- a/apps/score-tracker/frontend/app/games/index.tsx
+++ b/apps/score-tracker/frontend/app/games/index.tsx
@@ -20,7 +20,7 @@ function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bot
 	return 'middle';
 }
 
-function GamesHeaderRight({ color, onImport, onAdd }: { color: string; onImport: () => void; onAdd: () => void }) {
+function GamesHeaderRight({ color, onImport, onAdd }: Readonly<{ color: string; onImport: () => void; onAdd: () => void }>) {
 	return (
 		<View style={styles.headerButtons}>
 			<TouchableOpacity

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -587,13 +587,13 @@ function GameHeaderRight({
 	isEditingPlayers,
 	onToggleEditingPlayers,
 	onOpenSettings,
-}: {
+}: Readonly<{
 	color: string;
 	isActive: boolean;
 	isEditingPlayers: boolean;
 	onToggleEditingPlayers: () => void;
 	onOpenSettings: () => void;
-}) {
+}>) {
 	return (
 		<View style={styles.headerButtons}>
 			{isActive && (

--- a/apps/score-tracker/frontend/app/players/index.tsx
+++ b/apps/score-tracker/frontend/app/players/index.tsx
@@ -277,7 +277,7 @@ function FriendEditContent({ friendId, onClose }: Readonly<{ friendId: string; o
 
 // ─── Players (friends) screen ─────────────────────────────────────────────────
 
-function PlayersHeaderRight({ color, onPress }: { color: string; onPress: () => void }) {
+function PlayersHeaderRight({ color, onPress }: Readonly<{ color: string; onPress: () => void }>) {
 	return (
 		<TouchableOpacity
 			nativeID={ComponentIds.PLAYERS_SCREEN_OPTIONS_BUTTON}

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -4,10 +4,10 @@ import * as fs from 'node:fs';
 const API_BASE = 'https://api.appstoreconnect.apple.com/v1';
 
 // https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionstate
-const SUBMITTABLE_APP_VERSION_STATES = ['PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'REJECTED', 'METADATA_REJECTED', 'INVALID_BINARY'];
+const SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'REJECTED', 'METADATA_REJECTED', 'INVALID_BINARY']);
 
 // https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmission
-const NON_TERMINAL_REVIEW_SUBMISSION_STATES = ['READY_FOR_REVIEW', 'WAITING_FOR_REVIEW', 'IN_REVIEW', 'UNRESOLVED_ISSUES', 'CANCELING', 'COMPLETING'];
+const NON_TERMINAL_REVIEW_SUBMISSION_STATES = new Set(['READY_FOR_REVIEW', 'WAITING_FOR_REVIEW', 'IN_REVIEW', 'UNRESOLVED_ISSUES', 'CANCELING', 'COMPLETING']);
 
 type JsonApiResource = {
   type: string;
@@ -23,7 +23,7 @@ type JsonApiDocument = {
 
 function base64url(input: Buffer | string): string {
   const buffer = typeof input === 'string' ? Buffer.from(input) : input;
-  return buffer.toString('base64').replaceAll(/\+/g, '-').replaceAll(/\//g, '_').replace(/=+$/, '');
+  return buffer.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
 }
 
 function createAppStoreConnectToken(keyId: string, issuerId: string, privateKeyPath: string): string {
@@ -131,7 +131,7 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
   const exactMatch = versions.find(v => v.attributes?.versionString === versionString);
   if (exactMatch) {
     const state = exactMatch.attributes?.appStoreState as string;
-    if (!SUBMITTABLE_APP_VERSION_STATES.includes(state)) {
+    if (!SUBMITTABLE_APP_VERSION_STATES.has(state)) {
       throw new Error(
         `App Store Version ${versionString} existiert bereits mit Status "${state}" und kann nicht automatisch eingereicht werden. Bitte manuell in App Store Connect prüfen.`
       );
@@ -139,7 +139,7 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
     return exactMatch.id;
   }
 
-  const editableVersion = versions.find(v => SUBMITTABLE_APP_VERSION_STATES.includes(v.attributes?.appStoreState as string));
+  const editableVersion = versions.find(v => SUBMITTABLE_APP_VERSION_STATES.has(v.attributes?.appStoreState as string));
   if (editableVersion) {
     console.log(`   Benenne vorhandene Entwurfsversion "${editableVersion.attributes?.versionString}" (${editableVersion.id}) zu "${versionString}" um ...`);
     await ascRequest(token, 'PATCH', `/appStoreVersions/${editableVersion.id}`, {
@@ -213,7 +213,7 @@ async function findReusableReviewSubmission(token: string, appId: string): Promi
   const result = await ascRequest(token, 'GET', `/reviewSubmissions?${query}`);
   const submissions = asArray(result.data);
 
-  const active = submissions.find(submission => NON_TERMINAL_REVIEW_SUBMISSION_STATES.includes(submission.attributes?.state as string));
+  const active = submissions.find(submission => NON_TERMINAL_REVIEW_SUBMISSION_STATES.has(submission.attributes?.state as string));
   if (!active) return undefined;
 
   const state = active.attributes?.state as string;

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -61,8 +61,52 @@ bzw. dem nächsten SonarCloud-Scan. Details zu bereits gefixten Typen stehen in
 der Git-/PR-Historie.
 
 **Brauchen individuelle Refactorings statt mechanischer Fixes (Stand 2026-07-21):**
-„Cognitive Complexity" (109x), TODO-Kommentare (39x).
-Diese Typen in kleinen, thematisch gruppierten PRs angehen.
+„Cognitive Complexity" (109x). Diesen Typ in kleinen, thematisch gruppierten PRs angehen.
+
+„Move this component definition out of the parent component" ist trotz der
+weiter unten dokumentierten Abarbeitung erneut mit 67 Vorkommen im aktuellen
+CSV vertreten (Stand 2026-07-21). Vermutlich sind seit der letzten
+Abarbeitung neue Stellen (oder durch Codeänderungen verschobene Zeilen)
+hinzugekommen — vor der nächsten Runde die aktuelle CSV neu durchsehen statt
+sich auf die alte "komplett abgearbeitet"-Notiz weiter unten zu verlassen.
+
+TODO-Kommentare (36x, Regel „Complete the task associated to this TODO
+comment") werden **nicht mehr hier gefixt**, sondern in Tracking-Issue
+[#3984](https://github.com/rocket-meals/rocket-meals/issues/3984) verschoben:
+Für jede der 36 Stellen enthält das Issue einen GitHub-Permalink (Datei +
+Zeile zum Stand des Commits, an dem die TODOs entfernt wurden) sowie den
+ursprünglichen Kommentartext. Die TODO-Zeilen selbst wurden aus dem Code
+entfernt (nur der Kommentar, keine Logik geändert) — das eigentliche
+Nachholen der Arbeit passiert über das Issue, nicht über diesen Workflow.
+
+Am 2026-07-21 zusätzlich mechanisch abgearbeitet:
+- **„Mark the props of the component as read-only"** (7x): die betroffenen
+  Komponenten-Parameter wurden in `Readonly<{...}>` gewrappt (bestehende
+  Konvention im Repo für Inline-Prop-Typen).
+- **„`X` should be a `Set`..."** (9x) und **„This pattern can be replaced
+  with 'X'"** (10x, redundante Ein-Zeichen-Regex-Zeichenklassen): Arrays, die
+  nur für Existenzprüfungen genutzt werden, wurden zu `Set` +
+  `.has(...)` konvertiert (jede Fundstelle wurde vorher auf inkompatible
+  Array-only-Nutzung wie Indexzugriff/`.length`/Sortierung geprüft); die
+  Regex-Zeichenklassen (`[/]`, `["]`, `[+]`, …) wurden durch das
+  literale/escapte Zeichen ersetzt.
+- **„Review this redundant assignment..."** (9x): 8 von 9 Stellen waren
+  echte tote Zuweisungen (Variable wird auf allen Pfaden mit demselben Wert
+  belegt, den sie schon hält) und wurden entfernt.
+  `packages/common-ui/src/components/CardWithText/index.tsx:112` wurde
+  **bewusst unverändert gelassen** — dort wird `resolvedAspectRatio` aus dem
+  `aspectRatio`-Prop (beliebige Zahl, nicht nur der Default `1`) neu belegt;
+  die Werte stimmen nur zufällig für quadratische Verhältnisse überein,
+  Entfernen würde individuelle Aspect-Ratios stillschweigend brechen.
+- **„'X' is deprecated"** (3 von 18x): nur die mechanisch sicheren Stellen —
+  `hashHelper.ts` (`.substr` → `.slice`) sowie die zwei Aufrufstellen von
+  `TranslationHelper.updateItemTranslations` mit veralteter Signatur
+  (`food-sync-hook/ParseSchedule.ts:1184`,
+  `news-sync-hook/NewsParseSchedule.ts:72`). Die übrigen 15 Stellen
+  (Cesium-Deprecations `hexTilesEnclosed`/`billboardsFlat`/
+  `billboardAnchorColor` in Geonexia, `CollectionHelper`-Methoden,
+  `newWindow.document.write`) brauchen fachliche Migration und wurden
+  bewusst nicht angefasst.
 
 „Exception-Handling" (23x) ist als erster dieser schweren Fälle abgearbeitet: alle
 gemeldeten Catch-Blöcke (leer, nur Kommentar, oder Rethrow ohne Original-Error)


### PR DESCRIPTION
## Summary

Continues the SonarCloud maintainability workflow (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`). Fixes a batch of mechanical issue types (37x) and moves the "TODO comment" issue type (36x) into a tracking issue instead of fixing it ad-hoc.

### Fixed issue types

- **Mark the props of the component as read-only** (7x) — flagged component prop parameter types wrapped in `Readonly<{...}>`, matching the existing repo convention.
- **`X` should be a `Set`...** (9x) — array literals used only for existence checks converted to `Set` + `.has(...)`; every conversion site was checked for incompatible array-only usage (indexing, `.length`, sort) first.
- **This pattern can be replaced with 'X'** (10x) — redundant single-character regex classes (`[/]`, `["]`, `[+]`, …) replaced with the literal/escaped character.
- **Review this redundant assignment...** (8 of 9x) — dead reassignments removed where a variable was reassigned the same value it already held on every path. `packages/common-ui/.../CardWithText/index.tsx:112` was **left unchanged**: `resolvedAspectRatio` there is reassigned from the `aspectRatio` prop (any number, not just the default `1`), so removing it would silently break custom aspect ratios — looks like a Sonar false positive.
- **'X' is deprecated** (3 of 18x) — only the mechanically-safe subset: `String.substr` → `.slice()` in the MD5 helper, and the two `TranslationHelper.updateItemTranslations` call sites migrated to the non-deprecated `updateItemTranslationsForItemWithTranslationsFetched` (same query fields the deprecated wrapper used internally, so behavior is unchanged). The remaining 15 (Cesium `hexTilesEnclosed`/`billboardsFlat`/`billboardAnchorColor` deprecations in Geonexia, `CollectionHelper` methods, `document.write`) need domain-specific migration and were left untouched.

### TODO comments (36x) → tracking issue instead of fixing in place

Per user request, the 36 "Complete the task associated to this TODO comment" findings were **not implemented** — they were cataloged (file, line, GitHub permalink, original comment text) into **#3984**, then the TODO comment lines were removed from the source (no functional code changed). Future work on these items should happen via that issue.

### Docs

`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` updated to record this batch, the TODO tracking-issue approach, and a note that "Move this component definition out of the parent component" has 67 fresh occurrences in the current CSV despite an earlier "fully handled" note — needs a fresh look next round.

## Verification

- Each fix batch was typechecked in its affected workspace(s) (frontend, geonexia, score-tracker, backend directus extension) — only pre-existing, unrelated errors remain (missing `@reduxjs/toolkit` in some environments, unrelated prop-type mismatches).
- No behavior changes intended anywhere; every fix was checked against actual usage sites before applying.

## Test plan

- [ ] CI passes (lint, typecheck, build)
- [ ] Next SonarCloud scan shows the fixed types dropping out of the maintainability report and TODO-comment findings gone
- [ ] Issue #3984 tracks the moved TODO items for future follow-up


---
_Generated by [Claude Code](https://claude.ai/code/session_014eSPWDmGBLn1dD2gBh1JEA)_