### PR TITLE
fix(sonar): sixth maintainability batch - leftover mechanical fixes + small Cognitive Complexity extractions

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/utilization-canteen-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/utilization-canteen-hook/ParseSchedule.ts
@@ -187,7 +187,7 @@ export class ParseSchedule {
     intervalMinutes: number,
   ) {
     let now = new Date();
-    const { canteen, cashregisters, utilization_group } = utilizationContext;
+    const { utilization_group } = utilizationContext;
 
     let interval = await this.getInterval(intervalMinutes, date);
 

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -209,6 +209,17 @@ async function applyFormSubmissionLockState(
 	}
 }
 
+// Maps the tri-state boolean default (false/true/unset) to the stored 0/1/null value.
+function resolveBooleanFieldValue(defaultValue: any): number | null {
+	if (defaultValue === false) {
+		return 0;
+	}
+	if (defaultValue === true) {
+		return 1;
+	}
+	return null;
+}
+
 /**
  * Resolve the initial edit-form value for a form answer, based on its
  * custom field type (mirrors the per-type conversions used when submitting).
@@ -220,31 +231,25 @@ async function resolveInitialFieldValue(
 	parseDateForEditFn: (fieldType: string, value: string) => string,
 	getDirectusFilesDataFn: (data: any) => Promise<any[]>
 ): Promise<any> {
-	let value;
-
 	if (customType === 'value_custom') {
-		value = defaultValue || null;
-	} else if (FormHelperCommon.isFieldTypeNumber(fieldType)) {
-		value = defaultValue ? String(defaultValue)?.replace('.', ',') : null;
-	} else if (customType === 'value_boolean') {
-		if (defaultValue === false) {
-			value = 0;
-		} else if (defaultValue === true) {
-			value = 1;
-		} else {
-			value = null;
-		}
-	} else if (FormHelperCommon.isDateFieldType(fieldType)) {
-		value = parseDateForEditFn(fieldType, defaultValue);
-	} else if (customType === 'value_files') {
-		value = defaultValue ? await getDirectusFilesDataFn(defaultValue) : [];
-	} else if (customType === 'value_image') {
-		value = defaultValue ? getFormValueImageUrl(defaultValue) : null;
-	} else {
-		value = defaultValue || null;
+		return defaultValue || null;
 	}
-
-	return value;
+	if (FormHelperCommon.isFieldTypeNumber(fieldType)) {
+		return defaultValue ? String(defaultValue)?.replace('.', ',') : null;
+	}
+	if (customType === 'value_boolean') {
+		return resolveBooleanFieldValue(defaultValue);
+	}
+	if (FormHelperCommon.isDateFieldType(fieldType)) {
+		return parseDateForEditFn(fieldType, defaultValue);
+	}
+	if (customType === 'value_files') {
+		return defaultValue ? await getDirectusFilesDataFn(defaultValue) : [];
+	}
+	if (customType === 'value_image') {
+		return defaultValue ? getFormValueImageUrl(defaultValue) : null;
+	}
+	return defaultValue || null;
 }
 
 const Index = () => {

--- a/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
+++ b/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
@@ -24,45 +24,43 @@ const makeBackTrigger = (onPress: () => void, color: string) => (triggerProps: o
 	<BackTriggerButton triggerProps={triggerProps} onPress={onPress} color={color} />
 );
 
+// Ordered pathname-substring -> target mappings, checked top to bottom (first match wins),
+// for the plain cases where the target doesn't depend on anything but the pathname.
+const GO_BACK_TARGET_RULES: { pathIncludes: string; target: string }[] = [
+	{ pathIncludes: `/${AppScreens.FOOD_OFFERS}/details`, target: `/${AppScreens.FOOD_OFFERS}` },
+	{ pathIncludes: `/${AppScreens.HOUSING}/details`, target: `/${AppScreens.HOUSING}` },
+	{ pathIncludes: `/${AppScreens.STATISTICS}`, target: `/${AppScreens.MANAGEMENT}` },
+	{ pathIncludes: `/${AppScreens.SUPPORT_TICKET}`, target: `/${AppScreens.SUPPORT_FAQ}` },
+	{ pathIncludes: `/${AppScreens.FEEDBACK_SUPPORT}`, target: `/${AppScreens.SUPPORT_FAQ}` },
+	{ pathIncludes: `/${AppScreens.SUPPORT_FAQ}`, target: `/${AppScreens.SETTINGS}` },
+	{ pathIncludes: `/${AppScreens.CAMPUS}/details`, target: `/${AppScreens.CAMPUS}` },
+	{ pathIncludes: `/${AppScreens.LIST_WEEK_SCREEN}`, target: `/${AppScreens.FOOD_PLAN_WEEK}` },
+	{ pathIncludes: `/${AppScreens.FOOD_PLAN_WEEK}`, target: `/${AppScreens.MANAGEMENT}` },
+	{ pathIncludes: `/${AppScreens.FORMS}`, target: `/${AppScreens.FORM_CATEGORIES}` },
+	{ pathIncludes: `/${AppScreens.FORM_CATEGORIES}`, target: `/${AppScreens.MANAGEMENT}` },
+	{ pathIncludes: '/chats/details', target: '/chats' },
+];
+
 /**
  * Resolves which screen "go back" should navigate to, based on the current
  * pathname. Returns null when the router's own back-stack should be used
  * instead (`router.back()`).
  */
 function resolveGoBackTarget(pathname: string, loggedIn: boolean, canGoBack: boolean): string | null {
-	if (pathname.includes(`/${AppScreens.FOOD_OFFERS}/details`)) {
-		return `/${AppScreens.FOOD_OFFERS}`;
-	} else if (pathname.includes(`/${AppScreens.HOUSING}/details`)) {
-		return `/${AppScreens.HOUSING}`;
-	} else if (pathname.includes(`/${AppScreens.STATISTICS}`)) {
-		return `/${AppScreens.MANAGEMENT}`;
-	} else if (pathname.includes(`/${AppScreens.SUPPORT_TICKET}`)) {
-		return `/${AppScreens.SUPPORT_FAQ}`;
-	} else if (pathname.includes(`/${AppScreens.FEEDBACK_SUPPORT}`)) {
-		return `/${AppScreens.SUPPORT_FAQ}`;
-	} else if (pathname.includes(`/${AppScreens.SUPPORT_FAQ}`)) {
-		return `/${AppScreens.SETTINGS}`;
-	} else if (pathname.includes(`/${AppScreens.HOUSING_DELETE_USER}`)) {
+	// Checked before the table below since its target depends on `loggedIn`, not just the pathname.
+	if (pathname.includes(`/${AppScreens.HOUSING_DELETE_USER}`)) {
 		return loggedIn ? `/${AppScreens.SETTINGS}` : `/${AppScreens.LOGIN}`;
-	} else if (pathname.includes(`/${AppScreens.CAMPUS}/details`)) {
-		return `/${AppScreens.CAMPUS}`;
-	} else if (pathname.includes(`/${AppScreens.LIST_WEEK_SCREEN}`)) {
-		return `/${AppScreens.FOOD_PLAN_WEEK}`;
-	} else if (pathname.includes(`/${AppScreens.FOOD_PLAN_WEEK}`)) {
-		return `/${AppScreens.MANAGEMENT}`;
-	} else if (pathname.includes(`/${AppScreens.FORMS}`)) {
-		return `/${AppScreens.FORM_CATEGORIES}`;
-	} else if (pathname.includes(`/${AppScreens.FORM_CATEGORIES}`)) {
-		return `/${AppScreens.MANAGEMENT}`;
-	} else if (pathname.includes('/chats/details')) {
-		return '/chats';
-	} else if (canGoBack) {
-		return null;
-	} else if (loggedIn) {
-		return `/${AppScreens.FOOD_OFFERS}`;
-	} else {
-		return `/${AppScreens.LOGIN}`;
 	}
+
+	const matchedRule = GO_BACK_TARGET_RULES.find(rule => pathname.includes(rule.pathIncludes));
+	if (matchedRule) {
+		return matchedRule.target;
+	}
+
+	if (canGoBack) {
+		return null;
+	}
+	return loggedIn ? `/${AppScreens.FOOD_OFFERS}` : `/${AppScreens.LOGIN}`;
 }
 
 const CustomStackHeader: React.FC<CustomStackHeaderProps> = ({ label, rightElement }) => {

--- a/apps/frontend/app/components/DateTimeInputs/index.tsx
+++ b/apps/frontend/app/components/DateTimeInputs/index.tsx
@@ -421,6 +421,22 @@ const TimeInput = ({ id, value, onChange, onError, error, isDisabled, custom_typ
 	);
 };
 
+// Checks a single separator position against its expected character, updating `wasManualRef`
+// to reflect whether it was just manually typed (true) or is no longer present (false).
+function detectManualSeparatorAt(
+	text: string,
+	index: number,
+	expectedChar: string,
+	wasManualRef: React.MutableRefObject<boolean>,
+): boolean {
+	if (text[index] === expectedChar && !wasManualRef.current) {
+		wasManualRef.current = true;
+		return true;
+	}
+	wasManualRef.current = false;
+	return false;
+}
+
 /**
  * Checks whether the user manually typed one of the separator characters
  * (the two dots or the two colons) of a "DD.MM.YYYY HH:MM:SS" value at the
@@ -434,35 +450,15 @@ function detectManualTimestampSeparator(
 	isSecondLastColonManual: React.MutableRefObject<boolean>,
 	isLastColonManual: React.MutableRefObject<boolean>,
 ): boolean {
-	let isManualDot = false;
-	if (text.length > 0 && text.length <= 19) {
-		if (text[2] === '.' && !isThirdDotManual.current) {
-			isManualDot = true;
-			isThirdDotManual.current = true;
-		} else {
-			isThirdDotManual.current = false;
-		}
-		if (text[5] === '.' && !isFifthDotManual.current) {
-			isManualDot = true;
-			isFifthDotManual.current = true;
-		} else {
-			isFifthDotManual.current = false;
-		}
-		// Bei Timestamp (`DD.MM.YYYY HH:MM:SS`) stehen die Doppelpunkte bei Index 13 und 16 (0-basiert)
-		if (text[13] === ':' && !isSecondLastColonManual.current) {
-			isManualDot = true;
-			isSecondLastColonManual.current = true;
-		} else {
-			isSecondLastColonManual.current = false;
-		}
-		if (text[16] === ':' && !isLastColonManual.current) {
-			isManualDot = true;
-			isLastColonManual.current = true;
-		} else {
-			isLastColonManual.current = false;
-		}
+	if (text.length === 0 || text.length > 19) {
+		return false;
 	}
-	return isManualDot;
+	const isThirdDotManualNow = detectManualSeparatorAt(text, 2, '.', isThirdDotManual);
+	const isFifthDotManualNow = detectManualSeparatorAt(text, 5, '.', isFifthDotManual);
+	// Bei Timestamp (`DD.MM.YYYY HH:MM:SS`) stehen die Doppelpunkte bei Index 13 und 16 (0-basiert)
+	const isSecondLastColonManualNow = detectManualSeparatorAt(text, 13, ':', isSecondLastColonManual);
+	const isLastColonManualNow = detectManualSeparatorAt(text, 16, ':', isLastColonManual);
+	return isThirdDotManualNow || isFifthDotManualNow || isSecondLastColonManualNow || isLastColonManualNow;
 }
 
 const PreciseTimestampInput = ({ id, value, onChange, onError, error, isDisabled, custom_type, prefix, suffix }: { id: string; value: string; onChange: (id: string, value: string, custom_type: string) => void; onError: (id: string, error: string) => void; error: string; isDisabled: boolean; custom_type: string; prefix: string | null | undefined; suffix: string | null | undefined }) => {

--- a/apps/frontend/app/components/FoodOffersScrollList/index.tsx
+++ b/apps/frontend/app/components/FoodOffersScrollList/index.tsx
@@ -49,21 +49,32 @@ const EMPTY_FEEDBACKS: any[] = [];
 const daysCache: Record<string, DayData[]> = {};
 const canteenFeedbackLabelHelper = new CanteenFeedbackLabelHelper();
 
+interface RefreshFoodOffersInBackgroundOptions {
+	datesToLoad: string[];
+	loadDay: (date: string) => Promise<DayData>;
+	dayHashesRef: React.MutableRefObject<Record<string, string>>;
+	serverLoadingTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+	setDays: React.Dispatch<React.SetStateAction<DayData[]>>;
+	updateCache: (newDays: DayData[]) => void;
+	setServerLoading: React.Dispatch<React.SetStateAction<boolean>>;
+	setIsOffline: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
 /**
  * Re-fetches the given dates from the server while cached data is already
  * shown, updating state only if the server data actually changed (via hash
  * comparison), and manages the "offline hint" timer/flag around the request.
  */
-async function refreshFoodOffersInBackground(
-	datesToLoad: string[],
-	loadDay: (date: string) => Promise<DayData>,
-	dayHashesRef: React.MutableRefObject<Record<string, string>>,
-	serverLoadingTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>,
-	setDays: React.Dispatch<React.SetStateAction<DayData[]>>,
-	updateCache: (newDays: DayData[]) => void,
-	setServerLoading: React.Dispatch<React.SetStateAction<boolean>>,
-	setIsOffline: React.Dispatch<React.SetStateAction<boolean>>,
-): Promise<void> {
+async function refreshFoodOffersInBackground({
+	datesToLoad,
+	loadDay,
+	dayHashesRef,
+	serverLoadingTimerRef,
+	setDays,
+	updateCache,
+	setServerLoading,
+	setIsOffline,
+}: RefreshFoodOffersInBackgroundOptions): Promise<void> {
 	setServerLoading(true);
 	setIsOffline(false);
 	// Start a 5-second timer; if server fetch hasn't finished, show offline hint
@@ -400,7 +411,7 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 				setLoading(false);
 
 				// Step 2: Fetch from server in background and update if data changed
-				await refreshFoodOffersInBackground(
+				await refreshFoodOffersInBackground({
 					datesToLoad,
 					loadDay,
 					dayHashesRef,
@@ -408,8 +419,8 @@ const FoodOffersScrollList: React.FC<FoodOffersScrollListProps> = ({ canteenId, 
 					setDays,
 					updateCache,
 					setServerLoading,
-					setIsOffline
-				);
+					setIsOffline,
+				});
 			} else {
 				// No cached data, do a full load with loading spinner
 				await loadFoodOffersFullyFresh(datesToLoad, loadDay, setDays, updateCache, setLoading, setIsOffline);

--- a/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
+++ b/apps/frontend/app/components/HoursSheet/HoursSheet.tsx
@@ -160,56 +160,66 @@ const haveSameTimeRanges = (
 	return isSameTimeRange;
 };
 
+type TimeRange = { time_start: number | null; time_end: number | null };
+type GroupedTime = { day: string[]; time_start: string | null; time_end: string | null };
+type DayMergeState = { previousSavedTimeRanges: TimeRange[]; previousDaysForTimeRange: string[] };
+
+// Merges one day's consecutive ranges into `groupedTimes`, carrying the running
+// "same time range so far" state forward to the next day via the returned state.
+const mergeDayIntoGroupedTimes = (
+	currentDay: string,
+	currentTimeRanges: TimeRange[] | undefined,
+	isLastDay: boolean,
+	state: DayMergeState,
+	groupedTimes: GroupedTime[]
+): DayMergeState => {
+	let { previousSavedTimeRanges, previousDaysForTimeRange } = state;
+
+	if (!currentTimeRanges || currentTimeRanges.length === 0) {
+		// if we have no time ranges for this day, we can skip it
+		// but we need to check if we have a previous day with time ranges and if so, we need to add it to the groupedTimes
+		if (previousDaysForTimeRange.length > 0 && previousSavedTimeRanges.length > 0) {
+			// we have a previous day with time ranges
+			flushGroupedTimeRanges(previousSavedTimeRanges, previousDaysForTimeRange, groupedTimes);
+			previousSavedTimeRanges = [];
+			previousDaysForTimeRange = [];
+		}
+		return { previousSavedTimeRanges, previousDaysForTimeRange };
+	}
+
+	// So we have previous time ranges and now we want to check if the current time ranges are the same as the previous time ranges
+	let isSameTimeRange = haveSameTimeRanges(currentTimeRanges, previousSavedTimeRanges);
+
+	if (isSameTimeRange) {
+		// we have a same time range, so we can add the current day to the previous days
+		previousDaysForTimeRange = [...previousDaysForTimeRange, currentDay];
+	} else {
+		// we have a different time range, so we need to save the previous time ranges and add the current day to the grouped times
+		flushGroupedTimeRanges(previousSavedTimeRanges, previousDaysForTimeRange, groupedTimes);
+		previousDaysForTimeRange = [currentDay];
+		previousSavedTimeRanges = currentTimeRanges;
+	}
+
+	// if we are at the last day, we need to add the previous time ranges to the grouped times
+	if (isLastDay) {
+		flushGroupedTimeRanges(previousSavedTimeRanges, previousDaysForTimeRange, groupedTimes);
+	}
+
+	return { previousSavedTimeRanges, previousDaysForTimeRange };
+};
+
 const mergeDaysWithSameTimeRanges = (
 	sortedDayKeys: string[],
-	dayConsecutiveRanges: Record<string, { time_start: number | null; time_end: number | null }[]>
-): { day: string[]; time_start: string | null; time_end: string | null }[] => {
-	const groupedTimes: {
-		day: string[];
-		time_start: string | null;
-		time_end: string | null;
-	}[] = [];
+	dayConsecutiveRanges: Record<string, TimeRange[]>
+): GroupedTime[] => {
+	const groupedTimes: GroupedTime[] = [];
 
-	let previousSavedTimeRanges: {
-		time_start: number | null;
-		time_end: number | null;
-	}[] = [];
-	let previousDaysForTimeRange: string[] = [];
+	let state: DayMergeState = { previousSavedTimeRanges: [], previousDaysForTimeRange: [] };
 	for (let i = 0; i < sortedDayKeys.length; i++) {
 		let currentDay = sortedDayKeys[i];
 		let currentTimeRanges = dayConsecutiveRanges[currentDay];
-		if (!currentTimeRanges || currentTimeRanges.length === 0) {
-			// if we have no time ranges for this day, we can skip it
-			// but we need to check if we have a previous day with time ranges and if so, we need to add it to the groupedTimes
-			if (previousDaysForTimeRange.length > 0 && previousSavedTimeRanges.length > 0) {
-				// we have a previous day with time ranges
-				flushGroupedTimeRanges(previousSavedTimeRanges, previousDaysForTimeRange, groupedTimes);
-				previousSavedTimeRanges = [];
-				previousDaysForTimeRange = [];
-			} else {
-				// Do nothing as previous day has handled the time ranges
-			}
-		} else {
-			// So we have previous time ranges and now we want to check if the current time ranges are the same as the previous time ranges
-			let isLastDay = i === sortedDayKeys.length - 1;
-
-			let isSameTimeRange = haveSameTimeRanges(currentTimeRanges, previousSavedTimeRanges);
-
-			if (isSameTimeRange) {
-				// we have a same time range, so we can add the current day to the previous days
-				previousDaysForTimeRange.push(currentDay);
-			} else {
-				// we have a different time range, so we need to save the previous time ranges and add the current day to the grouped times
-				flushGroupedTimeRanges(previousSavedTimeRanges, previousDaysForTimeRange, groupedTimes);
-				previousDaysForTimeRange = [currentDay];
-				previousSavedTimeRanges = currentTimeRanges;
-			}
-
-			// if we are at the last day, we need to add the previous time ranges to the grouped times
-			if (isLastDay) {
-				flushGroupedTimeRanges(previousSavedTimeRanges, previousDaysForTimeRange, groupedTimes);
-			}
-		}
+		let isLastDay = i === sortedDayKeys.length - 1;
+		state = mergeDayIntoGroupedTimes(currentDay, currentTimeRanges, isLastDay, state, groupedTimes);
 	}
 
 	return groupedTimes;

--- a/apps/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
+++ b/apps/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
@@ -71,7 +71,7 @@ async function buildImageFormData(finalUri: string, file_name: string, storage: 
 		formData.append('image', blob, file_name);
 	} else {
 		const uriParts = finalUri.split('.');
-		const fileType = uriParts[uriParts.length - 1];
+		const fileType = uriParts.at(-1);
 		const fileExtension = `.${fileType}`;
 
 		const file: any = {

--- a/apps/frontend/app/components/NewsItem/NewsItem.tsx
+++ b/apps/frontend/app/components/NewsItem/NewsItem.tsx
@@ -52,35 +52,44 @@ const makeReadMoreTrigger = (props: Readonly<{
 const NEWS_ITEM_WIDE_BREAKPOINT = 768;
 const NEWS_ITEM_EXTRA_WIDE_BREAKPOINT = 900;
 
+const NEWS_ITEM_NARROW_LAYOUT = {
+	imageContainerWidth: '100%' as const,
+	newsContentWidth: '100%' as const,
+	cardFlexDirection: 'column' as const,
+	imageHeight: 180,
+	contentJustifyContent: 'flex-start' as const,
+	contentPadding: 0,
+	headerMarginTop: 5,
+	headerFlexDirection: 'column' as const,
+	titleWidth: '100%' as const,
+	dateWidth: '100%' as const,
+	actionAlignItems: 'center' as const,
+	readMoreWidth: '100%' as number | string,
+};
+
 /**
  * Resolves all the screenWidth-dependent layout values used by NewsItem's
  * JSX, so the `screenWidth > 768` breakpoint check isn't repeated ~10x.
  */
 function resolveNewsItemLayout(screenWidth: number) {
-	const isWide = screenWidth > NEWS_ITEM_WIDE_BREAKPOINT;
-
-	let imageContainerWidth: '20%' | '30%' | '100%' = '100%';
-	if (isWide) {
-		imageContainerWidth = screenWidth > NEWS_ITEM_EXTRA_WIDE_BREAKPOINT ? '20%' : '30%';
-	}
-	let newsContentWidth: '79%' | '69%' | '100%' = '100%';
-	if (isWide) {
-		newsContentWidth = screenWidth > NEWS_ITEM_EXTRA_WIDE_BREAKPOINT ? '79%' : '69%';
+	if (screenWidth <= NEWS_ITEM_WIDE_BREAKPOINT) {
+		return NEWS_ITEM_NARROW_LAYOUT;
 	}
 
+	const isExtraWide = screenWidth > NEWS_ITEM_EXTRA_WIDE_BREAKPOINT;
 	return {
-		imageContainerWidth,
-		newsContentWidth,
-		cardFlexDirection: isWide ? ('row' as const) : ('column' as const),
-		imageHeight: isWide ? 220 : 180,
-		contentJustifyContent: isWide ? ('space-between' as const) : ('flex-start' as const),
-		contentPadding: isWide ? 10 : 0,
-		headerMarginTop: isWide ? 10 : 5,
-		headerFlexDirection: isWide ? ('row' as const) : ('column' as const),
-		titleWidth: isWide ? ('80%' as const) : ('100%' as const),
-		dateWidth: isWide ? ('20%' as const) : ('100%' as const),
-		actionAlignItems: isWide ? ('flex-start' as const) : ('center' as const),
-		readMoreWidth: isWide ? (210 as number | string) : '100%',
+		imageContainerWidth: isExtraWide ? ('20%' as const) : ('30%' as const),
+		newsContentWidth: isExtraWide ? ('79%' as const) : ('69%' as const),
+		cardFlexDirection: 'row' as const,
+		imageHeight: 220,
+		contentJustifyContent: 'space-between' as const,
+		contentPadding: 10,
+		headerMarginTop: 10,
+		headerFlexDirection: 'row' as const,
+		titleWidth: '80%' as const,
+		dateWidth: '20%' as const,
+		actionAlignItems: 'flex-start' as const,
+		readMoreWidth: 210 as number | string,
 	};
 }
 

--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -175,7 +175,7 @@ async function buildImageFormData(finalUri: string, fileName: string, storage: s
 		formData.append('image', blob, fileName);
 	} else {
 		const uriParts = finalUri.split('.');
-		const fileType = uriParts[uriParts.length - 1];
+		const fileType = uriParts.at(-1);
 		const fileExtension = `.${fileType}`;
 		const file: any = {
 			uri: finalUri,

--- a/apps/geonexia/frontend/app/hex-texture-config/index.tsx
+++ b/apps/geonexia/frontend/app/hex-texture-config/index.tsx
@@ -502,8 +502,8 @@ export default function HexTextureConfigScreen() {
 			{/* Settings for selected terrain type */}
 			{selectedTerrainKey !== null && (() => {
 				const terrainKey = selectedTerrainKey;
-				const entry = ALL_TERRAIN_ENTRIES.find((e) => e.key === terrainKey);
-				if (!entry) return null;
+				const hasEntry = ALL_TERRAIN_ENTRIES.some((e) => e.key === terrainKey);
+				if (!hasEntry) return null;
 				const anchorX = getAnchorX(terrainKey);
 				const anchorY = getAnchorY(terrainKey);
 				const scale = getScale(terrainKey);

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -2635,16 +2635,27 @@ function computeGapTileCoordsAndDistance(
  * distributing the available time budget (`gapMs`) proportionally to distance
  * so the last synthetic point lands exactly at the end of that budget.
  */
-function buildSyntheticGapPoints(
-	gapTiles: string[],
-	gapCoords: Array<[number, number]>,
-	totalGapKm: number,
-	gapMs: number,
-	startLat: number,
-	startLng: number,
-	startTimestamp: number,
-	avgSpeedMs: number,
-): RoutePoint[] {
+interface BuildSyntheticGapPointsOptions {
+	gapTiles: string[];
+	gapCoords: Array<[number, number]>;
+	totalGapKm: number;
+	gapMs: number;
+	startLat: number;
+	startLng: number;
+	startTimestamp: number;
+	avgSpeedMs: number;
+}
+
+function buildSyntheticGapPoints({
+	gapTiles,
+	gapCoords,
+	totalGapKm,
+	gapMs,
+	startLat,
+	startLng,
+	startTimestamp,
+	avgSpeedMs,
+}: BuildSyntheticGapPointsOptions): RoutePoint[] {
 	let prevLat = startLat;
 	let prevLng = startLng;
 	let currentTimestamp = startTimestamp;
@@ -2730,16 +2741,16 @@ function reconstructInterruptedRoute(
 	// Generate interpolated GPS points along the gap tiles using their hex
 	// center coordinates. Each point is flagged as `interpolated: true` to
 	// indicate it was synthetically created to compensate for the GPS gap.
-	const syntheticPoints = buildSyntheticGapPoints(
+	const syntheticPoints = buildSyntheticGapPoints({
 		gapTiles,
 		gapCoords,
 		totalGapKm,
 		gapMs,
-		lastRecordedPoint.lat,
-		lastRecordedPoint.lng,
-		lastRecordedPoint.timestamp,
+		startLat: lastRecordedPoint.lat,
+		startLng: lastRecordedPoint.lng,
+		startTimestamp: lastRecordedPoint.timestamp,
 		avgSpeedMs,
-	);
+	});
 
 	return [...snapshot.routePoints, ...syntheticPoints];
 }

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -1196,7 +1196,7 @@ export default function RouteDetailScreen() {
 		);
 	}
 
-	const { activeTiles, routeInitialCenter, infoRows, lastInfoIdx, addModeHasAnchor } = computeRouteDetailDerivedState(
+	const { routeInitialCenter, infoRows, lastInfoIdx, addModeHasAnchor } = computeRouteDetailDerivedState(
 		route,
 		isEditing,
 		editedHexTiles,

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -859,6 +859,120 @@ Zusätzlich zwei Stellen aus dieser Runde (`settings/index.tsx` im
 Frontend, `routes/[id].tsx` in Geonexia) vormerken, falls der nächste Scan
 sie trotz der durchgeführten Extraktion weiterhin meldet.
 
+## Am 2026-07-21 (sechste Runde): Restfunde aus der fünften Runde selbst behoben
+
+Ausgangspunkt war die aktuelle CSV mit 125 Vorkommen: 63x „Cognitive
+Complexity", 16x Argument-Reihenfolge, 15x „Array index in keys", 12x „ist
+deprecated", 3x „useless assignment", 3x „Signatur ... ist deprecated", 2x
+„Prefer `X` over `X`" (generische Regel-ID, zwei unterschiedliche konkrete
+Meldungen), 2x „node:buffer", je 1x „too many parameters" (zwei
+Fundstellen). Abgleich mit den bereits in der fünften Runde dokumentierten 49
+bewusst unveränderten Stellen ergab: **exakt dieselben Dateien/Zeilen** wie
+dort dokumentiert (Array-index-Fälle, `hexTilesEnclosed`/`billboardsFlat`/
+`billboardAnchorColor`, `CollectionHelper`-Signaturen,
+`document.write`, `node:buffer`, `CardWithText`-Redundanz, die
+`hashHelper.ts`-Argument-Reihenfolge mit dem bestehenden
+`NOSONAR`-Kommentar) — seit der fünften Runde hat sich an diesen Stellen
+nichts geändert, die Begründungen dort gelten unverändert fort (nicht erneut
+einzeln neu hergeleitet, nur stichprobenartig gegengeprüft, u. a. dass der
+`NOSONAR`-Kommentar in `hashHelper.ts` weiterhin vorhanden ist).
+
+**Tatsächlich neu und mechanisch gefixt (8 Stellen):** Alle acht Stellen
+waren durch die Cognitive-Complexity-Extraktionen der fünften Runde selbst
+neu entstanden (frisch extrahierte Hilfsfunktionen, die ihrerseits ein neues,
+anderes Sonar-Finding auslösten) bzw. bislang unentdeckte Einzelfälle:
+
+- **„Async/Function 'X' has too many parameters" (2x):** Die in der fünften
+  Runde extrahierten `refreshFoodOffersInBackground`
+  (`FoodOffersScrollList/index.tsx`, 8 Parameter) und
+  `buildSyntheticGapPoints` (`geonexia/app/index.tsx`, 8 Parameter) wurden
+  auf je ein Options-Objekt umgestellt (analog zu `boundsOverlap`/
+  `getFoodofferToCreate`/`createBuildingMarkerSvg` aus der vierten Runde),
+  jeweils einzige Aufrufstelle angepasst.
+- **„Remove this useless assignment" (3x):**
+  `utilization-canteen-hook/ParseSchedule.ts:190` —
+  `updateUtilizationEntryForCanteenAtDate` destrukturierte `canteen` und
+  `cashregisters` aus `utilizationContext`, verwendete davon aber nur
+  `utilization_group` (die beiden anderen Felder werden ausschließlich in der
+  Schwesterfunktion `applyUtilizationForecastOrActual` gebraucht, die
+  denselben Destructuring-Ausdruck separat und dort korrekt vollständig
+  nutzt) — Destructuring auf `utilization_group` reduziert.
+  `geonexia/app/routes/[id].tsx:1199` — `activeTiles` wurde aus dem
+  Rückgabewert von `computeRouteDetailDerivedState` destrukturiert, aber in
+  der aufrufenden Komponente nirgends mehr gelesen (nur innerhalb der
+  Helper-Funktion selbst gebraucht) — aus dem Destructuring entfernt.
+- **„Prefer `.at(…)` over `[….length - index]`" (2x):**
+  `ImageManagementSheet.tsx:74` und
+  `useMyScrollviewDirectusImageEditModal.tsx:178` — beide identisch:
+  `uriParts[uriParts.length - 1]` zu `uriParts.at(-1)` (Ergebnis wird nur in
+  Template-Strings verwendet, `string | undefined` statt `string` ändert
+  hier nichts).
+- **„Prefer `.some(…)` over `.find(…)`" (1x):**
+  `hex-texture-config/index.tsx:505` — der gefundene Eintrag wurde nur für
+  den `if (!entry) return null;`-Existenz-Check gebraucht (kein Feld von
+  `entry` wird danach gelesen) — zu `ALL_TERRAIN_ENTRIES.some(...)` /
+  `if (!hasEntry) return null;` geändert.
+
+**Cognitive-Complexity: die fünf niedrigsten Fundstellen (16-18) behoben.**
+Alle fünf betrafen exakt die Funktionen, die in der fünften Runde bereits
+aus größeren Elternfunktionen/-komponenten extrahiert wurden, aber selbst
+weiterhin über der Grenze von 15 lagen (dieselbe Systematik wie beim „Move
+component"-Stale-CSV-Fund und den `resolveNewsItemLayout`/
+`resolveInitialFieldValue`-artigen Fällen oben — die fünfte Runde hatte
+diese neuen, kleineren Funde noch nicht im Blick, da der damalige Scan-Stand
+älter war):
+
+- `resolveNewsItemLayout` (`NewsItem.tsx`, 16→..): die zwölf
+  `isWide ? A : B`-Ternaries (teils mit verschachteltem
+  `>900`-Breakpoint-Ternary) durch zwei feste Layout-Objekte
+  (`NEWS_ITEM_NARROW_LAYOUT` als Konstante, das breite Layout als zweiter
+  `return`-Zweig) ersetzt — die Funktion trifft dadurch nur noch zwei
+  Entscheidungen (schmal/breit, dabei extra-breit) statt zwölf, identische
+  Werte für jede Kombination aus `screenWidth`.
+- `mergeDaysWithSameTimeRanges` (`HoursSheet.tsx`, 16→..): der komplette
+  Schleifenkörper (verschachteltes if/else mit je einem weiteren
+  if/else) in eine neue `mergeDayIntoGroupedTimes`-Funktion extrahiert, die
+  den laufenden Zustand (`previousSavedTimeRanges`/
+  `previousDaysForTimeRange`) explizit entgegennimmt und zurückgibt statt
+  über Closures zu mutieren — die Schleife selbst ruft die Funktion nur noch
+  auf.
+- `resolveInitialFieldValue` (`form-submission/index.tsx`, 17→..): die
+  äußere if/else-if-Kette (6 Fälle) auf frühe `return`s umgestellt (kein
+  gemeinsames `value`, keine `else`-Zweige mehr nötig); die verschachtelte
+  Boolean-Auflösung (`value_boolean`: false/true/sonst → 0/1/null) in eine
+  eigene `resolveBooleanFieldValue`-Funktion ausgelagert.
+- `resolveGoBackTarget` (`CustomStackHeader.tsx`, 18→..): die 13-fache
+  `if/else if`-Kette auf `pathname.includes(...)` in eine
+  `GO_BACK_TARGET_RULES`-Lookup-Tabelle (Pfad-Teilstring → Ziel) plus
+  `.find(...)` umgestellt; der einzige Fall mit von `loggedIn` abhängigem
+  Ziel (`HOUSING_DELETE_USER`) bleibt als expliziter Sonderfall vor der
+  Tabellen-Suche (Pfad-Muster überschneiden sich nicht mit den
+  Tabellen-Einträgen, geprüft anhand der `AppLinks`-Definitionen), der
+  `canGoBack`-Fallback danach unverändert.
+- `detectManualTimestampSeparator` (`DateTimeInputs/index.tsx`, 18→..): die
+  vier strukturell identischen
+  „Zeichen an Position X prüfen, Manual-Ref setzen/zurücksetzen"-Blöcke in
+  eine `detectManualSeparatorAt`-Hilfsfunktion gebündelt, viermal aufgerufen
+  (alle vier Aufrufe laufen weiterhin unbedingt vor der abschließenden
+  `||`-Verknüpfung, damit alle vier Refs wie zuvor bei jedem Aufruf
+  aktualisiert werden und kein Short-Circuit einen Ref-Reset überspringt).
+  Die strukturell ähnliche, aber nicht gemeldete `detectManualDateTimeSeparator`
+  (3 statt 4 Trennzeichen) blieb bewusst unverändert, um den Diff auf die
+  gemeldete Stelle zu beschränken.
+
+**Verifizierung:** `tsc --noEmit`-Baseline-Diff (`git stash`/`git stash pop`)
+für `apps/frontend/app`, `apps/geonexia/frontend` sowie `yarn typecheck` für
+die Backend-Extension: durchgehend keine neuen Fehler, nur
+Zeilennummern-Verschiebungen bei denselben vorbestehenden (unabhängigen)
+Fehlern wie vor dieser Runde. Keine dedizierten Testdateien für die
+betroffenen Komponenten/Hooks vorhanden (per Grep bestätigt).
+
+**Bilanz dieser Runde:** 8 mechanische Fixes + 5 Cognitive-Complexity-
+Extraktionen = 13 neu bearbeitete Fundstellen. **Noch offen für weitere
+Runden:** die übrigen ca. 58 Cognitive-Complexity-Funde (Komplexität 22 bis
+201, siehe Liste weiter oben in der fünften Runde) sowie das 51-Case-`switch`
+in `settingsReducer.ts`.
+
 ## Hinweise
 
 - Die CSV-Reports werden per CI aktualisiert (Commits `chore: update sonarcloud reports`).


### PR DESCRIPTION
## Summary

Continues the SonarCloud maintainability workflow documented in `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` (sixth round). Starting point was the current CSV with 125 issues (63x Cognitive Complexity, 16x argument order, 15x array-index-in-keys, 12x deprecated, 3x useless assignment, 3x deprecated signature, 2x `Prefer X over X`, 2x `node:buffer`, 2x too-many-parameters). All previously-documented "deliberately left unchanged" categories (49 locations from the fifth round) match the exact same files/lines again — nothing changed there, so those findings were only spot-checked, not re-derived.

**8 mechanical fixes** — all newly introduced/exposed by the previous round's Cognitive Complexity extractions:
- `refreshFoodOffersInBackground` (`FoodOffersScrollList/index.tsx`) and `buildSyntheticGapPoints` (`geonexia/app/index.tsx`): 8 parameters each → converted to options objects.
- `utilization-canteen-hook/ParseSchedule.ts:190` and `geonexia/app/routes/[id].tsx:1199`: removed two useless destructured-but-unused assignments (`canteen`/`cashregisters`, `activeTiles`).
- `ImageManagementSheet.tsx` and `useMyScrollviewDirectusImageEditModal.tsx`: `uriParts[uriParts.length - 1]` → `uriParts.at(-1)`.
- `hex-texture-config/index.tsx:505`: `.find()` used only for an existence check → `.some()`.

**5 Cognitive Complexity fixes (16-18, the lowest remaining)** — all in functions the previous round had already extracted out of larger components, but which themselves still sat above the threshold:
- `resolveNewsItemLayout` (`NewsItem.tsx`): twelve `isWide ? A : B` ternaries replaced by two fixed layout objects (narrow/wide).
- `mergeDaysWithSameTimeRanges` (`HoursSheet.tsx`): loop body extracted into `mergeDayIntoGroupedTimes`, explicit state in/out instead of closures.
- `resolveInitialFieldValue` (`form-submission/index.tsx`): if/else-if chain converted to early returns; boolean sub-case extracted into `resolveBooleanFieldValue`.
- `resolveGoBackTarget` (`CustomStackHeader.tsx`): 13-branch if/else-if chain replaced by a `GO_BACK_TARGET_RULES` lookup table + one special case.
- `detectManualTimestampSeparator` (`DateTimeInputs/index.tsx`): four duplicated separator-check blocks bundled into `detectManualSeparatorAt`, called unconditionally four times (no short-circuiting, so all refs still update every call).

No control-flow/business logic was changed — purely mechanical fixes and behavior-preserving extractions.

## Test plan

- [x] `tsc --noEmit` baseline diff (`git stash`/`git stash pop`) for `apps/frontend/app` and `apps/geonexia/frontend`: no new errors, only line-number shifts in the same pre-existing (unrelated) errors.
- [x] `yarn typecheck` for the backend extension (`utilization-canteen-hook/ParseSchedule.ts` change): clean, no errors.
- [x] Confirmed via grep that none of the touched components/hooks have dedicated test files.
- [x] `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` updated with the sixth round's findings, fixes, and reasoning.


---
_Generated by [Claude Code](https://claude.ai/code/session_01McmvRoLMKn74R1ADrAeSM2)_