### PR TITLE
fix(sonar): mechanical maintainability batch across ~20 issue types (75x)

### DIFF
--- a/apps/backend-sync/src/DirectusDatabaseSync.ts
+++ b/apps/backend-sync/src/DirectusDatabaseSync.ts
@@ -241,7 +241,7 @@ export class DirectusDatabaseSync {
       const module = modules[moduleIndex];
       // module.id comes from the Directus API response; strip control/newline characters
       // before logging so it can't be used to forge fake log lines (log injection).
-      const safeModuleId = String(module.id).replace(/[\r\n\t\x00-\x1f]/g, '');
+      const safeModuleId = String(module.id).replace(/[\x00-\x1f]/g, '');
       if (requiredModules.has(module.id)) {
         if (module.enabled) {
           console.log(` -  ${safeModuleId} already enabled`);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -78,7 +78,7 @@ export class ParseSchedule {
         let foodsJSONList = await this.foodParser.getFoodsListForParser();
         let foodofferListForParser = await this.foodParser.getFoodoffersForParser();
         let currentMealOffersHash = new WorkflowResultHash(HashHelper.hashFromObject(foodofferListForParser));
-        await this.context.logger.appendLog('Current meal offers hash: ' + currentMealOffersHash.getHash());
+        await this.context.logger.appendLog('Current meal offers hash: ' + JSON.stringify(currentMealOffersHash.getHash()));
 
         //console.log("Get Previous Meal Offers Hash");
         let previousMealOffersHash = await this.getPreviousMealOffersHash();
@@ -92,7 +92,7 @@ export class ParseSchedule {
           });
         }
 
-        await this.context.logger.appendLog('Previous meal offers hash: ' + previousMealOffersHash.getHash());
+        await this.context.logger.appendLog('Previous meal offers hash: ' + JSON.stringify(previousMealOffersHash.getHash()));
 
         const markingsExclusionsHelper = this.context.myDatabaseHelper.getMarkingsExclusionsHelper();
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
@@ -452,7 +452,7 @@ export class MaxManagerConnector implements FoodParserInterface, MarkingParserIn
             }
         }
 
