### PR TITLE
fix(sonar): move-to-outer-scope, param-count, and first Cognitive Complexity batch

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -938,7 +938,17 @@ export class ParseSchedule {
     };
   }
 
-  getFoodofferToCreate(foodofferForParser: FoodoffersTypeForParser, canteen: DatabaseTypes.Canteens, markings: DatabaseTypes.Markings[], food: DatabaseTypes.Foods, foodofferCategory: DatabaseTypes.FoodoffersCategories | undefined, helperObject: FoodCreationHelperObject, dictMarkingExternalIdentifierToMarking: Record<string, DatabaseTypes.Markings | null>, resultHash: string) {
+  getFoodofferToCreate(params: {
+    foodofferForParser: FoodoffersTypeForParser,
+    canteen: DatabaseTypes.Canteens,
+    markings: DatabaseTypes.Markings[],
+    food: DatabaseTypes.Foods,
+    foodofferCategory: DatabaseTypes.FoodoffersCategories | undefined,
+    helperObject: FoodCreationHelperObject,
+    dictMarkingExternalIdentifierToMarking: Record<string, DatabaseTypes.Markings | null>,
+    resultHash: string,
+  }) {
+    const { foodofferForParser, canteen, markings, food, foodofferCategory, helperObject, dictMarkingExternalIdentifierToMarking, resultHash } = params;
     let food_id = foodofferForParser.food_id;
     const basicFoodofferData = foodofferForParser.basicFoodofferData;
 
@@ -1082,7 +1092,7 @@ export class ParseSchedule {
       if (canteenFound && foodFound && !foodIsArchived) {
         const filteredMarkings = MarkingFilterHelper.filterMarkingByRestrictionRules(markings, helperObject.dictMarkingsExclusions);
         const resultHash = FoodParserHelper.getFoodofferHashFromFoodofferInformationForParser(foodofferForParser);
-        let foodOfferToCreate = this.getFoodofferToCreate(foodofferForParser, canteen, filteredMarkings, food, foodofferCategory, helperObject, dictMarkingExternalIdentifierToMarking, resultHash);
+        let foodOfferToCreate = this.getFoodofferToCreate({ foodofferForParser, canteen, markings: filteredMarkings, food, foodofferCategory, helperObject, dictMarkingExternalIdentifierToMarking, resultHash });
         foodoffersToCreate.push(foodOfferToCreate);
       } else if (foodIsArchived) {
         await this.context.logger.appendLog('Skip Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - food has status archived - food_id: ' + food_id);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/GooglePlayHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/GooglePlayHelper.ts
@@ -103,6 +103,35 @@ export class GooglePlayHelper {
    * Returns all reviews (paginated automatically).
    * Note: The Google Play Developer API only returns reviews from approximately the last 7 days.
    */
+  private static async fetchReviewsPage(packageName: string, accessToken: string, nextPageToken: string | undefined, logger?: { info: (msg: string) => void }): Promise<GooglePlayReviewsResponse> {
+    const url = new URL(`https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${packageName}/reviews`);
+    url.searchParams.set('maxResults', '100');
+    if (nextPageToken) {
+      url.searchParams.set('token', nextPageToken);
+    }
+
+    const response = await FetchHelper.fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const responseText = await response.text();
+    let data: GooglePlayReviewsResponse;
+    try {
+      data = JSON.parse(responseText) as GooglePlayReviewsResponse;
+    } catch (e) {
+      throw new Error(`Google Play API returned invalid JSON for package ${packageName}: ${responseText.substring(0, 500)}${responseText.length > 500 ? '... (truncated)' : ''}`);
+    }
+
+    if (logger && !data.reviews) {
+      logger.info('GooglePlayHelper: API response has no reviews field. Response keys: ' + Object.keys(data).join(', '));
+    }
+
+    return data;
+  }
+
   static async fetchAllReviews(packageName: string, serviceAccountKeyJson: string, logger?: { info: (msg: string) => void }): Promise<GooglePlayReview[]> {
     const serviceAccountKey = GooglePlayHelper.parseServiceAccountKey(serviceAccountKeyJson);
     const accessToken = await GooglePlayHelper.getAccessToken(serviceAccountKey);
@@ -111,30 +140,7 @@ export class GooglePlayHelper {
     let nextPageToken: string | undefined = undefined;
 
     while (true) {
-      const url = new URL(`https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${packageName}/reviews`);
-      url.searchParams.set('maxResults', '100');
-      if (nextPageToken) {
-        url.searchParams.set('token', nextPageToken);
-      }
-
-      const response = await FetchHelper.fetch(url.toString(), {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      const responseText = await response.text();
-      let data: GooglePlayReviewsResponse;
-      try {
-        data = JSON.parse(responseText) as GooglePlayReviewsResponse;
-      } catch (e) {
-        throw new Error(`Google Play API returned invalid JSON for package ${packageName}: ${responseText.substring(0, 500)}${responseText.length > 500 ? '... (truncated)' : ''}`);
-      }
-
-      if (logger && !data.reviews) {
-        logger.info('GooglePlayHelper: API response has no reviews field. Response keys: ' + Object.keys(data).join(', '));
-      }
+      const data = await GooglePlayHelper.fetchReviewsPage(packageName, accessToken, nextPageToken, logger);
 
       if (data.reviews && data.reviews.length > 0) {
         allReviews.push(...data.reviews);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/mails-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/mails-hook/index.ts
@@ -35,17 +35,17 @@ export type EmailDownloadLink = {
   url: string;
 };
 
-export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async ({ schedule, action, filter }, apiContext) => {
+function getTodayRangeIso(): { startOfDayIso: string; startOfNextDayIso: string } {
+  const now = new Date();
+  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfNextDay = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  return {
+    startOfDayIso: startOfDay.toISOString(),
+    startOfNextDayIso: startOfNextDay.toISOString(),
+  };
+}
 
-  function getTodayRangeIso(): { startOfDayIso: string; startOfNextDayIso: string } {
-    const now = new Date();
-    const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const startOfNextDay = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-    return {
-      startOfDayIso: startOfDay.toISOString(),
-      startOfNextDayIso: startOfNextDay.toISOString(),
-    };
-  }
+export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async ({ schedule, action, filter }, apiContext) => {
 
   async function sendMail(options: EmailOptions) {
     let { MailService } = apiContext.services;

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/push-notification-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/push-notification-hook/index.ts
@@ -25,6 +25,37 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
     return input;
   });
 
+  // Merge the updated fields into the current item for a single key, and send the
+  // notification if the merged item is now published. Returns the (possibly updated) input.
+  async function mergeUpdateAndNotifyIfPublished(itemService: ReturnType<typeof myDatabaseHelper.getPushNotificationsHelper>, currentItemId: any, input: Partial<DatabaseTypes.PushNotifications>) {
+    const currentItems = await itemService.readByQuery({
+      filter: { id: currentItemId },
+    });
+
+    if (!currentItems || currentItems.length === 0) {
+      throw new Error(`Item with ID ${currentItemId} not found`);
+    }
+
+    const currentItem = currentItems[0];
+    if (!currentItem) {
+      return input;
+    }
+
+    // Selectively merge the current item with the updated fields
+    for (const key in input) {
+      // @ts-ignore - we want to copy the value from input to currentItem
+      if (input[key] !== undefined) {
+        // @ts-ignore - we want to copy the value from input to currentItem
+        currentItem[key] = input[key];
+      }
+    }
+    if (ItemsServiceHelper.isStatusPublished(currentItem)) {
+      await sendNotification(currentItem, input);
+      return ItemsServiceHelper.setStatusPublished(input);
+    }
+    return input;
+  }
+
   filter<Partial<DatabaseTypes.PushNotifications>>(collectionName + '.items.update', async (input: Partial<DatabaseTypes.PushNotifications>, { keys, collection }) => {
     let itemService = myDatabaseHelper.getPushNotificationsHelper();
 
@@ -35,30 +66,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
 
     for (const key of keys) {
       const currentItemId = key; // Assuming only one item is being updated
-      const currentItems = await itemService.readByQuery({
-        filter: { id: currentItemId },
-      });
-
-      if (!currentItems || currentItems.length === 0) {
-        throw new Error(`Item with ID ${currentItemId} not found`);
-      }
-
-      const currentItem = currentItems[0];
-
-      // Selectively merge the current item with the updated fields
-      if (currentItem) {
-        for (const key in input) {
-          // @ts-ignore - we want to copy the value from input to currentItem
-          if (input[key] !== undefined) {
-            // @ts-ignore - we want to copy the value from input to currentItem
-            currentItem[key] = input[key];
-          }
-        }
-        if (ItemsServiceHelper.isStatusPublished(currentItem)) {
-          await sendNotification(currentItem, input);
-          input = ItemsServiceHelper.setStatusPublished(input);
-        }
-      }
+      input = await mergeUpdateAndNotifyIfPublished(itemService, currentItemId, input);
     }
 
     return input;

--- a/apps/frontend/app/app/(app)/map/index.tsx
+++ b/apps/frontend/app/app/(app)/map/index.tsx
@@ -628,7 +628,7 @@ function getFirstOrganisationFromDict(
 	return orgs && orgs.length > 0 ? orgs[0] : null;
 }
 
-function createBuildingMarkerSvg(
+function createBuildingMarkerSvg(params: {
 	externalIdentifier?: string | null,
 	markerColor?: string | null,
 	markerLabel?: string | null,
@@ -639,7 +639,19 @@ function createBuildingMarkerSvg(
 	fallbackLabelColor?: string | null,
 	alias?: string | null,
 	showLabel?: boolean,
-): string {
+}): string {
+	const {
+		externalIdentifier,
+		markerColor,
+		markerLabel,
+		markerLabelColor,
+		orgMarkerColor,
+		orgMarkerLabelColor,
+		fallbackColor,
+		fallbackLabelColor,
+		alias,
+		showLabel,
+	} = params;
 	const size = BUILDING_MARKER_SIZE;
 	const cx = size / 2;
 	const cy = size / 2;
@@ -950,18 +962,18 @@ const OsmVectorMapScreen: React.FC = () => {
 				return {
 					id: `building-${building.id}`,
 					position: { lat: Number(lat), lng: Number(lng) },
-					icon: createBuildingMarkerSvg(
-						building.external_identifier,
-						building.map_marker_color,
-						building.map_marker_label,
-						building.map_marker_label_color,
-						firstOrg?.map_marker_color ?? null,
-						firstOrg?.map_marker_label_color ?? null,
-						primaryColor,
-						primaryColorContrastColor,
-						building.alias,
-						showMarkerLabels,
-					),
+					icon: createBuildingMarkerSvg({
+						externalIdentifier: building.external_identifier,
+						markerColor: building.map_marker_color,
+						markerLabel: building.map_marker_label,
+						markerLabelColor: building.map_marker_label_color,
+						orgMarkerColor: firstOrg?.map_marker_color ?? null,
+						orgMarkerLabelColor: firstOrg?.map_marker_label_color ?? null,
+						fallbackColor: primaryColor,
+						fallbackLabelColor: primaryColorContrastColor,
+						alias: building.alias,
+						showLabel: showMarkerLabels,
+					}),
 					size: [BUILDING_MARKER_SIZE, BUILDING_MARKER_SIZE] as [number, number],
 					iconAnchor: [BUILDING_MARKER_SIZE / 2, BUILDING_MARKER_SIZE / 2] as [number, number],
 				};

--- a/apps/frontend/app/components/BuildingDetailsContent/BuildingDetailsContent.tsx
+++ b/apps/frontend/app/components/BuildingDetailsContent/BuildingDetailsContent.tsx
@@ -50,7 +50,12 @@ const BuildingDetailsContent: React.FC<BuildingDetailsContentProps> = ({ id }) =
 
     const organisationsDict = useMemo(
         () => organisations.reduce<Record<string, DatabaseTypes.Organizations>>(
-            (acc, org) => { if (org.id) acc[org.id] = org; return acc; },
+            (acc, org) => {
+                if (org.id) {
+                    acc[org.id] = org;
+                }
+                return acc;
+            },
             {}
         ),
         [organisations]

--- a/apps/frontend/app/components/Details/AttributeItem.tsx
+++ b/apps/frontend/app/components/Details/AttributeItem.tsx
@@ -15,6 +15,27 @@ interface AttributeItemProps {
 	groupPosition: GroupPosition;
 }
 
+/** Resolve the displayed value from a number/string attribute value, with prefix/suffix applied. */
+function resolveAttributeValue(attr: any, prefix: string, suffix: string): string | undefined {
+	let value: string | undefined;
+	if (attr?.number_value !== null && attr?.number_value !== undefined) {
+		value = formatFoodInformationValue(attr?.number_value, suffix) ?? undefined;
+	} else if (attr?.string_value) {
+		value = `${attr?.string_value}${suffix}`;
+	}
+	if (prefix && value) {
+		value = `${prefix} ${value}`;
+	}
+	return value;
+}
+
+/** Parse a `library:name` icon key (as used for `icon_expo`/`icon_value`) into its icon component and name. */
+function resolveIconFromKey(iconKey: string | undefined): { Icon: any; name: string | undefined } {
+	const [library, name] = iconKey?.split(':') || [];
+	const Icon = library && iconLibraries[library];
+	return { Icon, name };
+}
+
 const AttributeItem: React.FC<AttributeItemProps> = ({ attr, groupPosition }) => {
 	const { theme } = useTheme();
 	const { language, selectedTheme: mode } = useAppSelector((state) => state.settings);
@@ -26,31 +47,18 @@ const AttributeItem: React.FC<AttributeItemProps> = ({ attr, groupPosition }) =>
 	const label = attr?.food_attribute?.translations ? getFoodAttributesTranslation(attr?.food_attribute?.translations, language) : '';
 	const iconColor = useMyContrastColor(backgroundColor, theme, mode === 'dark');
 
-	let value: string | undefined;
-	if (attr?.number_value !== null && attr?.number_value !== undefined) {
-		value = formatFoodInformationValue(attr?.number_value, suffix) ?? undefined;
-	} else if (attr?.string_value) {
-		value = `${attr?.string_value}${suffix}`;
-	}
-
-	if (prefix && value) {
-		value = `${prefix} ${value}`;
-	}
+	const value = resolveAttributeValue(attr, prefix, suffix);
 
 	if (!(label || value) || status !== 'published') {
 		return null;
 	}
 
-	const iconParts = attr?.food_attribute?.icon_expo?.split(':') || [];
-	const [library, name] = iconParts;
-	const Icon = library && iconLibraries[library];
+	const { Icon, name } = resolveIconFromKey(attr?.food_attribute?.icon_expo);
 
 	const imageUri = attr?.food_attribute?.image_remote_url || getImageUrl(attr?.food_attribute?.image);
 	const imageSource = imageUri ? { uri: imageUri } : null;
 
-	const attributeIconParts = attr?.icon_value?.split(':') || [];
-	const [attributeIconLibrary, attributeIconName] = attributeIconParts;
-	const AttributeIcon = attributeIconLibrary && iconLibraries[attributeIconLibrary];
+	const { Icon: AttributeIcon, name: attributeIconName } = resolveIconFromKey(attr?.icon_value);
 	const attributeIconColor = attr?.color_value || theme.screen.text;
 
 	const leftIconComponent =

--- a/apps/frontend/app/components/ServerStatusLoader/ServerStatusLoader.tsx
+++ b/apps/frontend/app/components/ServerStatusLoader/ServerStatusLoader.tsx
@@ -9,19 +9,19 @@ export interface ServerStatusFlowLoaderProps {
 	children?: React.ReactNode;
 }
 
+async function loadServerInfo(): Promise<ServerInfo | null> {
+	try {
+		const result = await ServerAPI.downloadServerInfo();
+		return result;
+	} catch (error) {
+		console.error('Failed to fetch server info:', error);
+		return null;
+	}
+}
+
 export const ServerStatusLoader: React.FC<ServerStatusFlowLoaderProps> = ({ children }) => {
 	const dispatch = useDispatch();
 	const { primaryColor } = useAppSelector(state => state.settings);
-
-	async function loadServerInfo(): Promise<ServerInfo | null> {
-		try {
-			const result = await ServerAPI.downloadServerInfo();
-			return result;
-		} catch (error) {
-			console.error('Failed to fetch server info:', error);
-			return null;
-		}
-	}
 
 	async function loadInformation() {
 		const TIMEOUT_IN_SECONDS = 15;

--- a/apps/frontend/app/components/StatisticsCard/StatisticsCard.tsx
+++ b/apps/frontend/app/components/StatisticsCard/StatisticsCard.tsx
@@ -23,20 +23,32 @@ const StatisticsCard: React.FC<StatisticsCardProps> = ({ food, handleImageSheet,
 
 		return () => subscription?.remove();
 	}, []);
+
+	const isWide = screenWidth > 950;
+	const flexDirection = isWide ? 'row' : 'column';
+	const cardHeight = isWide ? 180 : 190;
+	const imageSize = isWide ? 178 : 90;
+	const contentPadding = isWide ? 15 : 5;
+	const contentMarginTop = isWide ? 0 : 10;
+	const rowMarginBottom = isWide ? 20 : 10;
+	const colGap = isWide ? 10 : 5;
+	const iconSize = isWide ? 24 : 20;
+	const fontSize = isWide ? 18 : 12;
+
 	return (
 		<View
 			style={{
 				...styles.container,
 				borderColor: theme.screen.icon,
-				flexDirection: screenWidth > 950 ? 'row' : 'column',
-				height: screenWidth > 950 ? 180 : 190,
+				flexDirection,
+				height: cardHeight,
 			}}
 		>
 			<View
 				style={{
 					...styles.imageContainer,
-					width: screenWidth > 950 ? 178 : 90,
-					height: screenWidth > 950 ? 178 : 90,
+					width: imageSize,
+					height: imageSize,
 				}}
 			>
 				<MyImage
@@ -59,18 +71,18 @@ const StatisticsCard: React.FC<StatisticsCardProps> = ({ food, handleImageSheet,
 			<View
 				style={{
 					...styles.ratingContainer,
-					padding: screenWidth > 950 ? 15 : 5,
-					marginTop: screenWidth > 950 ? 0 : 10,
+					padding: contentPadding,
+					marginTop: contentMarginTop,
 				}}
 			>
-				<View style={{ ...styles.row, marginBottom: screenWidth > 950 ? 20 : 10 }}>
-					<View style={{ ...styles.col, gap: screenWidth > 950 ? 10 : 5 }}>
-						<MaterialCommunityIcons name="chart-bar" color={theme.screen.icon} size={screenWidth > 950 ? 24 : 20} />
+				<View style={{ ...styles.row, marginBottom: rowMarginBottom }}>
+					<View style={{ ...styles.col, gap: colGap }}>
+						<MaterialCommunityIcons name="chart-bar" color={theme.screen.icon} size={iconSize} />
 						<Text
 							style={{
 								...styles.label,
 								color: theme.screen.text,
-								fontSize: screenWidth > 950 ? 18 : 12,
+								fontSize,
 							}}
 						>
 							Number of Ratings
@@ -80,20 +92,20 @@ const StatisticsCard: React.FC<StatisticsCardProps> = ({ food, handleImageSheet,
 						style={{
 							...styles.value,
 							color: theme.screen.text,
-							fontSize: screenWidth > 950 ? 18 : 12,
+							fontSize,
 						}}
 					>
 						{food?.rating_amount}
 					</Text>
 				</View>
-				<View style={{ ...styles.row, marginBottom: screenWidth > 950 ? 20 : 10 }}>
-					<View style={{ ...styles.col, gap: screenWidth > 950 ? 10 : 5 }}>
-						<MaterialCommunityIcons name="chart-areaspline" color={theme.screen.icon} size={screenWidth > 950 ? 24 : 20} />
+				<View style={{ ...styles.row, marginBottom: rowMarginBottom }}>
+					<View style={{ ...styles.col, gap: colGap }}>
+						<MaterialCommunityIcons name="chart-areaspline" color={theme.screen.icon} size={iconSize} />
 						<Text
 							style={{
 								...styles.label,
 								color: theme.screen.text,
-								fontSize: screenWidth > 950 ? 18 : 12,
+								fontSize,
 							}}
 						>
 							Average Rating
@@ -103,7 +115,7 @@ const StatisticsCard: React.FC<StatisticsCardProps> = ({ food, handleImageSheet,
 						style={{
 							...styles.value,
 							color: theme.screen.text,
-							fontSize: screenWidth > 950 ? 18 : 12,
+							fontSize,
 						}}
 					>
 						{food?.rating_average?.toFixed(2)}

--- a/apps/frontend/app/helper/animationHelper.ts
+++ b/apps/frontend/app/helper/animationHelper.ts
@@ -106,6 +106,23 @@ export function getLighterAndDarkerColors(projectColor: string): {
 	};
 }
 
+// Convert hex color to a Lottie-compatible normalized RGB array.
+function hexToLottieColor(hex: string): number[] {
+	if (hex?.length !== 7 || !hex.startsWith('#')) {
+		console.error(`Invalid hex color: ${hex}`);
+		return [0, 0, 0];
+	}
+	try {
+		const r = (Number.parseInt(hex.slice(1, 3), 16) / 255).toFixed(4);
+		const g = (Number.parseInt(hex.slice(3, 5), 16) / 255).toFixed(4);
+		const b = (Number.parseInt(hex.slice(5, 7), 16) / 255).toFixed(4);
+		return [Number.parseFloat(r), Number.parseFloat(g), Number.parseFloat(b)];
+	} catch (error) {
+		console.error(`Error converting hex to Lottie color: ${hex}`, error);
+		return [0, 0, 0];
+	}
+}
+
 export function replaceLottieColors(lottieJSON: any, primaryColor: string): any {
 	if (!lottieJSON || typeof lottieJSON !== 'object') {
 		console.error('Invalid Lottie JSON provided.');
@@ -118,23 +135,6 @@ export function replaceLottieColors(lottieJSON: any, primaryColor: string): any 
 		[DEFAULT_COLOR_LIGHTER_TO_BE_REPLACED]: lighter,
 		[DEFAULT_COLOR_DARKER_TO_BE_REPLACED]: darker,
 	};
-
-	// Helper: Convert hex color to a Lottie-compatible normalized RGB array.
-	function hexToLottieColor(hex: string): number[] {
-		if (hex?.length !== 7 || !hex.startsWith('#')) {
-			console.error(`Invalid hex color: ${hex}`);
-			return [0, 0, 0];
-		}
-		try {
-			const r = (Number.parseInt(hex.slice(1, 3), 16) / 255).toFixed(4);
-			const g = (Number.parseInt(hex.slice(3, 5), 16) / 255).toFixed(4);
-			const b = (Number.parseInt(hex.slice(5, 7), 16) / 255).toFixed(4);
-			return [Number.parseFloat(r), Number.parseFloat(g), Number.parseFloat(b)];
-		} catch (error) {
-			console.error(`Error converting hex to Lottie color: ${hex}`, error);
-			return [0, 0, 0];
-		}
-	}
 
 	// Build a mapping of the default Lottie colors (converted to a string key) to their replacement RGB arrays.
 	const usedColorReplaceMapAfter: { [key: string]: number[] } = {};

--- a/apps/frontend/app/helper/collectionHelper.ts
+++ b/apps/frontend/app/helper/collectionHelper.ts
@@ -27,8 +27,8 @@ export type AggregateQuery<CollectionScheme> = {
 };
 
 export class CollectionHelper<CollectionScheme> {
-private collection: string;
-	private _client?: DirectusClient<DatabaseTypes.CustomDirectusTypes> & RestClient<DatabaseTypes.CustomDirectusTypes>;
+	private readonly collection: string;
+	private readonly _client?: DirectusClient<DatabaseTypes.CustomDirectusTypes> & RestClient<DatabaseTypes.CustomDirectusTypes>;
 
 	constructor(collection: string, client?: DirectusClient<DatabaseTypes.CustomDirectusTypes> & RestClient<DatabaseTypes.CustomDirectusTypes>) {
 		this.collection = collection;

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -26,7 +26,7 @@ import { MapLocationButton, MyMap, MyMapHandle, QrCode, useTheme, useMyScrollVie
 import { HEX_TILE_SCRIPT } from '../assets/hexTileScript';
 import { TERRAIN_ASSETS, TERRAIN_CATEGORIES, TerrainAssetEntry } from '../assets/terrainAssets';
 import { MapLoadingOverlay } from '../components/MapLoadingOverlay';
-import { isAvailable as isH3Available, latLngToCell, cellToLatLng, gridDisk, gridDistance, areNeighborCells, cellToBoundary, gridPathCells, cellToChildren, cellToCenterChild, cellToParent, gridRingUnsafe, getResolution, isValidCell, computeRouteLengthKm, formatDistanceKm, getPentagons } from '../helpers/H3Helper';
+import { isAvailable as isH3Available, latLngToCell, cellToLatLng, gridDisk, gridDistance, areNeighborCells, cellToBoundary, gridPathCells, cellToChildren, cellToCenterChild, cellToParent, gridRingUnsafe, getResolution, isValidCell, computeRouteLengthKm, formatDistanceKm, getPentagons, type CoordPair } from '../helpers/H3Helper';
 import { queryTileFeaturesForHexCell } from '../helpers/TileFeatureHelper';
 import type { MapFeatureInfo } from '../helpers/RouteNameSuggestionHelper';
 import type { ViewportBounds } from '../helpers/ViewportBounds';
@@ -111,6 +111,104 @@ function getEffectiveBillboardsTexture(record: { billboardsTexture?: Record<stri
 function getAnchorAngleDeg(anchorPosition: string): number {
 	const match = /_(\d+)$/.exec(anchorPosition);
 	return match ? (240 - Number.parseInt(match[1], 10) + 360) % 360 : 0;
+}
+
+// Geometric lookup for all 12 degree positions (index = degree / 30).
+// type 'vertex': use boundary[idx] directly.
+// type 'edge':   midpoint of boundary[idx] and boundary[(idx+1)%n].
+const DEGREE_POSITION_GEO: Array<{ type: 'vertex' | 'edge'; idx: number }> = [
+	{ type: 'vertex', idx: 0 },  // 0°   vertex[0] top
+	{ type: 'edge',   idx: 0 },  // 30°  edge[0] (vertex[0]→vertex[1])
+	{ type: 'vertex', idx: 1 },  // 60°  vertex[1]
+	{ type: 'edge',   idx: 1 },  // 90°  edge[1]
+	{ type: 'vertex', idx: 2 },  // 120° vertex[2]
+	{ type: 'edge',   idx: 2 },  // 150° edge[2]
+	{ type: 'vertex', idx: 3 },  // 180° vertex[3]
+	{ type: 'edge',   idx: 3 },  // 210° edge[3]
+	{ type: 'vertex', idx: 4 },  // 240° vertex[4]
+	{ type: 'edge',   idx: 4 },  // 270° edge[4]
+	{ type: 'vertex', idx: 5 },  // 300° vertex[5]
+	{ type: 'edge',   idx: 5 },  // 330° edge[5] (vertex[5]→vertex[0])
+];
+
+// OUTER ring: 12 positions at 0°, 30°, …, 330°
+const OUTER_ANCHOR_BY_DEGREE: BillboardAnchorPosition[] = [
+	BillboardAnchorPosition.OUTER_0_DEGREE,
+	BillboardAnchorPosition.OUTER_30_DEGREE,
+	BillboardAnchorPosition.OUTER_60_DEGREE,
+	BillboardAnchorPosition.OUTER_90_DEGREE,
+	BillboardAnchorPosition.OUTER_120_DEGREE,
+	BillboardAnchorPosition.OUTER_150_DEGREE,
+	BillboardAnchorPosition.OUTER_180_DEGREE,
+	BillboardAnchorPosition.OUTER_210_DEGREE,
+	BillboardAnchorPosition.OUTER_240_DEGREE,
+	BillboardAnchorPosition.OUTER_270_DEGREE,
+	BillboardAnchorPosition.OUTER_300_DEGREE,
+	BillboardAnchorPosition.OUTER_330_DEGREE,
+];
+
+// MIDDLE ring: 12 positions at 0°, 30°, …, 330°
+const MIDDLE_ANCHOR_BY_DEGREE: BillboardAnchorPosition[] = [
+	BillboardAnchorPosition.MIDDLE_0_DEGREE,
+	BillboardAnchorPosition.MIDDLE_30_DEGREE,
+	BillboardAnchorPosition.MIDDLE_60_DEGREE,
+	BillboardAnchorPosition.MIDDLE_90_DEGREE,
+	BillboardAnchorPosition.MIDDLE_120_DEGREE,
+	BillboardAnchorPosition.MIDDLE_150_DEGREE,
+	BillboardAnchorPosition.MIDDLE_180_DEGREE,
+	BillboardAnchorPosition.MIDDLE_210_DEGREE,
+	BillboardAnchorPosition.MIDDLE_240_DEGREE,
+	BillboardAnchorPosition.MIDDLE_270_DEGREE,
+	BillboardAnchorPosition.MIDDLE_300_DEGREE,
+	BillboardAnchorPosition.MIDDLE_330_DEGREE,
+];
+
+/**
+ * Resolve the geographic [lng, lat] for a given anchor position string.
+ */
+function resolveAnchorPosition(
+	anchorColor: string,
+	boundary: CoordPair[],
+	n: number,
+	centerLng: number,
+	centerLat: number,
+): [number, number] {
+	let lng = centerLng;
+	let lat = centerLat;
+	const outerIdx = OUTER_ANCHOR_BY_DEGREE.indexOf(anchorColor as BillboardAnchorPosition);
+	const middleIdx = MIDDLE_ANCHOR_BY_DEGREE.indexOf(anchorColor as BillboardAnchorPosition);
+	if (outerIdx >= 0) {
+		// H3's cellToBoundary places boundary[0] at the visual 300° position.
+		// Positions are reflected across the 300°–120° axis: the formula
+		// (10 - idx + 12) % 12 applies both the boundary[0] offset and the
+		// axis reflection in one step.
+		const geo = DEGREE_POSITION_GEO[(10 - outerIdx + 12) % 12];
+		if (geo.type === 'vertex' && geo.idx < n) {
+			[lng, lat] = boundary[geo.idx] as [number, number];
+		} else if (geo.type === 'edge' && geo.idx < n) {
+			const [lng1, lat1] = boundary[geo.idx] as [number, number];
+			const [lng2, lat2] = boundary[(geo.idx + 1) % n] as [number, number];
+			lng = (lng1 + lng2) / 2;
+			lat = (lat1 + lat2) / 2;
+		}
+	} else if (middleIdx >= 0) {
+		// Same reflection formula as for the outer ring.
+		const geo = DEGREE_POSITION_GEO[(10 - middleIdx + 12) % 12];
+		let outerLng = centerLng;
+		let outerLat = centerLat;
+		if (geo.type === 'vertex' && geo.idx < n) {
+			[outerLng, outerLat] = boundary[geo.idx] as [number, number];
+		} else if (geo.type === 'edge' && geo.idx < n) {
+			const [lng1, lat1] = boundary[geo.idx] as [number, number];
+			const [lng2, lat2] = boundary[(geo.idx + 1) % n] as [number, number];
+			outerLng = (lng1 + lng2) / 2;
+			outerLat = (lat1 + lat2) / 2;
+		}
+		lng = (centerLng + outerLng) / 2;
+		lat = (centerLat + outerLat) / 2;
+	}
+	// else: CENTER → use centerLng/centerLat (already set above)
+	return [lng, lat];
 }
 
 /**
@@ -3066,56 +3164,6 @@ export default function RecordScreen() {
 		};
 		const billboardFeatures: BillboardFeature[] = [];
 
-		// Geometric lookup for all 12 degree positions (index = degree / 30).
-		// type 'vertex': use boundary[idx] directly.
-		// type 'edge':   midpoint of boundary[idx] and boundary[(idx+1)%n].
-		const DEGREE_POSITION_GEO: Array<{ type: 'vertex' | 'edge'; idx: number }> = [
-			{ type: 'vertex', idx: 0 },  // 0°   vertex[0] top
-			{ type: 'edge',   idx: 0 },  // 30°  edge[0] (vertex[0]→vertex[1])
-			{ type: 'vertex', idx: 1 },  // 60°  vertex[1]
-			{ type: 'edge',   idx: 1 },  // 90°  edge[1]
-			{ type: 'vertex', idx: 2 },  // 120° vertex[2]
-			{ type: 'edge',   idx: 2 },  // 150° edge[2]
-			{ type: 'vertex', idx: 3 },  // 180° vertex[3]
-			{ type: 'edge',   idx: 3 },  // 210° edge[3]
-			{ type: 'vertex', idx: 4 },  // 240° vertex[4]
-			{ type: 'edge',   idx: 4 },  // 270° edge[4]
-			{ type: 'vertex', idx: 5 },  // 300° vertex[5]
-			{ type: 'edge',   idx: 5 },  // 330° edge[5] (vertex[5]→vertex[0])
-		];
-
-		// OUTER ring: 12 positions at 0°, 30°, …, 330°
-		const OUTER_ANCHOR_BY_DEGREE: BillboardAnchorPosition[] = [
-			BillboardAnchorPosition.OUTER_0_DEGREE,
-			BillboardAnchorPosition.OUTER_30_DEGREE,
-			BillboardAnchorPosition.OUTER_60_DEGREE,
-			BillboardAnchorPosition.OUTER_90_DEGREE,
-			BillboardAnchorPosition.OUTER_120_DEGREE,
-			BillboardAnchorPosition.OUTER_150_DEGREE,
-			BillboardAnchorPosition.OUTER_180_DEGREE,
-			BillboardAnchorPosition.OUTER_210_DEGREE,
-			BillboardAnchorPosition.OUTER_240_DEGREE,
-			BillboardAnchorPosition.OUTER_270_DEGREE,
-			BillboardAnchorPosition.OUTER_300_DEGREE,
-			BillboardAnchorPosition.OUTER_330_DEGREE,
-		];
-
-		// MIDDLE ring: 12 positions at 0°, 30°, …, 330°
-		const MIDDLE_ANCHOR_BY_DEGREE: BillboardAnchorPosition[] = [
-			BillboardAnchorPosition.MIDDLE_0_DEGREE,
-			BillboardAnchorPosition.MIDDLE_30_DEGREE,
-			BillboardAnchorPosition.MIDDLE_60_DEGREE,
-			BillboardAnchorPosition.MIDDLE_90_DEGREE,
-			BillboardAnchorPosition.MIDDLE_120_DEGREE,
-			BillboardAnchorPosition.MIDDLE_150_DEGREE,
-			BillboardAnchorPosition.MIDDLE_180_DEGREE,
-			BillboardAnchorPosition.MIDDLE_210_DEGREE,
-			BillboardAnchorPosition.MIDDLE_240_DEGREE,
-			BillboardAnchorPosition.MIDDLE_270_DEGREE,
-			BillboardAnchorPosition.MIDDLE_300_DEGREE,
-			BillboardAnchorPosition.MIDDLE_330_DEGREE,
-		];
-
 		for (const [h3Index, record] of Object.entries(records)) {
 			// Build effective billboard maps for Hex Objects and Hex Texture Adaptions.
 			const effectiveBillboards = getEffectiveBillboards(record);
@@ -3145,48 +3193,6 @@ export default function RecordScreen() {
 			const clampedRes = Math.max(0, Math.min(cellRes, H3_EDGE_LENGTH_KM.length - 1));
 			const edgeLengthRatio = H3_EDGE_LENGTH_KM[clampedRes] / H3_EDGE_LENGTH_KM[BILLBOARD_REFERENCE_RESOLUTION];
 
-			/**
-			 * Resolve the geographic [lng, lat] for a given anchor position string.
-			 */
-			function resolveAnchorPosition(anchorColor: string): [number, number] {
-				let lng = centerLng;
-				let lat = centerLat;
-				const outerIdx = OUTER_ANCHOR_BY_DEGREE.indexOf(anchorColor as BillboardAnchorPosition);
-				const middleIdx = MIDDLE_ANCHOR_BY_DEGREE.indexOf(anchorColor as BillboardAnchorPosition);
-				if (outerIdx >= 0) {
-					// H3's cellToBoundary places boundary[0] at the visual 300° position.
-					// Positions are reflected across the 300°–120° axis: the formula
-					// (10 - idx + 12) % 12 applies both the boundary[0] offset and the
-					// axis reflection in one step.
-					const geo = DEGREE_POSITION_GEO[(10 - outerIdx + 12) % 12];
-					if (geo.type === 'vertex' && geo.idx < n) {
-						[lng, lat] = boundary[geo.idx] as [number, number];
-					} else if (geo.type === 'edge' && geo.idx < n) {
-						const [lng1, lat1] = boundary[geo.idx] as [number, number];
-						const [lng2, lat2] = boundary[(geo.idx + 1) % n] as [number, number];
-						lng = (lng1 + lng2) / 2;
-						lat = (lat1 + lat2) / 2;
-					}
-				} else if (middleIdx >= 0) {
-					// Same reflection formula as for the outer ring.
-					const geo = DEGREE_POSITION_GEO[(10 - middleIdx + 12) % 12];
-					let outerLng = centerLng;
-					let outerLat = centerLat;
-					if (geo.type === 'vertex' && geo.idx < n) {
-						[outerLng, outerLat] = boundary[geo.idx] as [number, number];
-					} else if (geo.type === 'edge' && geo.idx < n) {
-						const [lng1, lat1] = boundary[geo.idx] as [number, number];
-						const [lng2, lat2] = boundary[(geo.idx + 1) % n] as [number, number];
-						outerLng = (lng1 + lng2) / 2;
-						outerLat = (lat1 + lat2) / 2;
-					}
-					lng = (centerLng + outerLng) / 2;
-					lat = (centerLat + outerLat) / 2;
-				}
-				// else: CENTER → use centerLng/centerLat (already set above)
-				return [lng, lat];
-			}
-
 			// ── Hex Texture Adaptions (always flat on the map surface) ────────────
 			for (const [anchorColor, billboardKey] of Object.entries(effectiveBillboardsTexture)) {
 				const parsed = parseBillboardKey(billboardKey);
@@ -3199,7 +3205,7 @@ export default function RecordScreen() {
 				const anchorOverride = spriteAnchors[idx];
 				const anchorX = anchorOverride?.anchorX ?? sprite.anchorX;
 				const anchorY = anchorOverride?.anchorY ?? sprite.anchorY;
-				const [lng, lat] = resolveAnchorPosition(anchorColor);
+				const [lng, lat] = resolveAnchorPosition(anchorColor, boundary, n, centerLng, centerLat);
 				const perSpriteScale = anchorOverride?.scaleMultiplier ?? 1.0;
 				const billboardSizePx = Math.max(BILLBOARD_MIN_SIZE_PX, Math.round(
 					BILLBOARD_UNIT_PX * sprite.scaleFactor * billboardScaleRef.current * perSpriteScale * edgeLengthRatio,
@@ -3230,7 +3236,7 @@ export default function RecordScreen() {
 				const anchorOverride = spriteAnchors[idx];
 				const anchorX = anchorOverride?.anchorX ?? sprite.anchorX;
 				const anchorY = anchorOverride?.anchorY ?? sprite.anchorY;
-				const [lng, lat] = resolveAnchorPosition(anchorColor);
+				const [lng, lat] = resolveAnchorPosition(anchorColor, boundary, n, centerLng, centerLat);
 				const perSpriteScale = anchorOverride?.scaleMultiplier ?? 1.0;
 				const billboardSizePx = Math.max(BILLBOARD_MIN_SIZE_PX, Math.round(
 					BILLBOARD_UNIT_PX * sprite.scaleFactor * billboardScaleRef.current * perSpriteScale * edgeLengthRatio,

--- a/apps/geonexia/frontend/helpers/RouteNameSuggestionHelper.ts
+++ b/apps/geonexia/frontend/helpers/RouteNameSuggestionHelper.ts
@@ -158,25 +158,10 @@ type ScoredName = { name: string; score: number };
  * @param ownName         – The current route's own name (excluded from filter).
  * @returns Ordered list of unique name suggestions (highest priority first).
  */
-export function suggestRouteNames(
-	routeDict: AreaInfoDict,
-	enclosedDict: AreaInfoDict,
-	existingNames: string[] = [],
-	ownName?: string,
-): string[] {
-	const scored: ScoredName[] = [];
-	const seen = new Set<string>();
+type AddCandidateFn = (name: string, score: number) => void;
 
-	const addCandidate = (name: string, score: number) => {
-		const trimmed = name.trim();
-		if (!trimmed) return;
-		const lower = trimmed.toLowerCase();
-		if (seen.has(lower)) return;
-		seen.add(lower);
-		scored.push({ name: trimmed, score });
-	};
-
-	// ── Score entries from the route dict ──────────────────────────────────
+// ── Score entries from the route dict ──────────────────────────────────
+function scoreRouteDictEntries(routeDict: AreaInfoDict, addCandidate: AddCandidateFn): void {
 	for (const entry of Object.values(routeDict)) {
 		const lw = layerWeight(entry.layerId);
 		const baseScore = entry.count + lw * 2;
@@ -192,8 +177,10 @@ export function suggestRouteNames(
 			}
 		}
 	}
+}
 
-	// ── Score entries from enclosed dict (bonus for "around X") ────────────
+// ── Score entries from enclosed dict (bonus for "around X") ────────────
+function scoreEnclosedDictEntries(enclosedDict: AreaInfoDict, addCandidate: AddCandidateFn): void {
 	for (const entry of Object.values(enclosedDict)) {
 		const lw = layerWeight(entry.layerId);
 		// Enclosed features get a slight bonus because the route goes *around* them
@@ -204,8 +191,10 @@ export function suggestRouteNames(
 			addCandidate(entry.name, baseScore + 3);
 		}
 	}
+}
 
-	// ── Fallback: category-only names from high-priority layers ────────────
+// ── Fallback: category-only names from high-priority layers ────────────
+function scoreFallbackCategoryNames(routeDict: AreaInfoDict, enclosedDict: AreaInfoDict, addCandidate: AddCandidateFn): void {
 	const allEntries = [
 		...Object.values(routeDict).map((e) => ({ entry: e, enclosed: false })),
 		...Object.values(enclosedDict).map((e) => ({ entry: e, enclosed: true })),
@@ -220,6 +209,29 @@ export function suggestRouteNames(
 			}
 		}
 	}
+}
+
+export function suggestRouteNames(
+	routeDict: AreaInfoDict,
+	enclosedDict: AreaInfoDict,
+	existingNames: string[] = [],
+	ownName?: string,
+): string[] {
+	const scored: ScoredName[] = [];
+	const seen = new Set<string>();
+
+	const addCandidate: AddCandidateFn = (name, score) => {
+		const trimmed = name.trim();
+		if (!trimmed) return;
+		const lower = trimmed.toLowerCase();
+		if (seen.has(lower)) return;
+		seen.add(lower);
+		scored.push({ name: trimmed, score });
+	};
+
+	scoreRouteDictEntries(routeDict, addCandidate);
+	scoreEnclosedDictEntries(enclosedDict, addCandidate);
+	scoreFallbackCategoryNames(routeDict, enclosedDict, addCandidate);
 
 	// Sort by score descending
 	scored.sort((a, b) => b.score - a.score);

--- a/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
+++ b/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
@@ -62,13 +62,13 @@ function tileYToLat(yFrac: number, zoom: number): number {
 	return (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
 }
 
+/** Axis-aligned geographic bounding box. */
+type BoundingBox = { minLat: number; minLng: number; maxLat: number; maxLng: number };
+
 /** Simple axis-aligned bounding-box overlap check. */
-function boundsOverlap(
-	aMinLat: number, aMinLng: number, aMaxLat: number, aMaxLng: number,
-	bMinLat: number, bMinLng: number, bMaxLat: number, bMaxLng: number,
-): boolean {
-	return aMinLat <= bMaxLat && aMaxLat >= bMinLat &&
-		aMinLng <= bMaxLng && aMaxLng >= bMinLng;
+function boundsOverlap(a: BoundingBox, b: BoundingBox): boolean {
+	return a.minLat <= b.maxLat && a.maxLat >= b.minLat &&
+		a.minLng <= b.maxLng && a.maxLng >= b.minLng;
 }
 
 // ─── Name-null filter ───────────────────────────────────────────────────────
@@ -337,9 +337,8 @@ export async function fetchAndParseTile(
 				const featMinLat = tileYToLat(y + by2 / extent, z);
 
 				if (!boundsOverlap(
-					featMinLat, featMinLng, featMaxLat, featMaxLng,
-					filterBounds.minLat, filterBounds.minLng,
-					filterBounds.maxLat, filterBounds.maxLng,
+					{ minLat: featMinLat, minLng: featMinLng, maxLat: featMaxLat, maxLng: featMaxLng },
+					filterBounds,
 				)) {
 					continue;
 				}

--- a/apps/sonarCloudReportDownloader/src/generateIssueMarkdown.ts
+++ b/apps/sonarCloudReportDownloader/src/generateIssueMarkdown.ts
@@ -83,21 +83,28 @@ function parseCsvLine(line: string): string[] {
   const fields: string[] = [];
   let current = '';
   let inQuotes = false;
+  let i = 0;
 
-  for (let i = 0; i < line.length; i++) {
+  while (i < line.length) {
     const char = line[i];
+
     if (inQuotes) {
-      if (char === '"') {
-        if (i + 1 < line.length && line[i + 1] === '"') {
-          current += '"';
-          i++;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        current += char;
+      if (char === '"' && line[i + 1] === '"') {
+        current += '"';
+        i += 2;
+        continue;
       }
-    } else if (char === '"') {
+      if (char === '"') {
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      current += char;
+      i++;
+      continue;
+    }
+
+    if (char === '"') {
       inQuotes = true;
     } else if (char === ',') {
       fields.push(current);
@@ -105,6 +112,7 @@ function parseCsvLine(line: string): string[] {
     } else {
       current += char;
     }
+    i++;
   }
   fields.push(current);
   return fields;

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -454,6 +454,103 @@ Compile-Fehler gefunden und behoben (Aufrufstellen in `HoursSheet.tsx` und
 `CalendarSheet.tsx`, die `closeSheet` noch direkt an `<MyScrollViewModal>`
 übergeben hatten).
 
+## Am 2026-07-21 (vierte Runde): kleine Restfunde + erster Cognitive-Complexity-Schwung
+
+Nach der dritten Runde (siehe oben) wurden zunächst die noch offenen kleinen
+mechanischen Funde abgeschlossen, danach ein erster, bewusst kleiner Schwung
+des bislang unangetasteten „Cognitive Complexity"-Bergs (109x) abgearbeitet —
+ausgewählt wurden Funktionen mit Werten nur knapp über der Grenze von 15
+(meist 16-20), da diese mit 1-2 Extraktionen sicher unter die Grenze zu
+bringen sind, ohne die Fachlogik anzufassen.
+
+**Kleine Restfunde:**
+- **Irreführende Bedingung** (1x): `BuildingDetailsContent.tsx` —
+  `(acc, org) => { if (org.id) acc[org.id] = org; return acc; }` sah aus, als
+  wäre `return acc` Teil der Bedingung; explizite Klammern um den
+  `if`-Body ergänzt, `return acc` bleibt unbedingt (keine Verhaltensänderung).
+- **„Move function to the outer scope"** (4x): `resolveAnchorPosition`
+  (`geonexia/app/index.tsx`, schließt über `boundary`/`n`/`centerLng`/
+  `centerLat` — als explizite Parameter auf Modul-Ebene gehoben, dabei auch
+  die zugehörigen, bislang pro Aufruf neu angelegten Konstanten
+  `DEGREE_POSITION_GEO`/`OUTER_ANCHOR_BY_DEGREE`/`MIDDLE_ANCHOR_BY_DEGREE`
+  mit hochgezogen, da sie reine statische Lookup-Tabellen ohne
+  Render-Abhängigkeit sind), `getTodayRangeIso` (`mails-hook/index.ts`,
+  reine Funktion ohne Closures), `hexToLottieColor` (`animationHelper.ts`,
+  reine Funktion) und `loadServerInfo` (`ServerStatusLoader.tsx`, reine
+  Funktion) — alle vier schließen über nichts Komponentenspezifisches und
+  wurden 1:1 auf Modul-Ebene verschoben.
+- **„Too many parameters"** (3x): `boundsOverlap` (`TileFeatureHelper.ts`,
+  8→2 Parameter durch neuen `BoundingBox`-Typ statt 4 Einzelwerten pro Box),
+  `getFoodofferToCreate` (`ParseSchedule.ts`, 8→1 Parameter-Objekt) und
+  `createBuildingMarkerSvg` (`map/index.tsx`, 10→1 Parameter-Objekt) — jeweils
+  auf ein Options-Objekt umgestellt, einzige Aufrufstelle je Funktion
+  entsprechend angepasst.
+- **`Mark these members as readonly`** (1x): `CollectionHelper.collection`/
+  `_client` werden nur im Konstruktor zugewiesen — `readonly` ergänzt.
+- **Regex-Komplexität** (1x, `1_fix_viewbox.py`): bewusst NICHT geändert —
+  der SVG-Path-Tokenizer-Regex ist funktional korrekt und eine strukturelle
+  Vereinfachung birgt reales Risiko, Rand- fälle (Exponentialschreibweise,
+  führender/fehlender Dezimalpunkt) beim Parsen von SVG-Pfaddaten subtil zu
+  verändern; der Lint-Gewinn rechtfertigt dieses Risiko für dieses interne
+  Build-Skript nicht.
+
+**Cognitive-Complexity-Erstrunde (8 Funktionen, alle 16-20 → jetzt < 15):**
+- `SortingHelper.sortByEatingHabits` (`packages/common`, 19→..): die
+  Like/Dislike-Klassifizierung pro Angebot (verschachteltes `for`+`if`+`for`+
+  `if`+`if/else-if`) in eine eigene `classifyOfferByEatingHabits`-Funktion
+  extrahiert, die `'liked' | 'disliked' | 'neutral'` zurückgibt — per
+  bestehendem Test (`SortingHelper.test.ts`) verifiziert (weiterhin grün).
+- `suggestRouteNames` (`RouteNameSuggestionHelper.ts`, 19→..): die drei
+  unabhängigen Scoring-Durchläufe (Route-Dict, Enclosed-Dict, Fallback-
+  Kategorien) in `scoreRouteDictEntries`/`scoreEnclosedDictEntries`/
+  `scoreFallbackCategoryNames` extrahiert, `addCandidate`-Closure als
+  Parameter durchgereicht — identische Bewertungslogik, nur aufgeteilt.
+- `GooglePlayHelper.fetchAllReviews` (17→..): die Einzelseiten-Abfrage
+  (URL bauen, fetchen, JSON parsen, Logger-Warnung) in eine private
+  `fetchReviewsPage`-Methode ausgelagert, die Paginierungsschleife bleibt
+  in `fetchAllReviews`.
+- `push-notification-hook`s `.items.update`-Filter (16→..): die Merge- und
+  Notify-Logik pro Schlüssel in `mergeUpdateAndNotifyIfPublished`
+  extrahiert (Parameter-Typ bewusst `any` belassen wie zuvor implizit, da
+  `itemService.readByQuery`s Filter-Typ keine explizit typisierten
+  Primärschlüssel-Werte akzeptiert und eine strengere Typisierung hier
+  einen vorbestehenden, nicht verwandten Typkonflikt aufgerissen hätte).
+- `parseCsvLine` (`generateIssueMarkdown.ts`, 16→..): von `for`-Schleife mit
+  verschachteltem `if(inQuotes){if...else}else if...else if...else` auf eine
+  `while`-Schleife mit frühen `continue`s umgestellt (gleiches Zeichen-für-
+  Zeichen-Verhalten, u. a. beim Escaped-Anführungszeichen `""`, nur ohne die
+  zusätzliche Verschachtelungsebene).
+- `AttributeItem.tsx` (16→..): Wert-Auflösung (`number_value`/`string_value`/
+  Prefix) in `resolveAttributeValue` und Icon-Key-Parsing (`library:name`)
+  in `resolveIconFromKey` extrahiert (letzteres deckt sowohl `icon_expo` als
+  auch `icon_value` ab, vorher dupliziert).
+- `StatisticsCard.tsx` (16→..): die Breakpoint-Bedingung
+  `screenWidth > 950 ? X : Y` kam ~16x vor (teils identisch dupliziert für
+  beide Rating-Zeilen) — auf eine `isWide`-Variable plus einmalig berechnete
+  benannte Konstanten (`flexDirection`, `cardHeight`, `imageSize`, `fontSize`,
+  …) reduziert; jede Bedingung wird jetzt nur noch einmal ausgewertet statt
+  bis zu dreimal dupliziert.
+- `MyMap`s `loadHtml`-Effekt (`packages/common-ui`, 16→..): die fünf
+  unabhängigen HTML-Patch-Schritte (initiale Position, initialer Style,
+  Loading-Text, Inject-Script, Legal-Info ausblenden) in je eine eigene
+  `apply*Patch`-Funktion extrahiert, die `htmlContent` entgegennimmt und
+  zurückgibt — die Effekt-Funktion reiht die Aufrufe jetzt nur noch linear.
+
+Verifiziert per `tsc --noEmit`-Baseline-Diff (`git stash`/`git stash pop`)
+für `apps/frontend/app`, `apps/geonexia/frontend`, `apps/score-tracker/frontend`
+sowie `yarn typecheck` für die Backend-Extension: keine neuen Fehler. Zusätzlich
+die bestehenden Tests `SortingHelper.test.ts`, `GooglePlayReviews.test.ts` und
+`ParseScheduleSyncDiff.test.ts` laufen lassen — weiterhin grün.
+`RouteNameSuggestionHelper.test.ts` schlägt bereits auf dem unveränderten
+Stand mit einem umgebungsbedingten Jest/Expo-Fehler fehl (`expo-modules-core`
+EventEmitter-Setup in dieser Sandbox), unabhängig von dieser Änderung
+verifiziert (gleicher Fehler vor und nach dem Diff).
+
+**Noch offen für weitere Runden:** ca. 101 der 109 Cognitive-Complexity-Funde
+(die übrigen reichen bis zu 201 und brauchen fachliche Einzelbetrachtung,
+insbesondere die großen React-Komponenten und `ActivityMapRebuildHelper.ts`/
+`geonexia/app/index.tsx` mit mehreren Funktionen > 80).
+
 ## Hinweise
 
 - Die CSV-Reports werden per CI aktualisiert (Commits `chore: update sonarcloud reports`).

--- a/packages/common-ui/src/components/MyMap/index.tsx
+++ b/packages/common-ui/src/components/MyMap/index.tsx
@@ -18,6 +18,89 @@ function escapeHtml(text: string): string {
 	return result;
 }
 
+/** Patch the map's initial center/zoom/pitch into the bundled HTML template. */
+function applyInitialPositionPatch(
+	htmlContent: string,
+	initialCenter: { lat: number; lng: number } | undefined,
+	initialZoom: number | undefined,
+	initialPitch: number | undefined,
+): string {
+	if (initialCenter) {
+		const zoomArg = initialZoom !== undefined ? `${initialZoom}` : 'null';
+		const pitchArg = initialPitch !== undefined ? `${initialPitch}` : 'null';
+		const pitchSuffix = initialPitch !== undefined ? `, ${initialPitch}` : '';
+		// Replace the try/else branch (native path: no URL query params present)
+		htmlContent = StringHelper.replaceAllLiteralWithOptions({
+			str: htmlContent,
+			find: 'initMap(null, null, null, styleParam);',
+			replace: `initMap([${initialCenter.lng}, ${initialCenter.lat}], ${zoomArg}, ${pitchArg}, styleParam);`,
+		});
+		// Also replace the catch-block fallback (defensive)
+		return StringHelper.replaceAllLiteralWithOptions({
+			str: htmlContent,
+			find: 'initMap(null, null);',
+			replace: `initMap([${initialCenter.lng}, ${initialCenter.lat}], ${zoomArg}${pitchSuffix});`,
+		});
+	}
+	if (initialZoom !== undefined) {
+		// Replace both the try/else branch and catch fallback
+		htmlContent = StringHelper.replaceAllLiteralWithOptions({
+			str: htmlContent,
+			find: 'initMap(null, null, null, styleParam);',
+			replace: `initMap(null, ${initialZoom}, null, styleParam);`,
+		});
+		return StringHelper.replaceAllLiteralWithOptions({
+			str: htmlContent,
+			find: 'initMap(null, null);',
+			replace: `initMap(null, ${initialZoom});`,
+		});
+	}
+	return htmlContent;
+}
+
+/**
+ * Inject the initial map style URL so the first tile load uses the correct style
+ * without a visible switch after MapComponentMounted.
+ */
+function applyInitialStylePatch(htmlContent: string, initialStyleKey: MyMapProps['mapStyleKey']): string {
+	const def = initialStyleKey ? MAP_STYLE_DEFINITIONS[initialStyleKey] : undefined;
+	if (def && def.styleUrl !== LIBERTY_STYLE_URL) {
+		return StringHelper.replaceAllLiteralWithOptions({
+			str: htmlContent,
+			find: `'${LIBERTY_STYLE_URL}'`,
+			replace: `'${def.styleUrl}'`,
+		});
+	}
+	return htmlContent;
+}
+
+function applyLoadingTextPatch(htmlContent: string, loadingText: string | undefined): string {
+	if (!loadingText) return htmlContent;
+	return StringHelper.replaceAllLiteralWithOptions({
+		str: htmlContent,
+		find: '<span id="loading-text">Loading vector map…</span>',
+		replace: `<span id="loading-text">${escapeHtml(loadingText)}</span>`,
+	});
+}
+
+function applyInjectScriptPatch(htmlContent: string, injectScript: string | undefined): string {
+	if (!injectScript) return htmlContent;
+	return StringHelper.replaceAllLiteralWithOptions({
+		str: htmlContent,
+		find: '// INJECT_SCRIPT_HERE',
+		replace: injectScript,
+	});
+}
+
+function applyHideLegalInfoPatch(htmlContent: string, hideLegalInfo: boolean | undefined): string {
+	if (!hideLegalInfo) return htmlContent;
+	return StringHelper.replaceAllLiteralWithOptions({
+		str: htmlContent,
+		find: '/* INJECT_STYLE_HERE */',
+		replace: '.maplibregl-ctrl-attrib { display: none !important; }',
+	});
+}
+
 const MyMap = forwardRef<MyMapHandle, MyMapProps>(
 	({ initialCenter, initialZoom, initialPitch, loadingText, loadingOverlay, onMessage, centerAtUserLocationIfNoInitialPosition = true, injectScript, colorMap, mapStyleKey, hideLegalInfo }, ref) => {
 		const webViewRef = useRef<WebView>(null);
@@ -47,69 +130,11 @@ const MyMap = forwardRef<MyMapHandle, MyMapProps>(
 				const htmlAsset = Asset.fromModule(require('../../../assets/maplibre/index.html'));
 				await htmlAsset.downloadAsync();
 				let htmlContent = await FileSystem.readAsStringAsync(htmlAsset.localUri!);
-				if (initialCenter) {
-					const zoomArg = initialZoom !== undefined ? `${initialZoom}` : 'null';
-					const pitchArg = initialPitch !== undefined ? `${initialPitch}` : 'null';
-					const pitchSuffix = initialPitch !== undefined ? `, ${initialPitch}` : '';
-					// Replace the try/else branch (native path: no URL query params present)
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: 'initMap(null, null, null, styleParam);',
-						replace: `initMap([${initialCenter.lng}, ${initialCenter.lat}], ${zoomArg}, ${pitchArg}, styleParam);`,
-					});
-					// Also replace the catch-block fallback (defensive)
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: 'initMap(null, null);',
-						replace: `initMap([${initialCenter.lng}, ${initialCenter.lat}], ${zoomArg}${pitchSuffix});`,
-					});
-				} else if (initialZoom !== undefined) {
-					// Replace both the try/else branch and catch fallback
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: 'initMap(null, null, null, styleParam);',
-						replace: `initMap(null, ${initialZoom}, null, styleParam);`,
-					});
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: 'initMap(null, null);',
-						replace: `initMap(null, ${initialZoom});`,
-					});
-				}
-				// Inject the initial map style URL so the first tile load uses the correct style
-				// without a visible switch after MapComponentMounted.
-				const initialStyleKey = mapStyleKeyRef.current;
-				if (initialStyleKey) {
-					const def = MAP_STYLE_DEFINITIONS[initialStyleKey];
-					if (def && def.styleUrl !== LIBERTY_STYLE_URL) {
-						htmlContent = StringHelper.replaceAllLiteralWithOptions({
-							str: htmlContent,
-							find: `'${LIBERTY_STYLE_URL}'`,
-							replace: `'${def.styleUrl}'`,
-						});
-					}
-				}
-				if (loadingText) {
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: '<span id="loading-text">Loading vector map…</span>',
-						replace: `<span id="loading-text">${escapeHtml(loadingText)}</span>`,
-					});
-				}
-				if (injectScript) {
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: '// INJECT_SCRIPT_HERE',
-						replace: injectScript,
-					});
-				}
-				if (hideLegalInfo) {
-					htmlContent = StringHelper.replaceAllLiteralWithOptions({
-						str: htmlContent,
-						find: '/* INJECT_STYLE_HERE */',
-						replace: '.maplibregl-ctrl-attrib { display: none !important; }',
-					});
-				}
+				htmlContent = applyInitialPositionPatch(htmlContent, initialCenter, initialZoom, initialPitch);
+				htmlContent = applyInitialStylePatch(htmlContent, mapStyleKeyRef.current);
+				htmlContent = applyLoadingTextPatch(htmlContent, loadingText);
+				htmlContent = applyInjectScriptPatch(htmlContent, injectScript);
+				htmlContent = applyHideLegalInfoPatch(htmlContent, hideLegalInfo);
 				if (isMounted) {
 					// Write the (possibly patched) HTML to a local cache file so the WebView can be
 					// loaded from a file:// URI instead of inline HTML.  A file:// origin allows the

--- a/packages/common/src/SortingHelper.ts
+++ b/packages/common/src/SortingHelper.ts
@@ -260,6 +260,32 @@ export function sortByPrice(foodOffers: DatabaseTypes.Foodoffers[], priceGroup?:
   return foodOffers;
 }
 
+function classifyOfferByEatingHabits(offer: DatabaseTypes.Foodoffers, profileMarkingsMap: Map<string, any>): 'liked' | 'disliked' | 'neutral' {
+  if (!offer?.markings) {
+    return 'neutral';
+  }
+
+  let isLiked = false;
+  let isDisliked = false;
+
+  for (const marking of offer.markings) {
+    const profileMarking: any = profileMarkingsMap.get(marking.markings_id);
+    if (!profileMarking) {
+      continue;
+    }
+    if (profileMarking.like === true) {
+      isLiked = true;
+    } else if (profileMarking.like === false) {
+      isDisliked = true;
+    }
+  }
+
+  if (isDisliked) {
+    return 'disliked';
+  }
+  return isLiked ? 'liked' : 'neutral';
+}
+
 export function sortByEatingHabits(foodOffers: DatabaseTypes.Foodoffers[], profileMarkingsData: any) {
 
   const profileMarkingsMap = new Map<string, any>(profileMarkingsData?.map((marking: any) => [marking.markings_id, marking]));
@@ -269,26 +295,10 @@ export function sortByEatingHabits(foodOffers: DatabaseTypes.Foodoffers[], profi
   const neutral: DatabaseTypes.Foodoffers[] = [];
 
   for (const offer of foodOffers) {
-    let isLiked = false;
-    let isDisliked = false;
-
-    if (offer?.markings) {
-      for (const marking of offer.markings) {
-        const profileMarking: any = profileMarkingsMap.get(marking.markings_id);
-
-        if (profileMarking) {
-          if (profileMarking.like === true) {
-            isLiked = true;
-          } else if (profileMarking.like === false) {
-            isDisliked = true;
-          }
-        }
-      }
-    }
-
-    if (isDisliked) {
+    const category = classifyOfferByEatingHabits(offer, profileMarkingsMap);
+    if (category === 'disliked') {
       disliked.push(offer);
-    } else if (isLiked) {
+    } else if (category === 'liked') {
       liked.push(offer);
     } else {
       neutral.push(offer);


### PR DESCRIPTION
## Summary

Continues the SonarCloud maintainability workflow (`docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`), following up on #3991. This round closes out the remaining small mechanical findings and opens up the biggest remaining bucket, "Cognitive Complexity" (109x), with a first careful batch:

**Small mechanical findings:**
- Misleading conditional formatting (1x, `BuildingDetailsContent.tsx`) — added explicit braces so the `if`-body is unambiguous; `return acc` was already unconditional, no behavior change.
- "Move function to the outer scope" (4x): `resolveAnchorPosition` (geonexia `app/index.tsx`, including hoisting its static lookup tables that were needlessly recreated per tile), `getTodayRangeIso` (`mails-hook/index.ts`), `hexToLottieColor` (`animationHelper.ts`), `loadServerInfo` (`ServerStatusLoader.tsx`) — all four are pure functions with no real closures, moved 1:1 to module scope.
- "Too many parameters" (3x): `boundsOverlap` (8→2 via a `BoundingBox` type), `getFoodofferToCreate` (8→1 options object), `createBuildingMarkerSvg` (10→1 options object) — single call site each, updated accordingly.
- `Mark these members as readonly` (1x): `CollectionHelper.collection`/`_client` are only assigned in the constructor.
- Regex complexity in `1_fix_viewbox.py` **intentionally left unchanged** — the SVG-path tokenizer regex is correct, and restructuring it risks subtly changing edge-case parsing behavior (exponent notation, leading/trailing decimal points) for a low lint payoff on this internal build script.

**First Cognitive Complexity batch (8 functions, 16-20 → now under 15):**
Picked functions just over the threshold so 1-2 extractions bring them under 15 without touching business logic: `SortingHelper.sortByEatingHabits`, `RouteNameSuggestionHelper.suggestRouteNames`, `GooglePlayHelper.fetchAllReviews`, the push-notification-hook's `.items.update` filter, `generateIssueMarkdown.parseCsvLine`, `AttributeItem.tsx`, `StatisticsCard.tsx`, and `MyMap`'s `loadHtml` effect. Each was split into small, well-named helper functions with identical logic — details and rationale per function are in the workflow doc.

101 of the 109 Cognitive Complexity findings remain (up to 201!) for dedicated future rounds — those need real per-function understanding of business logic, especially the large React components and the biggest offenders in `ActivityMapRebuildHelper.ts`/`geonexia/app/index.tsx`.

## Test plan

- [x] `tsc --noEmit` diffed against a pre-change baseline (`git stash`/`git stash pop`) for every touched workspace (`apps/frontend/app`, `apps/geonexia/frontend`, `apps/score-tracker/frontend`) — identical error sets before/after, no new errors.
- [x] `yarn typecheck` in the backend Directus extension workspace — clean.
- [x] Ran the existing test suites covering refactored logic: `SortingHelper.test.ts`, `GooglePlayReviews.test.ts`, `ParseScheduleSyncDiff.test.ts` — all green.
- [x] Confirmed `RouteNameSuggestionHelper.test.ts`'s failure is a pre-existing sandbox/environment issue (`expo-modules-core` EventEmitter setup under Jest), reproduced identically before and after this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8nPEpiY5F44DxJ7ySnMsk)_