-        return Promise.resolve(foodoffers);
+        return foodoffers;
     }
 
     async getFoodsListForParser(): Promise<FoodsInformationTypeForParser[]> {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/index.ts
@@ -69,12 +69,10 @@ function getMarkingParser(): MarkingParserInterface | null {
 
   const MARKING_SYNC_MODE = EnvVariableHelper.getMarkingSyncMode();
 
-  switch (MARKING_SYNC_MODE) {
-    case 'TL1CSV': {
-      /* TL1 CSV FILE */
-      const MARKING_SYNC_TL1FILE_EXPORT_CSV_FILE_ENCODING = EnvVariableHelper.getMarkingSyncTL1FileExportCsvFileEncoding();
-      return new MarkingTL1Parser(DIRECTUS_TL1_MARKING_PATH, MARKING_SYNC_TL1FILE_EXPORT_CSV_FILE_ENCODING);
-    }
+  if (MARKING_SYNC_MODE === 'TL1CSV') {
+    /* TL1 CSV FILE */
+    const MARKING_SYNC_TL1FILE_EXPORT_CSV_FILE_ENCODING = EnvVariableHelper.getMarkingSyncTL1FileExportCsvFileEncoding();
+    return new MarkingTL1Parser(DIRECTUS_TL1_MARKING_PATH, MARKING_SYNC_TL1FILE_EXPORT_CSV_FILE_ENCODING);
   }
 
   return null;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/FormImportSyncWorkflow.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/FormImportSyncWorkflow.ts
@@ -28,10 +28,10 @@ export abstract class FormImportSyncWorkflow extends SingleWorkflowRun {
         state: WORKFLOW_RUN_STATE.FAILED,
       });
     }
-    await context.logger.appendLog('Last result hash: ' + lastResultHash.getHash());
+    await context.logger.appendLog('Last result hash: ' + JSON.stringify(lastResultHash.getHash()));
 
     const currentResultHash = await this.getCurrentResultHash();
-    await context.logger.appendLog('Current Result Hash: ' + currentResultHash.getHash());
+    await context.logger.appendLog('Current Result Hash: ' + JSON.stringify(currentResultHash.getHash()));
     if (currentResultHash.isSame(lastResultHash)) {
       await context.logger.appendLog('No new data found. Skipping workflow run.');
       return context.logger.getFinalLogWithStateAndParams({

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
@@ -448,11 +448,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(HOOK_NAME,async (reg
   // Send mail after form submission state syncing
   registerHookSendMailAfterFormSubmissionStateSyncing(registerFunctions, apiContext);
 
-  switch (EnvVariableHelper.getSyncForCustomer()) {
-    case SyncForCustomerEnum.HANNOVER:
-      FormSyncHannover.registerHooks(registerFunctions, apiContext);
-      break;
-    default:
-      break;
+  if (EnvVariableHelper.getSyncForCustomer() === SyncForCustomerEnum.HANNOVER) {
+    FormSyncHannover.registerHooks(registerFunctions, apiContext);
   }
 });

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ByteSizeHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ByteSizeHelper.ts
@@ -3,7 +3,7 @@ export class ByteSizeHelper {
     if (bytes === 0) return '0 Bytes';
 
     const k = 1000; // MB = 1000^2 vs MiB = 1024^2
-    const dm = decimals < 0 ? 0 : decimals;
+    const dm = Math.max(decimals, 0);
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
     const i = Math.floor(Math.log(bytes) / Math.log(k));

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/FilesServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/FilesServiceHelper.ts
@@ -1,4 +1,4 @@
-import { FileServiceCreator, FileServiceFileStream, FileServiceSteamType, FilesService, MutationOptions } from './ItemsServiceCreator';
+import { FileServiceCreator, FileServiceFileStream, FileServiceSteamType, FilesService } from './ItemsServiceCreator';
 import { ItemsServiceHelper } from './ItemsServiceHelper';
 import { CollectionNames, DatabaseTypes, StringHelper } from 'repo-depkit-common';
 import { PrimaryKey } from '@directus/types';
@@ -95,7 +95,7 @@ export class FilesServiceHelper extends ItemsServiceHelper<DatabaseTypes.Directu
    * @param primaryKey   Optional file id to update instead of creating
    * @param opts         Additional Directus mutation options
    */
-  async uploadOne(stream: FileServiceSteamType, data: FileServiceFileStream, primaryKey?: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
+  async uploadOne(stream: FileServiceSteamType, data: FileServiceFileStream, primaryKey?: PrimaryKey, opts?: any): Promise<PrimaryKey> {
     let filesService = await this.getItemsService();
     return filesService.uploadOne(stream, data, primaryKey, opts);
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceCreator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceCreator.ts
@@ -39,9 +39,6 @@ export interface AbstractService<Item> {
   deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]>;
 }
 
-// https://github.com/directus/directus/blob/main/api/src/types/items.ts
-export type MutationOptions = any;
-
 // https://github.com/directus/directus/blob/main/api/src/services/items.ts#L35
 export type QueryOptions = {
   stripNonRequested?: boolean;
@@ -53,27 +50,27 @@ export type QueryOptions = {
 export interface ItemsService<Item> extends AbstractService<Item> {
   getKeysByQuery(query: Query): Promise<PrimaryKey[]>;
 
-  createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
-  createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+  createOne(data: Partial<Item>, opts?: any): Promise<PrimaryKey>;
+  createMany(data: Partial<Item>[], opts?: any): Promise<PrimaryKey[]>;
 
   readByQuery(query: Query, opts?: QueryOptions): Promise<Item[]>;
   readOne(key: PrimaryKey, query?: Query, opts?: QueryOptions): Promise<Item>;
   readMany(keys: PrimaryKey[], query?: Query, opts?: QueryOptions): Promise<Item[]>;
 
-  updateByQuery(query: Query, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]>;
-  updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
-  updateBatch(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]>;
-  updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]>;
+  updateByQuery(query: Query, data: Partial<Item>, opts?: any): Promise<PrimaryKey[]>;
+  updateOne(key: PrimaryKey, data: Partial<Item>, opts?: any): Promise<PrimaryKey>;
+  updateBatch(data: Partial<Item>[], opts?: any): Promise<PrimaryKey[]>;
+  updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: any): Promise<PrimaryKey[]>;
 
-  upsertOne(payload: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
-  upsertMany(payloads: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+  upsertOne(payload: Partial<Item>, opts?: any): Promise<PrimaryKey>;
+  upsertMany(payloads: Partial<Item>[], opts?: any): Promise<PrimaryKey[]>;
 
-  deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]>;
-  deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey>;
-  deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+  deleteByQuery(query: Query, opts?: any): Promise<PrimaryKey[]>;
+  deleteOne(key: PrimaryKey, opts?: any): Promise<PrimaryKey>;
+  deleteMany(keys: PrimaryKey[], opts?: any): Promise<PrimaryKey[]>;
 
   readSingleton(query: Query, opts?: QueryOptions): Promise<Partial<Item>>;
-  upsertSingleton(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
+  upsertSingleton(data: Partial<Item>, opts?: any): Promise<PrimaryKey>;
 }
 
 class GetItemsService {
@@ -110,10 +107,10 @@ export class ItemsServiceCreator extends GetItemsService {
 }
 
 export interface FilesService extends ItemsService<DatabaseTypes.DirectusFiles> {
-  uploadOne(stream: FileServiceSteamType, data: FileServiceFileStream, primaryKey?: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey>;
+  uploadOne(stream: FileServiceSteamType, data: FileServiceFileStream, primaryKey?: PrimaryKey, opts?: any): Promise<PrimaryKey>;
 
   importOne(importURL: string, body: Partial<DatabaseTypes.DirectusFiles>): Promise<PrimaryKey>;
-  createOne(data: Partial<DatabaseTypes.DirectusFiles>, opts?: MutationOptions): Promise<PrimaryKey>;
+  createOne(data: Partial<DatabaseTypes.DirectusFiles>, opts?: any): Promise<PrimaryKey>;
   deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]>;
   readByQuery(query: Query, opts?: QueryOptions | undefined): Promise<DatabaseTypes.DirectusFiles[]>;
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/ItemsServiceHelper.ts
@@ -1,4 +1,4 @@
-import { ItemsService, ItemsServiceCreator, MutationOptions, QueryOptions } from './ItemsServiceCreator';
+import { ItemsService, ItemsServiceCreator, QueryOptions } from './ItemsServiceCreator';
 import type { Filter } from '@directus/types/dist/filter';
 import { ApiContext } from './ApiContext';
 import { Accountability, EventContext, PrimaryKey, Query } from '@directus/types';
@@ -318,12 +318,12 @@ export class ItemsServiceHelper<T> implements ItemsService<T> {
   accountability: Accountability | null | undefined;
   knex: Knex;
 
-  async createMany(data: Partial<T>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+  async createMany(data: Partial<T>[], opts?: any): Promise<PrimaryKey[]> {
     let itemsService = await this.getItemsService();
     return await itemsService.createMany(data, opts);
   }
 
-  async deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]> {
+  async deleteByQuery(query: Query, opts?: any): Promise<PrimaryKey[]> {
     let itemsService = await this.getItemsService();
     return await itemsService.deleteByQuery(query, opts);
   }
@@ -344,27 +344,27 @@ export class ItemsServiceHelper<T> implements ItemsService<T> {
     );
   }
 
-  async updateBatch(data: Partial<T>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+  async updateBatch(data: Partial<T>[], opts?: any): Promise<PrimaryKey[]> {
     let itemsService = await this.getItemsService();
     return await itemsService.updateBatch(data, opts);
   }
 
-  async updateByQuery(query: Query, data: Partial<T>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+  async updateByQuery(query: Query, data: Partial<T>, opts?: any): Promise<PrimaryKey[]> {
     let itemsService = await this.getItemsService();
     return await itemsService.updateByQuery(query, data, opts);
   }
 
-  async updateMany(keys: PrimaryKey[], data: Partial<T>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+  async updateMany(keys: PrimaryKey[], data: Partial<T>, opts?: any): Promise<PrimaryKey[]> {
     let itemsService = await this.getItemsService();
     return await itemsService.updateMany(keys, data, opts);
   }
 
-  async upsertMany(payloads: Partial<T>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+  async upsertMany(payloads: Partial<T>[], opts?: any): Promise<PrimaryKey[]> {
     let itemsService = await this.getItemsService();
     return await itemsService.upsertMany(payloads, opts);
   }
 
-  async upsertSingleton(data: Partial<T>, opts?: MutationOptions): Promise<PrimaryKey> {
+  async upsertSingleton(data: Partial<T>, opts?: any): Promise<PrimaryKey> {
     let itemsService = await this.getItemsService();
     return await itemsService.upsertSingleton(data, opts);
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -89,7 +89,7 @@ export class TranslationHelper {
     const { translationsFromParsing, items_primary_field_in_translation_table, itemsTablename, myDatabaseHelper } = config;
     const specificItemServiceReader = myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
     if (itemWithTranslations) {
-      const { updateObject: updateObject, updateNeeded: updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations(itemWithTranslations, itemWithTranslations, translationsFromParsing, items_primary_field_in_translation_table);
+      const { updateObject, updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations(itemWithTranslations, itemWithTranslations, translationsFromParsing, items_primary_field_in_translation_table);
 
       if (updateNeeded) {
         //const createTranslations = updateObject.translations.create;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PuppeteerGenerator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/pdf/PuppeteerGenerator.ts
@@ -1,5 +1,5 @@
 import {GeneratePdfFromHtmlProps, HtmlPdfGeneratorInterface} from "./HtmlPdfGeneratorInterface";
-import { default as puppeteerCore } from 'puppeteer-core';
+import puppeteerCore from 'puppeteer-core';
 import { EnvVariableHelper } from '../EnvVariableHelper';
 
 export class PuppeteerGenerator implements HtmlPdfGeneratorInterface {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/WorkflowRunJobInterface.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/WorkflowRunJobInterface.ts
@@ -47,9 +47,7 @@ export class WorkflowRunLogger {
   getFinalLogWithStateAndParams(workflowrun: Partial<DatabaseTypes.WorkflowsRuns>): Partial<DatabaseTypes.WorkflowsRuns> {
     let result: Partial<DatabaseTypes.WorkflowsRuns> = {
       ...workflowrun,
-      ...{
-        log: this.currentLog,
-      },
+      log: this.currentLog,
     };
     return result;
   }

--- a/apps/backend/Backend/scripts/getBase64IconForMail.py
+++ b/apps/backend/Backend/scripts/getBase64IconForMail.py
@@ -48,7 +48,7 @@ def load_available_icon_families(glyphmaps_path, fonts_path):
 # Function to find node_modules directory and ensure npm install is done
 def find_node_modules_directory(max_levels_up=10):
     current_dir = os.getcwd()
-    for level in range(max_levels_up):
+    for _ in range(max_levels_up):
         if os.path.isdir(os.path.join(current_dir, "backend")) and os.path.isdir(os.path.join(current_dir, "frontend")):
             possible_path = os.path.join(current_dir, "frontend/app/node_modules")
             if os.path.isdir(possible_path):

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -4,22 +4,18 @@ FROM directus/directus:11.9.3
 # Switch to root user to install packages
 USER root
 
-# Install Git using apk
-RUN apk update && \
-    apk add git
-
-
-# Install required dependencies for Puppeteer
+# Install Git and required dependencies for Puppeteer using apk
 RUN apk update && apk add --no-cache \
-    chromium \
-    nss \
-    freetype \
-    harfbuzz \
     ca-certificates \
-    ttf-freefont \
-    udev \
+    chromium \
+    curl \
     dbus \
-    curl
+    freetype \
+    git \
+    harfbuzz \
+    nss \
+    ttf-freefont \
+    udev
 
 # openssl # Apple Token generation# Apple Token generation
 # xxd # Apple Token generation
@@ -36,8 +32,6 @@ RUN corepack enable
 USER node
 
 RUN corepack enable && \
-    corepack prepare pnpm@8.6.12 --activate
-
-RUN pnpm install directus-extension-sync@3.0.3
-
-RUN pnpm install directus-extension-flow-manager@1.4.1
+    corepack prepare pnpm@8.6.12 --activate && \
+    pnpm install directus-extension-sync@3.0.3 && \
+    pnpm install directus-extension-flow-manager@1.4.1

--- a/apps/backend/dockerDatabaseBackup/Dockerfile
+++ b/apps/backend/dockerDatabaseBackup/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=13-master
 FROM postgis/postgis:${POSTGIS_VERSION}
 
 # Maintainer info
-MAINTAINER Your Name <your.email@example.com>
+LABEL maintainer="Your Name <your.email@example.com>"
 
 # Install cron
 RUN apt-get update && \

--- a/apps/backend/sync/importSchema.js
+++ b/apps/backend/sync/importSchema.js
@@ -247,7 +247,7 @@ const enableRequiredSettings = async headers => {
     const module = modules[moduleIndex];
     // module.id comes from the Directus API response; strip control/newline characters
     // before logging so it can't be used to forge fake log lines (log injection).
-    const safeModuleId = String(module.id).replace(/[\r\n\t\x00-\x1f]/g, '');
+    const safeModuleId = String(module.id).replace(/[\x00-\x1f]/g, '');
     if (requiredModules.has(module.id)) {
       if (!module.enabled) {
         console.log(` -  Enabling ${safeModuleId}`);
@@ -593,7 +593,7 @@ const fetchGetOptions = (headers, method) => {
 
 // Refactored fetch GET function
 const fetchGetResponse = async (url, headers) => {
-  let headersObject = undefined;
+  let headersObject;
   if (headers) {
     headersObject = { Cookie: headers.get('cookie') };
   }
@@ -626,11 +626,17 @@ const fetchPatchResponse = async (url, headers, body) => {
 
 // Command-line argument processing
 if (process.argv[2] === 'push') {
-  mainPush()
-    .then(() => process.exit(0))
-    .catch(console.error);
+  try {
+    await mainPush();
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+  }
 } else if (process.argv[2] === 'pull') {
-  mainPull()
-    .then(() => process.exit(0))
-    .catch(console.error);
+  try {
+    await mainPull();
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+  }
 }

--- a/apps/frontend/app/app.config.ts
+++ b/apps/frontend/app/app.config.ts
@@ -12,6 +12,6 @@ require('ts-node').register({
 
 const { getFinalConfig } = require('./config.ts');
 
-module.exports = function ({ config }: ConfigContext) {
+module.exports = function getExpoConfig({ config }: ConfigContext) {
 	return getFinalConfig(config);
 };

--- a/apps/frontend/app/app/(app)/account-balance/MyUnsupportedCardReader.ts
+++ b/apps/frontend/app/app/(app)/account-balance/MyUnsupportedCardReader.ts
@@ -6,10 +6,7 @@ const isExpoGo = isRunningInExpoGo();
 
 export default class MyUnsupportedCardReader implements MyCardReaderInterface {
 	async isNfcEnabled(): Promise<MyCardReaderResponseSupport> {
-		if (isExpoGo) {
-			return { result: false, message: 'NFC is not supported in Expo Go' };
-		}
-		return { result: false, message: 'NFC is not supported on this device' };
+		return this.isNfcSupported();
 	}
 
 	async isNfcSupported(): Promise<MyCardReaderResponseSupport> {

--- a/apps/frontend/app/app/(app)/foodoffers/hooks.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/hooks.ts
@@ -268,7 +268,7 @@ export const useSheetHandling = (
     // Optimization: Keep sheet active to prevent unmount/remount on navigation
     const [isActive] = useState(true);
 
-    const openSheet = useCallback((sheet: 'menu' | 'sort' | string, props = {}) => {
+    const openSheet = useCallback((sheet: string, props = {}) => {
         if (sheet === 'sort') {
             openFoodofferSortingModal();
             return;

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -107,7 +107,7 @@ const normalizeExpectedValue = (value: unknown): string => {
 		return value.map(item => String(item).trim().toLowerCase()).join(',');
 	}
 
-	return String(value).trim().toLowerCase();
+	return JSON.stringify(value).trim().toLowerCase();
 };
 
 const normalizeCurrentValue = (value: unknown, customType?: string): string => {
@@ -128,7 +128,7 @@ const normalizeCurrentValue = (value: unknown, customType?: string): string => {
 		return value.map(item => String(item).trim().toLowerCase()).join(',');
 	}
 
-	return String(value).trim().toLowerCase();
+	return JSON.stringify(value).trim().toLowerCase();
 };
 
 const isAnswerVisible = (
@@ -450,7 +450,7 @@ const Index = () => {
 				const dynamicCollectionHelper = new DynamicCollectionHelper(collection);
 				const data = (await dynamicCollectionHelper.fectAllCollection()) as any;
 				if (data) {
-					if (collection === 'apartments' && data && data?.length > 0) {
+					if (collection === 'apartments' && data?.length > 0) {
 						const buildingsHelper = new BuildingsHelper();
 						const apartmentWithBuilding = await Promise.all(
 							data.map(async (apartment: any) => {

--- a/apps/frontend/app/app/(app)/form-submissions/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submissions/index.tsx
@@ -206,31 +206,28 @@ const Index = () => {
 			const normalizedLocale = language || undefined;
 			const sortedSubmissions = [...submissions];
 
-			switch (option) {
-				case 'alphabetical':
-				default:
-					sortedSubmissions.sort((first, second) => {
-						const firstAlias = (first.alias || '').trim();
-						const secondAlias = (second.alias || '').trim();
+			// 'alphabetical' is currently the only supported option; any other
+			// value falls back to the same alphabetical sort.
+			sortedSubmissions.sort((first, second) => {
+				const firstAlias = (first.alias || '').trim();
+				const secondAlias = (second.alias || '').trim();
 
-						if (!firstAlias && !secondAlias) {
-							return 0;
-						}
+				if (!firstAlias && !secondAlias) {
+					return 0;
+				}
 
-						if (!firstAlias) {
-							return 1;
-						}
+				if (!firstAlias) {
+					return 1;
+				}
 
-						if (!secondAlias) {
-							return -1;
-						}
+				if (!secondAlias) {
+					return -1;
+				}
 
-						return firstAlias.localeCompare(secondAlias, normalizedLocale, {
-							sensitivity: 'base',
-						});
-					});
-					break;
-			}
+				return firstAlias.localeCompare(secondAlias, normalizedLocale, {
+					sensitivity: 'base',
+				});
+			});
 
 			return sortedSubmissions;
 		},

--- a/apps/frontend/app/app/(app)/housing/components/HousingHeader.tsx
+++ b/apps/frontend/app/app/(app)/housing/components/HousingHeader.tsx
@@ -15,7 +15,7 @@ import styles from '../styles';
 interface HousingHeaderProps {
 	theme: any;
 	translate: (key: string) => string;
-	drawerPosition: 'left' | 'right' | 'system' | string;
+	drawerPosition: string;
 	openHousingSortingModal: () => void;
 }
 

--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -178,7 +178,7 @@ export default function ImageFullScreen() {
 				link.download = `${name}.${extension}`;
 				document.body.appendChild(link);
 				link.click();
-				document.body.removeChild(link);
+				link.remove();
 			} else {
 				const filename = `${name}.${extension}`;
 				const fileUri = (FileSystem as any).documentDirectory + filename;

--- a/apps/frontend/app/app/index.tsx
+++ b/apps/frontend/app/app/index.tsx
@@ -65,7 +65,6 @@ async function savePushTokenToAPI(opts: { token: string | null; profile: Partial
 				type: UPDATE_PROFILE,
 				payload: updated,
 			});
-		} else {
 		}
 	} catch (e) {
 		console.error('Error in savePushTokenToAPI:', e);

--- a/apps/frontend/app/components/ApartmentDetailsContent/ApartmentDetailsContent.tsx
+++ b/apps/frontend/app/components/ApartmentDetailsContent/ApartmentDetailsContent.tsx
@@ -48,7 +48,7 @@ const ApartmentDetailsContent: React.FC<ApartmentDetailsContentProps> = ({ id })
     useEffect(() => {
         if (
             activeTab === HousingDetailTab.WASHING_MACHINE &&
-            !((apartmentDetails as any)?.washingmachines?.length > 0)
+            ((apartmentDetails as any)?.washingmachines?.length ?? 0) <= 0
         ) {
             setActiveTab(HousingDetailTab.INFORMATION);
         }

--- a/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
+++ b/apps/frontend/app/components/CalendarSheet/CalendarSheet.tsx
@@ -208,7 +208,6 @@ const CalendarSheet: React.FC<CalendarSheetProps> = (props) => {
     return (
         <MyScrollViewModal
             title={`${translate(TranslationKeys.select)} : ${translate(TranslationKeys.date)}`}
-            closeSheet={props.closeSheet}
         >
             <CalendarSheetContent {...props} />
         </MyScrollViewModal>

--- a/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseBottomSheet.tsx
@@ -68,7 +68,7 @@ const CourseBottomSheet: React.FC<CourseBottomSheetProps> = ({ timeTableData, cl
 	const handleSavePress = () => {
 		// Function to validate HH:MM format
 		const validateTime = (time: string) => {
-			const regex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/; // Regex for HH:MM format
+			const regex = /^([01]?\d|2[0-3]):[0-5]\d$/; // Regex for HH:MM format
 			return regex.test(time);
 		};
 

--- a/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
+++ b/apps/frontend/app/components/CourseTimeTable/CourseTimetable.tsx
@@ -89,7 +89,7 @@ const CourseTimetable: React.FC<CourseTimetableProps> = ({ events, openSheet, se
 			if (currentHour === 20) {
 				setShowCurrentTimeOffset(false);
 			} else {
-				setCurrentTimeOffset(offset > 0 ? offset : 0);
+				setCurrentTimeOffset(Math.max(offset, 0));
 			}
 		};
 

--- a/apps/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
+++ b/apps/frontend/app/components/EditFormSubmissionSheet/EditFormSubmissionSheet.tsx
@@ -5,7 +5,7 @@ import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import ModalTextInput from '@/components/ModalTextInput';
 import { isWeb } from '@/constants/Constants';
-import { sheetProps } from './types';
+import { SheetProps } from './types';
 import { useDispatch } from 'react-redux';
 import { useLanguage } from '@/hooks/useLanguage';
 import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
@@ -14,7 +14,7 @@ import { SET_FORM_SUBMISSION } from '@/redux/Types/types';
 import { TranslationKeys } from '@/locales/keys';
 import { useAppSelector } from '@/redux/hooks';
 
-const EditFormSubmissionSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
+const EditFormSubmissionSheet: React.FC<SheetProps> = ({ id, closeSheet }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const dispatch = useDispatch();

--- a/apps/frontend/app/components/EditFormSubmissionSheet/types.ts
+++ b/apps/frontend/app/components/EditFormSubmissionSheet/types.ts
@@ -1,4 +1,4 @@
-export interface sheetProps {
+export interface SheetProps {
 	id: string;
 	closeSheet: () => void;
 }

--- a/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
+++ b/apps/frontend/app/components/ExpoUpdateChecker/ExpoUpdateChecker.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, AppState, AppStateStatus, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import * as Updates from 'expo-updates';
 import ModalSheet from '../BaseBottomModal';
@@ -34,7 +34,7 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 	const [titleKey, setTitleKey] = useState<TranslationKeys>(TranslationKeys.update_available);
 	const [messageKey, setMessageKey] = useState<TranslationKeys>(TranslationKeys.update_available_message);
 
-	const checkForUpdates = async (showUpToDate = false) => {
+	const checkForUpdates = useCallback(async (showUpToDate = false) => {
 		if (!isSmartPhone()) return;
 		if (isInExpoGo()) return;
 		try {
@@ -53,7 +53,7 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 		} catch (e) {
 			console.error('Error while checking updates', e);
 		}
-	};
+	}, [isSmartPhone]);
 
 	useEffect(() => {
 		if (!isSmartPhone()) return;
@@ -78,8 +78,13 @@ const ExpoUpdateChecker: React.FC<ExpoUpdateCheckerProps> = ({ children }) => {
 		}
 	};
 
+	const contextValue = useMemo(
+		() => ({ manualCheck: () => checkForUpdates(true) }),
+		[checkForUpdates]
+	);
+
 	return (
-		<UpdateCheckerContext.Provider value={{ manualCheck: () => checkForUpdates(true) }}>
+		<UpdateCheckerContext.Provider value={contextValue}>
 			{children}
 			{modalVisible && (
 				<ModalSheet visible={modalVisible} onClose={() => setModalVisible(false)} title={translate(titleKey)}>

--- a/apps/frontend/app/components/FriendsContent/index.tsx
+++ b/apps/frontend/app/components/FriendsContent/index.tsx
@@ -31,6 +31,8 @@ const isWeb = Platform.OS === 'web';
 /* ───────────────────────── Scan / Add Friend Modal ──────────────────────── */
 type ScanPhase = 'scanning' | 'confirming' | 'error' | 'already_friends';
 
+type ProfileField = string | DatabaseTypes.Profiles | null | undefined;
+
 type ScanModalContentProps = {
 	onSubmit: (id: string) => Promise<void>;
 	checkAlreadyFriends?: (friendshipId: string) => Promise<boolean>;
@@ -447,18 +449,18 @@ export const FriendsContent: React.FC<FriendsContentProps> = ({ showHeading = tr
 	const friendshipsHelper = useMemo(() => new FriendshipsHelper(), []);
 	const [refreshing, setRefreshing] = useState(false);
 
-	const getProfileIdFromField = useCallback((field: string | DatabaseTypes.Profiles | null | undefined): string => {
+	const getProfileIdFromField = useCallback((field: ProfileField): string => {
 		if (!field) return '-';
 		if (typeof field === 'string') return field;
 		return (field as any)?.id ?? '-';
 	}, []);
 
-	const getProfileNicknameFromField = useCallback((field: string | DatabaseTypes.Profiles | null | undefined): string | null => {
+	const getProfileNicknameFromField = useCallback((field: ProfileField): string | null => {
 		if (!field || typeof field === 'string') return null;
 		return (field as DatabaseTypes.Profiles)?.nickname ?? null;
 	}, []);
 
-	const getProfileAvatarFromField = useCallback((field: string | DatabaseTypes.Profiles | null | undefined) => {
+	const getProfileAvatarFromField = useCallback((field: ProfileField) => {
 		if (!field || typeof field === 'string') return null;
 		return parseProfileAvatar((field as DatabaseTypes.Profiles)?.avatar);
 	}, []);

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -3,7 +3,7 @@ import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScroll
 import { useModal } from './useModal';
 import type { ModalCloseReason } from 'repo-depkit-common-ui';
 
-export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
+export type MyScrollViewModalConfig = MyScrollViewModalProps & { children?: ReactNode };
 
 type ScrollViewModalOptions = {
 	backgroundStyle?: any;
@@ -34,7 +34,7 @@ export const useMyScrollViewModal = () => {
                         : undefined;
 
                 const element = (
-                        <MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
+                        <MyScrollViewModal backgroundColor={backgroundColor} {...restProps}>
                                 {children}
                         </MyScrollViewModal>
                 );

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -82,8 +82,7 @@ const computeConsecutiveRangesByDay = (
 	// Iterate over each day and its corresponding time ranges
 	sortedDayKeys.forEach(day => {
 		const timeRanges = dayStartAndEndTimeDict[day];
-		if (!timeRanges || timeRanges.length === 0) {
-		} else {
+		if (timeRanges && timeRanges.length > 0) {
 			// sorting the time ranges by time_start
 			timeRanges.sort((a, b) => {
 				if (a.time_start === null || b.time_start === null) {
@@ -105,19 +104,17 @@ const computeConsecutiveRangesByDay = (
 				const { time_start, time_end } = timeRange;
 				if (currentRange?.time_start == null || currentRange.time_end == null) {
 					currentRange = { time_start, time_end };
-				} else {
-					if (time_start === currentRange.time_start && time_end === currentRange.time_end) {
-						// do nothing
-					} else if (time_start === null || time_end === null) {
-						// do nothing
-					} else if (time_start >= currentRange.time_start && time_end <= currentRange.time_end) {
-						// do nothing
-					} else if (time_start < currentRange.time_end && time_end > currentRange.time_end) {
-						currentRange.time_end = time_end;
-					} else if (time_start > currentRange.time_end) {
-						consecutiveRanges.push(currentRange); // push the current range to the consecutive ranges
-						currentRange = { time_start, time_end }; // start a new range
-					}
+				} else if (time_start === currentRange.time_start && time_end === currentRange.time_end) {
+					// do nothing
+				} else if (time_start === null || time_end === null) {
+					// do nothing
+				} else if (time_start >= currentRange.time_start && time_end <= currentRange.time_end) {
+					// do nothing
+				} else if (time_start < currentRange.time_end && time_end > currentRange.time_end) {
+					currentRange.time_end = time_end;
+				} else if (time_start > currentRange.time_end) {
+					consecutiveRanges.push(currentRange); // push the current range to the consecutive ranges
+					currentRange = { time_start, time_end }; // start a new range
 				}
 			});
 			if (currentRange) {
@@ -502,7 +499,7 @@ export const HoursSheetContent: React.FC = () => {
 const HourSheet: React.FC<HourSheetProps> = ({ closeSheet }) => {
 	const { translate } = useLanguage();
 	return (
-		<MyScrollViewModal title={translate(TranslationKeys.businesshours)} closeSheet={closeSheet}>
+		<MyScrollViewModal title={translate(TranslationKeys.businesshours)}>
 			<HoursSheetContent />
 		</MyScrollViewModal>
 	);

--- a/apps/frontend/app/components/LabelHeader/LabelHeader.tsx
+++ b/apps/frontend/app/components/LabelHeader/LabelHeader.tsx
@@ -6,7 +6,7 @@ import CompanyImage from '@/components/CompanyImage';
 import { StringHelper } from 'repo-depkit-common';
 
 
-const LabelHeader: React.FC<{ Label: any; isConnected?: Boolean }> = ({ Label, isConnected = true }) => {
+const LabelHeader: React.FC<{ Label: any; isConnected?: boolean }> = ({ Label, isConnected = true }) => {
 	const { theme } = useTheme();
 	const [currentTime, setCurrentTime] = useState('');
 	const [logoStyle, setLogoStyle] = useState(styles.logo);

--- a/apps/frontend/app/components/Login/types.ts
+++ b/apps/frontend/app/components/Login/types.ts
@@ -11,7 +11,7 @@ export type FormProps = {
 export type SheetProps = {
 	closeSheet: () => void;
 	handleLogin: HandleLoginType;
-	loading: Boolean;
+	loading: boolean;
 }
 
 export type AttentionSheetProps = {

--- a/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -218,7 +218,6 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 				} else {
 					setDislikeLoading(false);
 				}
-				return;
 			} else {
 				try {
 					const likeStats = ownMarking?.like === like ? null : like;

--- a/apps/frontend/app/components/MyMap/MyMapHelper.tsx
+++ b/apps/frontend/app/components/MyMap/MyMapHelper.tsx
@@ -8,5 +8,3 @@ export interface MyMapProps extends MyMapCoreProps {
 	initialCenter: { lat: number; lng: number };
 	onMessage: (data: object) => void;
 }
-
-export class MyMapHelper {}

--- a/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
+++ b/apps/frontend/app/components/MyScrollViewModal/MyScrollViewModal.tsx
@@ -6,7 +6,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { ScrollViewModalContentProps } from 'repo-depkit-common-ui';
 
 export interface MyScrollViewModalProps extends ScrollViewModalContentProps {
-  closeSheet?: () => void;
   // For FlatList mode
   renderItem?: (info: { item: any; index: number }) => ReactNode;
   keyExtractor?: (item: any, index: number) => string;

--- a/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
+++ b/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
@@ -129,7 +129,6 @@ const SettingsListMarkingLabel: React.FC<SettingsListMarkingLabelProps> = ({
 				} else {
 					setDislikeLoading(false);
 				}
-				return;
 			} else {
 				try {
 					const likeStats = ownMarking?.like === like ? null : like;

--- a/apps/frontend/app/components/SubmissionWarningModal/types.ts
+++ b/apps/frontend/app/components/SubmissionWarningModal/types.ts
@@ -1,5 +1,5 @@
 export interface SubmissionWarningModalProps {
 	isVisible: boolean;
 	setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
-	id: String;
+	id: string;
 }

--- a/apps/frontend/app/components/SubmissionWarningSheet/SubmissionWarningSheet.tsx
+++ b/apps/frontend/app/components/SubmissionWarningSheet/SubmissionWarningSheet.tsx
@@ -4,7 +4,7 @@ import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import styles from './styles';
 import { useTheme } from '@/hooks/useTheme';
 import { isWeb } from '@/constants/Constants';
-import { sheetProps } from './types';
+import { SheetProps } from './types';
 import { useAppSelector } from '@/redux/hooks';
 import { useLanguage } from '@/hooks/useLanguage';
 import { router } from 'expo-router';
@@ -12,7 +12,7 @@ import { FormsSubmissionsHelper } from '@/redux/actions/Forms/FormSubmitions';
 import { DatabaseTypes } from 'repo-depkit-common';
 import { TranslationKeys } from '@/locales/keys';
 
-const SubmissionWarningSheet: React.FC<sheetProps> = ({ id, closeSheet }) => {
+const SubmissionWarningSheet: React.FC<SheetProps> = ({ id, closeSheet }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const formsSubmissionsHelper = new FormsSubmissionsHelper();

--- a/apps/frontend/app/components/SubmissionWarningSheet/types.ts
+++ b/apps/frontend/app/components/SubmissionWarningSheet/types.ts
@@ -1,4 +1,4 @@
-export interface sheetProps {
+export interface SheetProps {
 	id: string;
 	closeSheet: () => void;
 }

--- a/apps/frontend/app/helper/resourceHelper.tsx
+++ b/apps/frontend/app/helper/resourceHelper.tsx
@@ -52,17 +52,17 @@ export const getDetailedDescriptionTranslation = (translations: Array<any>, lang
 	return translation?.detailed_description || '';
 };
 
-export const getFromCategoryTranslation = (translations: Array<DatabaseTypes.FormCategoriesTranslations | DatabaseTypes.FormsTranslations | DatabaseTypes.FormFieldsTranslations>, languageCode: string): string => {
+const getNameFromTranslation = (translations: Array<{ languages_code?: string | DatabaseTypes.Languages | null; name?: string | null }> | null | undefined, languageCode: string): string => {
 	if (!translations || translations.length === 0) return '';
 	const translation = translations.find(t => (t.languages_code as string)?.split('-')[0] === languageCode);
 	return translation?.name || '';
 };
 
-export const getFoodAttributesTranslation = (translations: Array<Partial<DatabaseTypes.FoodsAttributesTranslations> | Partial<Translation>> | null | undefined, languageCode: string): string => {
-	if (!translations || translations.length === 0) return '';
-	const translation = translations.find(t => (t.languages_code as string)?.split('-')[0] === languageCode);
-	return translation?.name || '';
-};
+export const getFromCategoryTranslation = (translations: Array<DatabaseTypes.FormCategoriesTranslations | DatabaseTypes.FormsTranslations | DatabaseTypes.FormFieldsTranslations>, languageCode: string): string =>
+	getNameFromTranslation(translations, languageCode);
+
+export const getFoodAttributesTranslation = (translations: Array<Partial<DatabaseTypes.FoodsAttributesTranslations> | Partial<Translation>> | null | undefined, languageCode: string): string =>
+	getNameFromTranslation(translations, languageCode);
 
 const getFoodCategoryName = (categories: DatabaseTypes.FoodsCategories[], category: string | DatabaseTypes.FoodsCategories | null | undefined, languageCode: string): string => {
 	if (!category) return '';

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -629,7 +629,7 @@ export enum TranslationKeys {
 	Feb = 'Feb',
 	Mar = 'Mar',
 	Apr = 'Apr',
-	MayShort = 'May',
+	MayShort = 'MayShort',
 	Jun = 'Jun',
 	Jul = 'Jul',
 	Aug = 'Aug',

--- a/apps/frontend/app/redux/reducer/authReducer.ts
+++ b/apps/frontend/app/redux/reducer/authReducer.ts
@@ -20,13 +20,7 @@ const authReducer = (state, actions: any) => {
 	state = state === undefined ? initialState : state;
 
 	switch (actions.type) {
-		case ON_LOGIN: {
-			return {
-				...state,
-				user: actions.payload,
-				loggedIn: true,
-			};
-		}
+		case ON_LOGIN:
 		case UPDATE_LOGIN: {
 			return {
 				...state,

--- a/apps/frontend/run-maestro-web-test.sh
+++ b/apps/frontend/run-maestro-web-test.sh
@@ -33,6 +33,8 @@ for arg in "$@"; do
         --skip-generate)
             SKIP_GENERATE=true
             ;;
+        *)
+            ;;
     esac
 done
 

--- a/apps/geonexia/frontend/app.config.ts
+++ b/apps/geonexia/frontend/app.config.ts
@@ -12,7 +12,7 @@ require('ts-node').register({
 
 const { getBuildNumber } = require('./config.ts');
 
-module.exports = function ({ config }: ConfigContext): ExpoConfig {
+module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
 	return {
 		...config,

--- a/apps/geonexia/frontend/app/achievements/index.tsx
+++ b/apps/geonexia/frontend/app/achievements/index.tsx
@@ -119,7 +119,7 @@ const ACHIEVEMENTS: AchievementDefinition[] = [
 		iconBgColor: '#cd7f32',
 		renderIcon: (color) => <MaterialCommunityIcons name="vector-polygon" size={22} color={color} />,
 		getProgress: ({ hexTileRecords }) => ({
-			current: Math.min(1, Object.values(hexTileRecords).filter((r) => r.enclosedCount > 0).length > 0 ? 1 : 0),
+			current: Math.min(1, Object.values(hexTileRecords).some((r) => r.enclosedCount > 0) ? 1 : 0),
 			goal: 1,
 		}),
 	},

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -117,7 +117,9 @@ function getAnchorAngleDeg(anchorPosition: string): number {
  * Group position of a list entry for settings list styling:
  * 'single' for one-item lists, otherwise 'top' / 'middle' / 'bottom'.
  */
-function getListGroupPosition(index: number, length: number): 'top' | 'middle' | 'bottom' | 'single' {
+type ListGroupPosition = 'top' | 'middle' | 'bottom' | 'single';
+
+function getListGroupPosition(index: number, length: number): ListGroupPosition {
 	if (length === 1) return 'single';
 	if (index === 0) return 'top';
 	if (index === length - 1) return 'bottom';
@@ -129,7 +131,7 @@ function getListGroupPosition(index: number, length: number): 'top' | 'middle' |
  * and tile-color pickers; each caller supplies its own per-entry row (selection state
  * and onPress differ between the two pickers).
  */
-function renderTerrainCategoryList(renderEntry: (entry: TerrainAssetEntry, position: 'top' | 'middle' | 'bottom' | 'single') => React.ReactNode) {
+function renderTerrainCategoryList(renderEntry: (entry: TerrainAssetEntry, position: ListGroupPosition) => React.ReactNode) {
 	return (
 		<View style={{ paddingBottom: 20 }}>
 			{TERRAIN_CATEGORIES.map((cat) => {
@@ -1348,7 +1350,7 @@ function DebugInfoContent({
 					<SettingsListGroupTitle title={`⬠ Pentagon Tiles (Res ${Math.round(h3Resolution)})`} />
 					{pentagons.map((cell, i) => {
 						const [lat, lng] = cellToLatLng(cell);
-						const position: 'top' | 'middle' | 'bottom' | 'single' = getListGroupPosition(i, pentagons.length);
+						const position: ListGroupPosition = getListGroupPosition(i, pentagons.length);
 						return (
 							<SettingsListSelectOptionSingle
 								key={cell}

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -372,7 +372,7 @@ export function hasForestFeature(features: MapFeatureInfo[]): boolean {
 export function getSmallTreeAnchorForHexId(hexId: string): BillboardAnchorPosition {
 	let hash = 0;
 	for (let i = 0; i < hexId.length; i++) {
-		hash = (hash * 31 + hexId.charCodeAt(i)) >>> 0;
+		hash = (hash * 31 + (hexId.codePointAt(i) ?? 0)) >>> 0;
 	}
 	return MIDDLE_RING_BY_DEGREE[hash % MIDDLE_RING_BY_DEGREE.length];
 }

--- a/apps/geonexia/frontend/helpers/H3Helper.ts
+++ b/apps/geonexia/frontend/helpers/H3Helper.ts
@@ -85,9 +85,6 @@ const {
 
 // ─── Re-exported types ────────────────────────────────────────────────────────
 
-/** 64-bit hex string representation of an H3 index */
-export type H3Index = string;
-
 /** Pair of lower/upper 32-bit integers representing a 64-bit H3 index */
 export type SplitLong = [number, number];
 
@@ -104,10 +101,10 @@ export const radsToDegs = (rad: number): number => _radsToDegs?.(rad) ?? 0;
 
 // ─── Split-long conversions ───────────────────────────────────────────────────
 
-export const h3IndexToSplitLong = (h3Index: H3Index | SplitLong): SplitLong =>
+export const h3IndexToSplitLong = (h3Index: string | SplitLong): SplitLong =>
     (_h3IndexToSplitLong?.(h3Index) as SplitLong) ?? [0, 0];
 
-export const splitLongToH3Index = (lower: number, upper: number): H3Index =>
+export const splitLongToH3Index = (lower: number, upper: number): string =>
     _splitLongToH3Index?.(lower, upper) ?? '';
 
 // ─── Cell indexing ─────────────────────────────────────────────────────────────
@@ -115,13 +112,13 @@ export const splitLongToH3Index = (lower: number, upper: number): H3Index =>
 /**
  * Convert a lat/lng coordinate (degrees) to an H3 cell index.
  */
-export const latLngToCell = (lat: number, lng: number, res: number): H3Index =>
+export const latLngToCell = (lat: number, lng: number, res: number): string =>
     _latLngToCell?.(lat, lng, res) ?? '';
 
 /**
  * Return the center lat/lng of an H3 cell as [lat, lng] in degrees.
  */
-export const cellToLatLng = (h3Index: H3Index): CoordPair =>
+export const cellToLatLng = (h3Index: string): CoordPair =>
     (_cellToLatLng?.(h3Index) as CoordPair) ?? [0, 0];
 
 /**
@@ -129,7 +126,7 @@ export const cellToLatLng = (h3Index: H3Index): CoordPair =>
  * Returns an empty array for invalid or empty cell indices.
  */
 export const cellToBoundary = (
-    h3Index: H3Index,
+    h3Index: string,
     formatAsGeoJson = false,
 ): CoordPair[] => {
     if (!h3Index || !(_isValidCell?.(h3Index) ?? false)) return [];
@@ -138,41 +135,41 @@ export const cellToBoundary = (
 
 // ─── Cell validation ──────────────────────────────────────────────────────────
 
-export const isValidCell = (h3Index: H3Index | SplitLong): boolean =>
+export const isValidCell = (h3Index: string | SplitLong): boolean =>
     _isValidCell?.(h3Index) ?? false;
 
-export const isValidIndex = (h3Index: H3Index | SplitLong): boolean =>
+export const isValidIndex = (h3Index: string | SplitLong): boolean =>
     _isValidIndex?.(h3Index) ?? false;
 
-export const isPentagon = (h3Index: H3Index | SplitLong): boolean =>
+export const isPentagon = (h3Index: string | SplitLong): boolean =>
     _isPentagon?.(h3Index) ?? false;
 
-export const isResClassIII = (h3Index: H3Index | SplitLong): boolean =>
+export const isResClassIII = (h3Index: string | SplitLong): boolean =>
     _isResClassIII?.(h3Index) ?? false;
 
 // ─── Cell properties ──────────────────────────────────────────────────────────
 
-export const getResolution = (h3Index: H3Index | SplitLong): number =>
+export const getResolution = (h3Index: string | SplitLong): number =>
     _getResolution?.(h3Index) ?? 0;
 
-export const getBaseCellNumber = (h3Index: H3Index | SplitLong): number =>
+export const getBaseCellNumber = (h3Index: string | SplitLong): number =>
     _getBaseCellNumber?.(h3Index) ?? 0;
 
-export const getIcosahedronFaces = (h3Index: H3Index | SplitLong): number[] =>
+export const getIcosahedronFaces = (h3Index: string | SplitLong): number[] =>
     (_getIcosahedronFaces?.(h3Index) as number[]) ?? [];
 
 // ─── Cell hierarchy ────────────────────────────────────────────────────────────
 
-export const cellToParent = (h3Index: H3Index, res: number): H3Index =>
+export const cellToParent = (h3Index: string, res: number): string =>
     _cellToParent?.(h3Index, res) ?? '';
 
-export const cellToChildren = (h3Index: H3Index, childRes: number): H3Index[] =>
-    (_cellToChildren?.(h3Index, childRes) as H3Index[]) ?? [];
+export const cellToChildren = (h3Index: string, childRes: number): string[] =>
+    (_cellToChildren?.(h3Index, childRes) as string[]) ?? [];
 
-export const cellToChildrenSize = (h3Index: H3Index, childRes: number): number =>
+export const cellToChildrenSize = (h3Index: string, childRes: number): number =>
     _cellToChildrenSize?.(h3Index, childRes) ?? 0;
 
-export const cellToCenterChild = (h3Index: H3Index, childRes: number): H3Index =>
+export const cellToCenterChild = (h3Index: string, childRes: number): string =>
     _cellToCenterChild?.(h3Index, childRes) ?? '';
 
 // ─── Grid traversal ───────────────────────────────────────────────────────────
@@ -180,45 +177,45 @@ export const cellToCenterChild = (h3Index: H3Index, childRes: number): H3Index =
 /**
  * Return all cells within k grid rings of h3Index (inclusive).
  */
-export const gridDisk = (h3Index: H3Index, k: number): H3Index[] =>
-    (_gridDisk?.(h3Index, k) as H3Index[]) ?? [];
+export const gridDisk = (h3Index: string, k: number): string[] =>
+    (_gridDisk?.(h3Index, k) as string[]) ?? [];
 
 /**
  * Return cells within k grid rings grouped by ring distance.
  */
-export const gridDiskDistances = (h3Index: H3Index, k: number): H3Index[][] =>
-    (_gridDiskDistances?.(h3Index, k) as H3Index[][]) ?? [];
+export const gridDiskDistances = (h3Index: string, k: number): string[][] =>
+    (_gridDiskDistances?.(h3Index, k) as string[][]) ?? [];
 
-export const gridRingUnsafe = (h3Index: H3Index, k: number): H3Index[] =>
-    (_gridRingUnsafe?.(h3Index, k) as H3Index[]) ?? [];
+export const gridRingUnsafe = (h3Index: string, k: number): string[] =>
+    (_gridRingUnsafe?.(h3Index, k) as string[]) ?? [];
 
-export const gridDistance = (origin: H3Index, dest: H3Index): number =>
+export const gridDistance = (origin: string, dest: string): number =>
     _gridDistance?.(origin, dest) ?? 0;
 
-export const gridPathCells = (origin: H3Index, dest: H3Index): H3Index[] =>
-    (_gridPathCells?.(origin, dest) as H3Index[]) ?? [];
+export const gridPathCells = (origin: string, dest: string): string[] =>
+    (_gridPathCells?.(origin, dest) as string[]) ?? [];
 
 // ─── Set operations ───────────────────────────────────────────────────────────
 
-export const compactCells = (cells: H3Index[]): H3Index[] =>
-    (_compactCells?.(cells) as H3Index[]) ?? [];
+export const compactCells = (cells: string[]): string[] =>
+    (_compactCells?.(cells) as string[]) ?? [];
 
-export const uncompactCells = (cells: H3Index[], res: number): H3Index[] =>
-    (_uncompactCells?.(cells, res) as H3Index[]) ?? [];
+export const uncompactCells = (cells: string[], res: number): string[] =>
+    (_uncompactCells?.(cells, res) as string[]) ?? [];
 
-export const areNeighborCells = (a: H3Index, b: H3Index): boolean =>
+export const areNeighborCells = (a: string, b: string): boolean =>
     _areNeighborCells?.(a, b) ?? false;
 
 export const polygonToCells = (
     coordinates: CoordPair[][] | CoordPair[][][],
     res: number,
     isGeoJson = false,
-): H3Index[] =>
+): string[] =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (_polygonToCells?.(coordinates as any, res, isGeoJson) as H3Index[]) ?? [];
+    (_polygonToCells?.(coordinates as any, res, isGeoJson) as string[]) ?? [];
 
 export const cellsToMultiPolygon = (
-    h3Indexes: H3Index[],
+    h3Indexes: string[],
     formatAsGeoJson = false,
 ): CoordPair[][][] =>
     (_cellsToMultiPolygon?.(h3Indexes, formatAsGeoJson) as CoordPair[][][]) ?? [];
@@ -226,9 +223,9 @@ export const cellsToMultiPolygon = (
 // ─── Global cell sets ─────────────────────────────────────────────────────────
 
 export const getNumCells = (res: number): number => _getNumCells?.(res) ?? 0;
-export const getRes0Cells = (): H3Index[] => (_getRes0Cells?.() as H3Index[]) ?? [];
-export const getPentagons = (res: number): H3Index[] =>
-    (_getPentagons?.(res) as H3Index[]) ?? [];
+export const getRes0Cells = (): string[] => (_getRes0Cells?.() as string[]) ?? [];
+export const getPentagons = (res: number): string[] =>
+    (_getPentagons?.(res) as string[]) ?? [];
 
 // ─── Measurement ──────────────────────────────────────────────────────────────
 
@@ -238,7 +235,7 @@ export const greatCircleDistance = (
     unit: string,
 ): number => _greatCircleDistance?.(a, b, unit) ?? 0;
 
-export const cellArea = (h3Index: H3Index, unit: string): number =>
+export const cellArea = (h3Index: string, unit: string): number =>
     _cellArea?.(h3Index, unit) ?? 0;
 
 export const getHexagonAreaAvg = (res: number, unit: string): number =>
@@ -278,7 +275,7 @@ export function formatDistanceKm(km: number): string {
  * length in kilometres.  Returns 0 when the H3 library is unavailable or the
  * cell list has fewer than 2 entries.
  */
-export function computeRouteLengthKm(orderedCells: H3Index[]): number {
+export function computeRouteLengthKm(orderedCells: string[]): number {
     if (orderedCells.length < 2 || !isAvailable()) return 0;
     let totalKm = 0;
     for (let i = 1; i < orderedCells.length; i++) {

--- a/apps/geonexia/frontend/helpers/TTSHelper.ts
+++ b/apps/geonexia/frontend/helpers/TTSHelper.ts
@@ -16,6 +16,8 @@ const SPEECH_RATE_MAP: Record<SpeechRate, number> = {
  * Convert a {@link SpeechRate} preset to the numeric rate value expected by
  * `expo-speech`.
  */
+const DEFAULT_KM_ANNOUNCEMENT_CONTENT: KmAnnouncementContent = { announcePace: true, announceSpeedKmh: false };
+
 export function speechRateToNumber(rate: SpeechRate): number {
 	return SPEECH_RATE_MAP[rate] ?? 1.0;
 }
@@ -79,7 +81,7 @@ export function buildKmAnnouncement(
 	km: number,
 	paceMinPerKm: number | null,
 	locale: string,
-	content: KmAnnouncementContent = { announcePace: true, announceSpeedKmh: false },
+	content: KmAnnouncementContent = DEFAULT_KM_ANNOUNCEMENT_CONTENT,
 ): string {
 	const langCode = locale.split('-')[0].toLowerCase();
 	const paceMin = paceMinPerKm != null ? Math.floor(paceMinPerKm) : null;

--- a/apps/geonexia/frontend/helpers/TTSStorage.ts
+++ b/apps/geonexia/frontend/helpers/TTSStorage.ts
@@ -1,14 +1,12 @@
 import { getStorageItem, setStorageItem } from 'repo-depkit-common-ui';
 
-export type TTSEnabled = boolean;
-
 const TTS_KEY = 'geonexia-tts.json';
 
 /**
  * Persist the TTS enabled flag to disk.
  * Silently ignores write errors to avoid crashing on storage failures.
  */
-export async function saveTTSEnabled(enabled: TTSEnabled): Promise<void> {
+export async function saveTTSEnabled(enabled: boolean): Promise<void> {
 	try {
 		await setStorageItem(TTS_KEY, JSON.stringify({ enabled }));
 	} catch (err) {
@@ -20,11 +18,11 @@ export async function saveTTSEnabled(enabled: TTSEnabled): Promise<void> {
  * Load the persisted TTS enabled flag from disk.
  * Returns true as the default when no file exists or on parse errors.
  */
-export async function loadTTSEnabled(): Promise<TTSEnabled> {
+export async function loadTTSEnabled(): Promise<boolean> {
 	try {
 		const raw = await getStorageItem(TTS_KEY);
 		if (raw === null) return true;
-		const parsed = JSON.parse(raw) as { enabled?: TTSEnabled };
+		const parsed = JSON.parse(raw) as { enabled?: boolean };
 		if (typeof parsed.enabled === 'boolean') return parsed.enabled;
 		return true;
 	} catch {

--- a/apps/geonexia/frontend/jest.resolver.js
+++ b/apps/geonexia/frontend/jest.resolver.js
@@ -12,7 +12,7 @@
 
 const rnResolver = require('react-native/jest/resolver.js');
 
-module.exports = (modulePath, options) => {
+function customJestResolver(modulePath, options) {
     const originalPackageFilter = options.packageFilter;
 
     return rnResolver(modulePath, {
@@ -25,4 +25,6 @@ module.exports = (modulePath, options) => {
             return filtered;
         },
     });
-};
+}
+
+module.exports = customJestResolver;

--- a/apps/score-tracker/frontend/app.config.ts
+++ b/apps/score-tracker/frontend/app.config.ts
@@ -12,7 +12,7 @@ require('ts-node').register({
 
 const { getBuildNumber } = require('./config.ts');
 
-module.exports = function ({ config }: ConfigContext): ExpoConfig {
+module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
 	return {
 		...config,

--- a/apps/score-tracker/run-maestro-web-test.sh
+++ b/apps/score-tracker/run-maestro-web-test.sh
@@ -39,6 +39,8 @@ for arg in "$@"; do
         --skip-generate)
             SKIP_GENERATE=true
             ;;
+        *)
+            ;;
     esac
 done
 

--- a/apps/score-tracker/scripts/generate-eas-config.ts
+++ b/apps/score-tracker/scripts/generate-eas-config.ts
@@ -72,4 +72,4 @@ function main() {
 	console.log(`EAS config generated at ${TARGET_FILE}`);
 }
 
-void main();
+main();

--- a/apps/scripts/generate-eas-config.ts
+++ b/apps/scripts/generate-eas-config.ts
@@ -95,4 +95,4 @@ function main() {
         console.log(`EAS config generated at ${TARGET_FILE} (customer: ${customer || 'default'})`);
 }
 
-void main();
+main();

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -273,6 +273,187 @@ nur `CustomMarkdown.tsx` (`TextContent`/`ImageContent`, als JSX-Tags gerendert
 — Bild-Ladefehler-State ist vorher bei jedem Re-Render von `CustomMarkdown`
 verloren gegangen) und `FeedbackSupport.tsx` (`IconSelector`).
 
+Am 2026-07-21 (dritte Runde desselben Tages) wurde ein breiter Schwung
+mechanischer Fixes über ~20 verschiedene, jeweils kleine (1-16x) Issue-Typen
+abgearbeitet (insgesamt ca. 75 Einzelfundstellen), da der häufigste
+verbleibende Typ „Cognitive Complexity" (109x) bewusst individuelle
+Refactorings statt mechanischer Fixes braucht (siehe oben) und daher nicht
+Teil dieser Runde war:
+
+- **Context-Provider-Werte in `useMemo`** (4x): `SettingsContext`,
+  `ThemeContext`, `ExpoUpdateChecker`, `ModalProvider` (`packages/common-ui`)
+  übergaben ein bei jedem Render neu erzeugtes Objekt an `Context.Provider`.
+  Bei `ModalProvider` wurden dazu zusätzlich `open`/`close`/
+  `openAndDiscardOthers`/`closeAll`/`handleSheetChange` und ihre internen
+  Helper (`clearCloseTimeout`, `notifyClosed`, `takePendingClosed`,
+  `finalizeConfirmedClose`) mit `useCallback` referenzstabil gemacht, da sie
+  nur auf Refs und stabile `setState`-Funktionen zugreifen (kein Zugriff auf
+  sich änderndes State/Props in der Closure) — rein additive Memoisierung,
+  keine Verhaltensänderung.
+- **Union-Type „von `string` überdeckt"** (5x): `foodoffers/hooks.ts`
+  (`sheet: 'menu' | 'sort' | string`) und `HousingHeader.tsx`
+  (`drawerPosition: 'left' | 'right' | 'system' | string`) — die
+  Literal-Member waren durch den bereits vorhandenen `string`-Typ ohnehin
+  nie eigenständig wirksam; auf den reinen `string`-Typ vereinfacht (keine
+  Laufzeitänderung).
+- **Doppelte Funktionsimplementierungen** (3x): `resourceHelper.tsx`
+  (`getFromCategoryTranslation`/`getFromCategoryTranslation`/
+  `getFoodAttributesTranslation` teilen sich jetzt eine private
+  `getNameFromTranslation`-Hilfsfunktion), `MyUnsupportedCardReader.ts`
+  (`isNfcEnabled` ruft jetzt `isNfcSupported()` auf statt den Body zu
+  duplizieren) und `packages/common/src/DateHelper.ts`
+  (`getDateInMinutes` ruft jetzt `addMinutes` auf).
+- **Anonyme Funktionen benannt** (3x): `module.exports = function (...)` in
+  allen drei `app.config.ts` (`frontend`, `geonexia`, `score-tracker`) zu
+  `function getExpoConfig(...)`.
+- **Redundante Type-Aliase entfernt** (3x): `TTSEnabled` (→ `boolean`),
+  `H3Index` (→ `string`, nur intern in `H3Helper.ts` verwendet) und
+  `MutationOptions` (→ `any`, Vorkommen und Imports in `FilesServiceHelper.ts`/
+  `ItemsServiceHelper.ts` mit aktualisiert).
+- **`switch` mit ≤2 Fällen durch `if` ersetzt** (3x): `forms-sync-hook/index.ts`
+  und `food-sync-hook/index.ts` (jeweils ein einzelner Case + leerer
+  `default`) sowie `form-submissions/index.tsx` (Case `'alphabetical'` und
+  `default` hatten identischen Fallthrough-Body — Switch komplett entfernt,
+  Sortierung läuft jetzt unbedingt, exakt gleiches Verhalten für alle
+  `option`-Werte).
+- **`Boolean`/`String`-Wrapper-Typen** (3x) durch `boolean`/`string` ersetzt:
+  `LabelHeader.tsx`, `Login/types.ts`, `SubmissionWarningModal/types.ts`.
+- **Union-Typen zu benannten Type-Aliasen extrahiert** (2 Meldungen, 3
+  Fundstellen): `ListGroupPosition` in `geonexia/app/index.tsx` (3
+  Vorkommen) und `ProfileField` in `FriendsContent/index.tsx` (3 Vorkommen).
+- **Fehlender `default`-Case in Shell-Scripts** (2x): beide
+  `run-maestro-web-test.sh` (`frontend`, `score-tracker`) bekamen einen
+  expliziten `*) ;;`-Case in der Flag-Parsing-`case`.
+- **Doppelte Zeichen in Regex-Zeichenklasse** (2x): `[\r\n\t\x00-\x1f]` in
+  `DirectusDatabaseSync.ts` und `importSchema.js` — `\r`/`\n`/`\t` sind
+  bereits Teil von `\x00-\x1f`; zu `[\x00-\x1f]` vereinfacht.
+- **Überflüssiger `void`-Operator** (2x): `void main();` in beiden
+  `generate-eas-config.ts` (`score-tracker`, `scripts`) — `main()` ist
+  synchron (kein Promise), `void` also ohne Zweck.
+- **Ungenutzte PropTypes/Props entfernt** (4x): `onDebugEvent` aus
+  `AvatarEditorModalContentProps` ausgenommen (`Omit<AvatarEditorBehaviorProps,
+  'onDebugEvent'>` — wird von `AvatarEditorModalContent` nirgends
+  konsumiert/weitergereicht, andere Komponenten mit `onDebugEvent` bleiben
+  unverändert), `accentColor` aus `SettingsListLeftRightProps` entfernt
+  (nirgends gelesen) und `closeSheet` aus `MyScrollViewModalProps` (beide
+  Varianten, `packages/common-ui` und `apps/frontend`) — die Komponente hat
+  `closeSheet` nie destrukturiert/verwendet. Da `closeSheet` an mehreren
+  Stellen dennoch an `<MyScrollViewModal>` durchgereicht wurde (totes
+  Prop-Drilling), mussten zusätzlich die Aufrufstellen angepasst werden:
+  beide `useMyScrollViewModal.tsx`-Hooks (`packages/common-ui` und
+  `apps/frontend`), `HoursSheet.tsx` (`HourSheet`) und `CalendarSheet.tsx` —
+  überall wurde nur der nie wirksame `closeSheet`-Prop entfernt, keine
+  Verhaltensänderung (per TypeScript-Diff gegen den Stand vor dieser Runde
+  verifiziert, siehe unten).
+- **`node:buffer`-Import bewusst NICHT geändert** (2x, `form-queue/index.tsx`,
+  `form-submission/index.tsx`, beide `apps/frontend`): Metro (React
+  Native/Expo) unterstützt das `node:`-URL-Schema für Kernmodul-Polyfills
+  nicht (im installierten `metro-resolver` gibt es keine entsprechende
+  Sonderbehandlung) — anders als bei den Node.js-ausgeführten Backend-Skripten
+  hätte das Bundle hier vermutlich mit „Unable to resolve module node:buffer"
+  gebrochen. Blieb bei `from 'buffer'`.
+- **Redundante Jump-Statements** (2x): `SettingsListMarkingLabel.tsx` und
+  `MarkingLabels.tsx` hatten je ein `if (isAnonymousUser) { ...; return; }
+  else { ... }` als letzte Anweisung der Funktion — das `return` wurde
+  entfernt (der `else`-Zweig wird dadurch weiterhin korrekt übersprungen,
+  keine Verhaltensänderung, da nichts nach dem `if/else` folgt).
+- **Object-Default-Stringifizierung** (6x): `form-submission/index.tsx`
+  (`normalizeExpectedValue`/`normalizeCurrentValue` nutzen jetzt
+  `JSON.stringify(...)` statt `String(...)` im Objekt-Fallback-Pfad) sowie
+  vier echte Logging-Stellen in `ParseSchedule.ts` und
+  `FormImportSyncWorkflow.ts`: `WorkflowResultHash.getHash()` gibt
+  `Record<string, unknown> | Array<unknown> | null` zurück (keinen String!)
+  — die String-Konkatenation `'... ' + hash.getHash()` produzierte in den
+  Logs tatsächlich `[object Object]` statt des Hash-Inhalts. Zu
+  `JSON.stringify(hash.getHash())` geändert — echte Verbesserung der
+  Log-Aussagekraft, keine Logik geändert.
+- **Leere Blöcke** (2x): `app/index.tsx` (`if (updated) {...} else {}` —
+  leeres `else` entfernt) und `HoursSheet.tsx` (`if (!timeRanges ...) {}
+  else { ... }` — Bedingung negiert (`if (timeRanges && timeRanges.length >
+  0) { ... }`), leerer Zweig entfernt).
+- **Dockerfile-RUN-Merges** (2x, `apps/backend/Dockerfile`): die beiden
+  `apk update`-RUNs (git, dann Puppeteer-Dependencies) zu einem RUN
+  zusammengeführt (dabei automatisch auch das separate „remove cache"-Finding
+  miterledigt, da der ganze Befehl jetzt `--no-cache` nutzt) sowie die drei
+  aufeinanderfolgenden `corepack`/`pnpm install`-RUNs zu einem RUN verkettet.
+  Zusätzlich die Paketliste alphanumerisch sortiert (weiteres Sonar-Finding)
+  und in `apps/backend/dockerDatabaseBackup/Dockerfile` das veraltete
+  `MAINTAINER`-Instruction durch `LABEL maintainer="..."` ersetzt.
+- **Regex-Vereinfachungen**: `[0-9]` → `\d` in `CourseBottomSheet.tsx` (2
+  Vorkommen in einer Zeile) und `hexId.charCodeAt(i)` →
+  `hexId.codePointAt(i) ?? 0` in `ActivityMapRebuildHelper.ts`.
+- **Ternary → `Math.max()`** (2x): `CourseTimetable.tsx`
+  (`offset > 0 ? offset : 0` → `Math.max(offset, 0)`) und
+  `ByteSizeHelper.ts` (`decimals < 0 ? 0 : decimals` →
+  `Math.max(decimals, 0)`).
+- **Interface-Namen an PascalCase angepasst** (2x): `sheetProps` →
+  `SheetProps` in `EditFormSubmissionSheet/types.ts` und
+  `SubmissionWarningSheet/types.ts` (inkl. aller Imports/Nutzungen).
+- **Promise-Chain → Top-Level-`await`**: `apps/backend/sync/importSchema.js`
+  ist ESM (`"type": "module"`, nutzt bereits `import`), Top-Level-`await` ist
+  also gültig — `mainPush()/mainPull().then(...).catch(console.error)` zu
+  `try { await ...; process.exit(0); } catch (error) { console.error(error);
+  }` geändert (identisches Verhalten: kein `process.exit` bei Fehlern, wie
+  zuvor bei `.catch`).
+- **Diverse Einzelfälle** (je 1x, ~20 Stück): u. a. `.slice(-2)` statt
+  `.slice(len-2, len)` in `hashHelper.ts`; `.some(...)` statt
+  `.filter(...).length > 0` in `achievements/index.tsx`; benannte
+  Jest-Resolver-Funktion statt anonymer Arrow in `jest.resolver.js`;
+  gehoistete `DEFAULT_KM_ANNOUNCEMENT_CONTENT`-Konstante statt
+  Objekt-Literal als Parameter-Default in `TTSHelper.ts`; `return value`
+  statt `return Promise.resolve(value)` in `MaxManagerConnector.ts`
+  (Funktion ist bereits `async`); unnötig umbenanntes Destructuring
+  (`updateObject: updateObject`) in `TranslationHelper.ts`; Default- statt
+  Named-Import für `puppeteer-core` in `PuppeteerGenerator.ts`
+  (`esModuleInterop` ist im Workspace aktiv); `let headersObject;` statt
+  `= undefined` in `importSchema.js`; leere `MyMapHelper`-Klasse entfernt
+  (nirgends als Wert importiert, nur der Dateiname für Typ-Imports
+  gebraucht); `link.remove()` statt `document.body.removeChild(link)` in
+  `image-full-screen/index.tsx`; zusammengelegte `ON_LOGIN`/`UPDATE_LOGIN`
+  Switch-Cases in `authReducer.ts` (identischer Body); unnötiges
+  Objekt-Spread-in-Objekt-Literal in `WorkflowRunJobInterface.ts`;
+  `for _ in range(...)` statt ungenutztem `level` in
+  `getBase64IconForMail.py`; redundante `data &&`-Prüfung entfernt in
+  `form-submission/index.tsx` (durch äußeres `if (data)` bereits garantiert);
+  einzelnes `if` im `else`-Block zu `else if`-Kette abgeflacht in
+  `HoursSheet.tsx`; `!(x > 0)` zu `(x ?? 0) <= 0` in
+  `ApartmentDetailsContent.tsx` (statt naivem `x <= 0`, da `x` über
+  Optional-Chaining `undefined` sein kann und `undefined <= 0` anders als
+  `!(undefined > 0)` auswertet — mit `?? 0` bleibt das Verhalten für den
+  `undefined`-Fall identisch).
+- **Echter Bug gefunden und mitgefixt**: `locales/keys.ts` —
+  `MayShort = 'May'` zeigte auf den Übersetzungs-Eintrag der ausgeschriebenen
+  „May"-Übersetzung statt auf den eigenständigen, bereits in
+  `translations.json` vorhandenen `"MayShort"`-Eintrag (der z. B. für
+  Arabisch/Spanisch/Chinesisch andere Werte als „May" hat). Der Kalender
+  (`CalendarSheet.tsx`, `monthNamesShort`) zeigte dadurch für den
+  abgekürzten Mai-Monatsnamen in diesen Sprachen fälschlich die
+  ausgeschriebene Übersetzung. Zu `MayShort = 'MayShort'` korrigiert.
+- **Bewusst nicht geändert:**
+  - `Object.prototype.hasOwnProperty.call(...)` in `packages/common/src/DateHelper.ts`
+    (→ `Object.hasOwn()`, ES2022): `DateHelper` wird auch vom
+    Backend-Extension-Workspace importiert, der `target`/`lib: ["ES2019"]`
+    nutzt — gleiche Kategorie Risiko wie das bereits dokumentierte
+    `toSorted()`-Skip oben.
+  - `JSON.parse(JSON.stringify(lottieJSON))` in `animationHelper.ts`
+    (→ `structuredClone(...)`): Laufzeitunterstützung in Hermes/React
+    Native über alle unterstützten Versionen hinweg nicht sicher verifizierbar
+    in dieser Session; Risiko eines Laufzeitfehlers (`structuredClone is not
+    defined`) höher bewertet als der Lint-Gewinn.
+  - `Cognitive Complexity` (weiterhin 109x) und das 51-Case-`switch` in
+    `settingsReducer.ts` (Meldung „Reduce non-empty switch cases from 51 to
+    30") bleiben für eigene, gezielte Refactoring-Runden vorgemerkt.
+
+Verifiziert per `tsc --noEmit` (Baseline vor dieser Runde vs. danach,
+`git stash`/`git stash pop`) für alle betroffenen Workspaces (`apps/frontend/app`,
+`apps/geonexia/frontend`, `apps/score-tracker/frontend`, `apps/backend-sync`,
+`apps/scripts`) sowie `yarn typecheck` für die Backend-Extension: keine neuen
+Fehler, nur Zeilennummern-Verschiebungen bei vorbestehenden (unabhängigen)
+Fehlern. Dabei zwei durch die `closeSheet`-Prop-Entfernung verursachte
+Compile-Fehler gefunden und behoben (Aufrufstellen in `HoursSheet.tsx` und
+`CalendarSheet.tsx`, die `closeSheet` noch direkt an `<MyScrollViewModal>`
+übergeben hatten).
+
 ## Hinweise
 
 - Die CSV-Reports werden per CI aktualisiert (Commits `chore: update sonarcloud reports`).

--- a/packages/common-ui/src/components/GlobalModal/ModalProvider.tsx
+++ b/packages/common-ui/src/components/GlobalModal/ModalProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useState, ReactNode, useRef, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState, ReactNode, useRef, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import BaseBottomSheet from '../BaseBottomSheet';
 import { useTheme } from '../../context/ThemeContext';
@@ -106,14 +106,14 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 		closeInvocations: 0,
 	});
 
-	const clearCloseTimeout = () => {
+	const clearCloseTimeout = useCallback(() => {
 		if (closeTimeoutRef.current) {
 			clearTimeout(closeTimeoutRef.current);
 			closeTimeoutRef.current = null;
 		}
-	};
+	}, []);
 
-	const notifyClosed = (items: ModalStackItem[], reason: ModalCloseReason) => {
+	const notifyClosed = useCallback((items: ModalStackItem[], reason: ModalCloseReason) => {
 		for (const item of items) {
 			try {
 				item.onClosed?.(reason);
@@ -121,26 +121,26 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 				// A consumer's onClosed callback must never break the modal stack itself.
 			}
 		}
-	};
+	}, []);
 
-	const takePendingClosed = (): ModalStackItem[] => {
+	const takePendingClosed = useCallback((): ModalStackItem[] => {
 		const items = pendingClosedRef.current;
 		pendingClosedRef.current = [];
 		return items;
-	};
+	}, []);
 
 	// The single place a confirmed close is finalized: unmount the sheet's content and
 	// only THEN notify the closed items, so an onClosed callback that opens the next
 	// modal (e.g. the popup-event queue) always starts from a settled, empty sheet.
-	const finalizeConfirmedClose = () => {
+	const finalizeConfirmedClose = useCallback(() => {
 		isClosingRef.current = false;
 		setIsSheetClosing(false);
 		clearCloseTimeout();
 		setModalStack([]);
 		notifyClosed(takePendingClosed(), 'closed');
-	};
+	}, [clearCloseTimeout, notifyClosed, takePendingClosed]);
 
-	const open = (c: ReactNode, options?: ModalOptions) => {
+	const open = useCallback((c: ReactNode, options?: ModalOptions) => {
 		const supersededClose = isClosingRef.current;
 		clearCloseTimeout();
 		isClosingRef.current = false;
@@ -173,9 +173,9 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 			sheetRefReady: Boolean(sheetRef.current),
 			openInvocations: prev.openInvocations + 1,
 		}));
-	};
+	}, [clearCloseTimeout, notifyClosed, takePendingClosed]);
 
-	const openAndDiscardOthers = (c: ReactNode, options?: ModalOptions) => {
+	const openAndDiscardOthers = useCallback((c: ReactNode, options?: ModalOptions) => {
 		clearCloseTimeout();
 		isClosingRef.current = false;
 		setIsSheetClosing(false);
@@ -205,9 +205,9 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 			sheetRefReady: Boolean(sheetRef.current),
 			openInvocations: prev.openInvocations + 1,
 		}));
-	};
+	}, [clearCloseTimeout, notifyClosed, takePendingClosed]);
 
-	const closeAll = () => {
+	const closeAll = useCallback(() => {
 		if (modalStackRef.current.length === 0) return;
 		if (isClosingRef.current) return;
 
@@ -239,9 +239,9 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 			sheetRefReady: Boolean(sheetRef.current),
 			closeInvocations: prev.closeInvocations + 1,
 		}));
-	};
+	}, [clearCloseTimeout, notifyClosed, finalizeConfirmedClose]);
 
-	const close = () => {
+	const close = useCallback(() => {
 		if (modalStackRef.current.length === 0) return;
 		if (isClosingRef.current) return;
 
@@ -283,7 +283,7 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 			sheetRefReady: Boolean(sheetRef.current),
 			closeInvocations: prev.closeInvocations + 1,
 		}));
-	};
+	}, [clearCloseTimeout, notifyClosed, finalizeConfirmedClose]);
 
 	// Desired dismiss behaviour (see BaseBottomSheetProps for the matching prop docs): a
 	// backdrop tap or a swipe-down-to-close gesture is a "get me out of here" gesture from
@@ -327,7 +327,7 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 				sheetRef.current?.expand?.();
 			}
 		}
-	}, []);
+	}, [clearCloseTimeout, notifyClosed, takePendingClosed, finalizeConfirmedClose]);
 
 	const ensureExpand = () => {
 		let tries = 0;
@@ -373,16 +373,22 @@ export const ModalContextProvider: React.FC<{ children: ReactNode }> = ({ childr
 	const currentItem = modalStack[modalStack.length - 1] ?? null;
 	const screenBackgroundColor = currentItem?.headerBackgroundColor || theme.screen.background;
 
+	const contextValue = useMemo<ModalContextType>(() => ({
+		open, close, openAndDiscardOthers, closeAll, debug,
+		_currentItem: currentItem,
+		_sheetRef: sheetRef,
+		_handleSheetChange: handleSheetChange,
+		_screenBackgroundColor: screenBackgroundColor,
+		_stackDepth: modalStack.length,
+		_isSheetClosing: isSheetClosing,
+	}), [
+		open, close, openAndDiscardOthers, closeAll, debug,
+		currentItem, handleSheetChange, screenBackgroundColor,
+		modalStack.length, isSheetClosing,
+	]);
+
 	return (
-		<ModalContext.Provider value={{
-			open, close, openAndDiscardOthers, closeAll, debug,
-			_currentItem: currentItem,
-			_sheetRef: sheetRef,
-			_handleSheetChange: handleSheetChange,
-			_screenBackgroundColor: screenBackgroundColor,
-			_stackDepth: modalStack.length,
-			_isSheetClosing: isSheetClosing,
-		}}>
+		<ModalContext.Provider value={contextValue}>
 			{children}
 		</ModalContext.Provider>
 	);

--- a/packages/common-ui/src/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/packages/common-ui/src/components/GlobalModal/useMyScrollViewModal.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '../MyScrollViewModal';
 import { useModal } from './useModal';
 
-export type MyScrollViewModalConfig = Omit<MyScrollViewModalProps, 'closeSheet'> & { children?: ReactNode };
+export type MyScrollViewModalConfig = MyScrollViewModalProps & { children?: ReactNode };
 
 type ScrollViewModalOptions = { backgroundStyle?: any; headerBackgroundColor?: string };
 
@@ -26,7 +26,7 @@ export const useMyScrollViewModal = () => {
 		};
 
 		const element = (
-			<MyScrollViewModal closeSheet={close} backgroundColor={backgroundColor} {...restProps}>
+			<MyScrollViewModal backgroundColor={backgroundColor} {...restProps}>
 				{children}
 			</MyScrollViewModal>
 		);

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -691,7 +691,7 @@ type AvatarEditorBehaviorProps = {
 };
 
 type AvatarEditorModalContentProps = AvatarPreviewAppearanceProps &
-	AvatarEditorBehaviorProps & {
+	Omit<AvatarEditorBehaviorProps, 'onDebugEvent'> & {
 		initialConfig: AvatarConfig;
 		configObservable: ConfigObservable;
 		configRef: React.MutableRefObject<AvatarConfig>;

--- a/packages/common-ui/src/components/MyScrollViewModal/index.tsx
+++ b/packages/common-ui/src/components/MyScrollViewModal/index.tsx
@@ -8,7 +8,6 @@ import type { ScrollViewModalContentProps } from './types';
 export type { ScrollViewModalContentProps } from './types';
 
 export interface MyScrollViewModalProps extends ScrollViewModalContentProps {
-	closeSheet?: () => void;
 	renderItem?: (info: { item: any; index: number }) => ReactNode;
 	keyExtractor?: (item: any, index: number) => string;
 	onClose?: () => void;

--- a/packages/common-ui/src/components/SettingsListLeftRight/SettingsListLeftRight.tsx
+++ b/packages/common-ui/src/components/SettingsListLeftRight/SettingsListLeftRight.tsx
@@ -19,7 +19,6 @@ export type SettingsListLeftRightProps<T extends string | number> = Pick<
 	selectedOption: T | null;
 	onSelect: (option: SettingsListLeftRightItem<T>) => void;
 	groupPosition?: SettingsListProps['groupPosition'];
-	accentColor?: string;
 	onPress?: () => void;
 	/** Optional element rendered between the value text and the right arrow. */
 	extraRightElement?: React.ReactNode;

--- a/packages/common-ui/src/context/SettingsContext.tsx
+++ b/packages/common-ui/src/context/SettingsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext } from 'react';
+import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 
 export type SettingsContextType = {
 	primaryColor: string;
@@ -13,11 +13,17 @@ type SettingsProviderProps = {
 	children: ReactNode;
 };
 
-export const SettingsProvider = ({ primaryColor, onAccountRequired, children }: SettingsProviderProps) => (
-	<SettingsContext.Provider value={{ primaryColor, onAccountRequired }}>
-		{children}
-	</SettingsContext.Provider>
-);
+export const SettingsProvider = ({ primaryColor, onAccountRequired, children }: SettingsProviderProps) => {
+	const value = useMemo(
+		() => ({ primaryColor, onAccountRequired }),
+		[primaryColor, onAccountRequired]
+	);
+	return (
+		<SettingsContext.Provider value={value}>
+			{children}
+		</SettingsContext.Provider>
+	);
+};
 
 export const useSettingsContext = (): SettingsContextType | undefined => {
 	return useContext(SettingsContext);

--- a/packages/common-ui/src/context/ThemeContext.tsx
+++ b/packages/common-ui/src/context/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Appearance } from 'react-native';
 import { darkTheme, lightTheme, Theme } from '../themes';
 
@@ -24,10 +24,10 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
 	const [theme, setTheme] = useState<Theme>(() => resolveTheme('systematic'));
 
-	const setThemeMode = (newMode: ThemeMode) => {
+	const setThemeMode = useCallback((newMode: ThemeMode) => {
 		setMode(newMode);
 		setTheme(resolveTheme(newMode));
-	};
+	}, []);
 
 	useEffect(() => {
 		setTheme(resolveTheme(mode));
@@ -46,8 +46,13 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
 	const isDark = theme === darkTheme;
 
+	const value = useMemo(
+		() => ({ theme, isDark, setThemeMode }),
+		[theme, isDark, setThemeMode]
+	);
+
 	return (
-		<ThemeContext.Provider value={{ theme, isDark, setThemeMode }}>
+		<ThemeContext.Provider value={value}>
 			{children}
 		</ThemeContext.Provider>
 	);

--- a/packages/common/src/DateHelper.ts
+++ b/packages/common/src/DateHelper.ts
@@ -496,9 +496,7 @@ export class DateHelper {
   }
 
   static getDateInMinutes(date: Date, minutes: number) {
-    const tempDate = new Date(date);
-    tempDate.setMinutes(tempDate.getMinutes() + minutes);
-    return tempDate;
+    return DateHelper.addMinutes(date, minutes);
   }
 
   static getCurrentDateInMinutes(minutes: number) {


### PR DESCRIPTION
## Summary

Continues the SonarCloud maintainability workflow (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`). The most frequent remaining issue type, "Cognitive Complexity" (109x), needs individual refactoring rather than mechanical fixes, so this PR instead clears ~20 smaller issue types end-to-end (~75 individual findings):

- Context-provider values wrapped in `useMemo` (4x) — `SettingsContext`, `ThemeContext`, `ExpoUpdateChecker`, `ModalProvider`
- Union types "overridden by string" simplified (5x)
- Duplicate function implementations deduplicated (3x)
- Anonymous `app.config.ts` functions named (3x)
- Redundant type aliases removed (3x): `TTSEnabled`, `H3Index`, `MutationOptions`
- Single-case/no-op `switch` replaced with `if` (3x)
- `Boolean`/`String` wrapper types → `boolean`/`string` (3x)
- Union types extracted into named type aliases (2 findings, 3 sites)
- Missing shell `default` case added (2x)
- Duplicate regex character-class entries removed (2x)
- Redundant `void` operator removed (2x)
- Unused PropTypes/props removed (4x) — including a dead `closeSheet` prop on `MyScrollViewModal` (see below)
- Redundant jump statements removed (2x)
- Object default stringification fixed (6x) — including a real logging bug (see below)
- Empty blocks removed (2x)
- Dockerfile `RUN` instructions merged + packages sorted + deprecated `MAINTAINER` → `LABEL` (3 findings)
- Regex/ternary simplifications (4x): `\d`, `codePointAt`, `Math.max()`
- `sheetProps` → `SheetProps` interface renames (2x)
- A promise chain converted to top-level `await` (the script is ESM)
- ~20 further single-occurrence mechanical fixes

**Real bugs found and fixed along the way:**
- `TranslationKeys.MayShort` pointed at the `"May"` translation entry instead of its own `"MayShort"` entry (which already exists in `translations.json` with different abbreviated values per locale) — the calendar's short month name was showing the wrong translation in several languages.
- `WorkflowResultHash.getHash()` returns an object, not a string — string-concatenating it into log messages produced `[object Object]` instead of the actual hash content in four log lines across `ParseSchedule.ts`/`FormImportSyncWorkflow.ts`.

**Intentionally left unchanged (documented in the workflow doc):**
- `node:buffer` imports in two frontend files — Metro (Expo/React Native) doesn't resolve the `node:` URL scheme, unlike the Node-executed backend scripts.
- `Object.hasOwn()` in `packages/common/src/DateHelper.ts` and `structuredClone()` in `animationHelper.ts` — both are newer APIs whose support in the ES2019-targeted backend workspace / Hermes runtime couldn't be confidently verified in this session.
- "Cognitive Complexity" (109x) and a 51-case `switch` in `settingsReducer.ts` remain for dedicated refactoring rounds.

The `closeSheet` prop removal from `MyScrollViewModal` required also cleaning up dead pass-through at its call sites (`useMyScrollViewModal.tsx` in both `packages/common-ui` and `apps/frontend`, `HoursSheet.tsx`, `CalendarSheet.tsx`) — the prop was never consumed by the component itself, so this is behavior-neutral.

## Test plan

- [x] `tsc --noEmit` diffed against a pre-change baseline (via `git stash`/`git stash pop`) for every touched TypeScript workspace (`apps/frontend/app`, `apps/geonexia/frontend`, `apps/score-tracker/frontend`, `apps/backend-sync`, `apps/scripts`) — identical error sets before/after (only line-number shifts from unrelated pre-existing errors), no new errors introduced.
- [x] `yarn typecheck` in the backend Directus extension workspace — passes cleanly.
- [x] `python3 -m py_compile` on the touched Python script.
- [x] Manually traced the `closeSheet` prop-removal through every JSX call site to confirm no compile regressions and no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8nPEpiY5F44DxJ7ySnMsk)_