### PR TITLE
fix(sonar): seventh maintainability batch - all remaining Cognitive Complexity + 51-case switch

### DIFF
--- a/apps/accessibilityTester/src/report.ts
+++ b/apps/accessibilityTester/src/report.ts
@@ -107,9 +107,8 @@ function escapeMarkdownTableCell(text: string): string {
   return text.replaceAll('|', String.raw`\|`).replaceAll('\n', ' ');
 }
 
-export function generateMarkdownReport(report: AccessibilityReport): string {
-  const lines: string[] = [];
-  lines.push(
+function buildSummaryLines(report: AccessibilityReport): string[] {
+  const lines: string[] = [
     '# Accessibility Report',
     '',
     `> Generated: ${report.generatedAt} | axe-core ${report.axeCoreVersion} | Rules: ${report.tags.join(', ')} | Viewport: ${report.viewport.width}x${report.viewport.height}`,
@@ -118,7 +117,7 @@ export function generateMarkdownReport(report: AccessibilityReport): string {
     '## Summary',
     '',
     `Total violations (affected elements): **${report.totals.violations}** — 🟥 Critical: ${report.totals.critical}, 🟧 Serious: ${report.totals.serious}, 🟨 Moderate: ${report.totals.moderate}, 🟦 Minor: ${report.totals.minor}`,
-  );
+  ];
   if (report.totals.screensWithErrors > 0) {
     lines.push('', `⚠️ ${report.totals.screensWithErrors} screen(s) could not be analyzed (load error) — see details below.`);
   }
@@ -127,28 +126,39 @@ export function generateMarkdownReport(report: AccessibilityReport): string {
     '| Screen | 🟥 Critical | 🟧 Serious | 🟨 Moderate | 🟦 Minor | Total | Passes |',
     '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
   );
+  return lines;
+}
 
-  const sortedScreens = [...report.screens].sort((a, b) => {
+function sortScreensByTotalViolations(screens: ScreenResult[]): ScreenResult[] {
+  return [...screens].sort((a, b) => {
     const countTotal = (s: ScreenResult) => s.violations.reduce((sum, v) => sum + v.nodeCount, 0);
     return countTotal(b) - countTotal(a);
   });
+}
 
-  for (const screen of sortedScreens) {
-    if (screen.error) {
-      lines.push(`| ${escapeMarkdownTableCell(screen.screen)} | - | - | - | - | ⚠️ error | - |`);
-      continue;
-    }
-    const byImpact = { critical: 0, serious: 0, moderate: 0, minor: 0 };
-    for (const violation of screen.violations) {
-      byImpact[violation.impact] += violation.nodeCount;
-    }
-    const total = byImpact.critical + byImpact.serious + byImpact.moderate + byImpact.minor;
-    lines.push(`| ${escapeMarkdownTableCell(screen.screen)} | ${byImpact.critical} | ${byImpact.serious} | ${byImpact.moderate} | ${byImpact.minor} | ${total} | ${screen.passCount} |`);
+function buildScreenSummaryTableRow(screen: ScreenResult): string {
+  if (screen.error) {
+    return `| ${escapeMarkdownTableCell(screen.screen)} | - | - | - | - | ⚠️ error | - |`;
   }
+  const byImpact = { critical: 0, serious: 0, moderate: 0, minor: 0 };
+  for (const violation of screen.violations) {
+    byImpact[violation.impact] += violation.nodeCount;
+  }
+  const total = byImpact.critical + byImpact.serious + byImpact.moderate + byImpact.minor;
+  return `| ${escapeMarkdownTableCell(screen.screen)} | ${byImpact.critical} | ${byImpact.serious} | ${byImpact.moderate} | ${byImpact.minor} | ${total} | ${screen.passCount} |`;
+}
 
-  lines.push('', '## Most common rule violations', '');
-  const ruleCounts = new Map<string, { impact: ImpactLevel; help: string; helpUrl: string; nodeCount: number; screenCount: number }>();
-  for (const screen of report.screens) {
+interface RuleCountInfo {
+  impact: ImpactLevel;
+  help: string;
+  helpUrl: string;
+  nodeCount: number;
+  screenCount: number;
+}
+
+function computeRuleCounts(screens: ScreenResult[]): Map<string, RuleCountInfo> {
+  const ruleCounts = new Map<string, RuleCountInfo>();
+  for (const screen of screens) {
     for (const violation of screen.violations) {
       const existing = ruleCounts.get(violation.id);
       if (existing) {
@@ -159,6 +169,11 @@ export function generateMarkdownReport(report: AccessibilityReport): string {
       }
     }
   }
+  return ruleCounts;
+}
+
+function buildRuleCountsSectionLines(ruleCounts: Map<string, RuleCountInfo>): string[] {
+  const lines: string[] = ['', '## Most common rule violations', ''];
   const sortedRules = [...ruleCounts.entries()].sort((a, b) => b[1].nodeCount - a[1].nodeCount);
   if (sortedRules.length === 0) {
     lines.push('No violations found. 🎉');
@@ -168,34 +183,58 @@ export function generateMarkdownReport(report: AccessibilityReport): string {
       lines.push(`| \`${ruleId}\` | ${impactEmoji(info.impact)} ${info.impact} | ${info.nodeCount} | ${info.screenCount} | [${escapeMarkdownTableCell(info.help)}](${info.helpUrl}) |`);
     }
   }
+  return lines;
+}
+
+function buildViolationDetailLines(violation: ViolationSummary, impact: ImpactLevel): string[] {
+  const lines: string[] = [
+    '',
+    `- ${impactEmoji(impact)} **${violation.id}** (${impact}) — ${violation.nodeCount} element(s)`,
+    `  - ${violation.help} ([docs](${violation.helpUrl}))`,
+  ];
+  for (const node of violation.nodes.slice(0, 3)) {
+    lines.push(`  - \`${escapeMarkdownTableCell(node.target)}\``);
+  }
+  if (violation.nodeCount > 3) {
+    lines.push(`  - … and ${violation.nodeCount - 3} more (see JSON report)`);
+  }
+  return lines;
+}
+
+function buildScreenDetailLines(screen: ScreenResult): string[] {
+  const lines: string[] = ['', `### ${screen.screen}`, '', `URL: \`${screen.url}\``];
+  if (screen.error) {
+    lines.push('', `⚠️ Could not analyze this screen: ${screen.error}`);
+    return lines;
+  }
+  if (screen.violations.length === 0) {
+    lines.push('', 'No violations found. 🎉');
+    return lines;
+  }
+  for (const impact of IMPACT_LEVELS) {
+    const violationsForImpact = screen.violations.filter(v => v.impact === impact);
+    for (const violation of violationsForImpact) {
+      lines.push(...buildViolationDetailLines(violation, impact));
+    }
+  }
+  return lines;
+}
+
+export function generateMarkdownReport(report: AccessibilityReport): string {
+  const lines: string[] = [];
+  lines.push(...buildSummaryLines(report));
+
+  const sortedScreens = sortScreensByTotalViolations(report.screens);
+  for (const screen of sortedScreens) {
+    lines.push(buildScreenSummaryTableRow(screen));
+  }
+
+  const ruleCounts = computeRuleCounts(report.screens);
+  lines.push(...buildRuleCountsSectionLines(ruleCounts));
 
   lines.push('', '## Details per screen');
   for (const screen of sortedScreens) {
-    lines.push('', `### ${screen.screen}`, '', `URL: \`${screen.url}\``);
-    if (screen.error) {
-      lines.push('', `⚠️ Could not analyze this screen: ${screen.error}`);
-      continue;
-    }
-    if (screen.violations.length === 0) {
-      lines.push('', 'No violations found. 🎉');
-      continue;
-    }
-    for (const impact of IMPACT_LEVELS) {
-      const violationsForImpact = screen.violations.filter(v => v.impact === impact);
-      for (const violation of violationsForImpact) {
-        lines.push(
-          '',
-          `- ${impactEmoji(impact)} **${violation.id}** (${impact}) — ${violation.nodeCount} element(s)`,
-          `  - ${violation.help} ([docs](${violation.helpUrl}))`,
-        );
-        for (const node of violation.nodes.slice(0, 3)) {
-          lines.push(`  - \`${escapeMarkdownTableCell(node.target)}\``);
-        }
-        if (violation.nodeCount > 3) {
-          lines.push(`  - … and ${violation.nodeCount - 3} more (see JSON report)`);
-        }
-      }
-    }
+    lines.push(...buildScreenDetailLines(screen));
   }
   lines.push('');
   return lines.join('\n');

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/app-reviews-pull-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/app-reviews-pull-hook/index.ts
@@ -11,6 +11,72 @@ import { EnvVariableHelper } from '../helpers/EnvVariableHelper';
 
 const SCHEDULE_NAME = 'app_reviews_pull';
 
+async function pullAppleReviewsIfConfigured(
+  pullHelper: AppReviewsPullHelper,
+  appleAppId: string | null | undefined,
+  privateKey: string | null | undefined,
+  context: WorkflowRunContext
+): Promise<PulledAppReview[]> {
+  if (appleAppId && privateKey) {
+    return pullHelper.pullAppleReviews(appleAppId, privateKey);
+  } else if (appleAppId && !privateKey) {
+    await context.logger.appendLog('app-reviews-pull-hook: Skipping Apple reviews — APP_STORE_CONNECT_PRIVATE_KEY not configured');
+  } else if (!appleAppId) {
+    await context.logger.appendLog('app-reviews-pull-hook: Skipping Apple reviews — no Apple App ID configured for this customer');
+  }
+  return [];
+}
+
+async function pullGoogleReviewsIfConfigured(
+  pullHelper: AppReviewsPullHelper,
+  googlePlayPackageName: string | null | undefined,
+  googleServiceAccountKeyJson: string | null | undefined,
+  context: WorkflowRunContext
+): Promise<PulledAppReview[]> {
+  if (googlePlayPackageName && googleServiceAccountKeyJson) {
+    return pullHelper.pullGoogleReviews(googlePlayPackageName, googleServiceAccountKeyJson);
+  } else if (googlePlayPackageName && !googleServiceAccountKeyJson) {
+    await context.logger.appendLog('app-reviews-pull-hook: Skipping Google Play reviews — GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON not configured');
+  } else if (!googlePlayPackageName) {
+    await context.logger.appendLog('app-reviews-pull-hook: Skipping Google Play reviews — no Google Play package name configured for this customer');
+  }
+  return [];
+}
+
+type ReviewSyncResult = 'created' | 'updated' | 'skipped';
+
+async function syncSingleReview(
+  review: PulledAppReview,
+  appFeedbacksHelper: ReturnType<MyDatabaseHelper['getAppFeedbacksHelper']>
+): Promise<ReviewSyncResult> {
+  const existing = await appFeedbacksHelper.readByQuery({
+    filter: { external_identifier: { _eq: review.external_identifier } },
+    limit: 1,
+  });
+
+  if (existing && existing.length > 0) {
+    // Update response if the pulled review has a response and the existing record has a different or empty response
+    const existingFeedback = existing[0]!;
+    const existingResponse = existingFeedback.response?.trim() || '';
+    const newResponse = review.response?.trim() || '';
+    if (newResponse && existingResponse !== newResponse) {
+      await appFeedbacksHelper.updateOne(existingFeedback.id, {
+        response: review.response,
+        feedback_read_by_support: true,
+      });
+      return 'updated';
+    }
+    return 'skipped';
+  }
+
+  const createData: Partial<DatabaseTypes.AppFeedbacks> = { ...review };
+  if (review.response) {
+    createData.feedback_read_by_support = true;
+  }
+  await appFeedbacksHelper.createOne(createData);
+  return 'created';
+}
+
 class AppReviewsPullWorkflow extends SingleWorkflowRun {
   getWorkflowId(): string {
     return 'app-reviews-pull';
@@ -36,23 +102,8 @@ class AppReviewsPullWorkflow extends SingleWorkflowRun {
         return context.logger.getFinalLogWithStateAndParams({ state: WORKFLOW_RUN_STATE.SKIPPED });
       }
 
-      let appleReviews: PulledAppReview[] = [];
-      if (appleAppId && privateKey) {
-        appleReviews = await pullHelper.pullAppleReviews(appleAppId, privateKey);
-      } else if (appleAppId && !privateKey) {
-        await context.logger.appendLog('app-reviews-pull-hook: Skipping Apple reviews — APP_STORE_CONNECT_PRIVATE_KEY not configured');
-      } else if (!appleAppId) {
-        await context.logger.appendLog('app-reviews-pull-hook: Skipping Apple reviews — no Apple App ID configured for this customer');
-      }
-
-      let googleReviews: PulledAppReview[] = [];
-      if (googlePlayPackageName && googleServiceAccountKeyJson) {
-        googleReviews = await pullHelper.pullGoogleReviews(googlePlayPackageName, googleServiceAccountKeyJson);
-      } else if (googlePlayPackageName && !googleServiceAccountKeyJson) {
-        await context.logger.appendLog('app-reviews-pull-hook: Skipping Google Play reviews — GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON not configured');
-      } else if (!googlePlayPackageName) {
-        await context.logger.appendLog('app-reviews-pull-hook: Skipping Google Play reviews — no Google Play package name configured for this customer');
-      }
+      const appleReviews = await pullAppleReviewsIfConfigured(pullHelper, appleAppId, privateKey, context);
+      const googleReviews = await pullGoogleReviewsIfConfigured(pullHelper, googlePlayPackageName, googleServiceAccountKeyJson, context);
       const allReviews = [...appleReviews, ...googleReviews];
       const appFeedbacksHelper = myDatabaseHelper.getAppFeedbacksHelper();
 
@@ -61,34 +112,14 @@ class AppReviewsPullWorkflow extends SingleWorkflowRun {
       let updated = 0;
 
       for (const review of allReviews) {
-        const existing = await appFeedbacksHelper.readByQuery({
-          filter: { external_identifier: { _eq: review.external_identifier } },
-          limit: 1,
-        });
-
-        if (existing && existing.length > 0) {
-          // Update response if the pulled review has a response and the existing record has a different or empty response
-          const existingFeedback = existing[0]!;
-          const existingResponse = existingFeedback.response?.trim() || '';
-          const newResponse = review.response?.trim() || '';
-          if (newResponse && existingResponse !== newResponse) {
-            await appFeedbacksHelper.updateOne(existingFeedback.id, {
-              response: review.response,
-              feedback_read_by_support: true,
-            });
-            updated++;
-          } else {
-            skipped++;
-          }
-          continue;
+        const result = await syncSingleReview(review, appFeedbacksHelper);
+        if (result === 'created') {
+          created++;
+        } else if (result === 'updated') {
+          updated++;
+        } else {
+          skipped++;
         }
-
-        const createData: Partial<DatabaseTypes.AppFeedbacks> = { ...review };
-        if (review.response) {
-          createData.feedback_read_by_support = true;
-        }
-        await appFeedbacksHelper.createOne(createData);
-        created++;
       }
 
       await context.logger.appendLog('Created ' + created + ' new reviews, updated ' + updated + ' with responses, skipped ' + skipped + ' duplicates');

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/DirectusCollectionTranslator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/DirectusCollectionTranslator.ts
@@ -295,6 +295,34 @@ export class DirectusCollectionTranslator {
     return undefined;
   }
 
+  /**
+   * Translates each field in fieldsToTranslate from sourceTranslation using the given translator,
+   * for the given destination language_code. Logs and skips fields that fail to translate.
+   */
+  private static async translateFields(
+    translator: Translator,
+    fieldsToTranslate: string[],
+    sourceTranslation: any,
+    sourceLanguageCode: string | undefined,
+    language_code: string
+  ): Promise<any> {
+    const translatedItem: any = {};
+    for (const field of fieldsToTranslate) {
+      const fieldValue = sourceTranslation[field];
+      if (fieldValue) {
+        try {
+          const translatedValue = await translator.translate({ text: fieldValue, source_language: sourceLanguageCode, destination_language: language_code });
+          if (translatedValue) {
+            translatedItem[field] = translatedValue;
+          }
+        } catch (err) {
+          console.error('Translation error for field "' + field + '" to language "' + language_code + '":', err);
+        }
+      }
+    }
+    return translatedItem;
+  }
+
   static async translateTranslationItem(options: TranslationEntryOptions) {
     const { sourceTranslation, language_code, translator, fieldsToTranslate, FIELD_LANGUAGES_ID_OR_CODE } = options;
     let translatedItem: any = {};
@@ -304,19 +332,7 @@ export class DirectusCollectionTranslator {
         console.warn('Translator is not ready - skipping translation for language: ' + language_code);
         // Skip translation attempts since translator cannot translate
       } else {
-        for (const field of fieldsToTranslate) {
-          const fieldValue = sourceTranslation[field];
-          if (fieldValue) {
-            try {
-              const translatedValue = await translator.translate({ text: fieldValue, source_language: sourceLanguageCode, destination_language: language_code });
-              if (translatedValue) {
-                translatedItem[field] = translatedValue;
-              }
-            } catch (err) {
-              console.error('Translation error for field "' + field + '" to language "' + language_code + '":', err);
-            }
-          }
-        }
+        translatedItem = await DirectusCollectionTranslator.translateFields(translator, fieldsToTranslate, sourceTranslation, sourceLanguageCode, language_code);
       }
     }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -339,16 +339,7 @@ export class ParseSchedule {
     // Compute the global oldest date from the entire report (across all canteens).
     // This is used later to scope deletion for canteens not present in the report.
     const allReportDates = this.getFoodofferDatesFromRawFoodofferJSONList(foodofferListForParser);
-    let globalOldestDate: FoodofferDateType | null = null;
-    let globalOldestDateMs: number | null = null;
-    for (const foodofferDate of allReportDates) {
-      const dateMs = new Date(DateHelper.foodofferDateTypeToString(foodofferDate)).getTime();
-      if (globalOldestDateMs === null || dateMs < globalOldestDateMs) {
-        globalOldestDate = foodofferDate;
-        globalOldestDateMs = dateMs;
-      }
-    }
-    const globalOldestDateString = globalOldestDate ? DateHelper.foodofferDateTypeToString(globalOldestDate) : null;
+    const globalOldestDateString = ParseSchedule.computeOldestFoodofferDateString(allReportDates);
 
     // Step 2: Process each canteen that IS in the report
     const canteenExternalIdentifiersInReport = new Set(Object.keys(foodoffersForParserGroupedByCanteen));
@@ -358,145 +349,11 @@ export class ParseSchedule {
       if (!canteen) continue;
 
       const canteenFoodoffers = foodoffersForParserGroupedByCanteen[canteenExternalIdentifier] || [];
-      const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
 
       if (canteen.foodoffers_import_without_date) {
-        // Import-without-date canteen: all offers have date=null, process as a single group.
-        // Filter by canteen._eq and date._null to avoid fetching the entire historical dataset.
-        // Component foodoffers have canteen=null, so canteen._eq already excludes them.
-        await this.context.logger.appendLog('Sync: fetching existing date=null non-component foodoffers for canteen (import without date): ' + canteen.id);
-
-        // Normalize date to null so the hash is consistent across parser runs regardless of
-        // what date the parser originally assigned to the foodoffer.
-        const canteenFoodoffersWithNullDate = canteenFoodoffers.map(f => ({...f, date: null as null}));
-
-        // Build report dict for this canteen
-        const reportDictByResultHash = ParseSchedule.buildReportDictByResultHash(canteenFoodoffersWithNullDate);
-
-        // Fetch existing date=null foodoffers for this canteen.
-        // canteen._eq excludes component foodoffers (which have canteen=null).
-        // date._null scopes to undated records only, avoiding a full table scan.
-        const existingFoodoffersForCanteen = await foodoffersHelper.readByQuery({
-          filter: {
-            _and: [
-              {
-                canteen: {
-                  _eq: canteen.id,
-                },
-              },
-              {
-                date: {
-                  _null: true,
-                },
-              },
-            ],
-          },
-          fields: ['id', 'result_hash'],
-          limit: -1,
-        });
-
-        const { existingDictByResultHash, existingWithoutResultHash } = ParseSchedule.buildExistingDictByResultHash(existingFoodoffersForCanteen);
-
-        // Compute diff, delete, then create
-        const diffResult = ParseSchedule.computeFoodofferSyncDiff(reportDictByResultHash, existingDictByResultHash, existingWithoutResultHash);
-        await this.context.logger.appendLog(`Sync result for canteen ${canteenExternalIdentifier} (without date): toDelete=${diffResult.toDeleteFoodoffers.length}, toSkip=${diffResult.toSkipResultHashes.length}, toCreate=${diffResult.toCreateResultHashes.length}`);
-
-        await this.deleteFoodOffers(diffResult.toDeleteFoodoffers, `Delete foodoffers not in report for canteen ${canteenExternalIdentifier} (without date)`);
-
-        const foodoffersForParserToCreate = diffResult.toCreateResultHashes
-          .map(hash => reportDictByResultHash[hash])
-          .filter((f): f is FoodoffersTypeForParser => !!f);
-        await this.createFoodOffers(foodoffersForParserToCreate, helperObject);
+        await this.syncFoodOffersForCanteenWithoutDate(canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject);
       } else {
-        // Regular canteen: process diffs per date
-        // Group report foodoffers for this canteen by date string
-        const reportByDate: Record<string, FoodoffersTypeForParser[]> = {};
-        for (const foodofferForParser of canteenFoodoffers) {
-          if (!foodofferForParser.date) continue;
-          const dateKey = DateHelper.foodofferDateTypeToString(foodofferForParser.date);
-          if (!reportByDate[dateKey]) {
-            reportByDate[dateKey] = [];
-          }
-          reportByDate[dateKey].push(foodofferForParser);
-        }
-
-        // Collect all dates: from report + from existing future foodoffers in DB
-        const allDateKeys = new Set<string>(Object.keys(reportByDate));
-
-        // Find the oldest date from the report to scope existing-foodoffer queries
-        const foodofferDates = this.getFoodofferDatesFromRawFoodofferJSONList(canteenFoodoffers);
-        let oldestFoodofferDate: FoodofferDateType | null = null;
-        for (const foodofferDate of foodofferDates) {
-          const dateAsDate = new Date(DateHelper.foodofferDateTypeToString(foodofferDate));
-          if (!oldestFoodofferDate || dateAsDate < new Date(DateHelper.foodofferDateTypeToString(oldestFoodofferDate))) {
-            oldestFoodofferDate = foodofferDate;
-          }
-        }
-
-        if (!oldestFoodofferDate) {
-          await this.context.logger.appendLog('Sync: no dates in report for canteen ' + canteenExternalIdentifier + ', skipping');
-          continue;
-        }
-
-        const oldestDateString = DateHelper.foodofferDateTypeToString(oldestFoodofferDate);
-        await this.context.logger.appendLog('Sync: fetching existing non-component foodoffers >= ' + oldestDateString + ' for canteen: ' + canteen.id);
-
-        // Fetch all existing foodoffers for this canteen >= oldest date.
-        // canteen._eq excludes component foodoffers (which have canteen=null).
-        // date._gte scopes to future/current dates, avoiding a full table scan.
-        const existingFoodoffersForCanteen = await foodoffersHelper.readByQuery({
-          filter: {
-            _and: [
-              {
-                date: {
-                  _gte: oldestDateString,
-                },
-              },
-              {
-                canteen: {
-                  _eq: canteen.id,
-                },
-              },
-            ],
-          },
-          fields: ['id', 'result_hash', 'date'],
-          limit: -1,
-        });
-
-        // Group existing foodoffers by date
-        const existingByDate: Record<string, DatabaseTypes.Foodoffers[]> = {};
-        for (const existing of existingFoodoffersForCanteen) {
-          const dateKey = existing.date || '__no_date__';
-          if (!existingByDate[dateKey]) {
-            existingByDate[dateKey] = [];
-          }
-          existingByDate[dateKey].push(existing);
-          allDateKeys.add(dateKey);
-        }
-
-        // Process each date independently
-        for (const dateKey of allDateKeys) {
-          const reportFoodoffersForDate = reportByDate[dateKey] || [];
-          const existingFoodoffersForDate = existingByDate[dateKey] || [];
-
-          // Build report dict for this date
-          const reportDictByResultHash = ParseSchedule.buildReportDictByResultHash(reportFoodoffersForDate);
-
-          // Build existing dict for this date
-          const { existingDictByResultHash, existingWithoutResultHash } = ParseSchedule.buildExistingDictByResultHash(existingFoodoffersForDate);
-
-          // Compute diff per date
-          const diffResult = ParseSchedule.computeFoodofferSyncDiff(reportDictByResultHash, existingDictByResultHash, existingWithoutResultHash);
-          await this.context.logger.appendLog(`Sync result for canteen ${canteenExternalIdentifier} date ${dateKey}: toDelete=${diffResult.toDeleteFoodoffers.length}, toSkip=${diffResult.toSkipResultHashes.length}, toCreate=${diffResult.toCreateResultHashes.length}`);
-
-          // Delete first, then create for this date
-          await this.deleteFoodOffers(diffResult.toDeleteFoodoffers, `Delete foodoffers not in report for canteen ${canteenExternalIdentifier} date ${dateKey}`);
-
-          const foodoffersForParserToCreate = diffResult.toCreateResultHashes
-            .map(hash => reportDictByResultHash[hash])
-            .filter((f): f is FoodoffersTypeForParser => !!f);
-          await this.createFoodOffers(foodoffersForParserToCreate, helperObject);
-        }
+        await this.syncFoodOffersForCanteenByDate(canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject);
       }
     }
 
@@ -505,55 +362,228 @@ export class ParseSchedule {
     // the report had no offers for them. Import-without-date canteens are excluded
     // because their offers are long-term and not expected in every report.
     if (globalOldestDateString) {
-      await this.context.logger.appendLog('Sync: checking all canteens for missing report data (oldest report date: ' + globalOldestDateString + ')');
-      const canteensHelper = this.context.myDatabaseHelper.getCanteensHelper();
-      const allCanteens = await canteensHelper.readAllItems();
-      const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
-
-      for (const canteen of allCanteens) {
-        const externalIdentifier = canteen.external_identifier;
-        if (!externalIdentifier) continue;
-
-        // Skip canteens already processed from the report
-        if (canteenExternalIdentifiersInReport.has(externalIdentifier)) continue;
-
-        // Skip import-without-date canteens: their offers are long-term and not in every report
-        if (canteen.foodoffers_import_without_date) {
-          await this.context.logger.appendLog('Sync: skipping canteen not in report (import without date): ' + externalIdentifier);
-          continue;
-        }
-
-        await this.context.logger.appendLog('Sync: canteen not in report, deleting future foodoffers >= ' + globalOldestDateString + ' for canteen: ' + canteen.id + ' (' + externalIdentifier + ')');
-
-        // Fetch all existing foodoffers for this canteen >= oldest report date.
-        // canteen._eq excludes component foodoffers (which have canteen=null).
-        const existingFoodoffersForCanteen = await foodoffersHelper.readByQuery({
-          filter: {
-            _and: [
-              {
-                date: {
-                  _gte: globalOldestDateString,
-                },
-              },
-              {
-                canteen: {
-                  _eq: canteen.id,
-                },
-              },
-            ],
-          },
-          fields: ['id'],
-          limit: -1,
-        });
-
-        if (existingFoodoffersForCanteen.length > 0) {
-          await this.deleteFoodOffers(existingFoodoffersForCanteen as DatabaseTypes.Foodoffers[], `Delete future foodoffers for canteen not in report: ${externalIdentifier}`);
-        } else {
-          await this.context.logger.appendLog('Sync: no future foodoffers to delete for canteen: ' + externalIdentifier);
-        }
-      }
+      await this.deleteFutureFoodoffersForCanteensNotInReport(canteenExternalIdentifiersInReport, globalOldestDateString);
     } else {
       await this.context.logger.appendLog('Sync: no dates in report at all, skipping canteen-not-in-report cleanup');
+    }
+  }
+
+  /**
+   * Finds the oldest date (by timestamp) among the given foodoffer dates and returns it as a
+   * date-only string via DateHelper. Returns null if the list is empty.
+   */
+  static computeOldestFoodofferDateString(foodofferDates: FoodofferDateType[]): string | null {
+    let oldestDate: FoodofferDateType | null = null;
+    let oldestDateMs: number | null = null;
+    for (const foodofferDate of foodofferDates) {
+      const dateMs = new Date(DateHelper.foodofferDateTypeToString(foodofferDate)).getTime();
+      if (oldestDateMs === null || dateMs < oldestDateMs) {
+        oldestDate = foodofferDate;
+        oldestDateMs = dateMs;
+      }
+    }
+    return oldestDate ? DateHelper.foodofferDateTypeToString(oldestDate) : null;
+  }
+
+  /**
+   * Syncs foodoffers for an "import without date" canteen: all offers have date=null and are
+   * processed as a single group via result_hash diffing.
+   */
+  async syncFoodOffersForCanteenWithoutDate(canteen: DatabaseTypes.Canteens, canteenExternalIdentifier: string, canteenFoodoffers: FoodoffersTypeForParser[], helperObject: FoodCreationHelperObject): Promise<void> {
+    const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
+
+    // Import-without-date canteen: all offers have date=null, process as a single group.
+    // Filter by canteen._eq and date._null to avoid fetching the entire historical dataset.
+    // Component foodoffers have canteen=null, so canteen._eq already excludes them.
+    await this.context.logger.appendLog('Sync: fetching existing date=null non-component foodoffers for canteen (import without date): ' + canteen.id);
+
+    // Normalize date to null so the hash is consistent across parser runs regardless of
+    // what date the parser originally assigned to the foodoffer.
+    const canteenFoodoffersWithNullDate = canteenFoodoffers.map(f => ({...f, date: null as null}));
+
+    // Build report dict for this canteen
+    const reportDictByResultHash = ParseSchedule.buildReportDictByResultHash(canteenFoodoffersWithNullDate);
+
+    // Fetch existing date=null foodoffers for this canteen.
+    // canteen._eq excludes component foodoffers (which have canteen=null).
+    // date._null scopes to undated records only, avoiding a full table scan.
+    const existingFoodoffersForCanteen = await foodoffersHelper.readByQuery({
+      filter: {
+        _and: [
+          {
+            canteen: {
+              _eq: canteen.id,
+            },
+          },
+          {
+            date: {
+              _null: true,
+            },
+          },
+        ],
+      },
+      fields: ['id', 'result_hash'],
+      limit: -1,
+    });
+
+    const { existingDictByResultHash, existingWithoutResultHash } = ParseSchedule.buildExistingDictByResultHash(existingFoodoffersForCanteen);
+
+    // Compute diff, delete, then create
+    const diffResult = ParseSchedule.computeFoodofferSyncDiff(reportDictByResultHash, existingDictByResultHash, existingWithoutResultHash);
+    await this.context.logger.appendLog(`Sync result for canteen ${canteenExternalIdentifier} (without date): toDelete=${diffResult.toDeleteFoodoffers.length}, toSkip=${diffResult.toSkipResultHashes.length}, toCreate=${diffResult.toCreateResultHashes.length}`);
+
+    await this.deleteFoodOffers(diffResult.toDeleteFoodoffers, `Delete foodoffers not in report for canteen ${canteenExternalIdentifier} (without date)`);
+
+    const foodoffersForParserToCreate = diffResult.toCreateResultHashes
+      .map(hash => reportDictByResultHash[hash])
+      .filter((f): f is FoodoffersTypeForParser => !!f);
+    await this.createFoodOffers(foodoffersForParserToCreate, helperObject);
+  }
+
+  /**
+   * Syncs foodoffers for a regular (dated) canteen: diffs are computed and applied per date
+   * to minimize the deletion window.
+   */
+  async syncFoodOffersForCanteenByDate(canteen: DatabaseTypes.Canteens, canteenExternalIdentifier: string, canteenFoodoffers: FoodoffersTypeForParser[], helperObject: FoodCreationHelperObject): Promise<void> {
+    const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
+
+    // Regular canteen: process diffs per date
+    // Group report foodoffers for this canteen by date string
+    const reportByDate: Record<string, FoodoffersTypeForParser[]> = {};
+    for (const foodofferForParser of canteenFoodoffers) {
+      if (!foodofferForParser.date) continue;
+      const dateKey = DateHelper.foodofferDateTypeToString(foodofferForParser.date);
+      if (!reportByDate[dateKey]) {
+        reportByDate[dateKey] = [];
+      }
+      reportByDate[dateKey].push(foodofferForParser);
+    }
+
+    // Collect all dates: from report + from existing future foodoffers in DB
+    const allDateKeys = new Set<string>(Object.keys(reportByDate));
+
+    // Find the oldest date from the report to scope existing-foodoffer queries
+    const foodofferDates = this.getFoodofferDatesFromRawFoodofferJSONList(canteenFoodoffers);
+    const oldestDateString = ParseSchedule.computeOldestFoodofferDateString(foodofferDates);
+
+    if (!oldestDateString) {
+      await this.context.logger.appendLog('Sync: no dates in report for canteen ' + canteenExternalIdentifier + ', skipping');
+      return;
+    }
+
+    await this.context.logger.appendLog('Sync: fetching existing non-component foodoffers >= ' + oldestDateString + ' for canteen: ' + canteen.id);
+
+    // Fetch all existing foodoffers for this canteen >= oldest date.
+    // canteen._eq excludes component foodoffers (which have canteen=null).
+    // date._gte scopes to future/current dates, avoiding a full table scan.
+    const existingFoodoffersForCanteen = await foodoffersHelper.readByQuery({
+      filter: {
+        _and: [
+          {
+            date: {
+              _gte: oldestDateString,
+            },
+          },
+          {
+            canteen: {
+              _eq: canteen.id,
+            },
+          },
+        ],
+      },
+      fields: ['id', 'result_hash', 'date'],
+      limit: -1,
+    });
+
+    // Group existing foodoffers by date
+    const existingByDate: Record<string, DatabaseTypes.Foodoffers[]> = {};
+    for (const existing of existingFoodoffersForCanteen) {
+      const dateKey = existing.date || '__no_date__';
+      if (!existingByDate[dateKey]) {
+        existingByDate[dateKey] = [];
+      }
+      existingByDate[dateKey].push(existing);
+      allDateKeys.add(dateKey);
+    }
+
+    // Process each date independently
+    for (const dateKey of allDateKeys) {
+      const reportFoodoffersForDate = reportByDate[dateKey] || [];
+      const existingFoodoffersForDate = existingByDate[dateKey] || [];
+
+      // Build report dict for this date
+      const reportDictByResultHash = ParseSchedule.buildReportDictByResultHash(reportFoodoffersForDate);
+
+      // Build existing dict for this date
+      const { existingDictByResultHash, existingWithoutResultHash } = ParseSchedule.buildExistingDictByResultHash(existingFoodoffersForDate);
+
+      // Compute diff per date
+      const diffResult = ParseSchedule.computeFoodofferSyncDiff(reportDictByResultHash, existingDictByResultHash, existingWithoutResultHash);
+      await this.context.logger.appendLog(`Sync result for canteen ${canteenExternalIdentifier} date ${dateKey}: toDelete=${diffResult.toDeleteFoodoffers.length}, toSkip=${diffResult.toSkipResultHashes.length}, toCreate=${diffResult.toCreateResultHashes.length}`);
+
+      // Delete first, then create for this date
+      await this.deleteFoodOffers(diffResult.toDeleteFoodoffers, `Delete foodoffers not in report for canteen ${canteenExternalIdentifier} date ${dateKey}`);
+
+      const foodoffersForParserToCreate = diffResult.toCreateResultHashes
+        .map(hash => reportDictByResultHash[hash])
+        .filter((f): f is FoodoffersTypeForParser => !!f);
+      await this.createFoodOffers(foodoffersForParserToCreate, helperObject);
+    }
+  }
+
+  /**
+   * For canteens NOT present in the current report: deletes their future foodoffers
+   * (date >= globalOldestDateString), since regular canteens are expected in every report.
+   * Import-without-date canteens are skipped, as their offers are long-term and not
+   * expected in every report.
+   */
+  async deleteFutureFoodoffersForCanteensNotInReport(canteenExternalIdentifiersInReport: Set<string>, globalOldestDateString: string): Promise<void> {
+    await this.context.logger.appendLog('Sync: checking all canteens for missing report data (oldest report date: ' + globalOldestDateString + ')');
+    const canteensHelper = this.context.myDatabaseHelper.getCanteensHelper();
+    const allCanteens = await canteensHelper.readAllItems();
+    const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
+
+    for (const canteen of allCanteens) {
+      const externalIdentifier = canteen.external_identifier;
+      if (!externalIdentifier) continue;
+
+      // Skip canteens already processed from the report
+      if (canteenExternalIdentifiersInReport.has(externalIdentifier)) continue;
+
+      // Skip import-without-date canteens: their offers are long-term and not in every report
+      if (canteen.foodoffers_import_without_date) {
+        await this.context.logger.appendLog('Sync: skipping canteen not in report (import without date): ' + externalIdentifier);
+        continue;
+      }
+
+      await this.context.logger.appendLog('Sync: canteen not in report, deleting future foodoffers >= ' + globalOldestDateString + ' for canteen: ' + canteen.id + ' (' + externalIdentifier + ')');
+
+      // Fetch all existing foodoffers for this canteen >= oldest report date.
+      // canteen._eq excludes component foodoffers (which have canteen=null).
+      const existingFoodoffersForCanteen = await foodoffersHelper.readByQuery({
+        filter: {
+          _and: [
+            {
+              date: {
+                _gte: globalOldestDateString,
+              },
+            },
+            {
+              canteen: {
+                _eq: canteen.id,
+              },
+            },
+          ],
+        },
+        fields: ['id'],
+        limit: -1,
+      });
+
+      if (existingFoodoffersForCanteen.length > 0) {
+        await this.deleteFoodOffers(existingFoodoffersForCanteen as DatabaseTypes.Foodoffers[], `Delete future foodoffers for canteen not in report: ${externalIdentifier}`);
+      } else {
+        await this.context.logger.appendLog('Sync: no future foodoffers to delete for canteen: ' + externalIdentifier);
+      }
     }
   }
 
@@ -1022,6 +1052,37 @@ export class ParseSchedule {
       : 'no date';
     await this.context.logger.appendLog('Create Food Offers (' + canteenInfo + ', ' + dateInfo + ')');
 
+    const { dictCanteenExternalIdentifierToCanteen, dictMarkingExternalIdentifierToMarking } = ParseSchedule.collectCanteenAndMarkingExternalIdentifierDicts(foodofferListForParser);
+
+    // create canteens
+    await this.resolveCanteensForExternalIdentifiers(dictCanteenExternalIdentifierToCanteen);
+
+    // create markings
+    await this.resolveMarkingsForExternalIdentifiers(dictMarkingExternalIdentifierToMarking);
+
+    // search for foods
+    const dictFoodsFound = await this.resolveFoodsForFoodofferList(foodofferListForParser);
+
+    const foodoffersToCreate: Partial<DatabaseTypes.Foodoffers>[] = [];
+    for (const [index, foodofferForParser] of foodofferListForParser.entries()) {
+      const foodOfferToCreate = await this.resolveFoodofferToCreateOrLog(foodofferForParser, index, amountOfRawMealOffers, dictCanteenExternalIdentifierToCanteen, dictMarkingExternalIdentifierToMarking, dictFoodsFound, helperObject);
+      if (foodOfferToCreate) {
+        foodoffersToCreate.push(foodOfferToCreate);
+      }
+    }
+
+    await this.createFoodOffersInBatches(foodoffersToCreate, canteenInfo, dateInfo);
+  }
+
+  /**
+   * Collects the distinct canteen and marking external identifiers referenced by the given
+   * foodoffers (including markings referenced by their components), as dicts pre-filled with
+   * null values ready to be resolved to actual database records.
+   */
+  static collectCanteenAndMarkingExternalIdentifierDicts(foodofferListForParser: FoodoffersTypeForParser[]): {
+    dictCanteenExternalIdentifierToCanteen: Record<string, DatabaseTypes.Canteens | null>;
+    dictMarkingExternalIdentifierToMarking: Record<string, DatabaseTypes.Markings | null>;
+  } {
     const dictCanteenExternalIdentifierToCanteen: Record<string, DatabaseTypes.Canteens | null> = {};
     const dictMarkingExternalIdentifierToMarking: Record<string, DatabaseTypes.Markings | null> = {};
 
@@ -1042,7 +1103,14 @@ export class ParseSchedule {
       }
     }
 
-    // create canteens
+    return { dictCanteenExternalIdentifierToCanteen, dictMarkingExternalIdentifierToMarking };
+  }
+
+  /**
+   * Resolves (find-or-creates) a canteen for each key of the given dict, mutating the dict
+   * in place with the found/created canteen.
+   */
+  async resolveCanteensForExternalIdentifiers(dictCanteenExternalIdentifierToCanteen: Record<string, DatabaseTypes.Canteens | null>): Promise<void> {
     let canteenExternalIdentifiers = Object.keys(dictCanteenExternalIdentifierToCanteen);
     for (let canteenExternalIdentifier of canteenExternalIdentifiers) {
       let canteen = await this.findOrCreateCanteenByExternalIdentifier(canteenExternalIdentifier);
@@ -1050,8 +1118,13 @@ export class ParseSchedule {
         dictCanteenExternalIdentifierToCanteen[canteenExternalIdentifier] = canteen;
       }
     }
+  }
 
-    // create markings
+  /**
+   * Resolves (find-or-creates) a marking for each key of the given dict, mutating the dict
+   * in place with the found/created marking.
+   */
+  async resolveMarkingsForExternalIdentifiers(dictMarkingExternalIdentifierToMarking: Record<string, DatabaseTypes.Markings | null>): Promise<void> {
     let markingExternalIdentifiers = Object.keys(dictMarkingExternalIdentifierToMarking);
     for (let markingExternalIdentifier of markingExternalIdentifiers) {
       let marking: DatabaseTypes.Markings | undefined | null = null;
@@ -1060,7 +1133,12 @@ export class ParseSchedule {
         dictMarkingExternalIdentifierToMarking[markingExternalIdentifier] = marking;
       }
     }
+  }
 
+  /**
+   * Looks up the food record for each food_id referenced by the given foodoffers.
+   */
+  async resolveFoodsForFoodofferList(foodofferListForParser: FoodoffersTypeForParser[]): Promise<Record<string, DatabaseTypes.Foods | null>> {
     // dict foodsFound
     const dictFoodsFound: Record<string, DatabaseTypes.Foods | null> = {};
     for (let foodofferForParser of foodofferListForParser) {
@@ -1076,52 +1154,72 @@ export class ParseSchedule {
         dictFoodsFound[foodId] = food;
       }
     }
+    return dictFoodsFound;
+  }
 
-    const foodoffersToCreate: Partial<DatabaseTypes.Foodoffers>[] = [];
-    for (const [index, foodofferForParser] of foodofferListForParser.entries()) {
-      const canteen = dictCanteenExternalIdentifierToCanteen[foodofferForParser.canteen_external_identifier];
-      const canteenFound = !!canteen;
+  /**
+   * Builds the foodoffer-to-create payload for a single parsed foodoffer, or logs a
+   * skip/error notice and returns null if the canteen/food could not be resolved or the
+   * food is archived.
+   */
+  async resolveFoodofferToCreateOrLog(
+    foodofferForParser: FoodoffersTypeForParser,
+    index: number,
+    amountOfRawMealOffers: number,
+    dictCanteenExternalIdentifierToCanteen: Record<string, DatabaseTypes.Canteens | null>,
+    dictMarkingExternalIdentifierToMarking: Record<string, DatabaseTypes.Markings | null>,
+    dictFoodsFound: Record<string, DatabaseTypes.Foods | null>,
+    helperObject: FoodCreationHelperObject,
+  ): Promise<Partial<DatabaseTypes.Foodoffers> | null> {
+    const canteen = dictCanteenExternalIdentifierToCanteen[foodofferForParser.canteen_external_identifier];
+    const canteenFound = !!canteen;
 
-      const marking_external_identifiers = foodofferForParser.marking_external_identifiers;
-      const markings: DatabaseTypes.Markings[] = [];
+    const marking_external_identifiers = foodofferForParser.marking_external_identifiers;
+    const markings: DatabaseTypes.Markings[] = [];
 
-      for (let marking_external_identifier of marking_external_identifiers) {
-        const marking = dictMarkingExternalIdentifierToMarking[marking_external_identifier];
-        if (marking) {
-          markings.push(marking);
-        }
-      }
-      const markingsAllFound = markings.length === marking_external_identifiers.length;
-
-      if (!markingsAllFound) {
-        const missingMarkings = marking_external_identifiers.filter(id => !dictMarkingExternalIdentifierToMarking[id]);
-        await this.context.logger.appendLog('Warning Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - some markings not found: [' + missingMarkings.join(', ') + '] - proceeding with available markings');
-      }
-
-      const foodofferCategoryExternalIdentifier = foodofferForParser.category_external_identifier;
-      let foodofferCategory: DatabaseTypes.FoodoffersCategories | undefined = undefined;
-      if (foodofferCategoryExternalIdentifier) {
-        foodofferCategory = helperObject.foodofferCategoryExternalIdentifiersToFoodofferCategoriesDict[foodofferCategoryExternalIdentifier];
-      }
-
-      const food_id = foodofferForParser.food_id;
-      const food = dictFoodsFound[food_id];
-      const foodFound = !!food;
-
-      const foodIsArchived = foodFound && food?.status === DirectusItemStatus.ARCHIVED;
-
-      if (canteenFound && foodFound && !foodIsArchived) {
-        const filteredMarkings = MarkingFilterHelper.filterMarkingByRestrictionRules(markings, helperObject.dictMarkingsExclusions);
-        const resultHash = FoodParserHelper.getFoodofferHashFromFoodofferInformationForParser(foodofferForParser);
-        let foodOfferToCreate = this.getFoodofferToCreate({ foodofferForParser, canteen, markings: filteredMarkings, food, foodofferCategory, helperObject, dictMarkingExternalIdentifierToMarking, resultHash });
-        foodoffersToCreate.push(foodOfferToCreate);
-      } else if (foodIsArchived) {
-        await this.context.logger.appendLog('Skip Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - food has status archived - food_id: ' + food_id);
-      } else {
-        await this.context.logger.appendLog('Error Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - canteenFound: ' + canteenFound + ' - foodFound: ' + foodFound + ' - food_id: ' + food_id);
+    for (let marking_external_identifier of marking_external_identifiers) {
+      const marking = dictMarkingExternalIdentifierToMarking[marking_external_identifier];
+      if (marking) {
+        markings.push(marking);
       }
     }
+    const markingsAllFound = markings.length === marking_external_identifiers.length;
 
+    if (!markingsAllFound) {
+      const missingMarkings = marking_external_identifiers.filter(id => !dictMarkingExternalIdentifierToMarking[id]);
+      await this.context.logger.appendLog('Warning Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - some markings not found: [' + missingMarkings.join(', ') + '] - proceeding with available markings');
+    }
+
+    const foodofferCategoryExternalIdentifier = foodofferForParser.category_external_identifier;
+    let foodofferCategory: DatabaseTypes.FoodoffersCategories | undefined = undefined;
+    if (foodofferCategoryExternalIdentifier) {
+      foodofferCategory = helperObject.foodofferCategoryExternalIdentifiersToFoodofferCategoriesDict[foodofferCategoryExternalIdentifier];
+    }
+
+    const food_id = foodofferForParser.food_id;
+    const food = dictFoodsFound[food_id];
+    const foodFound = !!food;
+
+    const foodIsArchived = foodFound && food?.status === DirectusItemStatus.ARCHIVED;
+
+    if (canteenFound && foodFound && !foodIsArchived) {
+      const filteredMarkings = MarkingFilterHelper.filterMarkingByRestrictionRules(markings, helperObject.dictMarkingsExclusions);
+      const resultHash = FoodParserHelper.getFoodofferHashFromFoodofferInformationForParser(foodofferForParser);
+      return this.getFoodofferToCreate({ foodofferForParser, canteen, markings: filteredMarkings, food, foodofferCategory, helperObject, dictMarkingExternalIdentifierToMarking, resultHash });
+    } else if (foodIsArchived) {
+      await this.context.logger.appendLog('Skip Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - food has status archived - food_id: ' + food_id);
+      return null;
+    } else {
+      await this.context.logger.appendLog('Error Foodoffer ' + (index + 1) + ' / ' + amountOfRawMealOffers + ' - canteenFound: ' + canteenFound + ' - foodFound: ' + foodFound + ' - food_id: ' + food_id);
+      return null;
+    }
+  }
+
+  /**
+   * Creates the given foodoffers in the database in batches, logging progress/timing and
+   * tolerating per-item creation errors (logged, not thrown).
+   */
+  async createFoodOffersInBatches(foodoffersToCreate: Partial<DatabaseTypes.Foodoffers>[], canteenInfo: string, dateInfo: string): Promise<void> {
     const batchSize = 10;
 
     const myFoodOffersService = this.context.myDatabaseHelper.getFoodoffersHelper();

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/foods-translation-fix-missing-schedule/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/foods-translation-fix-missing-schedule/index.ts
@@ -290,26 +290,8 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
       }
 
       // Resolve the language code for this translation entry.
-      const languageField = DirectusCollectionTranslator.detectLanguagesIdOrCodeField(translation);
-      if (!languageField) {
-        await context.logger.appendLog(
-          'Food ' + food.id + ', translation ' + translation.id +
-          ': Skipped – could not detect language field. Keys: [' + Object.keys(translation).join(', ') + ']'
-        );
-        continue;
-      }
-      const languageCodeValue = translation[languageField as keyof DatabaseTypes.FoodsTranslations];
-      let languageCode: string | undefined;
-      if (typeof languageCodeValue === 'string') {
-        languageCode = languageCodeValue;
-      } else if (languageCodeValue && typeof languageCodeValue === 'object' && 'code' in (languageCodeValue as any)) {
-        languageCode = (languageCodeValue as any).code;
-      }
+      const languageCode = await this.resolveTranslationLanguageCode(food, translation, context);
       if (!languageCode) {
-        await context.logger.appendLog(
-          'Food ' + food.id + ', translation ' + translation.id +
-          ': Skipped – could not resolve language code. Raw value: ' + JSON.stringify(languageCodeValue)
-        );
         continue;
       }
 
@@ -334,78 +316,22 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
         'Attempting translation for field(s): [' + fieldsToAttempt.join(', ') + ']'
       );
 
-      const translatedItem: any = {};
-
-      for (const field of fieldsToAttempt) {
-        if (attempted >= remainingCapacity) {
-          await context.logger.appendLog(
-            'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-            'Stopping mid-translation – reached remaining capacity of ' + remainingCapacity + '.'
-          );
-          break;
-        }
-
-        const sourceValue = (sourceTranslation as any)[field];
-        attempted++;
-
-        try {
-          await context.logger.appendLog(
-            'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-            'Translating field "' + field + '" from "' + sourceLanguageCode + '" to "' + languageCode + '", ' +
-            'source value="' + String(sourceValue).substring(0, 80) + '"'
-          );
-
-          const translatedValue = await translator.translate({
-            text: sourceValue,
-            source_language: sourceLanguageCode,
-            destination_language: languageCode,
-          });
-
-          if (translatedValue) {
-            translatedItem[field] = translatedValue;
-            await context.logger.appendLog(
-              'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-              'Field "' + field + '" → "' + String(translatedValue).substring(0, 80) + '"'
-            );
-          } else {
-            await context.logger.appendLog(
-              'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-              'Field "' + field + '" translator returned null/undefined – ' + getTranslationNullReason(languageCode)
-            );
-          }
-        } catch (err: any) {
-          await context.logger.appendLog(
-            'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-            'Error translating field "' + field + '": ' + err.toString()
-          );
-        }
-      }
+      const translateResult = await this.translateFieldsForTranslation(
+        food, translation, sourceTranslation, sourceLanguageCode, languageCode,
+        fieldsToAttempt, translator, context, attempted, remainingCapacity
+      );
+      const translatedItem = translateResult.translatedItem;
+      attempted = translateResult.attempted;
 
       translatedItem[FIELD_LANGUAGES_ID_OR_CODE] = {code: languageCode};
       translatedItem[DirectusCollectionTranslator.FIELD_LET_BE_TRANSLATED] = true;
       translatedItem[DirectusCollectionTranslator.FIELD_BE_SOURCE_FOR_TRANSLATION] = false;
 
-      if (fieldsToTranslate.some(field => translatedItem[field])) {
-        const foodsUpdateHelper = context.myDatabaseHelper.getItemsServiceHelper<DatabaseTypes.Foods>(
-          CollectionNames.FOODS
-        );
-        await foodsUpdateHelper.updateOne(food.id, {
-          translations: {
-            create: [],
-            update: [{...translation, ...translatedItem, id: translation.id}],
-            delete: [],
-          },
-        } as any);
+      const wasSaved = await this.saveTranslatedItemIfNeeded(
+        food, translation, translatedItem, fieldsToTranslate, languageCode, context
+      );
+      if (wasSaved) {
         fixed++;
-        await context.logger.appendLog(
-          'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-          'Saved. translatedItem=' + JSON.stringify(translatedItem)
-        );
-      } else {
-        await context.logger.appendLog(
-          'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
-          'Nothing to save – translator returned no usable values. translatedItem=' + JSON.stringify(translatedItem)
-        );
       }
     }
 
@@ -414,6 +340,143 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
       'attempted ' + attempted + ' operation(s).'
     );
     return {fixed, attempted};
+  }
+
+  /**
+   * Detects and resolves the language code for a single translation entry, logging (and
+   * returning `undefined` for) any case where the language field or its value can't be resolved.
+   */
+  private async resolveTranslationLanguageCode(
+    food: DatabaseTypes.Foods,
+    translation: DatabaseTypes.FoodsTranslations,
+    context: WorkflowRunContext,
+  ): Promise<string | undefined> {
+    const languageField = DirectusCollectionTranslator.detectLanguagesIdOrCodeField(translation);
+    if (!languageField) {
+      await context.logger.appendLog(
+        'Food ' + food.id + ', translation ' + translation.id +
+        ': Skipped – could not detect language field. Keys: [' + Object.keys(translation).join(', ') + ']'
+      );
+      return undefined;
+    }
+    const languageCodeValue = translation[languageField as keyof DatabaseTypes.FoodsTranslations];
+    let languageCode: string | undefined;
+    if (typeof languageCodeValue === 'string') {
+      languageCode = languageCodeValue;
+    } else if (languageCodeValue && typeof languageCodeValue === 'object' && 'code' in (languageCodeValue as any)) {
+      languageCode = (languageCodeValue as any).code;
+    }
+    if (!languageCode) {
+      await context.logger.appendLog(
+        'Food ' + food.id + ', translation ' + translation.id +
+        ': Skipped – could not resolve language code. Raw value: ' + JSON.stringify(languageCodeValue)
+      );
+      return undefined;
+    }
+    return languageCode;
+  }
+
+  /**
+   * Attempts to translate `fieldsToAttempt` for a single translation entry, respecting the
+   * remaining capacity. Returns the partially-built translated item and the updated attempted count.
+   */
+  private async translateFieldsForTranslation(
+    food: DatabaseTypes.Foods,
+    translation: DatabaseTypes.FoodsTranslations,
+    sourceTranslation: DatabaseTypes.FoodsTranslations,
+    sourceLanguageCode: string | undefined,
+    languageCode: string,
+    fieldsToAttempt: string[],
+    translator: Translator,
+    context: WorkflowRunContext,
+    attempted: number,
+    remainingCapacity: number,
+  ): Promise<{translatedItem: any; attempted: number}> {
+    const translatedItem: any = {};
+
+    for (const field of fieldsToAttempt) {
+      if (attempted >= remainingCapacity) {
+        await context.logger.appendLog(
+          'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+          'Stopping mid-translation – reached remaining capacity of ' + remainingCapacity + '.'
+        );
+        break;
+      }
+
+      const sourceValue = (sourceTranslation as any)[field];
+      attempted++;
+
+      try {
+        await context.logger.appendLog(
+          'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+          'Translating field "' + field + '" from "' + sourceLanguageCode + '" to "' + languageCode + '", ' +
+          'source value="' + String(sourceValue).substring(0, 80) + '"'
+        );
+
+        const translatedValue = await translator.translate({
+          text: sourceValue,
+          source_language: sourceLanguageCode,
+          destination_language: languageCode,
+        });
+
+        if (translatedValue) {
+          translatedItem[field] = translatedValue;
+          await context.logger.appendLog(
+            'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+            'Field "' + field + '" → "' + String(translatedValue).substring(0, 80) + '"'
+          );
+        } else {
+          await context.logger.appendLog(
+            'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+            'Field "' + field + '" translator returned null/undefined – ' + getTranslationNullReason(languageCode)
+          );
+        }
+      } catch (err: any) {
+        await context.logger.appendLog(
+          'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+          'Error translating field "' + field + '": ' + err.toString()
+        );
+      }
+    }
+
+    return {translatedItem, attempted};
+  }
+
+  /**
+   * Persists `translatedItem` onto the given translation if it contains any usable translated
+   * field values; otherwise just logs that there was nothing to save. Returns whether it saved.
+   */
+  private async saveTranslatedItemIfNeeded(
+    food: DatabaseTypes.Foods,
+    translation: DatabaseTypes.FoodsTranslations,
+    translatedItem: any,
+    fieldsToTranslate: string[],
+    languageCode: string,
+    context: WorkflowRunContext,
+  ): Promise<boolean> {
+    if (fieldsToTranslate.some(field => translatedItem[field])) {
+      const foodsUpdateHelper = context.myDatabaseHelper.getItemsServiceHelper<DatabaseTypes.Foods>(
+        CollectionNames.FOODS
+      );
+      await foodsUpdateHelper.updateOne(food.id, {
+        translations: {
+          create: [],
+          update: [{...translation, ...translatedItem, id: translation.id}],
+          delete: [],
+        },
+      } as any);
+      await context.logger.appendLog(
+        'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+        'Saved. translatedItem=' + JSON.stringify(translatedItem)
+      );
+      return true;
+    } else {
+      await context.logger.appendLog(
+        'Food ' + food.id + ', translation ' + translation.id + ' (lang=' + languageCode + '): ' +
+        'Nothing to save – translator returned no usable values. translatedItem=' + JSON.stringify(translatedItem)
+      );
+      return false;
+    }
   }
 }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/FormImportSyncWorkflow.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/FormImportSyncWorkflow.ts
@@ -5,6 +5,115 @@ import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { FormImportSyncFormSubmissions } from './FormImportTypes';
 import { WorkflowResultHash } from '../helpers/itemServiceHelpers/WorkflowsRunHelper';
 
+/**
+ * Builds a lookup from a form field's external_import_id to the form field itself.
+ */
+function buildFormFieldExternalImportIdMap(formFields: DatabaseTypes.FormFields[]): {
+  [key: string]: DatabaseTypes.FormFields;
+} {
+  let dictFormFieldExternalImportIdToFormFieldId: {
+    [key: string]: DatabaseTypes.FormFields;
+  } = {};
+  for (let formField of formFields) {
+    let external_import_id = formField.external_import_id;
+    if (external_import_id) {
+      dictFormFieldExternalImportIdToFormFieldId[external_import_id] = formField;
+    }
+  }
+  return dictFormFieldExternalImportIdToFormFieldId;
+}
+
+/**
+ * Maps the passed form answers to the matching form fields (by external_import_id)
+ * so they can be created together with a new form submission.
+ */
+function buildCreateFormAnswers(
+  formAnswers: FormImportSyncFormSubmissions['form_answers'],
+  dictFormFieldExternalImportIdToFormFieldId: { [key: string]: DatabaseTypes.FormFields },
+): Partial<DatabaseTypes.FormAnswers>[] {
+  let createFormAnswers: Partial<DatabaseTypes.FormAnswers>[] = [];
+  // now we need to fill the form answers with the data from the housing contract
+  // iterate over all data fields of the housing contract
+  for (let passedFormAnswer of formAnswers) {
+    let external_import_id = passedFormAnswer.external_import_id;
+    //await logger.appendLog("-- FormAnswer external_import_id: " + external_import_id);
+    let formField = dictFormFieldExternalImportIdToFormFieldId[external_import_id];
+    if (formField) {
+      createFormAnswers.push({
+        ...passedFormAnswer,
+        form_field: formField.id,
+      });
+    }
+  }
+  return createFormAnswers;
+}
+
+/**
+ * Searches for an existing form submission and creates it (together with its form answers)
+ * if it does not exist yet.
+ */
+async function syncFormSubmission(
+  context: WorkflowRunContext,
+  form: DatabaseTypes.Forms,
+  formSubmission: FormImportSyncFormSubmissions,
+  dictFormFieldExternalImportIdToFormFieldId: { [key: string]: DatabaseTypes.FormFields },
+  currentIndexOfFormSubmission: number,
+  amountOfFormSubmissions: number,
+): Promise<void> {
+  let internal_custom_id = formSubmission.internal_custom_id;
+  await context.logger.appendLog('Processing (' + currentIndexOfFormSubmission + '/' + amountOfFormSubmissions + '): ' + internal_custom_id);
+  let searchFormSubmission: Partial<DatabaseTypes.FormSubmissions> = {
+    form: form.id,
+    internal_custom_id: internal_custom_id, // identifier for the housing contract for future reference
+  };
+  let foundFormSubmission = await context.myDatabaseHelper.getFormsSubmissionsHelper().findFirstItem(searchFormSubmission);
+  if (!foundFormSubmission) {
+    //await logger.appendLog("- does not exist. Creating.");
+    //await logger.appendLog(JSON.stringify(formSubmission, null, 2));
+    let alias = formSubmission.alias;
+    let createFormSubmission: Partial<DatabaseTypes.FormSubmissions> = {
+      form: form.id,
+      internal_custom_id: internal_custom_id, // identifier for the form submission for future reference
+      alias: alias,
+    };
+
+    let createFormAnswers = buildCreateFormAnswers(formSubmission.form_answers, dictFormFieldExternalImportIdToFormFieldId);
+
+    // Set the form answers with provided data
+    createFormSubmission.form_answers = {
+      // @ts-ignore - this way directus will create the relation
+      create: createFormAnswers,
+      // @ts-ignore - this way directus will create the relation
+      update: [],
+      // @ts-ignore - this way directus will create the relation
+      delete: [],
+    };
+
+    await context.myDatabaseHelper.getFormsSubmissionsHelper().createOne(createFormSubmission);
+  } else {
+    //await logger.appendLog("- already exists. Skipping.");
+  }
+}
+
+/**
+ * Iterates over all form submissions and synchronizes each of them with the database.
+ */
+async function syncAllFormSubmissions(
+  context: WorkflowRunContext,
+  form: DatabaseTypes.Forms,
+  formSubmissions: FormImportSyncFormSubmissions[],
+  dictFormFieldExternalImportIdToFormFieldId: { [key: string]: DatabaseTypes.FormFields },
+): Promise<void> {
+  const amountOfFormSubmissions = formSubmissions.length;
+  await context.logger.appendLog('Amount of form submissions: ' + amountOfFormSubmissions);
+  let currentIndexOfFormSubmission = 0;
+  for (let formSubmission of formSubmissions) {
+    currentIndexOfFormSubmission++;
+    await syncFormSubmission(context, form, formSubmission, dictFormFieldExternalImportIdToFormFieldId, currentIndexOfFormSubmission, amountOfFormSubmissions);
+  }
+  await context.logger.appendLog('Finished processing all form submissions.');
+}
+
 export abstract class FormImportSyncWorkflow extends SingleWorkflowRun {
   constructor() {
     super();
@@ -62,15 +171,7 @@ export abstract class FormImportSyncWorkflow extends SingleWorkflowRun {
         let formFields = await context.myDatabaseHelper.getFormsFieldsHelper().findItems({
           form: form.id,
         });
-        let dictFormFieldExternalImportIdToFormFieldId: {
-          [key: string]: DatabaseTypes.FormFields;
-        } = {};
-        for (let formField of formFields) {
-          let external_import_id = formField.external_import_id;
-          if (external_import_id) {
-            dictFormFieldExternalImportIdToFormFieldId[external_import_id] = formField;
-          }
-        }
+        let dictFormFieldExternalImportIdToFormFieldId = buildFormFieldExternalImportIdMap(formFields);
         //await logger.appendLog("Found " + formFields.length + " form fields.");
         //await logger.appendLog("dictFormFieldExternalImportIdToFormFieldId")
         //await logger.appendLog(JSON.stringify(dictFormFieldExternalImportIdToFormFieldId, null, 2));
@@ -78,60 +179,7 @@ export abstract class FormImportSyncWorkflow extends SingleWorkflowRun {
         // Now we can create the form submissions or search for existing ones
         await context.logger.appendLog('Getting data.');
         let formSubmissions = await this.getData();
-        const amountOfFormSubmissions = formSubmissions.length;
-        await context.logger.appendLog('Amount of form submissions: ' + amountOfFormSubmissions);
-        let currentIndexOfFormSubmission = 0;
-        for (let formSubmission of formSubmissions) {
-          currentIndexOfFormSubmission++;
-          let internal_custom_id = formSubmission.internal_custom_id;
-          await context.logger.appendLog('Processing (' + currentIndexOfFormSubmission + '/' + amountOfFormSubmissions + '): ' + internal_custom_id);
-          let searchFormSubmission: Partial<DatabaseTypes.FormSubmissions> = {
-            form: form.id,
-            internal_custom_id: internal_custom_id, // identifier for the housing contract for future reference
-          };
-          let foundFormSubmission = await context.myDatabaseHelper.getFormsSubmissionsHelper().findFirstItem(searchFormSubmission);
-          if (!foundFormSubmission) {
-            //await logger.appendLog("- does not exist. Creating.");
-            //await logger.appendLog(JSON.stringify(formSubmission, null, 2));
-            let alias = formSubmission.alias;
-            let createFormSubmission: Partial<DatabaseTypes.FormSubmissions> = {
-              form: form.id,
-              internal_custom_id: internal_custom_id, // identifier for the form submission for future reference
-              alias: alias,
-            };
-
-            let createFormAnswers: Partial<DatabaseTypes.FormAnswers>[] = [];
-            // now we need to fill the form answers with the data from the housing contract
-            // iterate over all data fields of the housing contract
-            let formAnswers = formSubmission.form_answers;
-            for (let passedFormAnswer of formAnswers) {
-              let external_import_id = passedFormAnswer.external_import_id;
-              //await logger.appendLog("-- FormAnswer external_import_id: " + external_import_id);
-              let formField = dictFormFieldExternalImportIdToFormFieldId[external_import_id];
-              if (formField) {
-                createFormAnswers.push({
-                  ...passedFormAnswer,
-                  form_field: formField.id,
-                });
-              }
-            }
-
-            // Set the form answers with provided data
-            createFormSubmission.form_answers = {
-              // @ts-ignore - this way directus will create the relation
-              create: createFormAnswers,
-              // @ts-ignore - this way directus will create the relation
-              update: [],
-              // @ts-ignore - this way directus will create the relation
-              delete: [],
-            };
-
-            await context.myDatabaseHelper.getFormsSubmissionsHelper().createOne(createFormSubmission);
-          } else {
-            //await logger.appendLog("- already exists. Skipping.");
-          }
-        }
-        await context.logger.appendLog('Finished processing all form submissions.');
+        await syncAllFormSubmissions(context, form, formSubmissions, dictFormFieldExternalImportIdToFormFieldId);
 
         return context.logger.getFinalLogWithStateAndParams({
           state: WORKFLOW_RUN_STATE.SUCCESS,

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/forms-sync-hook/index.ts
@@ -56,6 +56,51 @@ function registerHookHandleFormSubmissionDateSubmitted(registerFunctions: Regist
   });
 }
 
+function isFormAnswerValueSet(form_answer: DatabaseTypes.FormAnswers): boolean {
+  let value_string_is_set = form_answer.value_string !== null && form_answer.value_string !== undefined;
+  let value_number_is_set = form_answer.value_number !== null && form_answer.value_number !== undefined;
+  let value_date_is_set = form_answer.value_date !== null && form_answer.value_date !== undefined;
+  let value_boolean_is_set = form_answer.value_boolean !== null && form_answer.value_boolean !== undefined;
+  let value_custom_is_set = form_answer.value_custom !== null && form_answer.value_custom !== undefined;
+  let value_files_is_set = form_answer.value_files !== null && form_answer.value_files !== undefined;
+  let value_image_is_set = form_answer.value_image !== null && form_answer.value_image !== undefined;
+  return value_string_is_set || value_number_is_set || value_date_is_set || value_boolean_is_set || value_custom_is_set || value_files_is_set || value_image_is_set;
+}
+
+function checkRequiredFormFieldHasAnswer(required_form_field: DatabaseTypes.FormFields, form_answers: DatabaseTypes.FormAnswers[]) {
+  let form_field_id = required_form_field.id;
+  let form_answer = form_answers.find(fa => fa.form_field === form_field_id);
+  if (!form_answer) {
+    throw new Error('Required form answer not found for form field with alias: ' + required_form_field.alias + ' (id: ' + required_form_field.id + ')');
+  }
+  let value_is_set = isFormAnswerValueSet(form_answer);
+  if (!value_is_set) {
+    throw new Error('Please fill out the required form field with alias: ' + required_form_field.alias + ' (id: ' + required_form_field.id + ')');
+  }
+}
+
+async function checkFormSubmissionRequiredFieldsFilled(form_submission_id: PrimaryKey, myDatabaseHelper: MyDatabaseHelper) {
+  let formSubmission = await myDatabaseHelper.getFormsSubmissionsHelper().readOne(form_submission_id);
+  let form_id = formSubmission.form;
+  if (!form_id) {
+    throw new Error('Form submission has no form id.');
+  }
+
+  // Get the answers of the user
+  let form_answers = await myDatabaseHelper.getFormsAnswersHelper().findItems({
+    form_submission: formSubmission.id,
+  });
+  // Get the form fields of the form
+  let form_fields = await myDatabaseHelper.getFormsFieldsHelper().findItems({
+    form: form_id,
+  });
+
+  let required_form_fields = form_fields.filter(ff => ff.is_required);
+  for (let required_form_field of required_form_fields) {
+    checkRequiredFormFieldHasAnswer(required_form_field, form_answers);
+  }
+}
+
 function registerHookCheckAllRequiredFieldsAreFilled(registerFunctions: RegisterFunctions, apiContext: ApiContext) {
   // Check if all required fields are filled
   registerFunctions.filter<Partial<DatabaseTypes.FormSubmissions>>(CollectionNames.FORM_SUBMISSIONS + '.items.update', async (input, meta, eventContext) => {
@@ -69,40 +114,7 @@ function registerHookCheckAllRequiredFieldsAreFilled(registerFunctions: Register
       let myDatabaseHelper = new MyDatabaseHelper(apiContext, eventContext);
       let form_submission_ids = meta.keys as PrimaryKey[];
       for (let form_submission_id of form_submission_ids) {
-        let formSubmission = await myDatabaseHelper.getFormsSubmissionsHelper().readOne(form_submission_id);
-        let form_id = formSubmission.form;
-        if (!form_id) {
-          throw new Error('Form submission has no form id.');
-        }
-
-        // Get the answers of the user
-        let form_answers = await myDatabaseHelper.getFormsAnswersHelper().findItems({
-          form_submission: formSubmission.id,
-        });
-        // Get the form fields of the form
-        let form_fields = await myDatabaseHelper.getFormsFieldsHelper().findItems({
-          form: form_id,
-        });
-
-        let required_form_fields = form_fields.filter(ff => ff.is_required);
-        for (let required_form_field of required_form_fields) {
-          let form_field_id = required_form_field.id;
-          let form_answer = form_answers.find(fa => fa.form_field === form_field_id);
-          if (!form_answer) {
-            throw new Error('Required form answer not found for form field with alias: ' + required_form_field.alias + ' (id: ' + required_form_field.id + ')');
-          }
-          let value_string_is_set = form_answer.value_string !== null && form_answer.value_string !== undefined;
-          let value_number_is_set = form_answer.value_number !== null && form_answer.value_number !== undefined;
-          let value_date_is_set = form_answer.value_date !== null && form_answer.value_date !== undefined;
-          let value_boolean_is_set = form_answer.value_boolean !== null && form_answer.value_boolean !== undefined;
-          let value_custom_is_set = form_answer.value_custom !== null && form_answer.value_custom !== undefined;
-          let value_files_is_set = form_answer.value_files !== null && form_answer.value_files !== undefined;
-          let value_image_is_set = form_answer.value_image !== null && form_answer.value_image !== undefined;
-          let value_is_set = value_string_is_set || value_number_is_set || value_date_is_set || value_boolean_is_set || value_custom_is_set || value_files_is_set || value_image_is_set;
-          if (!value_is_set) {
-            throw new Error('Please fill out the required form field with alias: ' + required_form_field.alias + ' (id: ' + required_form_field.id + ')');
-          }
-        }
+        await checkFormSubmissionRequiredFieldsFilled(form_submission_id, myDatabaseHelper);
       }
     }
 
@@ -145,228 +157,284 @@ export type FormExtractRelevantInformationSingle = {
 };
 export type FormExtractRelevantInformation = FormExtractRelevantInformationSingle[];
 
+function resolveFormIdFromFormSubmission(formSubmission: DatabaseTypes.FormSubmissions): string {
+  let form_id: string | undefined;
+  if (formSubmission.form) {
+    if (typeof formSubmission.form === 'string') {
+      form_id = formSubmission.form;
+    } else {
+      form_id = formSubmission.form.id;
+    }
+  }
+  if (!form_id) {
+    throw new Error('Form submission has no form id.');
+  }
+  return form_id;
+}
+
+function resolveStaticAndFieldRecipientEmails(form_extract: DatabaseTypes.FormExtracts, form_answers: FormExtractFormAnswer[]): string[] {
+  let recipient_emails: string[] = [];
+
+  let recipient_email_static = form_extract.recipient_email_static;
+  if (recipient_email_static) {
+    recipient_emails.push(recipient_email_static);
+  }
+
+  let recipient_email_field_id = form_extract.recipient_email_field; // if the recipient email is dynamic and set by the user in the form
+  if (recipient_email_field_id) {
+    let form_answer_recipient_email = form_answers.find(fa => fa.form_field === recipient_email_field_id);
+    if (!form_answer_recipient_email) {
+      throw new Error('Recipient email field not found for id: ' + recipient_email_field_id);
+    }
+    let dynamic_email_dynamic = form_answer_recipient_email.value_string;
+    if (dynamic_email_dynamic) {
+      recipient_emails.push(dynamic_email_dynamic);
+    }
+  }
+
+  return recipient_emails;
+}
+
+async function resolveRecipientUserEmail(form_extract: DatabaseTypes.FormExtracts, myDatabaseHelper: MyDatabaseHelper): Promise<string | undefined> {
+  let email_from_recipient_user: string | undefined;
+  const recipient_user_raw = form_extract.recipient_user; // if the recipient email is the user who submitted the form
+  if (recipient_user_raw) {
+    let recipient_user: DatabaseTypes.DirectusUsers | null = null;
+    if (typeof recipient_user_raw === 'string') {
+      let user = await myDatabaseHelper.getUsersHelper().readOne(recipient_user_raw);
+      if (!user) {
+        throw new Error('User not found for id: ' + recipient_user_raw);
+      }
+      recipient_user = user;
+    }
+    if (recipient_user) {
+      let email = recipient_user.email;
+      if (email) {
+        email_from_recipient_user = email;
+      }
+    }
+  }
+  return email_from_recipient_user;
+}
+
+async function resolveRecipientEmailsForFormExtract(form_extract: DatabaseTypes.FormExtracts, form_answers: FormExtractFormAnswer[], myDatabaseHelper: MyDatabaseHelper): Promise<string[]> {
+  let recipient_emails = resolveStaticAndFieldRecipientEmails(form_extract, form_answers);
+
+  let email_from_recipient_user = await resolveRecipientUserEmail(form_extract, myDatabaseHelper);
+  if (email_from_recipient_user) {
+    recipient_emails.push(email_from_recipient_user);
+  }
+
+  return recipient_emails;
+}
+
+async function resolveRelevantFormFieldsForExtract(form_extract: DatabaseTypes.FormExtracts, form_fields: DatabaseTypes.FormFields[], myDatabaseHelper: MyDatabaseHelper): Promise<DatabaseTypes.FormFields[]> {
+  let form_extract_id = form_extract.id;
+  let relevant_form_fields: DatabaseTypes.FormFields[] = [];
+  if (form_extract.all_fields) {
+    relevant_form_fields = form_fields;
+  } else {
+    let formExtractFields = await myDatabaseHelper.getFormExtractFormFieldsHelper().findItems({
+      form_extracts_id: form_extract_id,
+    });
+    for (let formExtractField of formExtractFields) {
+      let form_field_id = formExtractField.form_fields_id;
+      let form_field = form_fields.find(ff => ff.id === form_field_id);
+      if (!form_field) {
+        throw new Error('Form field not found for id: ' + form_field_id);
+      }
+      relevant_form_fields.push(form_field);
+    }
+  }
+  return relevant_form_fields;
+}
+
+function buildSortedFormAnswersForExtract(relevant_form_fields: DatabaseTypes.FormFields[], form_answers: FormExtractFormAnswer[]): FormExtractRelevantInformation {
+  let form_answers_relevant_for_form_extract: FormExtractRelevantInformation = [];
+  for (let relevant_form_field of relevant_form_fields) {
+    let form_field_id = relevant_form_field.id;
+    let form_answer = form_answers.find(fa => fa.form_field === form_field_id);
+    if (!form_answer) {
+      throw new Error('Form answer not found for form field id: ' + form_field_id);
+    }
+    form_answers_relevant_for_form_extract.push({
+      form_field_id: form_field_id,
+      sort: relevant_form_field.sort,
+      form_field: relevant_form_field,
+      form_answer: form_answer,
+    });
+  }
+
+  // sort the form answers by the sort of the form fields
+  form_answers_relevant_for_form_extract.sort((a, b) => {
+    if (a.sort === null || a.sort === undefined) {
+      return 1;
+    }
+    if (b.sort === null || b.sort === undefined) {
+      return -1;
+    }
+    // smaller sort values come first
+    return a.sort - b.sort;
+  });
+
+  return form_answers_relevant_for_form_extract;
+}
+
+async function processFormExtractMailForSubmission(
+  form_extract: DatabaseTypes.FormExtracts,
+  form_with_translations: DatabaseTypes.Forms,
+  formSubmission: DatabaseTypes.FormSubmissions,
+  form_answers: FormExtractFormAnswer[],
+  form_fields: DatabaseTypes.FormFields[],
+  myDatabaseHelper: MyDatabaseHelper
+) {
+  let form_extract_id = form_extract.id;
+
+  let recipient_emails = await resolveRecipientEmailsForFormExtract(form_extract, form_answers, myDatabaseHelper);
+
+  let atleast_one_recipient_email = recipient_emails.length > 0;
+  if (!atleast_one_recipient_email) {
+    throw new Error('No recipient email found for form extract id: ' + form_extract_id);
+  }
+
+  console.log('Get form_extract_form_fields for form_extract id: ' + form_extract_id);
+  let relevant_form_fields = await resolveRelevantFormFieldsForExtract(form_extract, form_fields, myDatabaseHelper);
+
+  let form_answers_relevant_for_form_extract = buildSortedFormAnswersForExtract(relevant_form_fields, form_answers);
+
+  // So now we have the fields and answers relevant for the
+  await sendFormExtractMail(form_with_translations, form_extract, formSubmission, form_answers_relevant_for_form_extract, recipient_emails, myDatabaseHelper);
+}
+
+async function syncFormSubmissionAndSendExtractMails(formSubmission: DatabaseTypes.FormSubmissions, myDatabaseHelper: MyDatabaseHelper) {
+  console.log('Form submission is syncing. Prepare mail.');
+  let form_id = resolveFormIdFromFormSubmission(formSubmission);
+
+  // Get the form
+  console.log('Get form');
+  let form_with_translations = await myDatabaseHelper.getFormsHelper().readOneWithTranslations(form_id);
+
+  // Get the answers of the user
+  console.log('Get form answers');
+  let form_answers_raw = await myDatabaseHelper.getFormsAnswersHelper().findItems(
+    {
+      form_submission: formSubmission.id,
+    },
+    {
+      fields: ['*', 'value_image.*', 'value_files.*'], // this allows us to parse as FormExtractFormAnswer
+    }
+  );
+  let form_answers: FormExtractFormAnswer[] = form_answers_raw as FormExtractFormAnswer[];
+
+  //console.log("Form answers: ");
+  //console.log(JSON.stringify(form_answers, null, 2));
+
+  /**
+   *  Form answers:
+   *  [
+   *    {
+   *      "date_created": "2025-05-13T15:42:17.078Z",
+   *      "date_updated": "2025-05-13T15:42:42.560Z",
+   *      "form_field": "5aa6c42e-9316-4e19-b012-33e6d3a6a3c4",
+   *      "form_submission": "854f22c6-51ac-4b18-97b1-b3695cc2c5ca",
+   *      "id": "486e0a7d-cf7c-4c80-b56d-82b9fb458faf",
+   *      "sort": null,
+   *      "status": "published",
+   *      "user_created": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
+   *      "user_updated": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
+   *      "value_boolean": null,
+   *      "value_custom": null,
+   *      "value_date": null,
+   *      "value_number": null,
+   *      "value_string": null,
+   *      "value_files": [
+   *        {
+   *          "directus_files_id": "24794e32-0db9-4e76-9a35-27545b99e4dd",
+   *          "form_answers_id": "486e0a7d-cf7c-4c80-b56d-82b9fb458faf",
+   *          "id": 10
+   *        }
+   *      ],
+   *      "value_image": null
+   *    },
+   *    {
+   *      "date_created": "2025-05-13T15:42:17.071Z",
+   *      "date_updated": "2025-05-13T15:42:42.568Z",
+   *      "form_field": "d5cda419-7a66-4208-b528-b293ead52844",
+   *      "form_submission": "854f22c6-51ac-4b18-97b1-b3695cc2c5ca",
+   *      "id": "32ab94fc-1273-405e-a9a7-0f0c2149ebdd",
+   *      "sort": null,
+   *      "status": "published",
+   *      "user_created": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
+   *      "user_updated": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
+   *      "value_boolean": null,
+   *      "value_custom": null,
+   *      "value_date": null,
+   *      "value_number": null,
+   *      "value_string": "Test",
+   *      "value_files": [],
+   *      "value_image": null
+   *    }
+   *  ]
+   */
+
+  // Get the form fields of the form
+  console.log('Get form fields');
+  let form_fields = await myDatabaseHelper.getFormsFieldsHelper().findItems(
+    {
+      form: form_id,
+    },
+    { withTranslations: true }
+  ); // with translations of the form fields
+
+  // send mail
+  // get form extracts and send mail according to the form extract fields
+  console.log('Get form extracts');
+  let formExtracts = await myDatabaseHelper.getFormExtractsHelper().findItems({
+    form: form_id,
+  });
+
+  for (let form_extract of formExtracts) {
+    await processFormExtractMailForSubmission(form_extract, form_with_translations, formSubmission, form_answers, form_fields, myDatabaseHelper);
+  }
+
+  // set state to closed
+  console.log('Set form submission state to closed');
+  await myDatabaseHelper.getFormsSubmissionsHelper().updateOneWithoutHookTrigger({
+    primary_key: formSubmission.id,
+    update: {
+      state: FormSubmissionState.CLOSED,
+    },
+  });
+}
+
+async function processFormSubmissionSyncingIfNeeded(form_submission_id: PrimaryKey, myDatabaseHelper: MyDatabaseHelper) {
+  console.log('Check Form submission id: ' + form_submission_id);
+  let formSubmission = await myDatabaseHelper.getFormsSubmissionsHelper().readOne(form_submission_id);
+  if (formSubmission.state === FormSubmissionState.SYNCING) {
+    try {
+      await syncFormSubmissionAndSendExtractMails(formSubmission, myDatabaseHelper);
+    } catch (e: any) {
+      console.error('Error while sending mail after form submission state syncing: ' + e.toString());
+      console.error(e);
+    }
+    // set state to closed on error
+    console.log('Set form submission state to closed on error');
+    await myDatabaseHelper.getFormsSubmissionsHelper().updateOneWithoutHookTrigger({
+        primary_key: formSubmission.id,
+        update: {
+            state: FormSubmissionState.CLOSED,
+        }
+    });
+  }
+}
+
 function registerHookSendMailAfterFormSubmissionStateSyncing(registerFunctions: RegisterFunctions, apiContext: ApiContext) {
   registerFunctions.action(CollectionNames.FORM_SUBMISSIONS + '.items.update', async (meta, context) => {
     console.log('Send mail after form submission state syncing');
     let myDatabaseHelper = new MyDatabaseHelper(apiContext, context);
     let form_submissions_ids = meta.keys as PrimaryKey[];
     for (let form_submission_id of form_submissions_ids) {
-      console.log('Check Form submission id: ' + form_submission_id);
-      let formSubmission = await myDatabaseHelper.getFormsSubmissionsHelper().readOne(form_submission_id);
-      if (formSubmission.state === FormSubmissionState.SYNCING) {
-        try {
-          console.log('Form submission is syncing. Prepare mail.');
-          let form_id: string | undefined;
-          if (formSubmission.form) {
-            if (typeof formSubmission.form === 'string') {
-              form_id = formSubmission.form;
-            } else {
-              form_id = formSubmission.form.id;
-            }
-          }
-          if (!form_id) {
-            throw new Error('Form submission has no form id.');
-          }
-
-          // Get the form
-          console.log('Get form');
-          let form_with_translations = await myDatabaseHelper.getFormsHelper().readOneWithTranslations(form_id);
-
-          // Get the answers of the user
-          console.log('Get form answers');
-          let form_answers_raw = await myDatabaseHelper.getFormsAnswersHelper().findItems(
-            {
-              form_submission: formSubmission.id,
-            },
-            {
-              fields: ['*', 'value_image.*', 'value_files.*'], // this allows us to parse as FormExtractFormAnswer
-            }
-          );
-          let form_answers: FormExtractFormAnswer[] = form_answers_raw as FormExtractFormAnswer[];
-
-          //console.log("Form answers: ");
-          //console.log(JSON.stringify(form_answers, null, 2));
-
-          /**
-           *  Form answers:
-           *  [
-           *    {
-           *      "date_created": "2025-05-13T15:42:17.078Z",
-           *      "date_updated": "2025-05-13T15:42:42.560Z",
-           *      "form_field": "5aa6c42e-9316-4e19-b012-33e6d3a6a3c4",
-           *      "form_submission": "854f22c6-51ac-4b18-97b1-b3695cc2c5ca",
-           *      "id": "486e0a7d-cf7c-4c80-b56d-82b9fb458faf",
-           *      "sort": null,
-           *      "status": "published",
-           *      "user_created": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
-           *      "user_updated": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
-           *      "value_boolean": null,
-           *      "value_custom": null,
-           *      "value_date": null,
-           *      "value_number": null,
-           *      "value_string": null,
-           *      "value_files": [
-           *        {
-           *          "directus_files_id": "24794e32-0db9-4e76-9a35-27545b99e4dd",
-           *          "form_answers_id": "486e0a7d-cf7c-4c80-b56d-82b9fb458faf",
-           *          "id": 10
-           *        }
-           *      ],
-           *      "value_image": null
-           *    },
-           *    {
-           *      "date_created": "2025-05-13T15:42:17.071Z",
-           *      "date_updated": "2025-05-13T15:42:42.568Z",
-           *      "form_field": "d5cda419-7a66-4208-b528-b293ead52844",
-           *      "form_submission": "854f22c6-51ac-4b18-97b1-b3695cc2c5ca",
-           *      "id": "32ab94fc-1273-405e-a9a7-0f0c2149ebdd",
-           *      "sort": null,
-           *      "status": "published",
-           *      "user_created": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
-           *      "user_updated": "b49bcb9c-97d7-4809-9c64-30cc38c9ad76",
-           *      "value_boolean": null,
-           *      "value_custom": null,
-           *      "value_date": null,
-           *      "value_number": null,
-           *      "value_string": "Test",
-           *      "value_files": [],
-           *      "value_image": null
-           *    }
-           *  ]
-           */
-
-          // Get the form fields of the form
-          console.log('Get form fields');
-          let form_fields = await myDatabaseHelper.getFormsFieldsHelper().findItems(
-            {
-              form: form_id,
-            },
-            { withTranslations: true }
-          ); // with translations of the form fields
-
-          // send mail
-          // get form extracts and send mail according to the form extract fields
-          console.log('Get form extracts');
-          let formExtracts = await myDatabaseHelper.getFormExtractsHelper().findItems({
-            form: form_id,
-          });
-
-          for (let form_extract of formExtracts) {
-            let form_extract_id = form_extract.id;
-
-            let recipient_emails: string[] = [];
-
-            let recipient_email_static = form_extract.recipient_email_static;
-            if (recipient_email_static) {
-              recipient_emails.push(recipient_email_static);
-            }
-
-            let recipient_email_field_id = form_extract.recipient_email_field; // if the recipient email is dynamic and set by the user in the form
-            let dynamic_email_dynamic: string | undefined | null = undefined;
-            if (recipient_email_field_id) {
-              let form_answer_recipient_email = form_answers.find(fa => fa.form_field === recipient_email_field_id);
-              if (!form_answer_recipient_email) {
-                throw new Error('Recipient email field not found for id: ' + recipient_email_field_id);
-              }
-              dynamic_email_dynamic = form_answer_recipient_email.value_string;
-              if (dynamic_email_dynamic) {
-                recipient_emails.push(dynamic_email_dynamic);
-              }
-            }
-
-            const recipient_user_raw = form_extract.recipient_user; // if the recipient email is the user who submitted the form
-            if (recipient_user_raw) {
-              let recipient_user: DatabaseTypes.DirectusUsers | null = null;
-              if (typeof recipient_user_raw === 'string') {
-                let user = await myDatabaseHelper.getUsersHelper().readOne(recipient_user_raw);
-                if (!user) {
-                  throw new Error('User not found for id: ' + recipient_user_raw);
-                }
-                recipient_user = user;
-              }
-              if (recipient_user) {
-                let email = recipient_user.email;
-                if (email) {
-                  recipient_emails.push(email);
-                }
-              }
-            }
-
-            let atleast_one_recipient_email = recipient_emails.length > 0;
-            if (!atleast_one_recipient_email) {
-              throw new Error('No recipient email found for form extract id: ' + form_extract_id);
-            }
-
-            console.log('Get form_extract_form_fields for form_extract id: ' + form_extract_id);
-            let relevant_form_fields: DatabaseTypes.FormFields[] = [];
-            if (form_extract.all_fields) {
-              relevant_form_fields = form_fields;
-            } else {
-              let formExtractFields = await myDatabaseHelper.getFormExtractFormFieldsHelper().findItems({
-                form_extracts_id: form_extract_id,
-              });
-              for (let formExtractField of formExtractFields) {
-                let form_field_id = formExtractField.form_fields_id;
-                let form_field = form_fields.find(ff => ff.id === form_field_id);
-                if (!form_field) {
-                  throw new Error('Form field not found for id: ' + form_field_id);
-                }
-                relevant_form_fields.push(form_field);
-              }
-            }
-
-            let form_answers_relevant_for_form_extract: FormExtractRelevantInformation = [];
-            for (let relevant_form_field of relevant_form_fields) {
-              let form_field_id = relevant_form_field.id;
-              let form_answer = form_answers.find(fa => fa.form_field === form_field_id);
-              if (!form_answer) {
-                throw new Error('Form answer not found for form field id: ' + form_field_id);
-              }
-              form_answers_relevant_for_form_extract.push({
-                form_field_id: form_field_id,
-                sort: relevant_form_field.sort,
-                form_field: relevant_form_field,
-                form_answer: form_answer,
-              });
-            }
-
-            // sort the form answers by the sort of the form fields
-            form_answers_relevant_for_form_extract.sort((a, b) => {
-              if (a.sort === null || a.sort === undefined) {
-                return 1;
-              }
-              if (b.sort === null || b.sort === undefined) {
-                return -1;
-              }
-              // smaller sort values come first
-              return a.sort - b.sort;
-            });
-
-            // So now we have the fields and answers relevant for the
-            await sendFormExtractMail(form_with_translations, form_extract, formSubmission, form_answers_relevant_for_form_extract, recipient_emails, myDatabaseHelper);
-          }
-
-          // set state to closed
-          console.log('Set form submission state to closed');
-          await myDatabaseHelper.getFormsSubmissionsHelper().updateOneWithoutHookTrigger({
-            primary_key: formSubmission.id,
-            update: {
-              state: FormSubmissionState.CLOSED,
-            },
-          });
-        } catch (e: any) {
-          console.error('Error while sending mail after form submission state syncing: ' + e.toString());
-          console.error(e);
-        }
-        // set state to closed on error
-        console.log('Set form submission state to closed on error');
-        await myDatabaseHelper.getFormsSubmissionsHelper().updateOneWithoutHookTrigger({
-            primary_key: formSubmission.id,
-            update: {
-                state: FormSubmissionState.CLOSED,
-            }
-        });
-      }
+      await processFormSubmissionSyncingIfNeeded(form_submission_id, myDatabaseHelper);
     }
   });
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MarkingFilterHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/MarkingFilterHelper.ts
@@ -20,33 +20,14 @@ export class MarkingFilterHelper {
   static filterMarkingByRestrictionRules<T extends MarkingWithIdAndExclusionRulesOnly>(markings: T[], dictMarkingsExclusions: DictMarkingsExclusions): T[] {
     // so we want to filter out all markings which have a restriction rule that is not fulfilled
     let filteredMarkings: T[] = [];
-    let markingsDictPresent: Record<string, T> = {}; // create a dict for faster lookup which markings are present
-    for (let marking of markings) {
-      markingsDictPresent[marking.id] = marking;
-    }
+    let markingsDictPresent: Record<string, T> = MarkingFilterHelper.buildMarkingsPresentDict(markings); // create a dict for faster lookup which markings are present
     for (let marking_to_be_checked of markings) {
       // for each marking
-      let isMarkingAllowed = true; // we assume that the marking is allowed
       let markingExclusionRulesForMarkingIds = MarkingFilterHelper.getMarkingExclusionRuleIdsFromMarking(marking_to_be_checked); // get the exclusion rules for the marking
+      let isMarkingAllowed = true; // we assume that the marking is allowed
       if (markingExclusionRulesForMarkingIds.length > 0) {
         // if there are exclusion rules for the marking
-        for (let markingExclusionRuleId of markingExclusionRulesForMarkingIds) {
-          // for each exclusion rule
-          let markingExclusionRule = dictMarkingsExclusions[markingExclusionRuleId]; // get the exclusion rule
-          if (markingExclusionRule) {
-            // if the exclusion rule exists
-            let marking_being_restricted_by_id = markingExclusionRule.restricted_by_markings_id as string; // get the marking that is restricting the marking
-            if (marking_being_restricted_by_id) {
-              // if the marking that is restricting the marking exists
-              let marking_being_restricted_found_in_present_markings = !!markingsDictPresent[marking_being_restricted_by_id]; // check if the marking that is restricting the marking is present in the present markings
-              if (marking_being_restricted_found_in_present_markings) {
-                // if the marking that is restricting the marking is present in the present markings
-                isMarkingAllowed = false; // the marking is not allowed
-                break; // we can stop checking the exclusion rules for this marking
-              }
-            }
-          }
-        }
+        isMarkingAllowed = !MarkingFilterHelper.isMarkingRestrictedByPresentMarking(markingExclusionRulesForMarkingIds, dictMarkingsExclusions, markingsDictPresent);
       }
       if (isMarkingAllowed) {
         // if the marking is allowed
@@ -55,6 +36,39 @@ export class MarkingFilterHelper {
     }
 
     return filteredMarkings; // return the filtered markings
+  }
+
+  static buildMarkingsPresentDict<T extends MarkingWithIdAndExclusionRulesOnly>(markings: T[]): Record<string, T> {
+    // create a dict for faster lookup which markings are present
+    let markingsDictPresent: Record<string, T> = {};
+    for (let marking of markings) {
+      markingsDictPresent[marking.id] = marking;
+    }
+    return markingsDictPresent;
+  }
+
+  static isMarkingRestrictedByPresentMarking(
+    markingExclusionRulesForMarkingIds: string[],
+    dictMarkingsExclusions: DictMarkingsExclusions,
+    markingsDictPresent: Record<string, MarkingWithIdAndExclusionRulesOnly>
+  ): boolean {
+    for (let markingExclusionRuleId of markingExclusionRulesForMarkingIds) {
+      // for each exclusion rule
+      let markingExclusionRule = dictMarkingsExclusions[markingExclusionRuleId]; // get the exclusion rule
+      if (markingExclusionRule) {
+        // if the exclusion rule exists
+        let marking_being_restricted_by_id = markingExclusionRule.restricted_by_markings_id as string; // get the marking that is restricting the marking
+        if (marking_being_restricted_by_id) {
+          // if the marking that is restricting the marking exists
+          let marking_being_restricted_found_in_present_markings = !!markingsDictPresent[marking_being_restricted_by_id]; // check if the marking that is restricting the marking is present in the present markings
+          if (marking_being_restricted_found_in_present_markings) {
+            // if the marking that is restricting the marking is present in the present markings
+            return true; // the marking is not allowed
+          }
+        }
+      }
+    }
+    return false; // no restriction found, the marking is allowed
   }
 
   static getMarkingExclusionRuleIdsFromMarking(marking: MarkingWithIdAndExclusionRulesOnly): string[] {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -175,11 +175,49 @@ export class TranslationHelper {
 
     let existingTranslations = itemWithTranslations?.translations || [];
 
-    let existingTranslationsDifferentFromParsing = false;
-    let newTranslationsFromParsing = false;
-
     // find the existing language which is source for translations
     let defaultLanguageCodeForSourceTranslation: LanguageCodesType = TranslationHelper.LANGUAGE_CODE_DE;
+    let usedLanguageCodeForSourceTranslation: LanguageCodesType = TranslationHelper._resolveSourceLanguageCodeForTranslations(existingTranslations, defaultLanguageCodeForSourceTranslation);
+
+    const { existingTranslationsDifferentFromParsing } = TranslationHelper._collectUpdateTranslationsFromExisting(
+      existingTranslations,
+      translationsFromParsing,
+      usedLanguageCodeForSourceTranslation,
+      remaining_translationsFromParsing,
+      updateTranslations
+    );
+
+    //check remaining translationsFromParsing, then put into createTranslations
+    const newTranslationsFromParsing = TranslationHelper._collectCreateTranslationsFromRemaining(
+      remaining_translationsFromParsing,
+      translationsFromParsing,
+      items_primary_field_in_translation_table,
+      item,
+      createTranslations
+    );
+
+    let updateObject = {
+      translations: {
+        create: createTranslations,
+        update: updateTranslations,
+        delete: deleteTranslations,
+      },
+    };
+
+    let updateNeeded = existingTranslationsDifferentFromParsing || newTranslationsFromParsing;
+
+    return {
+      updateObject: updateObject,
+      updateNeeded: updateNeeded,
+    };
+  }
+
+  /**
+   * Finds the language code of the existing translation that is marked as
+   * `be_source_for_translations`. Falls back to the given default language code
+   * when none is found or the found language code is not a string.
+   */
+  static _resolveSourceLanguageCodeForTranslations(existingTranslations: ExistingTranslation[], defaultLanguageCodeForSourceTranslation: LanguageCodesType): LanguageCodesType {
     let usedLanguageCodeForSourceTranslation: LanguageCodesType = defaultLanguageCodeForSourceTranslation;
     for (let existingTranslation of existingTranslations) {
       if (existingTranslation?.be_source_for_translations) {
@@ -190,6 +228,29 @@ export class TranslationHelper {
         }
       }
     }
+    return usedLanguageCodeForSourceTranslation;
+  }
+
+  /**
+   * Iterates over the existing translations and, for every one that also has a
+   * translation from parsing, either pushes an update (when there is a significant
+   * change) into `updateTranslations`, or does nothing (when the translation is
+   * unchanged). For every existing translation whose language code was handled here
+   * (whether updated or not, or not provided by the parser), the matching key is
+   * removed from `remaining_translationsFromParsing` so it will not be treated as a
+   * new translation later.
+   *
+   * Mutates `remaining_translationsFromParsing` and `updateTranslations` in place,
+   * mirroring the original inline loop's behavior.
+   */
+  static _collectUpdateTranslationsFromExisting<E extends ExistingTranslation>(
+    existingTranslations: ExistingTranslation[],
+    translationsFromParsing: TranslationsFromParsingType,
+    usedLanguageCodeForSourceTranslation: LanguageCodesType,
+    remaining_translationsFromParsing: any, // kept as `any` to match the loosely-typed work copy (JSON.parse(JSON.stringify(...))) from the caller
+    updateTranslations: ExistingTranslation[]
+  ): { existingTranslationsDifferentFromParsing: boolean } {
+    let existingTranslationsDifferentFromParsing = false;
 
     for (let existingTranslation of existingTranslations) {
       //check all existing translations
@@ -236,7 +297,27 @@ export class TranslationHelper {
         delete remaining_translationsFromParsing[existingLanguageCode]; // dont create a new translation for this language
       }
     }
-    //check remaining translationsFromParsing, then put into createTranslations
+
+    return { existingTranslationsDifferentFromParsing };
+  }
+
+  /**
+   * Iterates over the language keys still remaining in `remaining_translationsFromParsing`
+   * (i.e. languages from parsing that were not matched to an existing translation) and
+   * pushes a create-object for each one into `createTranslations`. Returns whether any
+   * new translation was found.
+   *
+   * Mutates `createTranslations` in place, mirroring the original inline loop's behavior.
+   */
+  static _collectCreateTranslationsFromRemaining<T extends ItemWithExistingTranslations, E extends ExistingTranslation>(
+    remaining_translationsFromParsing: TranslationsFromParsingType,
+    translationsFromParsing: TranslationsFromParsingType,
+    items_primary_field_in_translation_table: TranslationRelationField<E>,
+    item: T,
+    createTranslations: NewTranslationForCreation[]
+  ): boolean {
+    let newTranslationsFromParsing = false;
+
     let remaining_languageKeys = Object.keys(remaining_translationsFromParsing);
     for (let i = 0; i < remaining_languageKeys?.length; i++) {
       let remaining_languageKey = remaining_languageKeys[i] as LanguageCodesType | undefined;
@@ -264,19 +345,6 @@ export class TranslationHelper {
       }
     }
 
-    let updateObject = {
-      translations: {
-        create: createTranslations,
-        update: updateTranslations,
-        delete: deleteTranslations,
-      },
-    };
-
-    let updateNeeded = existingTranslationsDifferentFromParsing || newTranslationsFromParsing;
-
-    return {
-      updateObject: updateObject,
-      updateNeeded: updateNeeded,
-    };
+    return newTranslationsFromParsing;
   }
 }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/mails-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/mails-hook/index.ts
@@ -45,6 +45,111 @@ function getTodayRangeIso(): { startOfDayIso: string; startOfNextDayIso: string 
   };
 }
 
+async function enforceDailyMailLimitAndNotify(
+  todayMailCount: number,
+  input: Partial<DatabaseTypes.Mails>,
+  sendMail: (options: EmailOptions) => Promise<any>
+): Promise<void> {
+  if (todayMailCount > DAILY_MAIL_LIMIT - 1) {
+    const isSupportMail = input.recipient === MailAdresses.SupportMail;
+    const exceedsSupportLimit = !isSupportMail || todayMailCount > DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT - 1;
+    if (exceedsSupportLimit) {
+      const effectiveLimit = isSupportMail ? DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT : DAILY_MAIL_LIMIT;
+      throw new Error(`Daily mail limit reached (${effectiveLimit}).`);
+    }
+  }
+
+  if (todayMailCount === DAILY_MAIL_LIMIT - 1) {
+    await sendMail({
+      to: MailAdresses.SupportMail,
+      subject: `Mail Tageslimit erreicht (${DAILY_MAIL_LIMIT})`,
+      text: `Das Tageslimit von ${DAILY_MAIL_LIMIT} Mails wurde erreicht. Weitere Mails werden heute blockiert.`,
+    });
+  } else if (todayMailCount === DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT - 1) {
+    await sendMail({
+      to: MailAdresses.SupportMail,
+      subject: `Support-Mail Tageslimit erreicht (${DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT})`,
+      text: `Das erhöhte Tageslimit von ${DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT} Mails für die Support-Adresse wurde erreicht. Weitere Mails werden heute blockiert.`,
+    });
+  }
+}
+
+function extractDirectusFileIdsFromAttachments(input: Partial<DatabaseTypes.Mails>): string[] {
+  let directus_files_ids: string[] = [];
+  if (input.attachments) {
+    // @ts-ignore - create is not always defined
+    let attachments_create = input.attachments.create;
+    if (attachments_create) {
+      for (let attachment of attachments_create) {
+        let directus_files_id_raw = attachment.directus_files_id as DatabaseTypes.DirectusFiles | string | undefined;
+        if (directus_files_id_raw) {
+          if (typeof directus_files_id_raw === 'string') {
+            directus_files_ids.push(directus_files_id_raw);
+          } else {
+            directus_files_ids.push(directus_files_id_raw.id);
+          }
+        }
+      }
+    }
+  }
+  return directus_files_ids;
+}
+
+async function buildAttachmentsAndDownloadLinks(
+  filesHelper: any,
+  directus_files_ids: string[],
+  send_attachments_as_links: boolean | null | undefined
+): Promise<{ attachments: MailAttachment[]; downloadLinks: EmailDownloadLink[] }> {
+  let attachments: MailAttachment[] = [];
+  let downloadLinks: EmailDownloadLink[] = [];
+  for (let directus_files_id of directus_files_ids) {
+    try {
+      let direcuts_file = await filesHelper.readOne(directus_files_id);
+      // filename_disk is the name of the file on the server - its cryptic
+      if (send_attachments_as_links) {
+        let name = direcuts_file.filename_disk || direcuts_file.filename_download || 'file';
+        let shareLink = await filesHelper.createDirectusFilesShareLink({
+          directus_files_id: directus_files_id,
+          name: name,
+        });
+        if (shareLink) {
+          downloadLinks.push({
+            name: name,
+            url: shareLink,
+          });
+        }
+      } else {
+        // https://github.com/directus/directus/issues/23937
+        // https://nodemailer.com/message/attachments/
+        let buffer = await filesHelper.readFileContent(directus_files_id);
+        attachments.push({
+          filename: direcuts_file.filename_download,
+          content: buffer,
+        });
+      }
+    } catch (error: any) {
+      console.error('Filter: Error reading file: ', error);
+    }
+  }
+  return { attachments, downloadLinks };
+}
+
+function appendDownloadLinksToMarkdown(markdown_content: string | null | undefined, downloadLinks: EmailDownloadLink[]): string | null | undefined {
+  if (downloadLinks.length > 0) {
+    markdown_content += '\n\n';
+    markdown_content += `
+Sie können die Anhänge über folgende Links herunterladen:
+
+					`;
+    for (let downloadLink of downloadLinks) {
+      markdown_content += `
+[${downloadLink.name}](${downloadLink.url})
+					`;
+    }
+  }
+  return markdown_content;
+}
+
 export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async ({ schedule, action, filter }, apiContext) => {
 
   async function sendMail(options: EmailOptions) {
@@ -91,28 +196,7 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
       },
     });
 
-    if (todayMailCount > DAILY_MAIL_LIMIT - 1) {
-      const isSupportMail = input.recipient === MailAdresses.SupportMail;
-      const exceedsSupportLimit = !isSupportMail || todayMailCount > DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT - 1;
-      if (exceedsSupportLimit) {
-        const effectiveLimit = isSupportMail ? DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT : DAILY_MAIL_LIMIT;
-        throw new Error(`Daily mail limit reached (${effectiveLimit}).`);
-      }
-    }
-
-    if (todayMailCount === DAILY_MAIL_LIMIT - 1) {
-      await sendMail({
-        to: MailAdresses.SupportMail,
-        subject: `Mail Tageslimit erreicht (${DAILY_MAIL_LIMIT})`,
-        text: `Das Tageslimit von ${DAILY_MAIL_LIMIT} Mails wurde erreicht. Weitere Mails werden heute blockiert.`,
-      });
-    } else if (todayMailCount === DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT - 1) {
-      await sendMail({
-        to: MailAdresses.SupportMail,
-        subject: `Support-Mail Tageslimit erreicht (${DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT})`,
-        text: `Das erhöhte Tageslimit von ${DAILY_MAIL_LIMIT + SUPPORT_MAIL_EXTRA_LIMIT} Mails für die Support-Adresse wurde erreicht. Weitere Mails werden heute blockiert.`,
-      });
-    }
+    await enforceDailyMailLimitAndNotify(todayMailCount, input, sendMail);
 
     //console.log("Filter: Mails create: ", input);
     input.send_status = MAIL_SEND_STATUS.PENDING;
@@ -151,69 +235,14 @@ export default MyDefineHook.defineHookWithAllTablesExisting(SCHEDULE_NAME,async 
       //  "template_name": "base-german-markdown-content"
       //}
 
-      let directus_files_ids: string[] = [];
-      if (input.attachments) {
-        // @ts-ignore - create is not always defined
-        let attachments_create = input.attachments.create;
-        if (attachments_create) {
-          for (let attachment of attachments_create) {
-            let directus_files_id_raw = attachment.directus_files_id as DatabaseTypes.DirectusFiles | string | undefined;
-            if (directus_files_id_raw) {
-              if (typeof directus_files_id_raw === 'string') {
-                directus_files_ids.push(directus_files_id_raw);
-              } else {
-                directus_files_ids.push(directus_files_id_raw.id);
-              }
-            }
-          }
-        }
-      }
+      let directus_files_ids: string[] = extractDirectusFileIdsFromAttachments(input);
 
       let filesHelper = myDatabaseHelper.getFilesHelper();
-      let downloadLinks: EmailDownloadLink[] = [];
-      for (let directus_files_id of directus_files_ids) {
-        try {
-          let direcuts_file = await filesHelper.readOne(directus_files_id);
-          // filename_disk is the name of the file on the server - its cryptic
-          if (send_attachments_as_links) {
-            let name = direcuts_file.filename_disk || direcuts_file.filename_download || 'file';
-            let shareLink = await filesHelper.createDirectusFilesShareLink({
-              directus_files_id: directus_files_id,
-              name: name,
-            });
-            if (shareLink) {
-              downloadLinks.push({
-                name: name,
-                url: shareLink,
-              });
-            }
-          } else {
-            // https://github.com/directus/directus/issues/23937
-            // https://nodemailer.com/message/attachments/
-            let buffer = await filesHelper.readFileContent(directus_files_id);
-            attachments.push({
-              filename: direcuts_file.filename_download,
-              content: buffer,
-            });
-          }
-        } catch (error: any) {
-          console.error('Filter: Error reading file: ', error);
-        }
-      }
+      const attachmentsResult = await buildAttachmentsAndDownloadLinks(filesHelper, directus_files_ids, send_attachments_as_links);
+      attachments = attachmentsResult.attachments;
+      let downloadLinks: EmailDownloadLink[] = attachmentsResult.downloadLinks;
 
-      let markdown_content = input.markdown_content;
-      if (downloadLinks.length > 0) {
-        markdown_content += '\n\n';
-        markdown_content += `
-Sie können die Anhänge über folgende Links herunterladen:
-
-					`;
-        for (let downloadLink of downloadLinks) {
-          markdown_content += `
-[${downloadLink.name}](${downloadLink.url})
-					`;
-        }
-      }
+      let markdown_content = appendDownloadLinksToMarkdown(input.markdown_content, downloadLinks);
       input.markdown_content = markdown_content;
 
       let data = MailHelper.getHtmlTemplateDataFromMail(input);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/redirect-with-token-endpoint/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/redirect-with-token-endpoint/index.ts
@@ -152,6 +152,145 @@ function getValidUrl(url: string): URL | null {
   }
 }
 
+/**
+ * Check if the request referer is one of the allowed OAuth provider referers.
+ *
+ * @param referer The referer header value (already stringified)
+ * @returns True if the referer is allowed
+ */
+function isValidReferer(referer: string): boolean {
+  console.log('REFERER: ' + referer);
+  const validReferers = ['https://accounts.google.com/', 'https://appleid.apple.com/'];
+
+  if (validReferers.includes(referer)) {
+    console.log('redirect comes from valid referer');
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Determine whether the requested redirect target is allowed, based on the configured redirect whitelist.
+ *
+ * @param redirect        The raw redirect query parameter
+ * @param myDatabaseHelper Helper used to load the redirect whitelist app setting
+ * @returns True if the redirect is valid/allowed
+ */
+async function resolveRedirectUrlValidity(redirect: unknown, myDatabaseHelper: MyDatabaseHelper): Promise<boolean> {
+  if (!!redirect && typeof redirect === 'string') {
+    let redirectUrl = getValidUrl(redirect);
+
+    if (redirectUrl) {
+      const redirect_whitelist = await myDatabaseHelper.getAppSettingsHelper().getRedirectWhitelist();
+      if (redirect_whitelist) {
+        let foundValidRedirect = false;
+        if (redirect_whitelist.length === 0) {
+          foundValidRedirect = true; // no whitelist means all redirects are allowed
+        }
+
+        for (let i = 0; i < redirect_whitelist.length && !foundValidRedirect; i++) {
+          // iterate over the whitelist as long as we haven't found a valid redirect
+          let redirect_whitelist_entry = redirect_whitelist[i];
+          try {
+            if (isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry, redirectUrl)) {
+              foundValidRedirect = true;
+              break;
+            }
+          } catch (e) {
+            console.log('Error in redirect with token endpoint');
+            console.log('redirectUrl: ' + redirectUrl);
+            console.log('redirect_whitelist_entry: ' + redirect_whitelist_entry);
+            console.log(e);
+          }
+        }
+
+        return foundValidRedirect;
+      }
+      return true; // no whitelist configured means all redirects are allowed
+    }
+    return false; // no valid redirect URL found
+  }
+  return false; // no redirect URL found
+}
+
+/**
+ * Attempt to redirect using the directus_refresh_token cookie (cookie auth mode).
+ *
+ * @param req      The incoming request
+ * @param res      The response used to perform the redirect
+ * @param redirect The validated redirect target (without token)
+ * @returns True if the request was handled (a response was already sent)
+ */
+function tryRedirectWithCookieRefreshToken(req: any, res: any, redirect: any): boolean {
+  const directus_refresh_token = req.cookies.directus_refresh_token;
+
+  if (directus_refresh_token) {
+    // this means the auth provider is using "cookie" mode.
+    //console.log("directus_refresh_token found");
+
+    const redirectURL = redirect + directus_refresh_token;
+    //console.log("Redirect with token endpoint: redirectURL: " + redirectURL)
+    res.redirect(redirectURL);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Attempt to redirect using the directus_session_token cookie (session auth mode), creating a new
+ * directus_sessions row and exchanging it for a refresh token.
+ *
+ * @param req      The incoming request
+ * @param res      The response used to send errors or perform the redirect
+ * @param redirect The validated redirect target (without token)
+ * @param database The Directus database (knex) instance
+ * @param env      The Directus environment configuration
+ * @returns True if the request was handled (a response was already sent)
+ */
+async function tryRedirectWithSessionToken(req: any, res: any, redirect: any, database: any, env: any): Promise<boolean> {
+  const directus_session_token = req.cookies.directus_session_token;
+  if (!directus_session_token) {
+    return false;
+  }
+  // this means the auth provider is using "session" mode.
+  // we need to obtain the directus_refresh_token from the directus_session_token
+  //console.log("Redirect with token endpoint: directus_session_token: " + directus_session_token)
+  const accountability = AccountabilityHelper.getAccountabilityFromRequest(req);
+  const userId = accountability?.user;
+  //console.log("Redirect with token endpoint: userId: " + userId)
+  if (!userId) {
+    res.status(400).send('No user found');
+    return true;
+  }
+
+  const knex = database;
+
+  /**
+   * Start of copy: https://github.com/directus/directus/blob/main/api/src/services/authentication.ts Login
+   */
+  const refreshToken = await NanoidHelper.getNanoid(64);
+  const msRefreshTokenTTL: number = ms(String(env['REFRESH_TOKEN_TTL'])) || 0;
+  const refreshTokenExpiration = new Date(Date.now() + msRefreshTokenTTL);
+
+  await knex('directus_sessions').insert({
+    token: refreshToken,
+    user: userId,
+    expires: refreshTokenExpiration,
+    ip: accountability?.ip,
+    user_agent: accountability?.userAgent,
+    origin: accountability?.origin,
+  });
+
+  await knex('directus_sessions').delete().where('expires', '<', new Date());
+
+  // End of copy
+
+  const redirectURL = redirect + refreshToken;
+  //console.log("Redirect with token endpoint: redirectURL: " + redirectURL)
+  res.redirect(redirectURL);
+  return true;
+}
+
 // TO Test this Endpoint:
 // 1. Login with a user in the Directus Admin UI
 // 2. Go to the URL: http://127.0.0.1/rocket-meals/api/redirect-with-token?redirect=http://localhost:8081/login?directus_refresh_token=
@@ -166,12 +305,8 @@ export default defineEndpoint({
       }
 
       const referer = req.headers.referer + '';
-      console.log('REFERER: ' + referer);
-      const validReferers = ['https://accounts.google.com/', 'https://appleid.apple.com/'];
 
-      if (validReferers.includes(referer)) {
-        console.log('redirect comes from valid referer');
-      } else {
+      if (!isValidReferer(referer)) {
         res.status(400).send('Invalid referer URL (' + referer + '). Please contact the administrator: info@rocket-meals.de');
         return;
       }
@@ -183,45 +318,9 @@ export default defineEndpoint({
 
       //console.log("#################################")
       //console.log("Redirect with token endpoint: settings")
-      let redirectUrlIsValid = true;
-
       let redirect = req.query.redirect;
 
-      if (!!redirect && typeof redirect === 'string') {
-        let redirectUrl = getValidUrl(redirect);
-
-        if (redirectUrl) {
-          const redirect_whitelist = await myDatabaseHelper.getAppSettingsHelper().getRedirectWhitelist();
-          if (redirect_whitelist) {
-            let foundValidRedirect = false;
-            if (redirect_whitelist.length === 0) {
-              foundValidRedirect = true; // no whitelist means all redirects are allowed
-            }
-
-            for (let i = 0; i < redirect_whitelist.length && !foundValidRedirect; i++) {
-              // iterate over the whitelist as long as we haven't found a valid redirect
-              let redirect_whitelist_entry = redirect_whitelist[i];
-              try {
-                if (isRedirectUrlAllowedForWhitelistEntry(redirect_whitelist_entry, redirectUrl)) {
-                  foundValidRedirect = true;
-                  break;
-                }
-              } catch (e) {
-                console.log('Error in redirect with token endpoint');
-                console.log('redirectUrl: ' + redirectUrl);
-                console.log('redirect_whitelist_entry: ' + redirect_whitelist_entry);
-                console.log(e);
-              }
-            }
-
-            redirectUrlIsValid = foundValidRedirect;
-          }
-        } else {
-          redirectUrlIsValid = false; // no valid redirect URL found
-        }
-      } else {
-        redirectUrlIsValid = false; // no redirect URL found
-      }
+      const redirectUrlIsValid = await resolveRedirectUrlValidity(redirect, myDatabaseHelper);
 
       if (!redirectUrlIsValid) {
         res.status(400).send('Invalid redirect URL (' + redirect + '). Please contact the administrator: info@rocket-meals.de');
@@ -231,56 +330,13 @@ export default defineEndpoint({
       //console.log("Cookies")
       //console.log(JSON.stringify(req.cookies, null, 2))
 
-      const directus_refresh_token = req.cookies.directus_refresh_token;
-
-      if (directus_refresh_token) {
-        // this means the auth provider is using "cookie" mode.
-        //console.log("directus_refresh_token found");
-
-        const redirectURL = redirect + directus_refresh_token;
-        //console.log("Redirect with token endpoint: redirectURL: " + redirectURL)
-        res.redirect(redirectURL);
+      const handledByCookieRefreshToken = tryRedirectWithCookieRefreshToken(req, res, redirect);
+      if (handledByCookieRefreshToken) {
         return;
       }
 
-      const directus_session_token = req.cookies.directus_session_token;
-      if (directus_session_token) {
-        // this means the auth provider is using "session" mode.
-        // we need to obtain the directus_refresh_token from the directus_session_token
-        //console.log("Redirect with token endpoint: directus_session_token: " + directus_session_token)
-        const accountability = AccountabilityHelper.getAccountabilityFromRequest(req);
-        const userId = accountability?.user;
-        //console.log("Redirect with token endpoint: userId: " + userId)
-        if (!userId) {
-          res.status(400).send('No user found');
-          return;
-        }
-
-        const knex = database;
-
-        /**
-         * Start of copy: https://github.com/directus/directus/blob/main/api/src/services/authentication.ts Login
-         */
-        const refreshToken = await NanoidHelper.getNanoid(64);
-        const msRefreshTokenTTL: number = ms(String(env['REFRESH_TOKEN_TTL'])) || 0;
-        const refreshTokenExpiration = new Date(Date.now() + msRefreshTokenTTL);
-
-        await knex('directus_sessions').insert({
-          token: refreshToken,
-          user: userId,
-          expires: refreshTokenExpiration,
-          ip: accountability?.ip,
-          user_agent: accountability?.userAgent,
-          origin: accountability?.origin,
-        });
-
-        await knex('directus_sessions').delete().where('expires', '<', new Date());
-
-        // End of copy
-
-        const redirectURL = redirect + refreshToken;
-        //console.log("Redirect with token endpoint: redirectURL: " + redirectURL)
-        res.redirect(redirectURL);
+      const handledBySessionToken = await tryRedirectWithSessionToken(req, res, redirect, database, env);
+      if (handledBySessionToken) {
         return;
       }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/washingmachines-sync-hook/index.ts
@@ -12,6 +12,83 @@ import { WorkflowRunContext } from '../helpers/WorkflowRunContext';
 import { WORKFLOW_RUN_STATE } from '../helpers/itemServiceHelpers/WorkflowsRunEnum';
 import {MyDefineHook} from "../helpers/MyDefineHook";
 const HOOK_NAME = 'washingmachines-sync-hook';
+
+/**
+ * Computes the capped duration (Postgres time fields do not accept 24:xx:xx,
+ * so durations are capped at 23:59:59) and the derived duration fields used
+ * when persisting a finished washingmachine job.
+ */
+function computeWashingmachineJobDurationFields(durationInMilliseconds: number, current_date_stated: any, current_date_finished: any, washingmachine_id: any) {
+  const millisecondsInDay = 24 * 60 * 60 * 1000;
+  // Postgres time fields do not accept 24:xx:xx, so we cap durations at 23:59:59.
+  const maxPostgresTimeValueMilliseconds = millisecondsInDay - 1000; // 23:59:59
+  const cappedDurationInMilliseconds = Math.min(
+    durationInMilliseconds,
+    maxPostgresTimeValueMilliseconds
+  );
+
+  if (durationInMilliseconds > maxPostgresTimeValueMilliseconds) {
+    console.log(
+      `Capping washingmachine job duration to 23:59:59. date_start=${current_date_stated}, date_end=${current_date_finished}, washingmachine=${washingmachine_id}`
+    );
+  }
+
+  const time_hours = Math.floor(cappedDurationInMilliseconds / 1000 / 60 / 60);
+  const time_minutes = Math.floor((cappedDurationInMilliseconds / 1000 / 60) % 60);
+  const time_seconds = Math.floor((cappedDurationInMilliseconds / 1000) % 60);
+  const hh_mm_ss = time_hours + ':' + time_minutes + ':' + time_seconds;
+
+  const duration_in_minutes = Number.parseInt(cappedDurationInMilliseconds / 1000 / 60 + ''); // Total duration in minutes
+
+  // Round duration to the nearest 10-minute interval
+  const duration_rounded_10min_calculated = Math.ceil(duration_in_minutes / 10) * 10;
+
+  return {
+    hh_mm_ss,
+    duration_in_minutes,
+    duration_rounded_10min_calculated,
+  };
+}
+
+/**
+ * If the given washingmachine currently has both a start and finish date, persists
+ * a finished washingmachine job for it. Mirrors the previous inline loop body exactly.
+ */
+async function createFinishedWashingmachineJobIfApplicable(myDatabaseHelper: MyDatabaseHelper, washingmachine_id: any) {
+  let washingmachine_curent = await myDatabaseHelper.getWashingmachinesHelper().readOne(washingmachine_id);
+
+  let current_date_stated = washingmachine_curent.date_stated;
+  let current_date_finished = washingmachine_curent.date_finished;
+
+  if (!!current_date_stated && !!current_date_finished) {
+    // currently washing
+    // then save it as a finished washing job
+    let time_diff = new Date(current_date_finished).getTime() - new Date(current_date_stated).getTime();
+    if (time_diff > 0) {
+      const durationInMilliseconds = time_diff;
+
+      const { hh_mm_ss, duration_in_minutes, duration_rounded_10min_calculated } = computeWashingmachineJobDurationFields(
+        durationInMilliseconds,
+        current_date_stated,
+        current_date_finished,
+        washingmachine_curent.id
+      );
+
+      let partialWashingmachineJob: Partial<DatabaseTypes.WashingmachinesJobs> = {
+        date_start: current_date_stated,
+        date_end: current_date_finished,
+        duration_calculated: hh_mm_ss,
+        duration_in_minutes_calculated: duration_in_minutes,
+        duration_in_minutes_rounded_10min_calculated: duration_rounded_10min_calculated,
+        washingmachine: washingmachine_curent.id,
+        apartment: washingmachine_curent.apartment,
+      };
+
+      await myDatabaseHelper.getWashingmachinesJobsHelper().createOne(partialWashingmachineJob);
+    }
+  }
+}
+
 function registerWashingmachinesFilterUpdate(apiContext: any, registerFunctions: RegisterFunctions) {
   const { filter } = registerFunctions;
   // Washingmachines Jobs Creation
@@ -30,54 +107,7 @@ function registerWashingmachinesFilterUpdate(apiContext: any, registerFunctions:
       let myDatabaseHelper = new MyDatabaseHelper(apiContext, eventContext);
       if (washingmachines_ids) {
         for (let washingmachine_id of washingmachines_ids) {
-          let washingmachine_curent = await myDatabaseHelper.getWashingmachinesHelper().readOne(washingmachine_id);
-
-          let current_date_stated = washingmachine_curent.date_stated;
-          let current_date_finished = washingmachine_curent.date_finished;
-
-          if (!!current_date_stated && !!current_date_finished) {
-            // currently washing
-            // then save it as a finished washing job
-            let time_diff = new Date(current_date_finished).getTime() - new Date(current_date_stated).getTime();
-            if (time_diff > 0) {
-              const durationInMilliseconds = time_diff;
-              const millisecondsInDay = 24 * 60 * 60 * 1000;
-              // Postgres time fields do not accept 24:xx:xx, so we cap durations at 23:59:59.
-              const maxPostgresTimeValueMilliseconds = millisecondsInDay - 1000; // 23:59:59
-              const cappedDurationInMilliseconds = Math.min(
-                durationInMilliseconds,
-                maxPostgresTimeValueMilliseconds
-              );
-
-              if (durationInMilliseconds > maxPostgresTimeValueMilliseconds) {
-                console.log(
-                  `Capping washingmachine job duration to 23:59:59. date_start=${current_date_stated}, date_end=${current_date_finished}, washingmachine=${washingmachine_curent.id}`
-                );
-              }
-
-              const time_hours = Math.floor(cappedDurationInMilliseconds / 1000 / 60 / 60);
-              const time_minutes = Math.floor((cappedDurationInMilliseconds / 1000 / 60) % 60);
-              const time_seconds = Math.floor((cappedDurationInMilliseconds / 1000) % 60);
-              const hh_mm_ss = time_hours + ':' + time_minutes + ':' + time_seconds;
-
-              const duration_in_minutes = Number.parseInt(cappedDurationInMilliseconds / 1000 / 60 + ''); // Total duration in minutes
-
-              // Round duration to the nearest 10-minute interval
-              const duration_rounded_10min_calculated = Math.ceil(duration_in_minutes / 10) * 10;
-
-              let partialWashingmachineJob: Partial<DatabaseTypes.WashingmachinesJobs> = {
-                date_start: current_date_stated,
-                date_end: current_date_finished,
-                duration_calculated: hh_mm_ss,
-                duration_in_minutes_calculated: duration_in_minutes,
-                duration_in_minutes_rounded_10min_calculated: duration_rounded_10min_calculated,
-                washingmachine: washingmachine_curent.id,
-                apartment: washingmachine_curent.apartment,
-              };
-
-              await myDatabaseHelper.getWashingmachinesJobsHelper().createOne(partialWashingmachineJob);
-            }
-          }
+          await createFinishedWashingmachineJobIfApplicable(myDatabaseHelper, washingmachine_id);
         }
       }
     }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/workflows-runs-hook/index.ts
@@ -125,6 +125,81 @@ function getDictWorkflowIdToWorkflowRuns(workflowRuns: Partial<DatabaseTypes.Wor
   return dictWorkflowIdToWorkflowRuns;
 }
 
+async function ensureAllWorkflowsExist(workflowIds: string[], myDatabaseHelper: MyDatabaseHelper): Promise<void> {
+  for (let workflowId of workflowIds) {
+    try {
+      await createWorkflowIfNotExisting(workflowId, myDatabaseHelper);
+    } catch (err: any) {
+      console.error(err);
+      throw new Error('modifyInputForCreateOrUpdateWorkflowRunToRunning: Error while create/update of workflowRuns. Cannot find or create workflow with id: ' + workflowId);
+    }
+  }
+}
+
+async function ensureAllWorkflowsAreEnabled(workflowIds: string[], myDatabaseHelper: MyDatabaseHelper): Promise<void> {
+  for (let workflowId of workflowIds) {
+    console.log('Checking if workflow with id: ' + workflowId + ' is enabled');
+    let workflow: DatabaseTypes.Workflows | undefined = undefined;
+    try {
+      workflow = await myDatabaseHelper.getWorkflowsHelper().readOne(workflowId);
+    } catch (err: any) {
+      console.error(err);
+      throw new Error('modifyInputForCreateOrUpdateWorkflowRunToRunning: Error while create/update of workflowRuns. Cannot read workflow with id: ' + workflowId);
+    }
+    if (!workflow) {
+      throw new Error('Workflow with id: ' + workflowId + ' not found');
+    }
+    let enabled = workflow?.enabled;
+    if (enabled === false) {
+      throw new Error('Workflow with id: ' + workflowId + ' is not enabled');
+    }
+  }
+}
+
+function ensureAllWorkflowsAreRegistered(workflowIds: string[]): void {
+  let notRegisteredWorkflowIds = workflowIds.filter(workflowId => !WorkflowScheduler.getRegisteredWorkflow(workflowId));
+  if (notRegisteredWorkflowIds.length > 0) {
+    throw new Error('-- No WorkflowRunJobInterface found for workflowIds: ' + notRegisteredWorkflowIds.join(', '));
+  }
+}
+
+async function handleWorkflowRunsWantToRunForWorkflowId(
+  workflowId: string,
+  workflowRuns: Partial<DatabaseTypes.WorkflowsRuns>[],
+  input: Partial<DatabaseTypes.WorkflowsRuns>,
+  myDatabaseHelper: MyDatabaseHelper
+): Promise<void> {
+  console.log('Running workflowId: ' + workflowId);
+  let alreadyRunningWorkflowRuns = await getAlreadyRunningWorkflowruns(workflowId, myDatabaseHelper);
+  let workflowRunJobInterface = WorkflowScheduler.getRegisteredWorkflow(workflowId);
+  if (!workflowRunJobInterface) {
+    // never the case, because we checked before, but just to be sure
+    throw new Error('-- No WorkflowRunJobInterface found for workflowId: ' + workflowId);
+  } else {
+    console.log('Handling workflow_runs for workflowId: ' + workflowId);
+    let result = workflowRunJobInterface.handleWorkflowRunsWantToRun(input, workflowRuns, alreadyRunningWorkflowRuns);
+    if (result.errorMessage) {
+      console.error('Error while setting workflow_runs to running: ' + result.errorMessage);
+      throw new Error('Error while setting workflow_runs to running: ' + result.errorMessage);
+    }
+  }
+}
+
+async function handleWorkflowRunsWantToRunForAllWorkflows(
+  dictWorkflowIdToWorkflowRuns: {
+    [p: string]: Partial<DatabaseTypes.WorkflowsRuns>[];
+  },
+  input: Partial<DatabaseTypes.WorkflowsRuns>,
+  myDatabaseHelper: MyDatabaseHelper
+): Promise<void> {
+  for (let workflowId of Object.keys(dictWorkflowIdToWorkflowRuns)) {
+    const workflowRuns = dictWorkflowIdToWorkflowRuns[workflowId];
+    if (workflowRuns) {
+      await handleWorkflowRunsWantToRunForWorkflowId(workflowId, workflowRuns, input, myDatabaseHelper);
+    }
+  }
+}
+
 async function modifyInputForCreateOrUpdateWorkflowRunToRunning(
   input: Partial<DatabaseTypes.WorkflowsRuns>,
   dictWorkflowIdToWorkflowRuns: {
@@ -144,58 +219,14 @@ async function modifyInputForCreateOrUpdateWorkflowRunToRunning(
     }
 
     // check if all workflows exist
-    for (let workflowId of workflowIds) {
-      try {
-        await createWorkflowIfNotExisting(workflowId, myDatabaseHelper);
-      } catch (err: any) {
-        console.error(err);
-        throw new Error('modifyInputForCreateOrUpdateWorkflowRunToRunning: Error while create/update of workflowRuns. Cannot find or create workflow with id: ' + workflowId);
-      }
-    }
+    await ensureAllWorkflowsExist(workflowIds, myDatabaseHelper);
 
     // check if all workflows are enabled
-    for (let workflowId of workflowIds) {
-      console.log('Checking if workflow with id: ' + workflowId + ' is enabled');
-      let workflow: DatabaseTypes.Workflows | undefined = undefined;
-      try {
-        workflow = await myDatabaseHelper.getWorkflowsHelper().readOne(workflowId);
-      } catch (err: any) {
-        console.error(err);
-        throw new Error('modifyInputForCreateOrUpdateWorkflowRunToRunning: Error while create/update of workflowRuns. Cannot read workflow with id: ' + workflowId);
-      }
-      if (!workflow) {
-        throw new Error('Workflow with id: ' + workflowId + ' not found');
-      }
-      let enabled = workflow?.enabled;
-      if (enabled === false) {
-        throw new Error('Workflow with id: ' + workflowId + ' is not enabled');
-      }
-    }
+    await ensureAllWorkflowsAreEnabled(workflowIds, myDatabaseHelper);
 
-    let notRegisteredWorkflowIds = workflowIds.filter(workflowId => !WorkflowScheduler.getRegisteredWorkflow(workflowId));
-    if (notRegisteredWorkflowIds.length > 0) {
-      throw new Error('-- No WorkflowRunJobInterface found for workflowIds: ' + notRegisteredWorkflowIds.join(', '));
-    }
+    ensureAllWorkflowsAreRegistered(workflowIds);
 
-    for (let workflowId of Object.keys(dictWorkflowIdToWorkflowRuns)) {
-      console.log('Running workflowId: ' + workflowId);
-      const workflowRuns = dictWorkflowIdToWorkflowRuns[workflowId];
-      if (workflowRuns) {
-        let alreadyRunningWorkflowRuns = await getAlreadyRunningWorkflowruns(workflowId, myDatabaseHelper);
-        let workflowRunJobInterface = WorkflowScheduler.getRegisteredWorkflow(workflowId);
-        if (!workflowRunJobInterface) {
-          // never the case, because we checked before, but just to be sure
-          throw new Error('-- No WorkflowRunJobInterface found for workflowId: ' + workflowId);
-        } else {
-          console.log('Handling workflow_runs for workflowId: ' + workflowId);
-          let result = workflowRunJobInterface.handleWorkflowRunsWantToRun(input, workflowRuns, alreadyRunningWorkflowRuns);
-          if (result.errorMessage) {
-            console.error('Error while setting workflow_runs to running: ' + result.errorMessage);
-            throw new Error('Error while setting workflow_runs to running: ' + result.errorMessage);
-          }
-        }
-      }
-    }
+    await handleWorkflowRunsWantToRunForAllWorkflows(dictWorkflowIdToWorkflowRuns, input, myDatabaseHelper);
     input.log = input.log || WorkflowRunLogger.createLogRow('Workflow Run started');
   }
 
@@ -205,6 +236,86 @@ async function modifyInputForCreateOrUpdateWorkflowRunToRunning(
 async function handleActionWorkflowRunUpdatedOrCreated(payload: Partial<DatabaseTypes.WorkflowsRuns>, myDatabaseHelper: MyDatabaseHelper, keys: PrimaryKey[]): Promise<void> {
   await handleActionRunningCreatedOrUpdatedWorkflow(payload, myDatabaseHelper, keys);
   await handleActionOnUpdateOrCreateIfWorkflowRunShouldBeDeleted(payload, myDatabaseHelper, keys);
+}
+
+function resolveResultLegalState(result: Partial<DatabaseTypes.WorkflowsRuns>): Partial<DatabaseTypes.WorkflowsRuns> {
+  let legalStates = Object.values(WORKFLOW_RUN_STATE) as string[];
+  let hasResultLegalState = false;
+  if (
+    !!result.state &&
+    legalStates.includes(result.state) && // check if state is a legal state
+    result.state !== WORKFLOW_RUN_STATE.RUNNING // and not still running
+  ) {
+    hasResultLegalState = true;
+  }
+  if (!hasResultLegalState) {
+    result.state = WORKFLOW_RUN_STATE.FAILED;
+  }
+  return result;
+}
+
+async function runWorkflowRunJob(
+  workflowRun: DatabaseTypes.WorkflowsRuns,
+  workflowRunJobInterface: WorkflowRunJobInterface,
+  myDatabaseHelper: MyDatabaseHelper
+): Promise<Partial<DatabaseTypes.WorkflowsRuns>> {
+  let result: Partial<DatabaseTypes.WorkflowsRuns> = workflowRun;
+  let logger = new WorkflowRunLogger(workflowRun, myDatabaseHelper);
+  const context = new WorkflowRunContext(workflowRun, myDatabaseHelper, logger);
+  try {
+    //console.log("About to run job for workflowRun: "+workflowRun.id);
+    result = await workflowRunJobInterface.runJob(context);
+  } catch (e: any) {
+    console.log('Error while running workflow: ' + e.message);
+    result = logger.getFinalLogWithStateAndParams({
+      state: WORKFLOW_RUN_STATE.FAILED,
+    });
+  }
+  return result;
+}
+
+async function runAndFinalizeWorkflowRun(
+  workflowRun: DatabaseTypes.WorkflowsRuns,
+  workflowRunJobInterface: WorkflowRunJobInterface,
+  myDatabaseHelper: MyDatabaseHelper
+): Promise<void> {
+  //console.log("-- Running workflowRun: "+workflowRun.id);
+  let date_started = new Date().toISOString();
+  await myDatabaseHelper.getWorkflowsRunsHelper().updateOneWithoutHookTrigger({
+      primary_key: workflowRun.id,
+      update: {
+          date_started: date_started,
+      }
+  });
+
+  let result = await runWorkflowRunJob(workflowRun, workflowRunJobInterface, myDatabaseHelper);
+  //console.log("WorkflowRun finished: "+workflowRun.id);
+  result = resolveResultLegalState(result);
+  //console.log("Had result legal state: "+hasResultLegalState);
+
+  result.date_started = date_started; // make sure that date_started is not overwritten
+  result.date_finished = new Date().toISOString();
+  result.runtime_in_seconds = Number.parseInt('' + (new Date(result.date_finished).getTime() - new Date(date_started).getTime()) / 1000);
+
+  await myDatabaseHelper.getWorkflowsRunsHelper().updateOneWithoutHookTrigger({
+    primary_key: workflowRun.id,
+    update: result,
+  });
+}
+
+async function runWorkflowRunsForWorkflowId(
+  workflowId: string,
+  workflowRuns: DatabaseTypes.WorkflowsRuns[],
+  myDatabaseHelper: MyDatabaseHelper
+): Promise<void> {
+  let workflowRunJobInterface = WorkflowScheduler.getRegisteredWorkflow(workflowId);
+  if (!workflowRunJobInterface) {
+    throw new Error('No WorkflowRunJobInterface found for workflowId: ' + workflowId);
+  } else {
+    for (let workflowRun of workflowRuns) {
+      await runAndFinalizeWorkflowRun(workflowRun, workflowRunJobInterface, myDatabaseHelper);
+    }
+  }
 }
 
 async function handleActionRunningCreatedOrUpdatedWorkflow(payload: Partial<DatabaseTypes.WorkflowsRuns>, myDatabaseHelper: MyDatabaseHelper, keys: PrimaryKey[]): Promise<void> {
@@ -219,57 +330,7 @@ async function handleActionRunningCreatedOrUpdatedWorkflow(payload: Partial<Data
     for (let workflowId of Object.keys(dictWorkflowIdToWorkflowRuns)) {
       const workflowRuns = dictWorkflowIdToWorkflowRuns[workflowId];
       if (workflowRuns) {
-        let workflowRunJobInterface = WorkflowScheduler.getRegisteredWorkflow(workflowId);
-        if (!workflowRunJobInterface) {
-          throw new Error('No WorkflowRunJobInterface found for workflowId: ' + workflowId);
-        } else {
-          for (let workflowRun of workflowRuns) {
-            //console.log("-- Running workflowRun: "+workflowRun.id);
-            let date_started = new Date().toISOString();
-            await myDatabaseHelper.getWorkflowsRunsHelper().updateOneWithoutHookTrigger({
-                primary_key: workflowRun.id,
-                update: {
-                    date_started: date_started,
-                }
-            });
-
-            let result: Partial<DatabaseTypes.WorkflowsRuns> = workflowRun;
-            let logger = new WorkflowRunLogger(workflowRun, myDatabaseHelper);
-            const context = new WorkflowRunContext(workflowRun, myDatabaseHelper, logger);
-            try {
-              //console.log("About to run job for workflowRun: "+workflowRun.id);
-              result = await workflowRunJobInterface.runJob(context);
-            } catch (e: any) {
-              console.log('Error while running workflow: ' + e.message);
-              result = logger.getFinalLogWithStateAndParams({
-                state: WORKFLOW_RUN_STATE.FAILED,
-              });
-            }
-            //console.log("WorkflowRun finished: "+workflowRun.id);
-            let legalStates = Object.values(WORKFLOW_RUN_STATE) as string[];
-            let hasResultLegalState = false;
-            if (
-              !!result.state &&
-              legalStates.includes(result.state) && // check if state is a legal state
-              result.state !== WORKFLOW_RUN_STATE.RUNNING // and not still running
-            ) {
-              hasResultLegalState = true;
-            }
-            if (!hasResultLegalState) {
-              result.state = WORKFLOW_RUN_STATE.FAILED;
-            }
-            //console.log("Had result legal state: "+hasResultLegalState);
-
-            result.date_started = date_started; // make sure that date_started is not overwritten
-            result.date_finished = new Date().toISOString();
-            result.runtime_in_seconds = Number.parseInt('' + (new Date(result.date_finished).getTime() - new Date(date_started).getTime()) / 1000);
-
-            await myDatabaseHelper.getWorkflowsRunsHelper().updateOneWithoutHookTrigger({
-              primary_key: workflowRun.id,
-              update: result,
-            });
-          }
-        }
+        await runWorkflowRunsForWorkflowId(workflowId, workflowRuns, myDatabaseHelper);
       }
     }
   }

--- a/apps/frontend/app/app/(app)/foodoffers/details/components/FoodHeader.tsx
+++ b/apps/frontend/app/app/(app)/foodoffers/details/components/FoodHeader.tsx
@@ -46,6 +46,57 @@ function makeStarRatingTrigger(onPress: () => void, filled: boolean, color: stri
     );
 }
 
+// Resolves the average rating value to display, mirroring the previous inline
+// `(a || b) && numToOneDecimal(a || b)` expression used in both the web and
+// mobile render branches of FoodHeader.
+function resolveDisplayRating(foodDetails: any) {
+    const rating = foodDetails?.rating_average || foodDetails?.rating_average_legacy;
+    return rating && numToOneDecimal(rating);
+}
+
+// Renders the "average rating" badge (star icon + numeric value) shown when
+// `foods_ratings_average_display` is enabled. Extracted so the surrounding
+// web/mobile render branches don't each carry this conditional inline.
+const RatingAverageBadge = ({
+    appSettings,
+    foodDetails,
+    theme,
+    foodsAreaColor,
+    viewStyle,
+    textStyle,
+    starSize,
+}: {
+    appSettings: any;
+    foodDetails: any;
+    theme: any;
+    foodsAreaColor: string;
+    viewStyle: any;
+    textStyle: any;
+    starSize: number;
+}) => {
+    if (!appSettings?.foods_ratings_average_display) {
+        return null;
+    }
+    return (
+        <View
+            style={[
+                viewStyle,
+                { borderColor: theme.screen.text, backgroundColor: theme.screen.iconBg }
+            ]}
+        >
+            <AntDesign name="star" size={starSize} color={foodsAreaColor} />
+            <Text
+                style={[
+                    textStyle,
+                    { color: theme.screen.text }
+                ]}
+            >
+                {resolveDisplayRating(foodDetails)}
+            </Text>
+        </View>
+    );
+};
+
 const FoodHeader = ({
     foodDetails,
     screenWidth,
@@ -145,27 +196,15 @@ const FoodHeader = ({
                         ]}
                     >
                         <View style={styles.fullWidthEnd}>
-                            {appSettings?.foods_ratings_average_display && (
-                                <View
-                                    style={[
-                                        styles.ratingView,
-                                        { borderColor: theme.screen.text, backgroundColor: theme.screen.iconBg }
-                                    ]}
-                                >
-                                    <AntDesign name="star" size={22} color={foodsAreaColor} />
-                                    <Text
-                                        style={[
-                                            styles.totalRating,
-                                            { color: theme.screen.text }
-                                        ]}
-                                    >
-                                        {(foodDetails?.rating_average || foodDetails?.rating_average_legacy) &&
-                                            numToOneDecimal(
-                                                foodDetails?.rating_average || foodDetails?.rating_average_legacy
-                                            )}
-                                    </Text>
-                                </View>
-                            )}
+                            <RatingAverageBadge
+                                appSettings={appSettings}
+                                foodDetails={foodDetails}
+                                theme={theme}
+                                foodsAreaColor={foodsAreaColor}
+                                viewStyle={styles.ratingView}
+                                textStyle={styles.totalRating}
+                                starSize={22}
+                            />
                         </View>
                         <View style={isLargeScreen ? null : [styles.marginTopMedium, containerWidth ? { width: containerWidth } : null]}>
                             <SettingsList
@@ -219,27 +258,15 @@ const FoodHeader = ({
                 <View style={styles.mobileDetailsHeader}>
                     <View style={styles.row}>
                         <View />
-                        {appSettings?.foods_ratings_average_display && (
-                            <View
-                                style={[
-                                    styles.mobileRatingView,
-                                    { borderColor: theme.screen.text, backgroundColor: theme.screen.iconBg }
-                                ]}
-                            >
-                                <AntDesign name="star" size={18} color={foodsAreaColor} />
-                                <Text
-                                    style={[
-                                        styles.mobileTotalRating,
-                                        { color: theme.screen.text }
-                                    ]}
-                                >
-                                    {(foodDetails?.rating_average || foodDetails?.rating_average_legacy) &&
-                                        numToOneDecimal(
-                                            foodDetails?.rating_average || foodDetails?.rating_average_legacy
-                                        )}
-                                </Text>
-                            </View>
-                        )}
+                        <RatingAverageBadge
+                            appSettings={appSettings}
+                            foodDetails={foodDetails}
+                            theme={theme}
+                            foodsAreaColor={foodsAreaColor}
+                            viewStyle={styles.mobileRatingView}
+                            textStyle={styles.mobileTotalRating}
+                            starSize={18}
+                        />
                     </View>
                 </View>
                 <View style={styles.mobileDetailsFooter}></View>

--- a/apps/frontend/app/app/(app)/foodoffers/details/hooks/useFoodDetails.ts
+++ b/apps/frontend/app/app/(app)/foodoffers/details/hooks/useFoodDetails.ts
@@ -11,6 +11,60 @@ interface UseFoodDetailsProps {
     initialFoodId?: string | string[];
 }
 
+const findTranslationForLanguage = (
+    translations: DatabaseTypes.FoodsTranslations[] | undefined | null,
+    languageCode: string | undefined
+) => {
+    return translations?.find(
+        (val: DatabaseTypes.FoodsTranslations) => String(val?.languages_code)?.split('-')[0] === languageCode
+    );
+};
+
+const applyFoodOfferDetailsResponse = (
+    foodData: any,
+    languageCode: string | undefined,
+    translateDynamic: (value: any) => any,
+    setFoodDetails: (value: any) => void,
+    setFoodAttributes: (value: any) => void
+) => {
+    if (!foodData?.data) return;
+
+    const { food, attribute_values, foodoffer_category } = foodData?.data ?? {};
+
+    const translation = findTranslationForLanguage(food?.translations, languageCode);
+    setFoodDetails({
+        ...food,
+        foodoffer_category,
+        name: translation ? translateDynamic(translation.name) : null,
+    });
+    if (attribute_values) {
+        setFoodAttributes(attribute_values);
+    }
+};
+
+const applyFoodDetailsResponse = (
+    foodData: any,
+    languageCode: string | undefined,
+    translateDynamic: (value: any) => any,
+    setFoodDetails: (value: any) => void,
+    setFoodAttributes: (value: any) => void
+) => {
+    if (!foodData?.data) return;
+
+    const food = foodData.data;
+    const translation = findTranslationForLanguage(food?.translations, languageCode);
+    const rawName = translation?.name ?? food?.name ?? null;
+    setFoodDetails({
+        ...food,
+        name: rawName ? translateDynamic(rawName) : null,
+    });
+
+    const attributes = food?.attribute_values || food?.foods_attributes_values;
+    if (attributes) {
+        setFoodAttributes(attributes);
+    }
+};
+
 export const useFoodDetails = ({ offerId, initialFoodId }: UseFoodDetailsProps) => {
     const { language: languageCode, translate, translateDynamic } = useLanguage();
     const toast = useToast();
@@ -28,39 +82,10 @@ export const useFoodDetails = ({ offerId, initialFoodId }: UseFoodDetailsProps) 
         try {
             if (id) {
                 const foodData = await fetchFoodOffersDetailsById(id.toString());
-                if (foodData?.data) {
-                    const { food, attribute_values, foodoffer_category } = foodData?.data ?? {};
-
-                    const translation = food?.translations?.find(
-                        (val: DatabaseTypes.FoodsTranslations) => String(val?.languages_code)?.split('-')[0] === languageCode
-                    );
-                    setFoodDetails({
-                        ...food,
-                        foodoffer_category,
-                        name: translation ? translateDynamic(translation.name) : null,
-                    });
-                    if (attribute_values) {
-                        setFoodAttributes(attribute_values);
-                    }
-                }
+                applyFoodOfferDetailsResponse(foodData, languageCode, translateDynamic, setFoodDetails, setFoodAttributes);
             } else if (foodId) {
                 const foodData = await fetchFoodDetailsById(foodId.toString());
-                if (foodData?.data) {
-                    const food = foodData.data;
-                    const translation = food?.translations?.find(
-                        (val: DatabaseTypes.FoodsTranslations) => String(val?.languages_code)?.split('-')[0] === languageCode
-                    );
-                    const rawName = translation?.name ?? food?.name ?? null;
-                    setFoodDetails({
-                        ...food,
-                        name: rawName ? translateDynamic(rawName) : null,
-                    });
-
-                    const attributes = food?.attribute_values || food?.foods_attributes_values;
-                    if (attributes) {
-                        setFoodAttributes(attributes);
-                    }
-                }
+                applyFoodDetailsResponse(foodData, languageCode, translateDynamic, setFoodDetails, setFoodAttributes);
             }
         } catch (e: any) {
             console.error('Error fetching food details: ', e);

--- a/apps/frontend/app/app/(app)/form-queue/index.tsx
+++ b/apps/frontend/app/app/(app)/form-queue/index.tsx
@@ -20,6 +20,115 @@ import { uploadToDirectus, uploadToDirectusFromMobile } from '@/constants/Helper
 import { Buffer } from 'buffer';
 import { fetchSpecificField } from '@/redux/actions/Fields/Fields';
 
+const resolveDateValueField = (value: any, fieldType: string): Record<string, any> => {
+    let formattedDate: string | null = null;
+    try {
+        if (value) {
+            let dateObj;
+            if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE_DATE_AND_HH_MM) {
+                dateObj = parse(value, 'dd.MM.yyyy HH:mm', new Date());
+            } else if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE) {
+                dateObj = parse(value, 'dd.MM.yyyy', new Date());
+            } else if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE_HH_MM) {
+                const today = format(new Date(), 'yyyy-MM-dd');
+                dateObj = parse(`${today} ${value}`, 'yyyy-MM-dd HH:mm', new Date());
+            } else if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE_TIMESTAMP) {
+                dateObj = parse(value, 'dd.MM.yyyy HH:mm:ss', new Date());
+            }
+            if (dateObj && isValid(dateObj)) {
+                formattedDate = format(dateObj, "yyyy-MM-dd'T'HH:mm:ss.SSSX");
+            }
+        }
+    } catch {
+        formattedDate = null;
+    }
+    return { value_date: formattedDate };
+};
+
+const resolveImageValueField = async (value: any, fieldId: string, imageFolderId: string | null): Promise<Record<string, any>> => {
+    if (value?.name) {
+        try {
+            const response = await fetch(value.image);
+            const arrayBuffer = await response.arrayBuffer();
+            const buffer = Buffer.from(arrayBuffer);
+            const fileData = { name: value.name, type: value.type, buffer: isWeb ? buffer : value.image, edit: true };
+            const fileId = isWeb ? await uploadToDirectus(fileData, imageFolderId) : await uploadToDirectusFromMobile(fileData, imageFolderId);
+            return { value_image: fileId };
+        } catch (uploadError) {
+            console.error('Queue sync: image upload failed for field', fieldId, uploadError);
+            return {};
+        }
+    } else if (value === null || value === undefined) {
+        // Image/signature was cleared — explicitly set to null
+        return { value_image: null };
+    }
+    return {};
+};
+
+const resolveFilesValueField = async (value: any, fieldId: string, filesFolderId: string | null): Promise<Record<string, any>> => {
+    if (Array.isArray(value) && value.length > 0) {
+        try {
+            const newFiles = value.filter((file: any) => !file?.edit);
+            if (newFiles.length > 0) {
+                const uploadedIds = await Promise.all(
+                    newFiles.map(async (file: any) => {
+                        const response = await fetch(file.image);
+                        const arrayBuffer = await response.arrayBuffer();
+                        const buffer = Buffer.from(arrayBuffer);
+                        const fileData = { name: file.name, type: file.type, buffer: isWeb ? buffer : file.image, edit: true };
+                        return isWeb ? uploadToDirectus(fileData, filesFolderId) : uploadToDirectusFromMobile(fileData, filesFolderId);
+                    })
+                );
+                return {
+                    value_files: {
+                        create: uploadedIds.filter(Boolean).map((fileId: any) => ({ directus_files_id: fileId })),
+                    },
+                };
+            }
+            // else: only existing files, no new uploads needed
+            return {};
+        } catch (uploadError) {
+            console.error('Queue sync: file upload failed for field', fieldId, uploadError);
+            return {};
+        }
+    } else {
+        // All files cleared — explicitly set to empty
+        return { value_files: [] };
+    }
+};
+
+const resolveUpdatedValueFields = async (
+    customType: string | undefined,
+    value: any,
+    fieldId: string,
+    fieldType: string,
+    imageFolderId: string | null,
+    filesFolderId: string | null
+): Promise<Record<string, any>> => {
+    if (customType === 'value_string') {
+        return { value_string: value };
+    } else if (customType === 'value_number') {
+        return { value_number: value ? String(value).replace(',', '.') : null };
+    } else if (customType === 'value_boolean') {
+        let booleanValue: boolean | null = null;
+        if (value === 0) {
+            booleanValue = false;
+        } else if (value === 1) {
+            booleanValue = true;
+        }
+        return { value_boolean: booleanValue };
+    } else if (customType === 'value_custom') {
+        return { value_custom: value };
+    } else if (customType === 'value_date') {
+        return resolveDateValueField(value, fieldType);
+    } else if (customType === 'value_image') {
+        return resolveImageValueField(value, fieldId, imageFolderId);
+    } else if (customType === 'value_files') {
+        return resolveFilesValueField(value, fieldId, filesFolderId);
+    }
+    return {};
+};
+
 const Index = () => {
     useSetPageTitle(TranslationKeys.form_queue);
     const { translate } = useLanguage();
@@ -72,91 +181,14 @@ const Index = () => {
                     const { value, custom_type } = formDataEntry;
                     const fieldType = (answer?.form_field as DatabaseTypes.FormFields)?.field_type || '';
 
-                    let updatedValueFields: Record<string, any> = {};
-                    if (custom_type === 'value_string') {
-                        updatedValueFields = { value_string: value };
-                    } else if (custom_type === 'value_number') {
-                        updatedValueFields = { value_number: value ? String(value).replace(',', '.') : null };
-                    } else if (custom_type === 'value_boolean') {
-                        let booleanValue: boolean | null = null;
-                        if (value === 0) {
-                            booleanValue = false;
-                        } else if (value === 1) {
-                            booleanValue = true;
-                        }
-                        updatedValueFields = { value_boolean: booleanValue };
-                    } else if (custom_type === 'value_custom') {
-                        updatedValueFields = { value_custom: value };
-                    } else if (custom_type === 'value_date') {
-                        let formattedDate: string | null = null;
-                        try {
-                            if (value) {
-                                let dateObj;
-                                if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE_DATE_AND_HH_MM) {
-                                    dateObj = parse(value, 'dd.MM.yyyy HH:mm', new Date());
-                                } else if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE) {
-                                    dateObj = parse(value, 'dd.MM.yyyy', new Date());
-                                } else if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE_HH_MM) {
-                                    const today = format(new Date(), 'yyyy-MM-dd');
-                                    dateObj = parse(`${today} ${value}`, 'yyyy-MM-dd HH:mm', new Date());
-                                } else if (fieldType === FormHelperCommon.FORM_FIELD_TYPE.DATE_TIMESTAMP) {
-                                    dateObj = parse(value, 'dd.MM.yyyy HH:mm:ss', new Date());
-                                }
-                                if (dateObj && isValid(dateObj)) {
-                                    formattedDate = format(dateObj, "yyyy-MM-dd'T'HH:mm:ss.SSSX");
-                                }
-                            }
-                        } catch {
-                            formattedDate = null;
-                        }
-                        updatedValueFields = { value_date: formattedDate };
-                    } else if (custom_type === 'value_image') {
-                        if (value?.name) {
-                            try {
-                                const response = await fetch(value.image);
-                                const arrayBuffer = await response.arrayBuffer();
-                                const buffer = Buffer.from(arrayBuffer);
-                                const fileData = { name: value.name, type: value.type, buffer: isWeb ? buffer : value.image, edit: true };
-                                const fileId = isWeb ? await uploadToDirectus(fileData, imageFolderId) : await uploadToDirectusFromMobile(fileData, imageFolderId);
-                                updatedValueFields = { value_image: fileId };
-                            } catch (uploadError) {
-                                console.error('Queue sync: image upload failed for field', fieldId, uploadError);
-                                updatedValueFields = {};
-                            }
-                        } else if (value === null || value === undefined) {
-                            // Image/signature was cleared — explicitly set to null
-                            updatedValueFields = { value_image: null };
-                        }
-                    } else if (custom_type === 'value_files') {
-                        if (Array.isArray(value) && value.length > 0) {
-                            try {
-                                const newFiles = value.filter((file: any) => !file?.edit);
-                                if (newFiles.length > 0) {
-                                    const uploadedIds = await Promise.all(
-                                        newFiles.map(async (file: any) => {
-                                            const response = await fetch(file.image);
-                                            const arrayBuffer = await response.arrayBuffer();
-                                            const buffer = Buffer.from(arrayBuffer);
-                                            const fileData = { name: file.name, type: file.type, buffer: isWeb ? buffer : file.image, edit: true };
-                                            return isWeb ? uploadToDirectus(fileData, filesFolderId) : uploadToDirectusFromMobile(fileData, filesFolderId);
-                                        })
-                                    );
-                                    updatedValueFields = {
-                                        value_files: {
-                                            create: uploadedIds.filter(Boolean).map((fileId: any) => ({ directus_files_id: fileId })),
-                                        },
-                                    };
-                                }
-                                // else: only existing files, no new uploads needed
-                            } catch (uploadError) {
-                                console.error('Queue sync: file upload failed for field', fieldId, uploadError);
-                                updatedValueFields = {};
-                            }
-                        } else {
-                            // All files cleared — explicitly set to empty
-                            updatedValueFields = { value_files: [] };
-                        }
-                    }
+                    const updatedValueFields = await resolveUpdatedValueFields(
+                        custom_type,
+                        value,
+                        fieldId,
+                        fieldType,
+                        imageFolderId,
+                        filesFolderId
+                    );
 
                     return { id: fieldId, ...updatedValueFields };
                 })

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -252,6 +252,205 @@ async function resolveInitialFieldValue(
 	return defaultValue || null;
 }
 
+/**
+ * Resolve the Directus folder IDs used for image/file uploads during
+ * submission, re-fetching them if either wasn't already resolved at mount.
+ */
+async function resolveUploadFolderIds(
+	imageFolderIdState: string | null,
+	filesFolderIdState: string | null
+): Promise<{ imageFolderId: string | null; filesFolderId: string | null }> {
+	let imageFolderId: string | null = imageFolderIdState;
+	let filesFolderId: string | null = filesFolderIdState;
+	if (imageFolderId === null || filesFolderId === null) {
+		try {
+			const formAnswerFields: any = await fetchSpecificField('form_answers');
+			imageFolderId = imageFolderId ?? formAnswerFields?.value_image?.meta?.options?.folder ?? null;
+			filesFolderId = filesFolderId ?? formAnswerFields?.value_files?.meta?.options?.folder ?? null;
+		} catch {
+			// silently ignore, upload without folder
+		}
+	}
+	return { imageFolderId, filesFolderId };
+}
+
+/**
+ * Validate that all currently-visible required fields have a value, toasting
+ * an error for each missing one. Returns true if any field failed validation.
+ */
+function validateRequiredFormAnswers(
+	formAnswers: DatabaseTypes.FormAnswers[],
+	formData: { [key: string]: { value: any; error: string; custom_type?: string } },
+	getAnswerValueFn: (answer: DatabaseTypes.FormAnswers) => any,
+	language: string,
+	toastFn: (message: string, type: string) => void
+): boolean {
+	let hasError = false;
+	for (const answer of formAnswers) {
+		const formField = answer?.form_field as DatabaseTypes.FormFields;
+		if (!formField?.is_required) continue;
+		if (!isAnswerVisible(answer, formAnswers, getAnswerValueFn)) continue;
+		const value = formData[String(answer?.id)]?.value;
+		if (!value || (typeof value === 'string' && value.trim() === '')) {
+			hasError = true;
+			const fieldName = formField?.translations?.length > 0 ? getFromCategoryTranslation(formField.translations, language) : formField?.alias;
+			toastFn(`Field "${fieldName}" is required`, 'error');
+		}
+	}
+	return hasError;
+}
+
+// Maps a tri-state 0/1 UI value to the stored boolean for value_boolean answers.
+function buildBooleanFieldUpdate(value: any): Record<string, any> {
+	let booleanValue: boolean | null = null;
+	if (value === 0) {
+		booleanValue = false;
+	} else if (value === 1) {
+		booleanValue = true;
+	}
+	return { value_boolean: booleanValue };
+}
+
+/**
+ * Build the value_image update payload for a form answer submission.
+ * Handles new uploads (including signature base64 uris and deleting the
+ * previous signature file) and explicit clearing of the image.
+ */
+async function buildImageFieldUpdate(
+	value: any,
+	custom_id: string | undefined,
+	offlineMode: boolean,
+	answer: DatabaseTypes.FormAnswers,
+	imageFolderId: string | null,
+	uploadFileFn: (value: any, folderId?: string | null) => Promise<any>
+): Promise<Record<string, any>> {
+	if (value?.name) {
+		// New file: for signature fields delete the old Directus file first (online mode only)
+		if (custom_id === 'signature' && !offlineMode) {
+			const originalFileId = (answer as any)?.value_image;
+			if (originalFileId) {
+				try {
+					await deleteDirectusFile(String(originalFileId));
+				} catch (e) {
+					console.warn('Could not delete old signature file:', e);
+				}
+			}
+		}
+		if (custom_id === 'signature') {
+			// Signatures: send base64 data URI directly — the backend
+			// base64-file-upload-hook will create the Directus file automatically.
+			const base64DataUri = await toBase64DataUri(value);
+			return { value_image: base64DataUri };
+		}
+		// Regular images: upload the file first, then store the file ID
+		const directusFileId = await uploadFileFn(value, imageFolderId);
+		return { value_image: directusFileId };
+	}
+
+	if (value === null || value === undefined) {
+		// Image/signature cleared — explicitly set to null
+		if (custom_id === 'signature' && !offlineMode) {
+			const originalFileId = (answer as any)?.value_image;
+			if (originalFileId) {
+				try {
+					await deleteDirectusFile(String(originalFileId));
+				} catch (e) {
+					console.warn('Could not delete old signature file:', e);
+				}
+			}
+		}
+		return { value_image: null };
+	}
+
+	// existing URL unchanged — no update needed
+	return {};
+}
+
+/**
+ * Build the value_files update payload for a form answer submission,
+ * uploading newly added files and detecting removed file relations.
+ */
+async function buildFilesFieldUpdate(
+	value: any,
+	answer: DatabaseTypes.FormAnswers,
+	filesFolderId: string | null,
+	uploadFileFn: (value: any, folderId?: string | null) => Promise<any>
+): Promise<Record<string, any>> {
+	if (!(Array.isArray(value) && value.length > 0)) {
+		// All files cleared — explicitly set to empty
+		return { value_files: [] };
+	}
+
+	const newFiles = value.filter((file: any) => !file?.edit);
+	const existingFileIds = new Set(value.filter((file: any) => file?.edit).map((file: any) => file.directus_files_id).filter(Boolean));
+
+	// Detect deleted relations by comparing current files with original answer files
+	const originalValueFiles: any[] = (answer as any).value_files || [];
+	const deletedRelationIds = originalValueFiles
+		.filter((orig: any) => orig?.directus_files_id && !existingFileIds.has(orig.directus_files_id))
+		.map((orig: any) => orig.id)
+		.filter(Boolean);
+
+	if (newFiles.length === 0 && deletedRelationIds.length === 0) {
+		// only unchanged existing files, no action needed
+		return {};
+	}
+
+	const uploadedFileIds = newFiles.length > 0
+		? await Promise.all(newFiles.map(async (file: any) => await uploadFileFn(file, filesFolderId)))
+		: [];
+
+	const valueFilesUpdate: Record<string, any> = {};
+	const validUploadIds = uploadedFileIds.filter(Boolean);
+	if (validUploadIds.length > 0) {
+		valueFilesUpdate.create = validUploadIds.map(fileId => ({ directus_files_id: fileId }));
+	}
+	if (deletedRelationIds.length > 0) {
+		valueFilesUpdate.delete = deletedRelationIds;
+	}
+	return { value_files: valueFilesUpdate };
+}
+
+/**
+ * Build the per-custom-type updated value fields for a single form answer
+ * during submission (mirrors the field's storage column: value_string,
+ * value_number, value_boolean, value_custom, value_date, value_image or value_files).
+ */
+async function buildUpdatedValueFieldsForAnswer(
+	custom_type: string | undefined,
+	custom_id: string | undefined,
+	value: any,
+	formateDate: string | null | undefined,
+	answer: DatabaseTypes.FormAnswers,
+	offlineMode: boolean,
+	imageFolderId: string | null,
+	filesFolderId: string | null,
+	uploadFileFn: (value: any, folderId?: string | null) => Promise<any>
+): Promise<Record<string, any>> {
+	if (custom_type === 'value_string') {
+		return { value_string: value };
+	}
+	if (custom_type === 'value_number') {
+		return { value_number: value ? value.replace(',', '.') : null };
+	}
+	if (custom_type === 'value_boolean') {
+		return buildBooleanFieldUpdate(value);
+	}
+	if (custom_type === 'value_custom') {
+		return { value_custom: value };
+	}
+	if (custom_type === 'value_date') {
+		return { value_date: formateDate };
+	}
+	if (custom_type === 'value_image') {
+		return buildImageFieldUpdate(value, custom_id, offlineMode, answer, imageFolderId, uploadFileFn);
+	}
+	if (custom_type === 'value_files') {
+		return buildFilesFieldUpdate(value, answer, filesFolderId, uploadFileFn);
+	}
+	return {};
+}
+
 const Index = () => {
 	const toast = useToast();
 	const scrollViewRef = useRef(null);
@@ -696,33 +895,12 @@ const Index = () => {
 
 	const handleFormSubmission = async () => {
 		setSubmissionLoading(true);
-		let hasError = false;
 
 		// Use folder IDs already fetched at component mount; re-fetch if either is still null
-		let imageFolderId: string | null = imageFolderIdState;
-		let filesFolderId: string | null = filesFolderIdState;
-		if (imageFolderId === null || filesFolderId === null) {
-			try {
-				const formAnswerFields: any = await fetchSpecificField('form_answers');
-				imageFolderId = imageFolderId ?? formAnswerFields?.value_image?.meta?.options?.folder ?? null;
-				filesFolderId = filesFolderId ?? formAnswerFields?.value_files?.meta?.options?.folder ?? null;
-			} catch {
-				// silently ignore, upload without folder
-			}
-		}
+		const { imageFolderId, filesFolderId } = await resolveUploadFolderIds(imageFolderIdState, filesFolderIdState);
 
 		// Validate required fields that are currently visible in the form
-		for (const answer of formAnswers) {
-			const formField = answer?.form_field as DatabaseTypes.FormFields;
-			if (!formField?.is_required) continue;
-			if (!isAnswerVisible(answer, formAnswers, getAnswerValue)) continue;
-			const value = formData[String(answer?.id)]?.value;
-			if (!value || (typeof value === 'string' && value.trim() === '')) {
-				hasError = true;
-				const fieldName = formField?.translations?.length > 0 ? getFromCategoryTranslation(formField.translations, language) : formField?.alias;
-				toast(`Field "${fieldName}" is required`, 'error');
-			}
-		}
+		const hasError = validateRequiredFormAnswers(formAnswers, formData, getAnswerValue, language, toast);
 
 		if (hasError) {
 			setSubmissionLoading(false);
@@ -745,98 +923,18 @@ const Index = () => {
 					formateDate = formatDateForSubmission(fieldType, value);
 				}
 
-				let updatedValueFields: Record<string, any> = {};
-				if (custom_type === 'value_string') {
-					updatedValueFields = { value_string: value };
-				} else if (custom_type === 'value_number') {
-					updatedValueFields = {
-						value_number: value ? value.replace(',', '.') : null,
-					};
-				} else if (custom_type === 'value_boolean') {
-					let booleanValue: boolean | null = null;
-					if (value === 0) {
-						booleanValue = false;
-					} else if (value === 1) {
-						booleanValue = true;
-					}
-					updatedValueFields = {
-						value_boolean: booleanValue,
-					};
-				} else if (custom_type === 'value_custom') {
-					updatedValueFields = { value_custom: value };
-				} else if (custom_type === 'value_date') {
-					updatedValueFields = { value_date: formateDate };
-				} else if (custom_type === 'value_image') {
-					if (value?.name) {
-						// New file: for signature fields delete the old Directus file first (online mode only)
-						if (custom_id === 'signature' && !offlineMode) {
-							const originalFileId = (answer as any)?.value_image;
-							if (originalFileId) {
-								try {
-									await deleteDirectusFile(String(originalFileId));
-								} catch (e) {
-									console.warn('Could not delete old signature file:', e);
-								}
-							}
-						}
-						if (custom_id === 'signature') {
-							// Signatures: send base64 data URI directly — the backend
-							// base64-file-upload-hook will create the Directus file automatically.
-							const base64DataUri = await toBase64DataUri(value);
-							updatedValueFields = { value_image: base64DataUri };
-						} else {
-							// Regular images: upload the file first, then store the file ID
-							const directusFileId = await getDirectusUploadId(value, imageFolderId);
-							updatedValueFields = { value_image: directusFileId };
-						}
-					} else if (value === null || value === undefined) {
-						// Image/signature cleared — explicitly set to null
-						if (custom_id === 'signature' && !offlineMode) {
-							const originalFileId = (answer as any)?.value_image;
-							if (originalFileId) {
-								try {
-									await deleteDirectusFile(String(originalFileId));
-								} catch (e) {
-									console.warn('Could not delete old signature file:', e);
-								}
-							}
-						}
-						updatedValueFields = { value_image: null };
-					}
-					// else: existing URL unchanged — no update needed
-				} else if (custom_type === 'value_files') {
-					if (Array.isArray(value) && value.length > 0) {
-						const newFiles = value.filter((file: any) => !file?.edit);
-						const existingFileIds = new Set(value.filter((file: any) => file?.edit).map((file: any) => file.directus_files_id).filter(Boolean));
+				const updatedValueFields = await buildUpdatedValueFieldsForAnswer(
+					custom_type,
+					custom_id,
+					value,
+					formateDate,
+					answer,
+					offlineMode,
+					imageFolderId,
+					filesFolderId,
+					getDirectusUploadId
+				);
 
-						// Detect deleted relations by comparing current files with original answer files
-						const originalValueFiles: any[] = (answer as any).value_files || [];
-						const deletedRelationIds = originalValueFiles
-							.filter((orig: any) => orig?.directus_files_id && !existingFileIds.has(orig.directus_files_id))
-							.map((orig: any) => orig.id)
-							.filter(Boolean);
-
-						if (newFiles.length > 0 || deletedRelationIds.length > 0) {
-							const uploadedFileIds = newFiles.length > 0
-								? await Promise.all(newFiles.map(async (file: any) => await getDirectusUploadId(file, filesFolderId)))
-								: [];
-
-							const valueFilesUpdate: Record<string, any> = {};
-							const validUploadIds = uploadedFileIds.filter(Boolean);
-							if (validUploadIds.length > 0) {
-								valueFilesUpdate.create = validUploadIds.map(fileId => ({ directus_files_id: fileId }));
-							}
-							if (deletedRelationIds.length > 0) {
-								valueFilesUpdate.delete = deletedRelationIds;
-							}
-							updatedValueFields = { value_files: valueFilesUpdate };
-						}
-						// else: only unchanged existing files, no action needed
-					} else {
-						// All files cleared — explicitly set to empty
-						updatedValueFields = { value_files: [] };
-					}
-				}
 				return {
 					id: fieldId,
 					...updatedValueFields,

--- a/apps/frontend/app/app/(app)/form-submissions/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submissions/index.tsx
@@ -72,6 +72,47 @@ function resolveSubmissionsContent(
 	);
 }
 
+/**
+ * Filter cached (offline) form submissions by the currently selected state
+ * and the free-text alias query. Mirrors the filtering previously inlined in
+ * both the offline branch and the network-error fallback branch of
+ * loadFormSubmissions.
+ */
+function filterCachedSubmissions(
+	cached: DatabaseTypes.FormSubmissions[],
+	selectedOption: string,
+	query: string
+): DatabaseTypes.FormSubmissions[] {
+	const filterState = selectedOption || 'draft';
+	const filterQuery = query ? query.trim().toLowerCase() : '';
+
+	return cached.filter((s: DatabaseTypes.FormSubmissions) => {
+		const stateMatch = s.state === filterState;
+		const aliasMatch = filterQuery ? (s.alias || '').toLowerCase().includes(filterQuery) : true;
+		return stateMatch && aliasMatch;
+	});
+}
+
+/**
+ * Apply a (already sorted) submissions result to state, either replacing the
+ * current list or appending to it (re-sorting the merged list afterwards).
+ * Extracted since this append/replace decision was repeated three times
+ * inside loadFormSubmissions.
+ */
+function applySortedSubmissions(
+	setFormSubmissions: React.Dispatch<React.SetStateAction<DatabaseTypes.FormSubmissions[]>>,
+	sortFormSubmissions: (submissions: DatabaseTypes.FormSubmissions[], option: FormSubmissionSortOption) => DatabaseTypes.FormSubmissions[],
+	sortedResult: DatabaseTypes.FormSubmissions[],
+	sortOption: FormSubmissionSortOption,
+	append: boolean
+): void {
+	if (append) {
+		setFormSubmissions(prev => sortFormSubmissions([...(prev || []), ...sortedResult], sortOption));
+	} else {
+		setFormSubmissions(sortedResult);
+	}
+}
+
 const Index = () => {
 	useSetPageTitle(TranslationKeys.select_a_form_submission);
 	const { translate } = useLanguage();
@@ -282,19 +323,9 @@ const Index = () => {
 		// When offline mode is active, use cache directly without attempting API call
 		if (offlineMode) {
 			const cached = cachedFormData?.[String(form_id)]?.submissions || [];
-			const filterState = selectedOption || 'draft';
-			const filterQuery = query ? query.trim().toLowerCase() : '';
-			const filtered = cached.filter((s: DatabaseTypes.FormSubmissions) => {
-				const stateMatch = s.state === filterState;
-				const aliasMatch = filterQuery ? (s.alias || '').toLowerCase().includes(filterQuery) : true;
-				return stateMatch && aliasMatch;
-			});
+			const filtered = filterCachedSubmissions(cached, selectedOption, query);
 			const sortedResult = sortFormSubmissions(filtered, sortOption);
-			if (append) {
-				setFormSubmissions(prev => sortFormSubmissions([...(prev || []), ...sortedResult], sortOption));
-			} else {
-				setFormSubmissions(sortedResult);
-			}
+			applySortedSubmissions(setFormSubmissions, sortFormSubmissions, sortedResult, sortOption, append);
 			if (cached.length > 0) setIsShowingCachedData(true);
 			setLoading(false);
 			return;
@@ -309,32 +340,15 @@ const Index = () => {
 
 			if (result) {
 				const sortedResult = sortFormSubmissions(result, sortOption);
-				if (append) {
-					setFormSubmissions(prev => {
-						const merged = [...(prev || []), ...sortedResult];
-						return sortFormSubmissions(merged, sortOption);
-					});
-				} else {
-					setFormSubmissions(sortedResult);
-				}
+				applySortedSubmissions(setFormSubmissions, sortFormSubmissions, sortedResult, sortOption, append);
 			}
 		} catch (error) {
 			// Network failed – fall back to locally cached submissions for this form
 			const cached = cachedFormData?.[String(form_id)]?.submissions || [];
 			if (cached.length > 0) {
-				const filterState = selectedOption || 'draft';
-				const filterQuery = query ? query.trim().toLowerCase() : '';
-				const filtered = cached.filter((s: DatabaseTypes.FormSubmissions) => {
-					const stateMatch = s.state === filterState;
-					const aliasMatch = filterQuery ? (s.alias || '').toLowerCase().includes(filterQuery) : true;
-					return stateMatch && aliasMatch;
-				});
+				const filtered = filterCachedSubmissions(cached, selectedOption, query);
 				const sortedResult = sortFormSubmissions(filtered, sortOption);
-				if (append) {
-					setFormSubmissions(prev => sortFormSubmissions([...(prev || []), ...sortedResult], sortOption));
-				} else {
-					setFormSubmissions(sortedResult);
-				}
+				applySortedSubmissions(setFormSubmissions, sortFormSubmissions, sortedResult, sortOption, append);
 				setIsShowingCachedData(true);
 			} else {
 				console.error('Error fetching form submissions', error);

--- a/apps/frontend/app/app/(app)/image-full-screen/index.tsx
+++ b/apps/frontend/app/app/(app)/image-full-screen/index.tsx
@@ -17,6 +17,79 @@ import { useMyScrollViewModal } from '@/components/GlobalModal/useMyScrollViewMo
 import useDebugMode from '@/hooks/useDebugMode';
 import MyImage from '@/components/MyImage';
 
+function resolveImageExtension(highResUri: unknown, isDebugMode: boolean): string {
+	let extension = 'jpg';
+	try {
+		const urlObj = new URL(String(highResUri));
+		const format = urlObj.searchParams.get('format');
+		if (format) {
+			extension = format;
+		} else {
+			const lastSegment = urlObj.pathname.split('/').pop() ?? '';
+			const dotIndex = lastSegment.lastIndexOf('.');
+			if (dotIndex !== -1) {
+				const pathExt = lastSegment.slice(dotIndex + 1);
+				if (pathExt.length > 0 && pathExt.length <= 5) {
+					extension = pathExt;
+				}
+			}
+		}
+	} catch (urlError) {
+		// URL parsing failed, keep default extension
+		if (isDebugMode) {
+			console.warn('Failed to parse image URL for extension:', urlError);
+		}
+	}
+	return extension;
+}
+
+async function downloadImageForPlatform(highResUri: unknown, name: string, extension: string, toast: ReturnType<typeof useToast>): Promise<void> {
+	if (Platform.OS === 'web') {
+		const link = document.createElement('a');
+		link.href = String(highResUri);
+		link.download = `${name}.${extension}`;
+		document.body.appendChild(link);
+		link.click();
+		link.remove();
+	} else {
+		const filename = `${name}.${extension}`;
+		const fileUri = (FileSystem as any).documentDirectory + filename;
+		const { uri } = await FileSystem.downloadAsync(String(highResUri), fileUri);
+		await Share.share({
+			url: uri,
+			message: uri,
+		});
+		toast('Image downloaded', 'success');
+	}
+}
+
+function showDownloadErrorDebugModal(params: {
+	theme: ReturnType<typeof useTheme>['theme'];
+	highResUri: unknown;
+	lowResUri: unknown;
+	assetId: unknown;
+	error: unknown;
+	showScrollViewModal: ReturnType<typeof useMyScrollViewModal>['show'];
+}): void {
+	const { theme, highResUri, lowResUri, assetId, error, showScrollViewModal } = params;
+	const debugText = [
+		'Download failed',
+		`highResUri: ${highResUri}`,
+		`lowResUri: ${lowResUri}`,
+		`assetId: ${assetId}`,
+		`error: ${error instanceof Error ? error.message : String(error)}`,
+		`stack: ${error instanceof Error ? error.stack : ''}`,
+	].join('\n\n');
+	showScrollViewModal({
+		title: 'Debug: Download Error',
+		children: (
+			<Text selectable style={{ fontFamily: 'monospace', fontSize: 12, color: theme.screen.text }}>
+				{debugText}
+			</Text>
+		),
+	});
+}
+
 export default function ImageFullScreen() {
 	const { uri, assetId } = useLocalSearchParams<{
 		uri?: string;
@@ -149,65 +222,13 @@ export default function ImageFullScreen() {
 
 	const downloadImage = async () => {
 		try {
-			let extension = 'jpg';
-			try {
-				const urlObj = new URL(String(highResUri));
-				const format = urlObj.searchParams.get('format');
-				if (format) {
-					extension = format;
-				} else {
-					const lastSegment = urlObj.pathname.split('/').pop() ?? '';
-					const dotIndex = lastSegment.lastIndexOf('.');
-					if (dotIndex !== -1) {
-						const pathExt = lastSegment.slice(dotIndex + 1);
-						if (pathExt.length > 0 && pathExt.length <= 5) {
-							extension = pathExt;
-						}
-					}
-				}
-			} catch (urlError) {
-				// URL parsing failed, keep default extension
-				if (isDebugMode) {
-					console.warn('Failed to parse image URL for extension:', urlError);
-				}
-			}
+			const extension = resolveImageExtension(highResUri, isDebugMode);
 			const name = assetId || `image_${Date.now()}`;
-			if (Platform.OS === 'web') {
-				const link = document.createElement('a');
-				link.href = String(highResUri);
-				link.download = `${name}.${extension}`;
-				document.body.appendChild(link);
-				link.click();
-				link.remove();
-			} else {
-				const filename = `${name}.${extension}`;
-				const fileUri = (FileSystem as any).documentDirectory + filename;
-				const { uri } = await FileSystem.downloadAsync(String(highResUri), fileUri);
-				await Share.share({
-					url: uri,
-					message: uri,
-				});
-				toast('Image downloaded', 'success');
-			}
+			await downloadImageForPlatform(highResUri, name, extension, toast);
 		} catch (e) {
 			toast('Download failed', 'error');
 			if (isDebugMode) {
-				const debugText = [
-					'Download failed',
-					`highResUri: ${highResUri}`,
-					`lowResUri: ${lowResUri}`,
-					`assetId: ${assetId}`,
-					`error: ${e instanceof Error ? e.message : String(e)}`,
-					`stack: ${e instanceof Error ? e.stack : ''}`,
-				].join('\n\n');
-				showScrollViewModal({
-					title: 'Debug: Download Error',
-					children: (
-						<Text selectable style={{ fontFamily: 'monospace', fontSize: 12, color: theme.screen.text }}>
-							{debugText}
-						</Text>
-					),
-				});
+				showDownloadErrorDebugModal({ theme, highResUri, lowResUri, assetId, error: e, showScrollViewModal });
 			}
 		}
 	};

--- a/apps/frontend/app/app/(app)/map/index.tsx
+++ b/apps/frontend/app/app/(app)/map/index.tsx
@@ -689,6 +689,101 @@ function createBuildingMarkerSvg(params: {
 	return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}">${circleEl}${textEl}</svg>`;
 }
 
+function computePoiIconOverrides(
+	poiEnabled: boolean,
+	barriersEnabled: boolean,
+	parkingEnabled: boolean,
+	poiSubSettings: Record<string, boolean>,
+): Record<string, string | null> {
+	const overrides: Record<string, string | null> = {};
+	if (poiEnabled) {
+		POI_SUBTYPES.forEach(({ key }) => {
+			if (!(poiSubSettings[key] ?? true)) {
+				overrides[key] = null;
+			}
+		});
+	}
+	if (!barriersEnabled) {
+		BARRIER_ICON_KEYS.forEach((key) => {
+			overrides[key] = null;
+		});
+	}
+	if (!parkingEnabled) {
+		PARKING_ICON_KEYS.forEach((key) => {
+			overrides[key] = null;
+		});
+	}
+	return overrides;
+}
+
+function handleMapComponentMounted(params: {
+	mapMountedRef: React.MutableRefObject<boolean>;
+	gameModeRef: React.MutableRefObject<boolean>;
+	setGameMapReady: (ready: boolean) => void;
+	sendGameInitData: () => void;
+	pendingNavigateRef: React.MutableRefObject<boolean>;
+	sendMapData: () => void;
+	sendToMapRef: React.MutableRefObject<(data: object) => void>;
+	peopleCountRef: React.MutableRefObject<number>;
+	peopleModeRef: React.MutableRefObject<boolean>;
+	intelligentMovementRef: React.MutableRefObject<boolean>;
+	carModeRef: React.MutableRefObject<boolean>;
+	showSettingsRef: React.MutableRefObject<Record<string, boolean>>;
+	poiSubSettingsRef: React.MutableRefObject<Record<string, boolean>>;
+	addLog: (entry: string) => void;
+}): void {
+	const {
+		mapMountedRef,
+		gameModeRef,
+		setGameMapReady,
+		sendGameInitData,
+		pendingNavigateRef,
+		sendMapData,
+		sendToMapRef,
+		peopleCountRef,
+		peopleModeRef,
+		intelligentMovementRef,
+		carModeRef,
+		showSettingsRef,
+		poiSubSettingsRef,
+		addLog,
+	} = params;
+
+	mapMountedRef.current = true;
+	if (gameModeRef.current) {
+		setGameMapReady(true);
+		sendGameInitData();
+	} else {
+		pendingNavigateRef.current = true;
+		sendMapData();
+	}
+	sendToMapRef.current({ peopleCount: peopleCountRef.current });
+	if (peopleModeRef.current) {
+		sendToMapRef.current({ peopleMode: true });
+	}
+	if (intelligentMovementRef.current) {
+		sendToMapRef.current({ intelligentMovement: true });
+	}
+	if (carModeRef.current) {
+		sendToMapRef.current({ carMode: true });
+	}
+	// Send the emoji map so the HTML has no hardcoded emoji data
+	sendToMapRef.current({ iconEmojiMap: ICON_EMOJI_MAP });
+	const GROUP_MAP: Record<string, string> = { poi: 'poi', transit: 'transit', roadNames: 'roadLabels', leisure: 'leisure', barriers: 'barriers', parking: 'parking' };
+	Object.entries(GROUP_MAP).forEach(([key, group]) => {
+		if (!(showSettingsRef.current[key] ?? key !== 'barriers')) {
+			sendToMapRef.current({ setLayerGroupVisibility: { group, visible: false } });
+		}
+	});
+	// Send initial POI icon overrides for disabled sub-types, barrier group, and parking group
+	const poiEnabled = showSettingsRef.current.poi ?? true;
+	const barriersEnabled = showSettingsRef.current.barriers ?? false;
+	const parkingEnabled = showSettingsRef.current.parking ?? true;
+	const initialPoiOverrides = computePoiIconOverrides(poiEnabled, barriersEnabled, parkingEnabled, poiSubSettingsRef.current);
+	sendToMapRef.current({ poiIconOverrides: initialPoiOverrides });
+	addLog('MapComponentMounted');
+}
+
 function resolveMapOverlayStyle(
 	gameMode: boolean,
 	headingUpMode: boolean,
@@ -1252,24 +1347,7 @@ const OsmVectorMapScreen: React.FC = () => {
 		const poiEnabled = showSettings.poi ?? true;
 		const barriersEnabled = showSettings.barriers ?? false;
 		const parkingEnabled = showSettings.parking ?? true;
-		const overrides: Record<string, string | null> = {};
-		if (poiEnabled) {
-			POI_SUBTYPES.forEach(({ key }) => {
-				if (!(poiSubSettings[key] ?? true)) {
-					overrides[key] = null;
-				}
-			});
-		}
-		if (!barriersEnabled) {
-			BARRIER_ICON_KEYS.forEach((key) => {
-				overrides[key] = null;
-			});
-		}
-		if (!parkingEnabled) {
-			PARKING_ICON_KEYS.forEach((key) => {
-				overrides[key] = null;
-			});
-		}
+		const overrides = computePoiIconOverrides(poiEnabled, barriersEnabled, parkingEnabled, poiSubSettings);
 		sendToMapRef.current({ poiIconOverrides: overrides });
 	}, [showSettings, poiSubSettings]);
 
@@ -1329,56 +1407,22 @@ const OsmVectorMapScreen: React.FC = () => {
 		(data: object) => {
 			const d = data as any;
 			if (d.tag === 'MapComponentMounted') {
-				mapMountedRef.current = true;
-				if (gameModeRef.current) {
-					setGameMapReady(true);
-					sendGameInitData();
-				} else {
-					pendingNavigateRef.current = true;
-					sendMapData();
-				}
-				sendToMapRef.current({ peopleCount: peopleCountRef.current });
-				if (peopleModeRef.current) {
-					sendToMapRef.current({ peopleMode: true });
-				}
-				if (intelligentMovementRef.current) {
-					sendToMapRef.current({ intelligentMovement: true });
-				}
-				if (carModeRef.current) {
-					sendToMapRef.current({ carMode: true });
-				}
-				// Send the emoji map so the HTML has no hardcoded emoji data
-				sendToMapRef.current({ iconEmojiMap: ICON_EMOJI_MAP });
-				const GROUP_MAP: Record<string, string> = { poi: 'poi', transit: 'transit', roadNames: 'roadLabels', leisure: 'leisure', barriers: 'barriers', parking: 'parking' };
-				Object.entries(GROUP_MAP).forEach(([key, group]) => {
-					if (!(showSettingsRef.current[key] ?? key !== 'barriers')) {
-						sendToMapRef.current({ setLayerGroupVisibility: { group, visible: false } });
-					}
+				handleMapComponentMounted({
+					mapMountedRef,
+					gameModeRef,
+					setGameMapReady,
+					sendGameInitData,
+					pendingNavigateRef,
+					sendMapData,
+					sendToMapRef,
+					peopleCountRef,
+					peopleModeRef,
+					intelligentMovementRef,
+					carModeRef,
+					showSettingsRef,
+					poiSubSettingsRef,
+					addLog,
 				});
-				// Send initial POI icon overrides for disabled sub-types, barrier group, and parking group
-				const poiEnabled = showSettingsRef.current.poi ?? true;
-				const barriersEnabled = showSettingsRef.current.barriers ?? false;
-				const parkingEnabled = showSettingsRef.current.parking ?? true;
-				const initialPoiOverrides: Record<string, string | null> = {};
-				if (poiEnabled) {
-					POI_SUBTYPES.forEach(({ key }) => {
-						if (!(poiSubSettingsRef.current[key] ?? true)) {
-							initialPoiOverrides[key] = null;
-						}
-					});
-				}
-				if (!barriersEnabled) {
-					BARRIER_ICON_KEYS.forEach((key) => {
-						initialPoiOverrides[key] = null;
-					});
-				}
-				if (!parkingEnabled) {
-					PARKING_ICON_KEYS.forEach((key) => {
-						initialPoiOverrides[key] = null;
-					});
-				}
-				sendToMapRef.current({ poiIconOverrides: initialPoiOverrides });
-				addLog('MapComponentMounted');
 				return;
 			}
 			if (d.tag === 'onZoomEnd') {

--- a/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/bigScreen/index.tsx
@@ -25,6 +25,62 @@ export const bigScreenDefaultValues = {
 	showMarkingsOnCard: true,
 };
 
+const resolveBooleanParam = (param: string | string[] | undefined, fallback: boolean) => {
+	if (Array.isArray(param)) {
+		return param[0] === 'true';
+	}
+	if (typeof param === 'string') {
+		return param === 'true';
+	}
+	return fallback;
+};
+
+const resolveCardMarkingSize = (screenWidth: number): number => {
+	if (screenWidth > 1200) {
+		return 100;
+	}
+	if (screenWidth > 900) {
+		return 80;
+	}
+	return 60;
+};
+
+const filterFoodsByParams = (data: any[], params: any) => {
+	let filteredData = data;
+
+	// First filter by foodCategoryIds if exists
+	if (params?.foodCategoryIds) {
+		filteredData = filteredData.filter((food: any) => food?.foodoffer_category === params.foodCategoryIds);
+	}
+
+	// Then filter by foodOfferCategoryIds if exists (using previous filtered results)
+	if (params?.foodOfferCategoryIds) {
+		const offerFiltered = filteredData.filter((food: any) => food?.food?.food_category === params.foodOfferCategoryIds);
+		// Only overwrite if we have results from both filters
+		filteredData = offerFiltered.length > 0 ? offerFiltered : [];
+	}
+
+	return filteredData;
+};
+
+const shouldClearStaleFoods = (referenceTime: number, thirtyMinutesMs: number): boolean => {
+	return Date.now() - referenceTime >= thirtyMinutesMs;
+};
+
+const resolveTargetCategoryId = (filterId: any, fallbackId: any) => {
+	return filterId ? filterId : fallbackId;
+};
+
+const resolveCurrentCategoryFromList = (categoriesList: any[], targetId: any) => {
+	const currentCategory = categoriesList?.filter((category: any) => category?.id === targetId);
+	return currentCategory[0];
+};
+
+const resolveFoodImageSource = (currentFood: any, defaultImage: any) => {
+	const remoteUrl = currentFood?.food?.image_remote_url || getImageUrl(currentFood?.food?.image);
+	return remoteUrl ? { uri: remoteUrl } : { uri: defaultImage };
+};
+
 const Index = () => {
 	useSetPageTitle(TranslationKeys.big_screen);
 	const dispatch = useDispatch();
@@ -57,30 +113,12 @@ const Index = () => {
 
 	const defaultImage = getImageUrl(String(appSettings.foods_placeholder_image)) || appSettings.foods_placeholder_image_remote_url || getImageUrl(serverInfo?.info?.project?.project_logo);
 
-	const resolveBooleanParam = (param: string | string[] | undefined, fallback: boolean) => {
-		if (Array.isArray(param)) {
-			return param[0] === 'true';
-		}
-		if (typeof param === 'string') {
-			return param === 'true';
-		}
-		return fallback;
-	};
-
 	const showMarkingsOnCard = useMemo(
 		() => resolveBooleanParam(params?.showMarkingsOnCard, bigScreenDefaultValues.showMarkingsOnCard),
 		[params?.showMarkingsOnCard]
 	);
 
-	const cardMarkingSize = useMemo(() => {
-		if (screenWidth > 1200) {
-			return 100;
-		}
-		if (screenWidth > 900) {
-			return 80;
-		}
-		return 60;
-	}, [screenWidth]);
+	const cardMarkingSize = useMemo(() => resolveCardMarkingSize(screenWidth), [screenWidth]);
 	const cardMarkings = useMemo(
 		() => currentMarking.filter(mark => mark?.show_on_card),
 		[currentMarking]
@@ -148,19 +186,7 @@ const Index = () => {
 			const todayDate = new Date().toISOString().split('T')[0];
 			const foodData = await fetchFoodsByCanteen(String(params?.canteens_id), todayDate);
 
-			let filteredData = foodData?.data || [];
-
-			// First filter by foodCategoryIds if exists
-			if (params?.foodCategoryIds) {
-				filteredData = filteredData.filter((food: any) => food?.foodoffer_category === params.foodCategoryIds);
-			}
-
-			// Then filter by foodOfferCategoryIds if exists (using previous filtered results)
-			if (params?.foodOfferCategoryIds) {
-				const offerFiltered = filteredData.filter((food: any) => food?.food?.food_category === params.foodOfferCategoryIds);
-				// Only overwrite if we have results from both filters
-				filteredData = offerFiltered.length > 0 ? offerFiltered : [];
-			}
+			const filteredData = filterFoodsByParams(foodData?.data || [], params);
 
 			if (filteredData?.length > 0) {
 				setFoods(filteredData);
@@ -170,7 +196,7 @@ const Index = () => {
 				startProgressAnimation();
 			} else {
 				const referenceTime = lastNonEmptyFoodsFetchTimeRef.current ?? mountTimeRef.current;
-				if (Date.now() - referenceTime >= THIRTY_MINUTES_MS) {
+				if (shouldClearStaleFoods(referenceTime, THIRTY_MINUTES_MS)) {
 					setFoods([]);
 				}
 			}
@@ -260,13 +286,8 @@ const Index = () => {
 
 	const fetchCurrentFoodCategory = async () => {
 		try {
-			if (params?.foodCategoryIds) {
-				const currentCategory = foodOfferCategories?.filter((category: any) => category?.id === params?.foodCategoryIds);
-				setCurrentFoodCategory(currentCategory[0]);
-			} else {
-				const currentCategory = foodOfferCategories?.filter((category: any) => category?.id === currentFood?.foodoffer_category);
-				setCurrentFoodCategory(currentCategory[0]);
-			}
+			const targetId = resolveTargetCategoryId(params?.foodCategoryIds, currentFood?.foodoffer_category);
+			setCurrentFoodCategory(resolveCurrentCategoryFromList(foodOfferCategories, targetId));
 		} catch (error) {
 			console.error('Error fetching food categories:', error);
 		}
@@ -274,13 +295,8 @@ const Index = () => {
 
 	const fetchCurrentFoodOfferCategory = async () => {
 		try {
-			if (params?.foodOfferCategoryIds) {
-				const currentCategory = foodCategories?.filter((category: any) => category?.id === params?.foodOfferCategoryIds);
-				setCurrentFoodOfferCategory(currentCategory[0]);
-			} else {
-				const currentCategory = foodCategories?.filter((category: any) => category?.id === currentFood?.food?.food_category);
-				setCurrentFoodOfferCategory(currentCategory[0]);
-			}
+			const targetId = resolveTargetCategoryId(params?.foodOfferCategoryIds, currentFood?.food?.food_category);
+			setCurrentFoodOfferCategory(resolveCurrentCategoryFromList(foodCategories, targetId));
 		} catch (error) {
 			console.error('Error fetching food categories:', error);
 		}
@@ -326,12 +342,7 @@ const Index = () => {
 		}).start();
 	};
 
-	const imageSource =
-		currentFood?.food?.image_remote_url || getImageUrl(currentFood?.food?.image)
-			? {
-					uri: currentFood?.food?.image_remote_url || getImageUrl(currentFood?.food?.image),
-				}
-			: { uri: defaultImage };
+	const imageSource = resolveFoodImageSource(currentFood, defaultImage);
 
 	const renderFoodImage = (containerStyle: { width: number; height: number; backgroundColor?: string }) => (
 		<View style={[styles.imageWrapper, containerStyle]}>

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -19,24 +19,129 @@ const CONTENT_PATTERNS = {
 	heading: /^#{1,3}\s*(.*)$/,
 };
 
+// Flush the buffered paragraph lines into the current stack frame's items.
+// Returns the (always empty) replacement paragraph buffer.
+const flushParagraph = (
+	paragraph: Array<{ text: string; indent: number }>,
+	targetItems: any[],
+): Array<{ text: string; indent: number }> => {
+	if (paragraph.length) {
+		const minIndent = Math.min(...paragraph.map(item => item.indent));
+		const textContent = paragraph.map(item => item.text).join('\n');
+		targetItems.push({
+			type: 'text',
+			content: textContent,
+			indent: Number.isFinite(minIndent) ? minIndent : 0,
+		});
+	}
+	return [];
+};
+
+// Look ahead from fromIndex for the next non-empty line and report whether it is indented.
+const computeStartCollapsed = (lines: string[], fromIndex: number): boolean => {
+	for (let lookahead = fromIndex; lookahead < lines.length; lookahead += 1) {
+		const lookLine = lines[lookahead];
+		if (lookLine.trim() === '') {
+			continue;
+		}
+		const lookNormalized = StringHelper.replaceAllLiteralWithOptions({ str: lookLine, find: '\t', replace: '    ' });
+		const lookIndent = lookNormalized.match(/^\s*/)?.[0].length ?? 0;
+		return lookIndent > 0;
+	}
+	return false;
+};
+
+// Apply a matched heading line to the section stack (push/pop levels, open collapsibles).
+const applyHeadingToStack = (
+	stack: Array<{ level: number; items: any[] }>,
+	lines: string[],
+	currentIndex: number,
+	headingMatch: RegExpExecArray,
+): void => {
+	const level = headingMatch[0].match(/#/g)?.length || 1;
+	const headerText = headingMatch[1].trim();
+
+	if (level === 1) {
+		while (stack.length > 1) {
+			stack.pop();
+		}
+
+		stack.at(-1)!.items.push({
+			type: 'heading',
+			content: headerText,
+			level,
+		});
+		return;
+	}
+
+	while (stack.length > 1 && stack.at(-1)!.level >= level) {
+		stack.pop();
+	}
+
+	const startCollapsed = computeStartCollapsed(lines, currentIndex + 1);
+
+	const newSection = {
+		type: 'collapsible',
+		header: headerText,
+		items: [],
+		level,
+		startCollapsed,
+	};
+
+	stack.at(-1)!.items.push(newSection);
+	stack.push({ level, items: newSection.items });
+};
+
+// Try to match the line against the inline content patterns (image/email/location/link).
+const matchInlineContentItem = (trimmedForMatch: string, indentLength: number): any | null => {
+	const imageMatch = CONTENT_PATTERNS.image.exec(trimmedForMatch);
+	if (imageMatch) {
+		return {
+			type: 'image',
+			altText: imageMatch[1] || '',
+			url: imageMatch[2] || '',
+			indent: indentLength,
+		};
+	}
+
+	const emailMatch = CONTENT_PATTERNS.email.exec(trimmedForMatch);
+	if (emailMatch) {
+		return {
+			type: 'email',
+			displayText: emailMatch[1],
+			email: emailMatch[2],
+			indent: indentLength,
+		};
+	}
+
+	const locationMatch = CONTENT_PATTERNS.location.exec(trimmedForMatch);
+	if (locationMatch) {
+		return {
+			type: 'location',
+			displayText: locationMatch[1],
+			url: locationMatch[2],
+			indent: indentLength,
+		};
+	}
+
+	const linkMatch = CONTENT_PATTERNS.link.exec(trimmedForMatch);
+	if (linkMatch) {
+		return {
+			type: 'link',
+			displayText: linkMatch[1],
+			url: linkMatch[2],
+			indent: indentLength,
+		};
+	}
+
+	return null;
+};
+
 // Process markdown content into a structured format
 const processMarkdownContent = (lines: string[]) => {
 	const result: any[] = [];
 	const stack: Array<{ level: number; items: any[] }> = [{ level: 0, items: result }];
 	let currentParagraph: Array<{ text: string; indent: number }> = [];
-
-	const flushTextContent = () => {
-		if (currentParagraph.length) {
-			const minIndent = Math.min(...currentParagraph.map(item => item.indent));
-			const textContent = currentParagraph.map(item => item.text).join('\n');
-			stack.at(-1)!.items.push({
-				type: 'text',
-				content: textContent,
-				indent: Number.isFinite(minIndent) ? minIndent : 0,
-			});
-			currentParagraph = [];
-		}
-	};
 
 	for (let i = 0; i < lines.length; i += 1) {
 		const line = lines[i];
@@ -46,106 +151,23 @@ const processMarkdownContent = (lines: string[]) => {
 
 		const headingMatch = CONTENT_PATTERNS.heading.exec(trimmedLine);
 		if (headingMatch) {
-			flushTextContent();
-
-			const level = headingMatch[0].match(/#/g)?.length || 1;
-			const headerText = headingMatch[1].trim();
-
-			if (level === 1) {
-				while (stack.length > 1) {
-					stack.pop();
-				}
-
-				stack.at(-1)!.items.push({
-					type: 'heading',
-					content: headerText,
-					level,
-				});
-				continue;
-			}
-
-			while (stack.length > 1 && stack.at(-1)!.level >= level) {
-				stack.pop();
-			}
-
-			let startCollapsed = false;
-			for (let lookahead = i + 1; lookahead < lines.length; lookahead += 1) {
-				const lookLine = lines[lookahead];
-				if (lookLine.trim() === '') {
-					continue;
-				}
-				const lookNormalized = StringHelper.replaceAllLiteralWithOptions({ str: lookLine, find: '\t', replace: '    ' });
-				const lookIndent = lookNormalized.match(/^\s*/)?.[0].length ?? 0;
-				startCollapsed = lookIndent > 0;
-				break;
-			}
-
-			const newSection = {
-				type: 'collapsible',
-				header: headerText,
-				items: [],
-				level,
-				startCollapsed,
-			};
-
-			stack.at(-1)!.items.push(newSection);
-			stack.push({ level, items: newSection.items });
+			currentParagraph = flushParagraph(currentParagraph, stack.at(-1)!.items);
+			applyHeadingToStack(stack, lines, i, headingMatch);
 			continue;
 		}
 
 		if (trimmedLine === '') {
-			flushTextContent();
+			currentParagraph = flushParagraph(currentParagraph, stack.at(-1)!.items);
 			stack.at(-1)!.items.push({ type: 'emptyLine' });
 			continue;
 		}
 
 		const trimmedForMatch = trimmedLine;
 
-		if (CONTENT_PATTERNS.image.test(trimmedForMatch)) {
-			flushTextContent();
-			const match = CONTENT_PATTERNS.image.exec(trimmedForMatch);
-			stack.at(-1)!.items.push({
-				type: 'image',
-				altText: match?.[1] || '',
-				url: match?.[2] || '',
-				indent: indentLength,
-			});
-			continue;
-		}
-
-		if (CONTENT_PATTERNS.email.test(trimmedForMatch)) {
-			flushTextContent();
-			const match = CONTENT_PATTERNS.email.exec(trimmedForMatch);
-			stack.at(-1)!.items.push({
-				type: 'email',
-				displayText: match?.[1],
-				email: match?.[2],
-				indent: indentLength,
-			});
-			continue;
-		}
-
-		if (CONTENT_PATTERNS.location.test(trimmedForMatch)) {
-			flushTextContent();
-			const match = CONTENT_PATTERNS.location.exec(trimmedForMatch);
-			stack.at(-1)!.items.push({
-				type: 'location',
-				displayText: match?.[1],
-				url: match?.[2],
-				indent: indentLength,
-			});
-			continue;
-		}
-
-		if (CONTENT_PATTERNS.link.test(trimmedForMatch)) {
-			flushTextContent();
-			const match = CONTENT_PATTERNS.link.exec(trimmedForMatch);
-			stack.at(-1)!.items.push({
-				type: 'link',
-				displayText: match?.[1],
-				url: match?.[2],
-				indent: indentLength,
-			});
+		const inlineItem = matchInlineContentItem(trimmedForMatch, indentLength);
+		if (inlineItem) {
+			currentParagraph = flushParagraph(currentParagraph, stack.at(-1)!.items);
+			stack.at(-1)!.items.push(inlineItem);
 			continue;
 		}
 
@@ -155,7 +177,7 @@ const processMarkdownContent = (lines: string[]) => {
 		});
 	}
 
-	flushTextContent();
+	flushParagraph(currentParagraph, stack.at(-1)!.items);
 	return result;
 };
 

--- a/apps/frontend/app/components/DropdownInput/DropdownSheet.tsx
+++ b/apps/frontend/app/components/DropdownInput/DropdownSheet.tsx
@@ -29,6 +29,108 @@ const ensureStringArray = (options: string[]): string[] => {
   return Array.from(uniqueValues);
 };
 
+type DropdownSheetTheme = ReturnType<typeof useTheme>['theme'];
+
+const renderDeselectRow = (
+  active: boolean,
+  isDisabled: boolean | undefined,
+  primaryColor: string,
+  theme: DropdownSheetTheme,
+  translate: (key: TranslationKeys) => string,
+  handleDeselect: () => void,
+) => {
+  return (
+    <TouchableOpacity
+      key="deselect"
+      style={[styles.optionRow, { backgroundColor: active ? primaryColor : theme.screen.iconBg }]}
+      onPress={handleDeselect}
+      disabled={isDisabled}
+      onPressIn={() => console.log('[DropdownSheet] deselect pressed')}
+    >
+      <Text style={[styles.optionLabel, { color: active ? theme.activeText : theme.screen.text }]}>
+        {translate(TranslationKeys.deselect)}
+      </Text>
+      <MaterialCommunityIcons name={active ? 'checkbox-marked' : 'checkbox-blank-outline'} size={24} color={active ? theme.activeText : theme.screen.icon} />
+    </TouchableOpacity>
+  );
+};
+
+const renderCustomRow = (
+  customSelected: boolean,
+  isDisabled: boolean | undefined,
+  primaryColor: string,
+  theme: DropdownSheetTheme,
+  translate: (key: TranslationKeys) => string,
+  handleSelectCustom: () => void,
+) => {
+  return (
+    <TouchableOpacity
+      key="custom"
+      style={[styles.optionRow, { backgroundColor: customSelected ? primaryColor : theme.screen.iconBg }]}
+      onPress={handleSelectCustom}
+      disabled={isDisabled}
+      onPressIn={() => console.log('[DropdownSheet] select custom pressed')}
+    >
+      <Text style={[styles.optionLabel, { color: customSelected ? theme.activeText : theme.screen.text }]}>
+        {translate(TranslationKeys.enter_custom_value)}
+      </Text>
+      <MaterialCommunityIcons name={customSelected ? 'checkbox-marked' : 'checkbox-blank-outline'} size={24} color={customSelected ? theme.activeText : theme.screen.icon} />
+    </TouchableOpacity>
+  );
+};
+
+const renderCustomInputRow = (
+  customValue: string,
+  error: string | undefined,
+  isDisabled: boolean | undefined,
+  prefix: AffixProps['prefix'],
+  suffix: AffixProps['suffix'],
+  onCustomValueChange: (val: string) => void,
+) => {
+  return (
+    <View key="customInput" style={{ width: '100%', marginBottom: 2 }}>
+      <SingleLineInput
+        id="custom"
+        value={customValue}
+        onChange={(_, val) => {
+          onCustomValueChange(val);
+          console.log('[DropdownSheet] custom input changed to', val);
+        }}
+        error={error || ''}
+        isDisabled={!!isDisabled}
+        custom_type="string"
+        insideBottomSheet
+        prefix={prefix}
+        suffix={suffix}
+        autoFocus
+      />
+    </View>
+  );
+};
+
+const renderOptionRow = (
+  optionValue: string,
+  index: number,
+  isSelected: boolean,
+  isDisabled: boolean | undefined,
+  primaryColor: string,
+  theme: DropdownSheetTheme,
+  handleSelectOption: (option: string) => void,
+) => {
+  return (
+    <TouchableOpacity
+      key={`option-${optionValue}-${index}`}
+      style={[styles.optionRow, { backgroundColor: isSelected ? primaryColor : theme.screen.iconBg }]}
+      onPress={() => handleSelectOption(optionValue)}
+      disabled={isDisabled}
+      onPressIn={() => console.log('[DropdownSheet] option pressed', optionValue)}
+    >
+      <Text style={[styles.optionLabel, { color: isSelected ? theme.activeText : theme.screen.text }]}>{optionValue}</Text>
+      <MaterialCommunityIcons name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'} size={24} color={isSelected ? theme.activeText : theme.screen.icon} />
+    </TouchableOpacity>
+  );
+};
+
 const DropdownSheet: React.FC<DropdownSheetProps> = ({ closeSheet, options, allowCustomValues, value, onSelectOption, onSelectCustom, onDeselect, isDisabled, prefix, suffix, error }) => {
   const { theme } = useTheme();
   const { translate } = useLanguage();
@@ -87,78 +189,27 @@ const DropdownSheet: React.FC<DropdownSheetProps> = ({ closeSheet, options, allo
     return rows;
   }, [normalizedOptions, allowCustomValues, customSelected]);
 
+  const handleCustomValueChange = (val: string) => {
+    setCustomValue(val);
+    onSelectCustom(val);
+  };
+
   return (
     <View style={{ gap: 10 }}>
       {listItems.map((item, index) => {
         if (item.kind === 'deselect') {
           const active = !customSelected && value.trim().length === 0;
-          return (
-            <TouchableOpacity
-              key={item.kind}
-              style={[styles.optionRow, { backgroundColor: active ? primaryColor : theme.screen.iconBg }]}
-              onPress={handleDeselect}
-              disabled={isDisabled}
-              onPressIn={() => console.log('[DropdownSheet] deselect pressed')}
-            >
-              <Text style={[styles.optionLabel, { color: active ? theme.activeText : theme.screen.text }]}>
-                {translate(TranslationKeys.deselect)}
-              </Text>
-              <MaterialCommunityIcons name={active ? 'checkbox-marked' : 'checkbox-blank-outline'} size={24} color={active ? theme.activeText : theme.screen.icon} />
-            </TouchableOpacity>
-          );
+          return renderDeselectRow(active, isDisabled, primaryColor, theme, translate, handleDeselect);
         }
         if (item.kind === 'custom') {
-          return (
-            <TouchableOpacity
-              key={item.kind}
-              style={[styles.optionRow, { backgroundColor: customSelected ? primaryColor : theme.screen.iconBg }]}
-              onPress={handleSelectCustom}
-              disabled={isDisabled}
-              onPressIn={() => console.log('[DropdownSheet] select custom pressed')}
-            >
-              <Text style={[styles.optionLabel, { color: customSelected ? theme.activeText : theme.screen.text }]}>
-                {translate(TranslationKeys.enter_custom_value)}
-              </Text>
-              <MaterialCommunityIcons name={customSelected ? 'checkbox-marked' : 'checkbox-blank-outline'} size={24} color={customSelected ? theme.activeText : theme.screen.icon} />
-            </TouchableOpacity>
-          );
+          return renderCustomRow(customSelected, isDisabled, primaryColor, theme, translate, handleSelectCustom);
         }
         if (item.kind === 'customInput') {
-          return (
-            <View key={item.kind} style={{ width: '100%', marginBottom: 2 }}>
-              <SingleLineInput
-                id="custom"
-                value={customValue}
-                onChange={(_, val) => {
-                  setCustomValue(val);
-                  onSelectCustom(val);
-                  console.log('[DropdownSheet] custom input changed to', val);
-                }}
-                error={error || ''}
-                isDisabled={!!isDisabled}
-                custom_type="string"
-                insideBottomSheet
-                prefix={prefix}
-                suffix={suffix}
-                autoFocus
-              />
-            </View>
-          );
+          return renderCustomInputRow(customValue, error, isDisabled, prefix, suffix, handleCustomValueChange);
         }
         // option
         const isSelected = !customSelected && value === item.value;
-        return (
-          <TouchableOpacity
-            key={`option-${item.value}-${index}`}
-            style={[styles.optionRow, { backgroundColor: isSelected ? primaryColor : theme.screen.iconBg }]}
-            onPress={() => handleSelectOption(item.value)}
-            disabled={isDisabled}
-            onPressIn={() => console.log('[DropdownSheet] option pressed', item.value)}
-          >
-            <Text style={[styles.optionLabel, { color: isSelected ? theme.activeText : theme.screen.text }]}>{item.value}</Text>
-            <MaterialCommunityIcons name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'} size={24} color={isSelected ? theme.activeText : theme.screen.icon} />
-          </TouchableOpacity>
-        );
+        return renderOptionRow(item.value, index, isSelected, isDisabled, primaryColor, theme, handleSelectOption);
       })}
     </View>
   );

--- a/apps/frontend/app/components/ManagmentFoodPlan/FoodPlan.tsx
+++ b/apps/frontend/app/components/ManagmentFoodPlan/FoodPlan.tsx
@@ -5,6 +5,101 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import styles from './styles';
 import useSelectedCanteen from '@/hooks/useSelectedCanteen';
 
+const renderItemDetailInputs = (
+	item: any,
+	theme: any,
+	windowWidth: number,
+	selectedCanteen: any,
+	selectedValue: string,
+	selectedValuNext: string,
+	nextFoodInterval: string,
+	foodOffer: string
+) => (
+	<>
+		{item.name === 'Canteen' && (
+			<TextInput
+				style={[
+					styles.textInput,
+					{
+						color: theme.screen.text,
+						backgroundColor: theme.screen.icon,
+						fontSize: windowWidth > 600 ? 18 : 16,
+						width: windowWidth > 600 ? 200 : 120,
+					},
+				]}
+				editable={false}
+				pointerEvents="none"
+				value={selectedCanteen?.alias || undefined}
+			/>
+		)}
+		{item.name === 'Speiseangebot Kategorie (optional)' && (
+			<TextInput
+				style={[
+					styles.textInput,
+					{
+						color: theme.screen.text,
+						backgroundColor: theme.screen.iconBg,
+						fontSize: windowWidth > 600 ? 18 : 16,
+						width: windowWidth > 600 ? 200 : 120,
+					},
+				]}
+				editable={false}
+				pointerEvents="none"
+				value={selectedValue}
+			/>
+		)}
+		{item.name === 'Speise Kategorie (optional)' && (
+			<TextInput
+				style={{
+					backgroundColor: theme.screen.iconBg,
+					marginRight: 10,
+					textAlign: 'right',
+					color: theme.screen.text,
+					fontSize: windowWidth > 600 ? 18 : 16,
+					width: windowWidth > 600 ? 200 : 120,
+				}}
+				editable={false}
+				pointerEvents="none"
+				value={selectedValuNext}
+			/>
+		)}
+		{item.name === 'Next Food Interval' && (
+			<TextInput
+				style={[
+					styles.textInput,
+					{
+						color: theme.screen.text,
+						backgroundColor: theme.screen.iconBg,
+						fontSize: windowWidth > 600 ? 18 : 16,
+						width: windowWidth > 600 ? 200 : 120,
+					},
+				]}
+				editable={false}
+				pointerEvents="none"
+				value={nextFoodInterval}
+			/>
+		)}
+		{item.name === 'Refresh Food Offers Interval' && (
+			<TextInput
+				style={[
+					styles.textInput,
+					{
+						color: theme.screen.text,
+						backgroundColor: theme.screen.iconBg,
+						fontSize: windowWidth > 600 ? 18 : 16,
+						width: windowWidth > 600 ? 200 : 120,
+					},
+				]}
+				editable={false}
+				pointerEvents="none"
+				value={foodOffer}
+			/>
+		)}
+
+		<MaterialCommunityIcons name="pencil" size={22} color={theme.screen.icon} style={{ marginHorizontal: 5 }} />
+	</>
+);
+
 const FoodPlan = ({ data, onPressItem, selectedValue, selectedValuNext, nextFoodInterval, foodOffer, intervalNext, refreshData }: { data: any[]; onPressItem: (item: any) => void; selectedValue: string; selectedValuNext: string; nextFoodInterval: string; foodOffer: string; intervalNext: string; refreshData: string }) => {
 	const { theme } = useTheme();
 
@@ -69,89 +164,7 @@ const FoodPlan = ({ data, onPressItem, selectedValue, selectedValuNext, nextFood
 								}}
 							/>
 						) : (
-							<>
-								{item.name === 'Canteen' && (
-									<TextInput
-										style={[
-											styles.textInput,
-											{
-												color: theme.screen.text,
-												backgroundColor: theme.screen.icon,
-												fontSize: windowWidth > 600 ? 18 : 16,
-												width: windowWidth > 600 ? 200 : 120,
-											},
-										]}
-										editable={false}
-										pointerEvents="none"
-										value={selectedCanteen?.alias || undefined}
-									/>
-								)}
-								{item.name === 'Speiseangebot Kategorie (optional)' && (
-									<TextInput
-										style={[
-											styles.textInput,
-											{
-												color: theme.screen.text,
-												backgroundColor: theme.screen.iconBg,
-												fontSize: windowWidth > 600 ? 18 : 16,
-												width: windowWidth > 600 ? 200 : 120,
-											},
-										]}
-										editable={false}
-										pointerEvents="none"
-										value={selectedValue}
-									/>
-								)}
-								{item.name === 'Speise Kategorie (optional)' && (
-									<TextInput
-										style={{
-											backgroundColor: theme.screen.iconBg,
-											marginRight: 10,
-											textAlign: 'right',
-											color: theme.screen.text,
-											fontSize: windowWidth > 600 ? 18 : 16,
-											width: windowWidth > 600 ? 200 : 120,
-										}}
-										editable={false}
-										pointerEvents="none"
-										value={selectedValuNext}
-									/>
-								)}
-								{item.name === 'Next Food Interval' && (
-									<TextInput
-										style={[
-											styles.textInput,
-											{
-												color: theme.screen.text,
-												backgroundColor: theme.screen.iconBg,
-												fontSize: windowWidth > 600 ? 18 : 16,
-												width: windowWidth > 600 ? 200 : 120,
-											},
-										]}
-										editable={false}
-										pointerEvents="none"
-										value={nextFoodInterval}
-									/>
-								)}
-								{item.name === 'Refresh Food Offers Interval' && (
-									<TextInput
-										style={[
-											styles.textInput,
-											{
-												color: theme.screen.text,
-												backgroundColor: theme.screen.iconBg,
-												fontSize: windowWidth > 600 ? 18 : 16,
-												width: windowWidth > 600 ? 200 : 120,
-											},
-										]}
-										editable={false}
-										pointerEvents="none"
-										value={foodOffer}
-									/>
-								)}
-
-								<MaterialCommunityIcons name="pencil" size={22} color={theme.screen.icon} style={{ marginHorizontal: 5 }} />
-							</>
+							renderItemDetailInputs(item, theme, windowWidth, selectedCanteen, selectedValue, selectedValuNext, nextFoodInterval, foodOffer)
 						)}
 					</View>
 				</TouchableOpacity>

--- a/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
+++ b/apps/frontend/app/components/MarkingLabels/MarkingLabels.tsx
@@ -131,6 +131,47 @@ const makeMarkingReactionTrigger = (props: Readonly<{
 	inactiveColor: string;
 }>) => (triggerProps: object) => <MarkingReactionTrigger triggerProps={triggerProps} {...props} />;
 
+// Sets the like/dislike loading flag depending on which reaction is being toggled.
+const setMarkingLoadingState = (
+	like: boolean,
+	value: boolean,
+	setLikeLoading: (value: boolean) => void,
+	setDislikeLoading: (value: boolean) => void
+) => {
+	if (like) {
+		setLikeLoading(value);
+	} else {
+		setDislikeLoading(value);
+	}
+};
+
+// Applies the updated marking to the profile's markings array (removing, replacing, or adding it), mutating and returning profileData.
+const applyMarkingUpdateToProfile = (profileData: any, updatedMarking: any, markingId: any): any => {
+	let markingFound = false;
+
+	profileData?.markings.forEach((profileMarkings: any, index: number) => {
+		if (profileMarkings.markings_id === updatedMarking?.markings_id) {
+			markingFound = true;
+			if (updatedMarking?.like === null) {
+				profileData.markings.splice(index, 1); // Remove if unliked
+			} else {
+				profileData.markings[index] = updatedMarking; // Update like status
+			}
+		}
+	});
+
+	// If the marking doesn't exist, add it
+	if (!markingFound) {
+		profileData.markings.push({
+			...updatedMarking,
+			markings_id: markingId,
+			profiles_id: profileData?.id,
+		});
+	}
+
+	return profileData;
+};
+
 const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet, size = 30 }) => {
 	const { theme } = useTheme();
 	const dispatch = useDispatch();
@@ -206,46 +247,16 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 
 	const handleUpdateMarking = useCallback(
 		async (like: boolean) => {
-			if (like) {
-				setLikeLoading(true);
-			} else {
-				setDislikeLoading(true);
-			}
+			setMarkingLoadingState(like, true, setLikeLoading, setDislikeLoading);
 			if (isAnonymousUser) {
 				handleAnonymousMarking(like);
-				if (like) {
-					setLikeLoading(false);
-				} else {
-					setDislikeLoading(false);
-				}
+				setMarkingLoadingState(like, false, setLikeLoading, setDislikeLoading);
 			} else {
 				try {
 					const likeStats = ownMarking?.like === like ? null : like;
 					const updatedMarking = { ...ownMarking, like: likeStats };
 
-					const profileData = { ...profile };
-					let markingFound = false;
-
-					// Update or remove marking in the profile
-					profileData?.markings.forEach((profileMarkings: any, index: number) => {
-						if (profileMarkings.markings_id === updatedMarking?.markings_id) {
-							markingFound = true;
-							if (updatedMarking?.like === null) {
-								profileData.markings.splice(index, 1); // Remove if unliked
-							} else {
-								profileData.markings[index] = updatedMarking; // Update like status
-							}
-						}
-					});
-
-					// If the marking doesn't exist, add it
-					if (!markingFound) {
-						profileData.markings.push({
-							...updatedMarking,
-							markings_id: markingId,
-							profiles_id: profileData?.id,
-						});
-					}
+					const profileData = applyMarkingUpdateToProfile({ ...profile }, updatedMarking, markingId);
 
 					dispatch({ type: UPDATE_PROFILE, payload: profileData });
 
@@ -253,20 +264,12 @@ const MarkingLabels: React.FC<MarkingLabelProps> = ({ markingId, handleMenuSheet
 					const result = (await profileHelper.updateProfile(profileData)) as DatabaseTypes.Profiles;
 					if (result) {
 						fetchProfile();
-						if (like) {
-							setLikeLoading(false);
-						} else {
-							setDislikeLoading(false);
-						}
+						setMarkingLoadingState(like, false, setLikeLoading, setDislikeLoading);
 					}
 				} catch (error) {
 					console.error('Error updating marking:', error);
 				} finally {
-					if (like) {
-						setLikeLoading(false);
-					} else {
-						setDislikeLoading(false);
-					}
+					setMarkingLoadingState(like, false, setLikeLoading, setDislikeLoading);
 				}
 			}
 		},

--- a/apps/frontend/app/components/MyImage/index.tsx
+++ b/apps/frontend/app/components/MyImage/index.tsx
@@ -14,6 +14,46 @@ export type MyImageProps = {
         useAccessTokenForWebAsParameter?: boolean;
 } & Omit<ExpoImageProps, 'source'>;
 
+function resolveRemoteUrlSource(
+	remote_image_url: string,
+	authToken: string | null,
+	useAccessTokenForWebAsParameter: boolean
+): { uri: string } {
+	const isLocalhostUrl = remote_image_url.startsWith('http://localhost');
+	if (Platform.OS === 'web' && authToken && (useAccessTokenForWebAsParameter || isLocalhostUrl)) {
+		const isRemoteUrl = remote_image_url.startsWith('http://') || remote_image_url.startsWith('https://');
+		if (isRemoteUrl) {
+			const separator = remote_image_url.includes('?') ? '&' : '?';
+			return { uri: `${remote_image_url}${separator}access_token=${encodeURIComponent(authToken)}` };
+		}
+	}
+	return { uri: remote_image_url };
+}
+
+function resolveDirectusAssetSource(
+	directusAssetId: string | number,
+	authToken: string | null,
+	useAccessTokenForWebAsParameter: boolean
+): { uri?: string; headers?: { Authorization: string } } {
+	const baseUrl = getHighResImageUrl(String(directusAssetId));
+	if (!baseUrl) return { uri: undefined };
+	if (authToken) {
+		if (Platform.OS === 'web') {
+			const isLocalhostUrl = baseUrl.startsWith('http://localhost');
+			if (useAccessTokenForWebAsParameter || isLocalhostUrl) {
+				// On web, <img> tags cannot send custom headers in cross-origin requests,
+				// so we include the token as a query parameter. This is the standard Directus approach.
+				// For localhost (development), token is added automatically since the connection is insecure (HTTP).
+				const separator = baseUrl.includes('?') ? '&' : '?';
+				return { uri: `${baseUrl}${separator}access_token=${encodeURIComponent(authToken)}` };
+			}
+			return { uri: baseUrl };
+		}
+		return { uri: baseUrl, headers: { Authorization: `Bearer ${authToken}` } };
+	}
+	return { uri: baseUrl };
+}
+
 const MyImage: React.FC<MyImageProps> = ({
         remote_image_url,
         directus_asset_id,
@@ -53,35 +93,11 @@ const MyImage: React.FC<MyImageProps> = ({
 
         const source = useMemo(() => {
                 if (remote_image_url) {
-                        const isLocalhostUrl = remote_image_url.startsWith('http://localhost');
-                        if (Platform.OS === 'web' && authToken && (useAccessTokenForWebAsParameter || isLocalhostUrl)) {
-                                const isRemoteUrl = remote_image_url.startsWith('http://') || remote_image_url.startsWith('https://');
-                                if (isRemoteUrl) {
-                                        const separator = remote_image_url.includes('?') ? '&' : '?';
-                                        return { uri: `${remote_image_url}${separator}access_token=${encodeURIComponent(authToken)}` };
-                                }
-                        }
-                        return { uri: remote_image_url };
+                        return resolveRemoteUrlSource(remote_image_url, authToken, useAccessTokenForWebAsParameter);
                 }
 
                 if (directusAssetId) {
-                        const baseUrl = getHighResImageUrl(String(directusAssetId));
-                        if (!baseUrl) return { uri: undefined };
-                        if (authToken) {
-                                if (Platform.OS === 'web') {
-                                        const isLocalhostUrl = baseUrl.startsWith('http://localhost');
-                                        if (useAccessTokenForWebAsParameter || isLocalhostUrl) {
-                                                // On web, <img> tags cannot send custom headers in cross-origin requests,
-                                                // so we include the token as a query parameter. This is the standard Directus approach.
-                                                // For localhost (development), token is added automatically since the connection is insecure (HTTP).
-                                                const separator = baseUrl.includes('?') ? '&' : '?';
-                                                return { uri: `${baseUrl}${separator}access_token=${encodeURIComponent(authToken)}` };
-                                        }
-                                        return { uri: baseUrl };
-                                }
-                                return { uri: baseUrl, headers: { Authorization: `Bearer ${authToken}` } };
-                        }
-                        return { uri: baseUrl };
+                        return resolveDirectusAssetSource(directusAssetId, authToken, useAccessTokenForWebAsParameter);
                 }
 
                 if (defaultImageUrl) {

--- a/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
+++ b/apps/frontend/app/components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx
@@ -49,6 +49,35 @@ const makeMarkingLabelTrigger = (props: Readonly<{
 	size: number;
 }>) => (triggerProps: object) => <MarkingLabelTrigger triggerProps={triggerProps} {...props} />;
 
+const buildUpdatedProfileData = (profile: any, ownMarking: any, like: boolean, markingId: any) => {
+	const likeStats = ownMarking?.like === like ? null : like;
+	const updatedMarking = { ...ownMarking, like: likeStats };
+
+	const profileData = { ...profile };
+	let markingFound = false;
+
+	profileData?.markings.forEach((profileMarkings: any, index: number) => {
+		if (profileMarkings.markings_id === updatedMarking?.markings_id) {
+			markingFound = true;
+			if (updatedMarking?.like === null) {
+				profileData.markings.splice(index, 1);
+			} else {
+				profileData.markings[index] = updatedMarking;
+			}
+		}
+	});
+
+	if (!markingFound) {
+		profileData.markings.push({
+			...updatedMarking,
+			markings_id: markingId,
+			profiles_id: profileData?.id,
+		});
+	}
+
+	return profileData;
+};
+
 const SettingsListMarkingLabel: React.FC<SettingsListMarkingLabelProps> = ({
 	markingId,
 	handleMenuSheet,
@@ -115,66 +144,35 @@ const SettingsListMarkingLabel: React.FC<SettingsListMarkingLabelProps> = ({
 		}
 	};
 
+	const setLikeDislikeLoading = (like: boolean, value: boolean) => {
+		if (like) {
+			setLikeLoading(value);
+		} else {
+			setDislikeLoading(value);
+		}
+	};
+
 	const handleUpdateMarking = useCallback(
 		async (like: boolean) => {
-			if (like) {
-				setLikeLoading(true);
-			} else {
-				setDislikeLoading(true);
-			}
+			setLikeDislikeLoading(like, true);
 			if (isAnonymousUser) {
 				handleAnonymousMarking(like);
-				if (like) {
-					setLikeLoading(false);
-				} else {
-					setDislikeLoading(false);
-				}
+				setLikeDislikeLoading(like, false);
 			} else {
 				try {
-					const likeStats = ownMarking?.like === like ? null : like;
-					const updatedMarking = { ...ownMarking, like: likeStats };
-
-					const profileData = { ...profile };
-					let markingFound = false;
-
-					profileData?.markings.forEach((profileMarkings: any, index: number) => {
-						if (profileMarkings.markings_id === updatedMarking?.markings_id) {
-							markingFound = true;
-							if (updatedMarking?.like === null) {
-								profileData.markings.splice(index, 1);
-							} else {
-								profileData.markings[index] = updatedMarking;
-							}
-						}
-					});
-
-					if (!markingFound) {
-						profileData.markings.push({
-							...updatedMarking,
-							markings_id: markingId,
-							profiles_id: profileData?.id,
-						});
-					}
+					const profileData = buildUpdatedProfileData(profile, ownMarking, like, markingId);
 
 					dispatch({ type: UPDATE_PROFILE, payload: profileData });
 
 					const result = (await profileHelper.updateProfile(profileData)) as DatabaseTypes.Profiles;
 					if (result) {
 						fetchProfile();
-						if (like) {
-							setLikeLoading(false);
-						} else {
-							setDislikeLoading(false);
-						}
+						setLikeDislikeLoading(like, false);
 					}
 				} catch (error) {
 					console.error('Error updating marking:', error);
 				} finally {
-					if (like) {
-						setLikeLoading(false);
-					} else {
-						setDislikeLoading(false);
-					}
+					setLikeDislikeLoading(like, false);
 				}
 			}
 		},

--- a/apps/frontend/app/components/TimeTable/TimeTableList.tsx
+++ b/apps/frontend/app/components/TimeTable/TimeTableList.tsx
@@ -7,6 +7,64 @@ import { Feather, FontAwesome5, MaterialCommunityIcons, MaterialIcons } from '@e
 import { TimeTableListProps } from './types';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
+type TimeTableListRowTheme = {
+	screen: {
+		icon: string;
+		text: string;
+	};
+};
+
+const renderTimeTableListRow = (
+	icon: React.ReactNode,
+	labelText: string,
+	valueText: string,
+	windowWidth: number,
+	theme: TimeTableListRowTheme,
+	key: string
+) => {
+	return (
+		<TouchableOpacity
+			key={key}
+			style={{
+				...styles.list,
+				paddingHorizontal: isWeb ? 20 : 10,
+			}}
+		>
+			<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
+				{icon}
+				<Text
+					style={{
+						...styles.label,
+						color: theme.screen.text,
+						fontSize: windowWidth > 500 ? 16 : 13,
+					}}
+				>
+					{labelText}
+				</Text>
+			</View>
+			<View
+				style={{
+					...styles.col,
+					gap: isWeb ? 10 : 5,
+					alignItems: 'center',
+					justifyContent: 'flex-end',
+				}}
+			>
+				<Text
+					style={{
+						...styles.value,
+						color: theme.screen.text,
+						fontSize: windowWidth > 500 ? 16 : 13,
+					}}
+				>
+					{valueText}
+				</Text>
+				<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
+			</View>
+		</TouchableOpacity>
+	);
+};
+
 const TimeTableList: React.FC<TimeTableListProps> = ({ leftIcon, label, rightIcon, value, handleFunction }) => {
 	const { theme } = useTheme();
 	const [windowWidth, setWindowWidth] = useState(Dimensions.get('window').width);
@@ -24,235 +82,57 @@ const TimeTableList: React.FC<TimeTableListProps> = ({ leftIcon, label, rightIco
 
 	return (
 		<BottomSheetScrollView style={{ ...styles.sheetView, backgroundColor: theme.sheet.sheetBg }} contentContainerStyle={styles.contentContainer}>
-			<TouchableOpacity
-				style={{
-					...styles.list,
-					paddingHorizontal: isWeb ? 20 : 10,
-				}}
-			>
-				<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-					<MaterialCommunityIcons name="tag-text-outline" size={24} color={theme.screen.icon} />
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						Title
-					</Text>
-				</View>
-				<View
-					style={{
-						...styles.col,
-						gap: isWeb ? 10 : 5,
-						alignItems: 'center',
-						justifyContent: 'flex-end',
-					}}
-				>
-					<Text
-						style={{
-							...styles.value,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						New
-					</Text>
-					<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
-				</View>
-			</TouchableOpacity>
-			<TouchableOpacity
-				style={{
-					...styles.list,
-					paddingHorizontal: isWeb ? 20 : 10,
-				}}
-			>
-				<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-					<MaterialCommunityIcons name="tag-text-outline" size={24} color={theme.screen.icon} />
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						Location
-					</Text>
-				</View>
-				<View
-					style={{
-						...styles.col,
-						gap: isWeb ? 10 : 5,
-						alignItems: 'center',
-						justifyContent: 'flex-end',
-					}}
-				>
-					<Text
-						style={{
-							...styles.value,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					></Text>
-					<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
-				</View>
-			</TouchableOpacity>
-			<TouchableOpacity
-				style={{
-					...styles.list,
-					paddingHorizontal: isWeb ? 20 : 10,
-				}}
-			>
-				<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-					<MaterialIcons name="color-lens" size={24} color={theme.screen.icon} />
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						Colors
-					</Text>
-				</View>
-				<View
-					style={{
-						...styles.col,
-						gap: isWeb ? 10 : 5,
-						alignItems: 'center',
-						justifyContent: 'flex-end',
-					}}
-				>
-					<Text
-						style={{
-							...styles.value,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						#fff
-					</Text>
-					<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
-				</View>
-			</TouchableOpacity>
+			{renderTimeTableListRow(
+				<MaterialCommunityIcons name="tag-text-outline" size={24} color={theme.screen.icon} />,
+				'Title',
+				'New',
+				windowWidth,
+				theme,
+				'title'
+			)}
+			{renderTimeTableListRow(
+				<MaterialCommunityIcons name="tag-text-outline" size={24} color={theme.screen.icon} />,
+				'Location',
+				'',
+				windowWidth,
+				theme,
+				'location'
+			)}
+			{renderTimeTableListRow(
+				<MaterialIcons name="color-lens" size={24} color={theme.screen.icon} />,
+				'Colors',
+				'#fff',
+				windowWidth,
+				theme,
+				'colors'
+			)}
 
-			<TouchableOpacity
-				style={{
-					...styles.list,
-					paddingHorizontal: isWeb ? 20 : 10,
-				}}
-			>
-				<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-					<MaterialCommunityIcons name="clock-start" size={24} color={theme.screen.icon} />
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						Start Time
-					</Text>
-				</View>
-				<View
-					style={{
-						...styles.col,
-						gap: isWeb ? 10 : 5,
-						alignItems: 'center',
-						justifyContent: 'flex-end',
-					}}
-				>
-					<Text
-						style={{
-							...styles.value,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						08:00
-					</Text>
-					<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
-				</View>
-			</TouchableOpacity>
+			{renderTimeTableListRow(
+				<MaterialCommunityIcons name="clock-start" size={24} color={theme.screen.icon} />,
+				'Start Time',
+				'08:00',
+				windowWidth,
+				theme,
+				'start-time'
+			)}
 
-			<TouchableOpacity
-				style={{
-					...styles.list,
-					paddingHorizontal: isWeb ? 20 : 10,
-				}}
-			>
-				<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-					<MaterialCommunityIcons name="clock-end" size={24} color={theme.screen.icon} />
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						End Time
-					</Text>
-				</View>
-				<View
-					style={{
-						...styles.col,
-						gap: isWeb ? 10 : 5,
-						alignItems: 'center',
-						justifyContent: 'flex-end',
-					}}
-				>
-					<Text
-						style={{
-							...styles.value,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						10:00
-					</Text>
-					<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
-				</View>
-			</TouchableOpacity>
+			{renderTimeTableListRow(
+				<MaterialCommunityIcons name="clock-end" size={24} color={theme.screen.icon} />,
+				'End Time',
+				'10:00',
+				windowWidth,
+				theme,
+				'end-time'
+			)}
 
-			<TouchableOpacity
-				style={{
-					...styles.list,
-					paddingHorizontal: isWeb ? 20 : 10,
-				}}
-			>
-				<View style={{ ...styles.col, gap: isWeb ? 10 : 5 }}>
-					<Feather name="calendar" size={24} color={theme.screen.icon} />
-					<Text
-						style={{
-							...styles.label,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						Week Days
-					</Text>
-				</View>
-				<View
-					style={{
-						...styles.col,
-						gap: isWeb ? 10 : 5,
-						alignItems: 'center',
-						justifyContent: 'flex-end',
-					}}
-				>
-					<Text
-						style={{
-							...styles.value,
-							color: theme.screen.text,
-							fontSize: windowWidth > 500 ? 16 : 13,
-						}}
-					>
-						Monday
-					</Text>
-					<FontAwesome5 name="pen" size={20} color={theme.screen.icon} />
-				</View>
-			</TouchableOpacity>
+			{renderTimeTableListRow(
+				<Feather name="calendar" size={24} color={theme.screen.icon} />,
+				'Week Days',
+				'Monday',
+				windowWidth,
+				theme,
+				'week-days'
+			)}
 
 			{/* <TouchableOpacity
         style={{

--- a/apps/frontend/app/redux/reducer/settingsReducer.ts
+++ b/apps/frontend/app/redux/reducer/settingsReducer.ts
@@ -75,255 +75,75 @@ const initialState = {
         },
 };
 
+// Action types whose handling is a simple, uniform "replace one field with the
+// action payload" operation. Grouping them into a lookup table (instead of one
+// switch-case each) keeps the reducer's switch statement below the maintainability
+// threshold for number of case clauses, without changing behavior for any action type.
+const SIMPLE_FIELD_ASSIGNMENTS: Record<string, string> = {
+	[CHANGE_THEME]: 'selectedTheme',
+	[SET_WARNING]: 'isWarning',
+	[SET_SORTING]: 'sortBy',
+	[SET_CAMPUSES_SORTING]: 'campusesSortBy',
+	[SET_APARTMENTS_SORTING]: 'apartmentsSortBy',
+	[SET_SERVER_INFO]: 'serverInfo',
+	[SET_COLOR]: 'primaryColor',
+	[CHANGE_LANGUAGE]: 'language',
+	[SET_DRAWER_POSITION]: 'drawerPosition',
+	[SET_APP_SETTINGS]: 'appSettings',
+	[SET_WIKIS_PAGES]: 'wikisPages',
+	[SET_WIKIS]: 'wikis',
+	[SET_NICKNAME_LOCAL]: 'nickNameLocal',
+	[SET_FIRST_DAY_OF_THE_WEEK]: 'firstDayOfTheWeek',
+	[SET_AMOUNT_COLUMNS_FOR_CARDS]: 'amountColumnsForcard',
+	[SET_FOOD_DETAILS_LAST_TAB]: 'foodDetailsLastTab',
+	[SET_USE_WEBP_FOR_ASSETS]: 'useWebpForAssets',
+	[SET_FOODOFFERS_NEXT_DAY_THRESHOLD]: 'foodOffersNextDayThreshold',
+	[SET_DEBUG_MODE]: 'debugMode',
+	[SET_SIMULATE_EXPO_UPDATE_AVAILABLE]: 'simulateExpoUpdateAvailable',
+	[SET_COLLECTIBLE_ITEM_SIZE]: 'collectibleItemSize',
+	[SET_COLLECTIBLE_RANDOM_POSITION]: 'collectibleRandomPosition',
+	[SET_OFFLINE_MODE]: 'offlineMode',
+	[SET_MAP_TILE_VARIANT_KEY]: 'mapTileVariantKey',
+	[SET_MAP_USE_FLY_ANIMATION]: 'mapUseFlyAnimation',
+	[SET_MAP_VIRTUAL_ZOOM]: 'mapVirtualZoom',
+	[SET_MAP_ORGANISATION_FILTER]: 'mapOrganisationFilter',
+	[SET_OSM_VECTOR_MAP_STYLE_KEY]: 'osmVectorMapStyleKey',
+	[SET_OSM_VECTOR_MAP_USE_FLY_ANIMATION]: 'osmVectorMapUseFlyAnimation',
+	[SET_OSM_VECTOR_MAP_ORGANISATION_FILTER]: 'osmVectorMapOrganisationFilter',
+	[SET_OSM_VECTOR_MAP_PITCH]: 'osmVectorMapPitch',
+	[SET_OSM_VECTOR_MAP_CLUSTER_DISTANCE]: 'osmVectorMapClusterDistance',
+	[SET_OSM_VECTOR_MAP_SHOW_CONTROLS_HINT]: 'osmVectorMapShowControlsHint',
+	[SET_OSM_VECTOR_MAP_GAME_MODE]: 'osmVectorMapGameMode',
+	[SET_OSM_VECTOR_MAP_AUTO_ROTATE_MODE]: 'osmVectorMapAutoRotateMode',
+	[SET_OSM_VECTOR_MAP_PEOPLE_MODE]: 'osmVectorMapPeopleMode',
+	[SET_OSM_VECTOR_MAP_INTELLIGENT_MOVEMENT]: 'osmVectorMapIntelligentMovement',
+	[SET_OSM_VECTOR_MAP_PEOPLE_COUNT]: 'osmVectorMapPeopleCount',
+	[SET_OSM_VECTOR_MAP_CAR_MODE]: 'osmVectorMapCarMode',
+	[SET_OSM_VECTOR_MAP_CONSENT]: 'osmVectorMapConsent',
+	[SET_MAP_CLUSTER_PIXEL_RADIUS]: 'mapClusterPixelRadius',
+	[SET_PIRATE_LANGUAGE]: 'pirateLanguage',
+	[SET_FUN_LANGUAGE_MODE]: 'funLanguageMode',
+	[SET_FOODOFFERS_SHOW_SEPARATED_MARKINGS_BREAKDOWN]: 'foodoffersShowSeparatedMarkingsBreakdown',
+	[SET_FOODOFFERS_SHOW_AVERAGE_RATING_ON_CARD]: 'foodoffersShowAverageRatingOnCard',
+};
+
 const settingReducer = (state, actions: any) => {
 	state = state === undefined ? initialState : state;
 
+	const simpleField = SIMPLE_FIELD_ASSIGNMENTS[actions.type];
+	if (simpleField !== undefined) {
+		return {
+			...state,
+			[simpleField]: actions.payload,
+		};
+	}
+
 	switch (actions.type) {
-		case CHANGE_THEME: {
-			return {
-				...state,
-				selectedTheme: actions.payload,
-			};
-		}
-		case SET_WARNING: {
-			return {
-				...state,
-				isWarning: actions.payload,
-			};
-		}
-		case SET_SORTING: {
-			return {
-				...state,
-				sortBy: actions.payload,
-			};
-		}
-		case SET_CAMPUSES_SORTING: {
-			return {
-				...state,
-				campusesSortBy: actions.payload,
-			};
-		}
-		case SET_APARTMENTS_SORTING: {
-			return {
-				...state,
-				apartmentsSortBy: actions.payload,
-			};
-		}
-		case SET_SERVER_INFO: {
-			return {
-				...state,
-				serverInfo: actions.payload,
-			};
-		}
-		case SET_COLOR: {
-			return {
-				...state,
-				primaryColor: actions.payload,
-			};
-		}
-		case CHANGE_LANGUAGE: {
-			return {
-				...state,
-				language: actions.payload,
-			};
-		}
-		case SET_DRAWER_POSITION: {
-			return {
-				...state,
-				drawerPosition: actions.payload,
-			};
-		}
-		case SET_APP_SETTINGS: {
-			return {
-				...state,
-				appSettings: actions.payload,
-			};
-		}
-		case SET_WIKIS_PAGES: {
-			return {
-				...state,
-				wikisPages: actions.payload,
-			};
-		}
-		case SET_WIKIS: {
-			return {
-				...state,
-				wikis: actions.payload,
-			};
-		}
-		case SET_NICKNAME_LOCAL: {
-			return {
-				...state,
-				nickNameLocal: actions.payload,
-			};
-		}
-		case SET_FIRST_DAY_OF_THE_WEEK: {
-			return {
-				...state,
-				firstDayOfTheWeek: actions.payload,
-			};
-		}
-		case SET_AMOUNT_COLUMNS_FOR_CARDS: {
-			return {
-				...state,
-				amountColumnsForcard: actions.payload,
-			};
-		}
-                case SET_FOOD_DETAILS_LAST_TAB: {
-                        return {
-                                ...state,
-                                foodDetailsLastTab: actions.payload,
-                        };
-                }
-                case SET_USE_WEBP_FOR_ASSETS: {
-                        return {
-                                ...state,
-                                useWebpForAssets: actions.payload,
-                        };
-                }
-                case SET_FOODOFFERS_NEXT_DAY_THRESHOLD: {
-                        return {
-                                ...state,
-                                foodOffersNextDayThreshold: actions.payload,
-                        };
-                }
                 case SET_SELECTED_CUSTOMER: {
                         return {
                                 ...state,
                                 selectedCustomer: actions.payload,
                                 foodoffersShowSeparatedMarkingsBreakdown: null,
-                        };
-                }
-                case SET_DEBUG_MODE: {
-                        return {
-                                ...state,
-                                debugMode: actions.payload,
-                        };
-                }
-                case SET_SIMULATE_EXPO_UPDATE_AVAILABLE: {
-                        return {
-                                ...state,
-                                simulateExpoUpdateAvailable: actions.payload,
-                        };
-                }
-                case SET_COLLECTIBLE_ITEM_SIZE: {
-                        return {
-                                ...state,
-                                collectibleItemSize: actions.payload,
-                        };
-                }
-                case SET_COLLECTIBLE_RANDOM_POSITION: {
-                        return {
-                                ...state,
-                                collectibleRandomPosition: actions.payload,
-                        };
-                }
-                case SET_OFFLINE_MODE: {
-                        return {
-                                ...state,
-                                offlineMode: actions.payload,
-                        };
-                }
-                case SET_MAP_TILE_VARIANT_KEY: {
-                        return {
-                                ...state,
-                                mapTileVariantKey: actions.payload,
-                        };
-                }
-                case SET_MAP_USE_FLY_ANIMATION: {
-                        return {
-                                ...state,
-                                mapUseFlyAnimation: actions.payload,
-                        };
-                }
-                case SET_MAP_VIRTUAL_ZOOM: {
-                        return {
-                                ...state,
-                                mapVirtualZoom: actions.payload,
-                        };
-                }
-                case SET_MAP_ORGANISATION_FILTER: {
-                        return {
-                                ...state,
-                                mapOrganisationFilter: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_STYLE_KEY: {
-                        return {
-                                ...state,
-                                osmVectorMapStyleKey: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_USE_FLY_ANIMATION: {
-                        return {
-                                ...state,
-                                osmVectorMapUseFlyAnimation: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_ORGANISATION_FILTER: {
-                        return {
-                                ...state,
-                                osmVectorMapOrganisationFilter: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_PITCH: {
-                        return {
-                                ...state,
-                                osmVectorMapPitch: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_CLUSTER_DISTANCE: {
-                        return {
-                                ...state,
-                                osmVectorMapClusterDistance: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_SHOW_CONTROLS_HINT: {
-                        return {
-                                ...state,
-                                osmVectorMapShowControlsHint: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_GAME_MODE: {
-                        return {
-                                ...state,
-                                osmVectorMapGameMode: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_AUTO_ROTATE_MODE: {
-                        return {
-                                ...state,
-                                osmVectorMapAutoRotateMode: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_PEOPLE_MODE: {
-                        return {
-                                ...state,
-                                osmVectorMapPeopleMode: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_INTELLIGENT_MOVEMENT: {
-                        return {
-                                ...state,
-                                osmVectorMapIntelligentMovement: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_PEOPLE_COUNT: {
-                        return {
-                                ...state,
-                                osmVectorMapPeopleCount: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_CAR_MODE: {
-                        return {
-                                ...state,
-                                osmVectorMapCarMode: actions.payload,
-                        };
-                }
-                case SET_OSM_VECTOR_MAP_CONSENT: {
-                        return {
-                                ...state,
-                                osmVectorMapConsent: actions.payload,
                         };
                 }
                 case SET_OSM_VECTOR_MAP_SHOW_SETTINGS: {
@@ -342,36 +162,6 @@ const settingReducer = (state, actions: any) => {
                                         ...(state as any).osmVectorMapPoiSubSettings,
                                         ...actions.payload,
                                 },
-                        };
-                }
-                case SET_MAP_CLUSTER_PIXEL_RADIUS: {
-                        return {
-                                ...state,
-                                mapClusterPixelRadius: actions.payload,
-                        };
-                }
-                case SET_PIRATE_LANGUAGE: {
-                        return {
-                                ...state,
-                                pirateLanguage: actions.payload,
-                        };
-                }
-                case SET_FUN_LANGUAGE_MODE: {
-                        return {
-                                ...state,
-                                funLanguageMode: actions.payload,
-                        };
-                }
-                case SET_FOODOFFERS_SHOW_SEPARATED_MARKINGS_BREAKDOWN: {
-                        return {
-                                ...state,
-                                foodoffersShowSeparatedMarkingsBreakdown: actions.payload,
-                        };
-                }
-                case SET_FOODOFFERS_SHOW_AVERAGE_RATING_ON_CARD: {
-                        return {
-                                ...state,
-                                foodoffersShowAverageRatingOnCard: actions.payload,
                         };
                 }
                 case SET_CANTEEN_VISITS_VISIBILITY: {

--- a/apps/geonexia/frontend/app/_layout.tsx
+++ b/apps/geonexia/frontend/app/_layout.tsx
@@ -460,6 +460,82 @@ async function rebuildWorldFromActivitiesIfStale(
 	return false;
 }
 
+// Dispatches billboard updates for whichever of the center/small forest trees
+// are still missing at the given hex tile.
+function dispatchMissingForestTrees(
+	hexId: string,
+	smallTreeAnchor: BillboardAnchorPosition,
+	hasCenterTree: boolean,
+	hasSmallTree: boolean,
+) {
+	if (!hasCenterTree) {
+		store.dispatch(setBillboardAtAnchor({
+			h3Index: hexId,
+			anchorColor: BillboardAnchorPosition.CENTER,
+			billboard: BILLBOARD_PINE_TREE_LARGE,
+		}));
+	}
+	if (!hasSmallTree) {
+		store.dispatch(setBillboardAtAnchor({
+			h3Index: hexId,
+			anchorColor: smallTreeAnchor,
+			billboard: BILLBOARD_PINE_TREE_SMALL,
+		}));
+	}
+}
+
+// If the given hex tile record is missing its forest trees, resolves (from
+// cache or by querying) whether the tile has a forest feature and, if so,
+// dispatches the missing tree billboards. Newly queried features are
+// collected into `newEntries` so the caller can merge them into the cache.
+async function applyForestTreesForHex(
+	hexId: string,
+	rec: any,
+	hexTileFeatureCache: HexTileFeatureCache,
+	newEntries: HexTileFeatureCache,
+) {
+	const needsTrees = !rec.walkedOn && rec.enclosedCount > 0;
+	if (!needsTrees) return;
+	const smallTreeAnchor = getSmallTreeAnchorForHexId(hexId);
+	const hasCenterTree = rec.billboards?.[BillboardAnchorPosition.CENTER] === BILLBOARD_PINE_TREE_LARGE;
+	const hasSmallTree = rec.billboards?.[smallTreeAnchor] === BILLBOARD_PINE_TREE_SMALL;
+	if (hasCenterTree && hasSmallTree) return;
+	const cached = hexTileFeatureCache[hexId];
+	if (cached) {
+		if (hasForestFeature(cached)) {
+			dispatchMissingForestTrees(hexId, smallTreeAnchor, hasCenterTree, hasSmallTree);
+		}
+	} else {
+		try {
+			const features = await queryTileFeaturesForHexCell(hexId);
+			newEntries[hexId] = features;
+			if (hasForestFeature(features)) {
+				dispatchMissingForestTrees(hexId, smallTreeAnchor, hasCenterTree, hasSmallTree);
+			}
+		} catch {
+			// ignore per-cell errors
+		}
+	}
+}
+
+// Fire-and-forget on startup: apply forest trees to enclosed tiles that are
+// missing them. This covers cases where a recording ended before the
+// in-session tree dispatch completed (e.g. app was killed mid-run).
+async function applyMissingForestBillboardsOnStartup(records: Record<string, any>) {
+	try {
+		const hexTileFeatureCache = await loadHexTileFeatureCache();
+		const newEntries: HexTileFeatureCache = {};
+		for (const [hexId, rec] of Object.entries(records)) {
+			await applyForestTreesForHex(hexId, rec, hexTileFeatureCache, newEntries);
+		}
+		if (Object.keys(newEntries).length > 0) {
+			await mergeHexTileFeatureCache(newEntries);
+		}
+	} catch (err) {
+		console.warn('[Layout] Feature cache update on startup failed:', err);
+	}
+}
+
 export default function Layout() {
 	useEffect(() => {
 		(async () => {
@@ -480,67 +556,7 @@ export default function Layout() {
 			// Fire-and-forget: apply forest trees to enclosed tiles that are
 			// missing them. This covers cases where a recording ended before the
 			// in-session tree dispatch completed (e.g. app was killed mid-run).
-			void (async () => {
-				try {
-					const hexTileFeatureCache = await loadHexTileFeatureCache();
-					const newEntries: HexTileFeatureCache = {};
-					for (const [hexId, rec] of Object.entries(records)) {
-						const needsTrees = !rec.walkedOn && rec.enclosedCount > 0;
-						if (!needsTrees) continue;
-						const smallTreeAnchor = getSmallTreeAnchorForHexId(hexId);
-						const hasCenterTree = rec.billboards?.[BillboardAnchorPosition.CENTER] === BILLBOARD_PINE_TREE_LARGE;
-						const hasSmallTree = rec.billboards?.[smallTreeAnchor] === BILLBOARD_PINE_TREE_SMALL;
-						if (hasCenterTree && hasSmallTree) continue;
-						const cached = hexTileFeatureCache[hexId];
-						if (cached) {
-							if (hasForestFeature(cached)) {
-								if (!hasCenterTree) {
-									store.dispatch(setBillboardAtAnchor({
-										h3Index: hexId,
-										anchorColor: BillboardAnchorPosition.CENTER,
-										billboard: BILLBOARD_PINE_TREE_LARGE,
-									}));
-								}
-								if (!hasSmallTree) {
-									store.dispatch(setBillboardAtAnchor({
-										h3Index: hexId,
-										anchorColor: smallTreeAnchor,
-										billboard: BILLBOARD_PINE_TREE_SMALL,
-									}));
-								}
-							}
-						} else {
-							try {
-								const features = await queryTileFeaturesForHexCell(hexId);
-								newEntries[hexId] = features;
-								if (hasForestFeature(features)) {
-									if (!hasCenterTree) {
-										store.dispatch(setBillboardAtAnchor({
-											h3Index: hexId,
-											anchorColor: BillboardAnchorPosition.CENTER,
-											billboard: BILLBOARD_PINE_TREE_LARGE,
-										}));
-									}
-									if (!hasSmallTree) {
-										store.dispatch(setBillboardAtAnchor({
-											h3Index: hexId,
-											anchorColor: smallTreeAnchor,
-											billboard: BILLBOARD_PINE_TREE_SMALL,
-										}));
-									}
-								}
-							} catch {
-								// ignore per-cell errors
-							}
-						}
-					}
-					if (Object.keys(newEntries).length > 0) {
-						await mergeHexTileFeatureCache(newEntries);
-					}
-				} catch (err) {
-					console.warn('[Layout] Feature cache update on startup failed:', err);
-				}
-			})();
+			void applyMissingForestBillboardsOnStartup(records);
 		})().catch((err) => {
 			console.warn('[Layout] Failed to load persisted hex tile state:', err);
 		});

--- a/apps/geonexia/frontend/app/activities/[id].tsx
+++ b/apps/geonexia/frontend/app/activities/[id].tsx
@@ -102,21 +102,19 @@ function filterUnrealisticPoints(points: RoutePoint[], maxSpeedKmh: number): Rou
 	return result;
 }
 
-function computeActivityStats(points: RoutePoint[]): RunStats {
-	if (points.length < 2) {
-		const durationSeconds = points.length === 1 ? (Date.now() - points[0].timestamp) / 1000 : 0;
-		return {
-			distanceKm: 0, durationSeconds, paceMinPerKm: 0,
-			maxSpeedKmh: 0, minSpeedKmh: 0, avgSpeedKmh: 0, medianSpeedKmh: 0,
-			q1SpeedKmh: 0, q3SpeedKmh: 0,
-			kcal: 0, steps: 0, elevationGainM: 0, elevationLossM: 0, fluidNeedsMl: 0,
-		};
-	}
+/**
+ * Accumulate distance, elevation change and per-segment speeds across the
+ * given points. Extracted from computeActivityStats() to keep that function's
+ * cognitive complexity manageable.
+ */
+function accumulateDistanceElevationAndSpeeds(
+	points: RoutePoint[],
+	startTimestamp: number,
+): { distanceKm: number; elevationGainM: number; elevationLossM: number; speedsKmh: number[] } {
 	let distanceKm = 0;
 	let elevationGainM = 0;
 	let elevationLossM = 0;
 	const speedsKmh: number[] = [];
-	const startTimestamp = points[0].timestamp;
 	for (let i = 1; i < points.length; i++) {
 		const segKm = haversineKm(points[i - 1].lat, points[i - 1].lng, points[i].lat, points[i].lng);
 		distanceKm += segKm;
@@ -136,15 +134,41 @@ function computeActivityStats(points: RoutePoint[]): RunStats {
 			speedsKmh.push(segSpeedKmh);
 		}
 	}
-	const durationSeconds = (points.at(-1)!.timestamp - points[0].timestamp) / 1000;
-	const paceMinPerKm = distanceKm > 0 ? durationSeconds / 60 / distanceKm : 0;
+	return { distanceKm, elevationGainM, elevationLossM, speedsKmh };
+}
+
+/**
+ * Smooth the given speed samples with a trailing moving-average window.
+ * Extracted from computeActivityStats() to keep that function's cognitive
+ * complexity manageable.
+ */
+function computeWindowedSpeeds(speedsKmh: number[], windowSize: number): number[] {
 	const windowedSpeeds: number[] = [];
 	let windowSum = 0;
 	for (let i = 0; i < speedsKmh.length; i++) {
 		windowSum += speedsKmh[i];
-		if (i >= SPEED_WINDOW_SIZE) windowSum -= speedsKmh[i - SPEED_WINDOW_SIZE];
-		windowedSpeeds.push(windowSum / Math.min(i + 1, SPEED_WINDOW_SIZE));
+		if (i >= windowSize) windowSum -= speedsKmh[i - windowSize];
+		windowedSpeeds.push(windowSum / Math.min(i + 1, windowSize));
 	}
+	return windowedSpeeds;
+}
+
+function computeActivityStats(points: RoutePoint[]): RunStats {
+	if (points.length < 2) {
+		const durationSeconds = points.length === 1 ? (Date.now() - points[0].timestamp) / 1000 : 0;
+		return {
+			distanceKm: 0, durationSeconds, paceMinPerKm: 0,
+			maxSpeedKmh: 0, minSpeedKmh: 0, avgSpeedKmh: 0, medianSpeedKmh: 0,
+			q1SpeedKmh: 0, q3SpeedKmh: 0,
+			kcal: 0, steps: 0, elevationGainM: 0, elevationLossM: 0, fluidNeedsMl: 0,
+		};
+	}
+	const startTimestamp = points[0].timestamp;
+	const { distanceKm, elevationGainM, elevationLossM, speedsKmh } =
+		accumulateDistanceElevationAndSpeeds(points, startTimestamp);
+	const durationSeconds = (points.at(-1)!.timestamp - points[0].timestamp) / 1000;
+	const paceMinPerKm = distanceKm > 0 ? durationSeconds / 60 / distanceKm : 0;
+	const windowedSpeeds = computeWindowedSpeeds(speedsKmh, SPEED_WINDOW_SIZE);
 	// min/max/median/q1/q3 AND avg all come from the same windowed speed samples,
 	// so they can never contradict each other (e.g. avg ending up below min, which
 	// happened when avg was separately computed as a raw distance/time ratio while
@@ -592,19 +616,16 @@ const H3_GEOJSON_ORDER = true;
 const ACTIVITY_GPS_PATH_INTERPOLATION_MAX_CELLS = 10;
 
 /**
- * Derive the sequence of unique H3 cells visited during an activity, including
- * interpolated cells for GPS gaps, and build a hexTileGeoJSON with one polygon
- * per visited cell (at `h3Resolution`, typically h10), colored by its level
- * from the global Redux store.
+ * Walk the route's GPS points and derive the sequence of unique H3 cells
+ * visited, including interpolated cells for GPS gaps. Extracted from
+ * buildActivityHexGeoJson() to keep that function's cognitive complexity
+ * manageable.
  */
-function buildActivityHexGeoJson(
+function computeVisitedHexCells(
 	routePoints: RoutePoint[],
 	h3Resolution: number,
-	hexTileRecords: Record<string, HexTileRecord>,
-): {
-	hexTileGeoJson: { type: 'FeatureCollection'; features: object[] };
-} {
-	// h10 tile tracking
+	maxInterpolationCells: number,
+): Set<string> {
 	const visitedCells = new Set<string>();
 	let lastCell: string | null = null;
 
@@ -615,8 +636,8 @@ function buildActivityHexGeoJson(
 				if (lastCell && cell !== lastCell) {
 					try {
 						const pathCells = gridPathCells(lastCell, cell);
-						if (pathCells.length - 2 <= ACTIVITY_GPS_PATH_INTERPOLATION_MAX_CELLS) {
-							for (const cell of pathCells) visitedCells.add(cell);
+						if (pathCells.length - 2 <= maxInterpolationCells) {
+							for (const c of pathCells) visitedCells.add(c);
 						}
 					} catch {
 						// Different icosahedron faces; just mark the two endpoints
@@ -630,9 +651,21 @@ function buildActivityHexGeoJson(
 		}
 	}
 
-	// Build hex tile polygon features (h10)
+	return visitedCells;
+}
+
+/**
+ * Build one hex tile GeoJSON polygon Feature per given H3 cell, colored by
+ * its level from the global Redux store. Extracted from
+ * buildActivityHexGeoJson() (and reused for the manual-activity variant) to
+ * keep the cognitive complexity of its callers manageable.
+ */
+function buildHexTileFeaturesFromCells(
+	cells: Iterable<string>,
+	hexTileRecords: Record<string, HexTileRecord>,
+): object[] {
 	const tileFeatures: object[] = [];
-	for (const cell of visitedCells) {
+	for (const cell of cells) {
 		try {
 			const boundary = cellToBoundary(cell, H3_GEOJSON_ORDER);
 			if (boundary.length === 0) continue;
@@ -646,6 +679,24 @@ function buildActivityHexGeoJson(
 			// Skip invalid cells
 		}
 	}
+	return tileFeatures;
+}
+
+/**
+ * Derive the sequence of unique H3 cells visited during an activity, including
+ * interpolated cells for GPS gaps, and build a hexTileGeoJSON with one polygon
+ * per visited cell (at `h3Resolution`, typically h10), colored by its level
+ * from the global Redux store.
+ */
+function buildActivityHexGeoJson(
+	routePoints: RoutePoint[],
+	h3Resolution: number,
+	hexTileRecords: Record<string, HexTileRecord>,
+): {
+	hexTileGeoJson: { type: 'FeatureCollection'; features: object[] };
+} {
+	const visitedCells = computeVisitedHexCells(routePoints, h3Resolution, ACTIVITY_GPS_PATH_INTERPOLATION_MAX_CELLS);
+	const tileFeatures = buildHexTileFeaturesFromCells(visitedCells, hexTileRecords);
 
 	return {
 		hexTileGeoJson: { type: 'FeatureCollection', features: tileFeatures },
@@ -688,6 +739,200 @@ function ActivityDetailBackHeaderButton({ color, onPress }: Readonly<{ color: st
 
 function makeActivityDetailHeaderLeft(color: string, onPress: () => void) {
 	return () => <ActivityDetailBackHeaderButton color={color} onPress={onPress} />;
+}
+
+/**
+ * Migrate an activity saved before the `computed` field was introduced by
+ * deriving and persisting it. Returns the activity unchanged if migration is
+ * not applicable or fails. Extracted from the activity-loading effect to keep
+ * its cognitive complexity manageable.
+ */
+async function migrateActivityComputedField(a: SavedActivity): Promise<SavedActivity> {
+	if (a.computed || (a.hexTilesOrdered?.length ?? 0) === 0 || !isH3Available()) {
+		return a;
+	}
+	try {
+		const h3Res = a.h3Resolution ?? H3_RESOLUTION_FALLBACK;
+		const enclosed = a.hexTilesOrdered!.length >= MIN_TILES_FOR_ENCLOSED_POLYGON
+			? findEnclosedCellsFromHexTiles(
+				buildFullRouteTileIds(a.hexTilesOrdered!, a.routePoints, h3Res),
+				h3Res,
+			)
+			: (a.enclosedHexTiles ?? a.hexTilesEnclosed ?? []);
+		const computedData = computeActivityData(a, enclosed);
+		const updated = { ...a, computed: computedData };
+		saveActivity(updated);
+		return updated;
+	} catch {
+		// Migration failed; continue without computed
+		return a;
+	}
+}
+
+/**
+ * Migrate an activity saved before the speed boxplot quartiles were
+ * introduced by deriving and persisting them. Returns the activity unchanged
+ * if migration is not applicable. Extracted from the activity-loading effect
+ * to keep its cognitive complexity manageable.
+ */
+function migrateActivityStatsQuartiles(a: SavedActivity): SavedActivity {
+	if (a.stats.q1SpeedKmh !== undefined && a.stats.q3SpeedKmh !== undefined) {
+		return a;
+	}
+	const { q1SpeedKmh, q3SpeedKmh } = computeActivityStats(a.routePoints);
+	const updated = { ...a, stats: { ...a.stats, q1SpeedKmh, q3SpeedKmh } };
+	saveActivity(updated);
+	return updated;
+}
+
+/**
+ * Send the (possibly smoothed) route line to the map, speed-colored when
+ * segment data is available. Extracted from the "send route to map" effect
+ * to keep its cognitive complexity manageable.
+ */
+function sendActivityRouteSegmentsToMap(
+	mapHandle: MyMapHandle,
+	displayCoords: [number, number][],
+	showRoadMatch: boolean,
+	result: { segments: { coords: number[][]; speedKmh: number }[]; speedRange: unknown } | null,
+): void {
+	if (showRoadMatch) {
+		// Straßen/Wege mode: the GPS-connected track is not rendered at all.
+		// The road-match effect sends the road-matched line as speed-colored
+		// routeSegments once the road network has been fetched.
+		mapHandle.sendToMap({ routeSegments: null, routeCoordinates: null });
+	} else if (result && result.segments.length > 0) {
+		// Rebuild segments using the (possibly smoothed) display coordinates
+		// while preserving the speed value from each original segment.
+		const smoothedSegments = result.segments.map((seg, i) => ({
+			...seg,
+			coords: [displayCoords[i], displayCoords[i + 1]] as [[number, number], [number, number]],
+		}));
+		mapHandle.sendToMap({ routeSegments: smoothedSegments, routeSpeedRange: result.speedRange });
+	} else {
+		// Fallback: plain route without speed coloring
+		mapHandle.sendToMap({ routeCoordinates: displayCoords });
+	}
+}
+
+/**
+ * Send hex tile GeoJSON to the map, either derived from the GPS route or (for
+ * manual activities without GPS points) from the ordered hex tile list.
+ * Extracted from the "send route to map" effect to keep its cognitive
+ * complexity manageable.
+ */
+function sendActivityHexTileGeoJsonToMap(
+	mapHandle: MyMapHandle,
+	activity: SavedActivity,
+	hexTileRecords: Record<string, HexTileRecord>,
+): void {
+	if (isH3Available() && activity.routePoints.length > 0) {
+		try {
+			const h3Res = activity.h3Resolution ?? 10;
+			const { hexTileGeoJson } = buildActivityHexGeoJson(
+				activity.routePoints,
+				h3Res,
+				hexTileRecords,
+			);
+			mapHandle.sendToMap({ hexTileGeoJson });
+		} catch (err) {
+			console.warn('[ActivityDetailScreen] Failed to build activity hex GeoJSON:', err);
+		}
+	} else if (isH3Available() && activity.isManual && (activity.hexTilesOrdered?.length ?? 0) > 0) {
+		// Manual activity has no GPS points – build the hex tile GeoJSON
+		// directly from the ordered hex tile list.
+		try {
+			const tileFeatures = buildHexTileFeaturesFromCells(activity.hexTilesOrdered!, hexTileRecords);
+			mapHandle.sendToMap({ hexTileGeoJson: { type: 'FeatureCollection', features: tileFeatures } });
+		} catch (err) {
+			console.warn('[ActivityDetailScreen] Failed to build manual activity hex GeoJSON:', err);
+		}
+	}
+}
+
+/**
+ * Compute the camera fit (center + fitBounds/mapCenterPosition map message)
+ * for an activity's route, falling back to the hex tile bounding box for
+ * manual activities without GPS points. Returns null when there is nothing
+ * to fit to. Extracted from the "send route to map" effect to keep its
+ * cognitive complexity manageable.
+ */
+function computeActivityCameraFit(
+	activity: SavedActivity,
+	computeRouteBoundsFn: (points: RoutePoint[]) => { minLat: number; maxLat: number; minLng: number; maxLng: number } | null,
+): { center: { lat: number; lng: number }; mapMessage: Record<string, unknown> } | null {
+	const points = activity.routePoints;
+	if (points.length >= 2) {
+		const bounds = computeRouteBoundsFn(points)!;
+		const { minLat, maxLat, minLng, maxLng } = bounds;
+		const center = { lat: (minLat + maxLat) / 2, lng: (minLng + maxLng) / 2 };
+		// Expand the bounding box to 1.5× the route span so the route is
+		// not clipped at the edges (adds 25 % padding on every side).
+		// Use at least 0.001 deg (~100 m) so very short routes don't get
+		// a degenerate zero-size bounding box that fitBounds ignores.
+		const latPad = Math.max((maxLat - minLat) * 0.25, 0.001);
+		const lngPad = Math.max((maxLng - minLng) * 0.25, 0.001);
+		return {
+			center,
+			mapMessage: {
+				fitBounds: [[minLng - lngPad, minLat - latPad], [maxLng + lngPad, maxLat + latPad]],
+				fitBoundsPadding: 20,
+				pitch: 45,
+				bearing: 0,
+			},
+		};
+	}
+	if (points.length === 1) {
+		const center = { lat: points[0].lat, lng: points[0].lng };
+		return {
+			center,
+			mapMessage: { mapCenterPosition: center, pitch: 45, bearing: 0 },
+		};
+	}
+	if (activity.isManual && (activity.hexTilesOrdered?.length ?? 0) >= 1) {
+		// Manual activity: fit the camera to the hex tile bounding box
+		const hexBounds = computeHexBounds(activity.hexTilesOrdered!);
+		if (hexBounds) {
+			const { minLat, maxLat, minLng, maxLng } = hexBounds;
+			const center = { lat: (minLat + maxLat) / 2, lng: (minLng + maxLng) / 2 };
+			const latPad = Math.max((maxLat - minLat) * 0.25, 0.001);
+			const lngPad = Math.max((maxLng - minLng) * 0.25, 0.001);
+			return {
+				center,
+				mapMessage: {
+					fitBounds: [[minLng - lngPad, minLat - latPad], [maxLng + lngPad, maxLat + latPad]],
+					fitBoundsPadding: 20,
+					pitch: 45,
+					bearing: 0,
+				},
+			};
+		}
+	}
+	return null;
+}
+
+/**
+ * Load the saved routes and find the best matching route for the given
+ * activity, for pre-filling the route-assignment modal. Returns empty
+ * results on error (the modal is then shown with empty routes). Extracted
+ * from the activity-loading effect to keep its cognitive complexity
+ * manageable.
+ */
+async function resolveRouteAssignmentCandidates(
+	a: SavedActivity,
+): Promise<{ routes: SavedRoute[]; bestMatch: RouteMatchResult | null }> {
+	let routes: SavedRoute[] = [];
+	let bestMatch: RouteMatchResult | null = null;
+	try {
+		routes = await loadRoutes();
+		if (a.hexTilesOrdered && a.hexTilesOrdered.length > 0 && a.h3Resolution != null) {
+			const matches = findMatchingRoutes(a.hexTilesOrdered, routes, a.h3Resolution);
+			bestMatch = matches.length > 0 ? matches[0] : null;
+		}
+	} catch {
+		// Show modal with empty routes on error
+	}
+	return { routes, bestMatch };
 }
 
 export default function ActivityDetailScreen() {
@@ -806,29 +1051,10 @@ export default function ActivityDetailScreen() {
 
 				// Migrate activities saved before the computed field was introduced.
 				// Compute and persist it so subsequent loads skip this step.
-				if (!a.computed && (a.hexTilesOrdered?.length ?? 0) > 0 && isH3Available()) {
-					try {
-						const h3Res = a.h3Resolution ?? H3_RESOLUTION_FALLBACK;
-						const enclosed = a.hexTilesOrdered!.length >= MIN_TILES_FOR_ENCLOSED_POLYGON
-							? findEnclosedCellsFromHexTiles(
-								buildFullRouteTileIds(a.hexTilesOrdered!, a.routePoints, h3Res),
-								h3Res,
-							)
-							: (a.enclosedHexTiles ?? a.hexTilesEnclosed ?? []);
-						const computedData = computeActivityData(a, enclosed);
-						a = { ...a, computed: computedData };
-						saveActivity(a);
-					} catch {
-						// Migration failed; continue without computed
-					}
-				}
+				a = await migrateActivityComputedField(a);
 
 				// Migrate activities saved before the speed boxplot quartiles were introduced.
-				if (a.stats.q1SpeedKmh === undefined || a.stats.q3SpeedKmh === undefined) {
-					const { q1SpeedKmh, q3SpeedKmh } = computeActivityStats(a.routePoints);
-					a = { ...a, stats: { ...a.stats, q1SpeedKmh, q3SpeedKmh } };
-					saveActivity(a);
-				}
+				a = migrateActivityStatsQuartiles(a);
 
 				setActivity(a);
 
@@ -842,17 +1068,7 @@ export default function ActivityDetailScreen() {
 				// If routeId has never been decided, load routes and show assignment modal
 				if (a.routeId === undefined && !routeModalShownRef.current) {
 					routeModalShownRef.current = true;
-					let routes: SavedRoute[] = [];
-					let bestMatch: RouteMatchResult | null = null;
-					try {
-						routes = await loadRoutes();
-						if (a.hexTilesOrdered && a.hexTilesOrdered.length > 0 && a.h3Resolution != null) {
-							const matches = findMatchingRoutes(a.hexTilesOrdered, routes, a.h3Resolution);
-							bestMatch = matches.length > 0 ? matches[0] : null;
-						}
-					} catch {
-						// Show modal with empty routes on error
-					}
+					const { routes, bestMatch } = await resolveRouteAssignmentCandidates(a);
 					showRouteModal({
 						title: '🗺️ Route zuordnen',
 						children: (
@@ -1055,23 +1271,7 @@ export default function ActivityDetailScreen() {
 			: rawCoords;
 
 		const result = buildRouteSegments(activity.routePoints, activity.stats);
-		if (showRoadMatch) {
-			// Straßen/Wege mode: the GPS-connected track is not rendered at all.
-			// The road-match effect below sends the road-matched line as
-			// speed-colored routeSegments once the road network has been fetched.
-			mapRef.current.sendToMap({ routeSegments: null, routeCoordinates: null });
-		} else if (result && result.segments.length > 0) {
-			// Rebuild segments using the (possibly smoothed) display coordinates
-			// while preserving the speed value from each original segment.
-			const smoothedSegments = result.segments.map((seg, i) => ({
-				...seg,
-				coords: [displayCoords[i], displayCoords[i + 1]] as [[number, number], [number, number]],
-			}));
-			mapRef.current.sendToMap({ routeSegments: smoothedSegments, routeSpeedRange: result.speedRange });
-		} else {
-			// Fallback: plain route without speed coloring
-			mapRef.current.sendToMap({ routeCoordinates: displayCoords });
-		}
+		sendActivityRouteSegmentsToMap(mapRef.current, displayCoords, showRoadMatch, result);
 
 		// Send start point circle (green, on top of the route lines)
 		const pts = activity.routePoints;
@@ -1095,84 +1295,13 @@ export default function ActivityDetailScreen() {
 		// Send hex tile GeoJSON so the activity screen shows the same hexagon
 		// visualization as the main map, but only for the tiles that were
 		// visited during this specific activity.
-		if (isH3Available() && activity.routePoints.length > 0) {
-			try {
-				const h3Res = activity.h3Resolution ?? 10;
-				const { hexTileGeoJson } = buildActivityHexGeoJson(
-					activity.routePoints,
-					h3Res,
-					hexTileRecords,
-				);
-				mapRef.current.sendToMap({ hexTileGeoJson });
-			} catch (err) {
-				console.warn('[ActivityDetailScreen] Failed to build activity hex GeoJSON:', err);
-			}
-		} else if (isH3Available() && activity.isManual && (activity.hexTilesOrdered?.length ?? 0) > 0) {
-			// Manual activity has no GPS points – build the hex tile GeoJSON
-			// directly from the ordered hex tile list.
-			try {
-				const hexTiles = activity.hexTilesOrdered!;
-				const tileFeatures: object[] = [];
-				for (const cell of hexTiles) {
-					try {
-						const boundary = cellToBoundary(cell, H3_GEOJSON_ORDER);
-						if (boundary.length === 0) continue;
-						const level = hexTileRecords[cell]?.level ?? 0;
-						tileFeatures.push({
-							type: 'Feature',
-							geometry: { type: 'Polygon', coordinates: [boundary] },
-							properties: { h3Index: cell, level },
-						});
-					} catch {
-						// Skip invalid cells
-					}
-				}
-				mapRef.current.sendToMap({ hexTileGeoJson: { type: 'FeatureCollection', features: tileFeatures } });
-			} catch (err) {
-				console.warn('[ActivityDetailScreen] Failed to build manual activity hex GeoJSON:', err);
-			}
-		}
+		sendActivityHexTileGeoJsonToMap(mapRef.current, activity, hexTileRecords);
 
 		// Fit the camera to the full route extent
-		const points = activity.routePoints;
-		if (points.length >= 2) {
-			const bounds = computeRouteBounds(points)!;
-			const { minLat, maxLat, minLng, maxLng } = bounds;
-			routeCenterRef.current = { lat: (minLat + maxLat) / 2, lng: (minLng + maxLng) / 2 };
-			// Expand the bounding box to 1.5× the route span so the route is
-			// not clipped at the edges (adds 25 % padding on every side).
-			// Use at least 0.001 deg (~100 m) so very short routes don't get
-			// a degenerate zero-size bounding box that fitBounds ignores.
-			const latPad = Math.max((maxLat - minLat) * 0.25, 0.001);
-			const lngPad = Math.max((maxLng - minLng) * 0.25, 0.001);
-			mapRef.current.sendToMap({
-				fitBounds: [[minLng - lngPad, minLat - latPad], [maxLng + lngPad, maxLat + latPad]],
-				fitBoundsPadding: 20,
-				pitch: 45,
-				bearing: 0,
-			});
-		} else if (points.length === 1) {
-			routeCenterRef.current = { lat: points[0].lat, lng: points[0].lng };
-			mapRef.current.sendToMap({
-				mapCenterPosition: { lat: points[0].lat, lng: points[0].lng },
-				pitch: 45,
-				bearing: 0,
-			});
-		} else if (activity.isManual && (activity.hexTilesOrdered?.length ?? 0) >= 1) {
-			// Manual activity: fit the camera to the hex tile bounding box
-			const hexBounds = computeHexBounds(activity.hexTilesOrdered!);
-			if (hexBounds) {
-				const { minLat, maxLat, minLng, maxLng } = hexBounds;
-				routeCenterRef.current = { lat: (minLat + maxLat) / 2, lng: (minLng + maxLng) / 2 };
-				const latPad = Math.max((maxLat - minLat) * 0.25, 0.001);
-				const lngPad = Math.max((maxLng - minLng) * 0.25, 0.001);
-				mapRef.current.sendToMap({
-					fitBounds: [[minLng - lngPad, minLat - latPad], [maxLng + lngPad, maxLat + latPad]],
-					fitBoundsPadding: 20,
-					pitch: 45,
-					bearing: 0,
-				});
-			}
+		const cameraFit = computeActivityCameraFit(activity, computeRouteBounds);
+		if (cameraFit) {
+			routeCenterRef.current = cameraFit.center;
+			mapRef.current.sendToMap(cameraFit.mapMessage);
 		}
 
 		// Start smooth auto-rotate after the fitBounds animation finishes.

--- a/apps/geonexia/frontend/app/activities/index.tsx
+++ b/apps/geonexia/frontend/app/activities/index.tsx
@@ -402,6 +402,111 @@ function makeActivitiesHeaderRight(onRebuild: () => void, onExport: () => void, 
 	return () => <ActivitiesHeaderRight onRebuild={onRebuild} onExport={onExport} onImport={onImport} />;
 }
 
+// ─── Import helpers ────────────────────────────────────────────────────────
+
+/**
+ * Normalizes the parsed import payload into a raw activities array plus any
+ * exported routes. Supports three formats:
+ *  1. New: { activities: [...], routes: [...] }
+ *  2. Old: [...] (array of activities)
+ *  3. Old: single activity object
+ */
+function extractImportedActivitiesAndRoutes(parsed: unknown): { rawActivities: unknown[]; exportedRoutes: SavedRoute[] } {
+	if (
+		typeof parsed === 'object' &&
+		parsed !== null &&
+		!Array.isArray(parsed) &&
+		Array.isArray((parsed as Record<string, unknown>).activities)
+	) {
+		const wrapper = parsed as Record<string, unknown>;
+		const rawActivities = wrapper.activities as unknown[];
+		const exportedRoutes = Array.isArray(wrapper.routes) ? (wrapper.routes as SavedRoute[]) : [];
+		return { rawActivities, exportedRoutes };
+	}
+	return { rawActivities: Array.isArray(parsed) ? parsed : [parsed], exportedRoutes: [] };
+}
+
+/** Validates that every raw imported entry looks like a SavedActivity. Returns null if any entry is invalid. */
+function validateImportedActivities(rawActivities: unknown[]): SavedActivity[] | null {
+	const validActivities: SavedActivity[] = [];
+	for (const item of rawActivities) {
+		const activity = item as SavedActivity;
+		if (
+			typeof activity.id !== 'string' ||
+			typeof activity.startedAt !== 'number' ||
+			!Array.isArray(activity.routePoints)
+		) {
+			return null;
+		}
+		validActivities.push(activity);
+	}
+	return validActivities;
+}
+
+/**
+ * Resolves (or creates) the route an imported activity should link to, mutating
+ * `existingRoutes` in place when a route is matched or newly created. Returns the
+ * resolved routeId together with the (possibly incremented) routeIdOffset used to
+ * keep generated route ids unique within a single import batch.
+ */
+function resolveRouteForImportedActivity(
+	activity: SavedActivity,
+	existingRoutes: SavedRoute[],
+	exportedRouteMap: Map<string, SavedRoute>,
+	routeIdOffset: number,
+): { routeId: string | null | undefined; routeIdOffset: number } {
+	const hexTiles = activity.hexTilesOrdered ?? [];
+	const h3Res = activity.h3Resolution ?? H3_RESOLUTION_FALLBACK;
+	let routeId: string | null | undefined = activity.routeId;
+
+	if (hexTiles.length > 0 && isH3Available()) {
+		const match = findMatchingRoutes(hexTiles, existingRoutes, h3Res)[0];
+		if (match) {
+			// Link to the existing matching route.
+			routeId = match.route.id;
+			const updatedRoute: SavedRoute = {
+				...match.route,
+				activityIds: [...new Set([...(match.route.activityIds ?? []), activity.id])],
+			};
+			saveRoute(updatedRoute);
+			const idx = existingRoutes.findIndex((r) => r.id === match.route.id);
+			if (idx >= 0) existingRoutes[idx] = updatedRoute;
+		} else {
+			// No matching route on this device — create one from the imported tiles.
+			// Prefer the exported route's name when available.
+			const exportedRoute = activity.routeId ? exportedRouteMap.get(activity.routeId) : undefined;
+			const d = new Date(activity.startedAt);
+			const name = exportedRoute?.name ?? `Route ${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.${d.getFullYear()}`;
+			const routePoints =
+				activity.routePoints.length > 0
+					? activity.routePoints
+					: synthesizeManualActivityRoutePoints(
+						hexTiles,
+						activity.startedAt,
+						(activity.endedAt - activity.startedAt),
+						activity.stats.distanceKm,
+					);
+			const newRoute: SavedRoute = {
+				id: String(Date.now() + routeIdOffset++),
+				name,
+				hexTiles,
+				h3Resolution: h3Res,
+				createdAt: activity.startedAt,
+				sportType: activity.sportType,
+				walkedEdges: computeEdgesFromRoutePoints(routePoints, h3Res),
+				walkedEdgesRedLine: computeEdgesFromRoutePoints(routePoints, RED_LINE_GRID_RESOLUTION),
+				walkedEdgesRedLineResolution: RED_LINE_GRID_RESOLUTION,
+				activityIds: [activity.id],
+			};
+			saveRoute(newRoute);
+			existingRoutes.push(newRoute);
+			routeId = newRoute.id;
+		}
+	}
+
+	return { routeId, routeIdOffset };
+}
+
 // ─── Activities Screen ────────────────────────────────────────────────────────
 
 export default function ActivitiesScreen() {
@@ -455,39 +560,12 @@ export default function ActivitiesScreen() {
 			return;
 		}
 
-		// Support three formats:
-		//  1. New: { activities: [...], routes: [...] }
-		//  2. Old: [...] (array of activities)
-		//  3. Old: single activity object
-		let rawActivities: unknown[];
-		let exportedRoutes: SavedRoute[] = [];
-		if (
-			typeof parsed === 'object' &&
-			parsed !== null &&
-			!Array.isArray(parsed) &&
-			Array.isArray((parsed as Record<string, unknown>).activities)
-		) {
-			const wrapper = parsed as Record<string, unknown>;
-			rawActivities = wrapper.activities as unknown[];
-			if (Array.isArray(wrapper.routes)) {
-				exportedRoutes = wrapper.routes as SavedRoute[];
-			}
-		} else {
-			rawActivities = Array.isArray(parsed) ? parsed : [parsed];
-		}
+		const { rawActivities, exportedRoutes } = extractImportedActivitiesAndRoutes(parsed);
 
-		const validActivities: SavedActivity[] = [];
-		for (const item of rawActivities) {
-			const activity = item as SavedActivity;
-			if (
-				typeof activity.id !== 'string' ||
-				typeof activity.startedAt !== 'number' ||
-				!Array.isArray(activity.routePoints)
-			) {
-				showAlert('Import Failed', 'One or more entries do not look like valid activities.');
-				return;
-			}
-			validActivities.push(activity);
+		const validActivities = validateImportedActivities(rawActivities);
+		if (!validActivities) {
+			showAlert('Import Failed', 'One or more entries do not look like valid activities.');
+			return;
 		}
 
 		// Build a lookup map for exported route names so new routes inherit the
@@ -500,54 +578,9 @@ export default function ActivitiesScreen() {
 		let routeIdOffset = 0;
 
 		for (const activity of validActivities) {
-			const hexTiles = activity.hexTilesOrdered ?? [];
-			const h3Res = activity.h3Resolution ?? H3_RESOLUTION_FALLBACK;
-			let routeId: string | null | undefined = activity.routeId;
-
-			if (hexTiles.length > 0 && isH3Available()) {
-				const match = findMatchingRoutes(hexTiles, existingRoutes, h3Res)[0];
-				if (match) {
-					// Link to the existing matching route.
-					routeId = match.route.id;
-					const updatedRoute: SavedRoute = {
-						...match.route,
-						activityIds: [...new Set([...(match.route.activityIds ?? []), activity.id])],
-					};
-					saveRoute(updatedRoute);
-					const idx = existingRoutes.findIndex((r) => r.id === match.route.id);
-					if (idx >= 0) existingRoutes[idx] = updatedRoute;
-				} else {
-					// No matching route on this device — create one from the imported tiles.
-					// Prefer the exported route's name when available.
-					const exportedRoute = activity.routeId ? exportedRouteMap.get(activity.routeId) : undefined;
-					const d = new Date(activity.startedAt);
-					const name = exportedRoute?.name ?? `Route ${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.${d.getFullYear()}`;
-					const routePoints =
-						activity.routePoints.length > 0
-							? activity.routePoints
-							: synthesizeManualActivityRoutePoints(
-								hexTiles,
-								activity.startedAt,
-								(activity.endedAt - activity.startedAt),
-								activity.stats.distanceKm,
-							);
-					const newRoute: SavedRoute = {
-						id: String(Date.now() + routeIdOffset++),
-						name,
-						hexTiles,
-						h3Resolution: h3Res,
-						createdAt: activity.startedAt,
-						sportType: activity.sportType,
-						walkedEdges: computeEdgesFromRoutePoints(routePoints, h3Res),
-						walkedEdgesRedLine: computeEdgesFromRoutePoints(routePoints, RED_LINE_GRID_RESOLUTION),
-						walkedEdgesRedLineResolution: RED_LINE_GRID_RESOLUTION,
-						activityIds: [activity.id],
-					};
-					saveRoute(newRoute);
-					existingRoutes.push(newRoute);
-					routeId = newRoute.id;
-				}
-			}
+			const resolved = resolveRouteForImportedActivity(activity, existingRoutes, exportedRouteMap, routeIdOffset);
+			const { routeId } = resolved;
+			routeIdOffset = resolved.routeIdOffset;
 
 			const activityToSave: SavedActivity =
 				routeId !== activity.routeId ? { ...activity, routeId } : activity;

--- a/apps/geonexia/frontend/app/challenges/index.tsx
+++ b/apps/geonexia/frontend/app/challenges/index.tsx
@@ -38,6 +38,69 @@ function roundToHalf(km: number): number {
   return Math.round(km * 2) / 2;
 }
 
+/** Max additional km a single week's total distance may grow by. */
+const MAX_WEEKLY_INCREASE_KM = 5;
+
+interface WeekComputation {
+  newTotal: number;
+  newLongest: number;
+  debugInfo: string;
+}
+
+function computeVolumeWeek(prev: PrevState, isSecondBlock: boolean, inputDebug: string): WeekComputation {
+  const pct = isSecondBlock ? 0.10 : 0.08;
+  const increase = Math.min(prev.totalKm * pct, MAX_WEEKLY_INCREASE_KM);
+  const newTotal = roundToHalf(prev.totalKm + increase);
+  const longestIncrease = isSecondBlock ? 0.03 : 0.02;
+  const newLongest = roundToHalf(Math.min(prev.longestKm * (1 + longestIncrease), newTotal * 0.40));
+  const debugInfo =
+    `${inputDebug}\n` +
+    `Block ${isSecondBlock ? '2' : '1'} | ` +
+    `Gesamt: ${prev.totalKm} + ${increase.toFixed(1)} km (+${(pct * 100).toFixed(0)}%) = ${newTotal} km | ` +
+    `Langer Lauf: ${prev.longestKm} × ${(1 + longestIncrease).toFixed(2)} = ${newLongest} km (max 40% von ${newTotal} km)`;
+  return { newTotal, newLongest, debugInfo };
+}
+
+function computeLongRunWeek(prev: PrevState, isSecondBlock: boolean, inputDebug: string): WeekComputation {
+  const pct = isSecondBlock ? 0.12 : 0.10;
+  let newTotal: number;
+  const newLongest = roundToHalf(prev.longestKm * (1 + pct));
+  const diff = newLongest - prev.longestKm;
+  newTotal = roundToHalf(Math.min(prev.totalKm + diff, prev.totalKm + MAX_WEEKLY_INCREASE_KM));
+  if (newLongest > newTotal * 0.40) {
+    newTotal = roundToHalf(newLongest / 0.40);
+  }
+  const debugInfo =
+    `${inputDebug}\n` +
+    `Block ${isSecondBlock ? '2' : '1'} | ` +
+    `Langer Lauf: ${prev.longestKm} × ${(1 + pct).toFixed(2)} = ${newLongest} km (+${diff.toFixed(1)} km) | ` +
+    `Gesamt: ${newTotal} km (Diff + Total, max +5 km, LR ≤ 40%)`;
+  return { newTotal, newLongest, debugInfo };
+}
+
+function computeStabilizationWeek(prev: PrevState, isSecondBlock: boolean, inputDebug: string): WeekComputation {
+  const pct = isSecondBlock ? 0.05 : 0.03;
+  const increase = Math.min(prev.totalKm * pct, MAX_WEEKLY_INCREASE_KM);
+  const newTotal = roundToHalf(prev.totalKm + increase);
+  const newLongest = prev.longestKm;
+  const debugInfo =
+    `${inputDebug}\n` +
+    `Block ${isSecondBlock ? '2' : '1'} | ` +
+    `Gesamt: ${prev.totalKm} + ${increase.toFixed(1)} km (+${(pct * 100).toFixed(0)}%) = ${newTotal} km | ` +
+    `Langer Lauf: ${newLongest} km (unverändert)`;
+  return { newTotal, newLongest, debugInfo };
+}
+
+function computeDeloadWeek(prev: PrevState, inputDebug: string): WeekComputation {
+  const newTotal = roundToHalf(prev.totalKm * 0.75);
+  const newLongest = roundToHalf(prev.longestKm * 0.80);
+  const debugInfo =
+    `${inputDebug}\n` +
+    `Gesamt: ${prev.totalKm} × 0.75 = ${newTotal} km | ` +
+    `Langer Lauf: ${prev.longestKm} × 0.80 = ${newLongest} km`;
+  return { newTotal, newLongest, debugInfo };
+}
+
 /**
  * Compute the challenge for a given week index (1 = KW 1 of the year).
  * Returns the challenge description and the resulting state to carry forward.
@@ -58,7 +121,6 @@ function computeWeekChallenge(prev: PrevState, weekIndex: number): { challenge: 
   const mod = weekIndex % 4;
   const posIn8 = ((weekIndex - 1) % 8) + 1; // 1–8
   const isSecondBlock = posIn8 >= 5;
-  const MAX_WEEKLY_INCREASE_KM = 5;
 
   let type: ChallengeType;
   if (mod === 0) type = 'deload';
@@ -68,61 +130,25 @@ function computeWeekChallenge(prev: PrevState, weekIndex: number): { challenge: 
 
   const inputDebug = `Eingabe: Gesamt ${prev.totalKm} km | LR ${prev.longestKm} km | KW-Index ${weekIndex}`;
 
-  let newTotal: number;
-  let newLongest: number;
-  let debugInfo: string;
-
+  let computation: WeekComputation;
   switch (type) {
-    case 'volume': {
-      const pct = isSecondBlock ? 0.10 : 0.08;
-      const increase = Math.min(prev.totalKm * pct, MAX_WEEKLY_INCREASE_KM);
-      newTotal = roundToHalf(prev.totalKm + increase);
-      const longestIncrease = isSecondBlock ? 0.03 : 0.02;
-      newLongest = roundToHalf(Math.min(prev.longestKm * (1 + longestIncrease), newTotal * 0.40));
-      debugInfo =
-        `${inputDebug}\n` +
-        `Block ${isSecondBlock ? '2' : '1'} | ` +
-        `Gesamt: ${prev.totalKm} + ${increase.toFixed(1)} km (+${(pct * 100).toFixed(0)}%) = ${newTotal} km | ` +
-        `Langer Lauf: ${prev.longestKm} × ${(1 + longestIncrease).toFixed(2)} = ${newLongest} km (max 40% von ${newTotal} km)`;
+    case 'volume':
+      computation = computeVolumeWeek(prev, isSecondBlock, inputDebug);
       break;
-    }
-    case 'long-run': {
-      const pct = isSecondBlock ? 0.12 : 0.10;
-      newLongest = roundToHalf(prev.longestKm * (1 + pct));
-      const diff = newLongest - prev.longestKm;
-      newTotal = roundToHalf(Math.min(prev.totalKm + diff, prev.totalKm + MAX_WEEKLY_INCREASE_KM));
-      if (newLongest > newTotal * 0.40) {
-        newTotal = roundToHalf(newLongest / 0.40);
-      }
-      debugInfo =
-        `${inputDebug}\n` +
-        `Block ${isSecondBlock ? '2' : '1'} | ` +
-        `Langer Lauf: ${prev.longestKm} × ${(1 + pct).toFixed(2)} = ${newLongest} km (+${diff.toFixed(1)} km) | ` +
-        `Gesamt: ${newTotal} km (Diff + Total, max +5 km, LR ≤ 40%)`;
+    case 'long-run':
+      computation = computeLongRunWeek(prev, isSecondBlock, inputDebug);
       break;
-    }
-    case 'stabilization': {
-      const pct = isSecondBlock ? 0.05 : 0.03;
-      const increase = Math.min(prev.totalKm * pct, MAX_WEEKLY_INCREASE_KM);
-      newTotal = roundToHalf(prev.totalKm + increase);
-      newLongest = prev.longestKm;
-      debugInfo =
-        `${inputDebug}\n` +
-        `Block ${isSecondBlock ? '2' : '1'} | ` +
-        `Gesamt: ${prev.totalKm} + ${increase.toFixed(1)} km (+${(pct * 100).toFixed(0)}%) = ${newTotal} km | ` +
-        `Langer Lauf: ${newLongest} km (unverändert)`;
+    case 'stabilization':
+      computation = computeStabilizationWeek(prev, isSecondBlock, inputDebug);
       break;
-    }
-    case 'deload': {
-      newTotal = roundToHalf(prev.totalKm * 0.75);
-      newLongest = roundToHalf(prev.longestKm * 0.80);
-      debugInfo =
-        `${inputDebug}\n` +
-        `Gesamt: ${prev.totalKm} × 0.75 = ${newTotal} km | ` +
-        `Langer Lauf: ${prev.longestKm} × 0.80 = ${newLongest} km`;
+    case 'deload':
+      computation = computeDeloadWeek(prev, inputDebug);
       break;
-    }
   }
+
+  let newTotal = computation.newTotal;
+  let newLongest = computation.newLongest;
+  const debugInfo = computation.debugInfo;
 
   // Hard constraint: longest run must not exceed 40 % of total distance
   if (newLongest > newTotal * 0.40) {

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -38,9 +38,10 @@ import { SavedRoute, loadRoutes, saveRoute } from '../helpers/RouteStorage';
 import { buildRouteDisplayData, computeEdgesFromHexTiles, computeEdgesFromRoutePoints, computeHexBounds } from '../helpers/RouteDisplayHelper';
 import { HexTileRecord, BillboardAnchorPosition } from '../helpers/HexTileStorage';
 import { startRun, markVisited, markEnclosed, setHexTileCustomization, setBillboardAtAnchor, setTextureAdaptionAtAnchor, applyMapCustomizations, addWalkedEdges, addWalkedEdgesRedLine, HexTileCustomizationPayload } from '../store/hexTileSlice';
-import { setSportType, SPORT_TYPES, SportType } from '../store/sportTypeSlice';
-import { store, RootState } from '../store/store';
+import { setSportType, SPORT_TYPES, SportType, SportTypeDefinition } from '../store/sportTypeSlice';
+import { store, RootState, AppDispatch } from '../store/store';
 import { setHomeHexTile } from '../store/playerInformationSlice';
+import type { SpeechSettingsState } from '../store/speechSettingsSlice';
 import { resetMapSearchState, setMapSearchName, toggleMapSearchKey } from '../store/mapSearchSlice';
 import { buildJsonExportFilename, pickJsonFromFile, saveJsonToFile } from '../helpers/JsonFileTransferHelper';
 import { getLocales } from 'expo-localization';
@@ -362,52 +363,34 @@ type H3FeatureCollection = {
 	features: H3GeoJsonFeature[];
 };
 
-function buildH3GeoJson(
-	bounds: ViewportBounds,
-	zoom: number,
-	resolution: number,
-	showAlways: boolean,
-	hexTileRecords: Record<string, HexTileRecord>,
-	minZoom: number = H3_MIN_ZOOM_DEFAULT,
-): H3FeatureCollection {
-	if (!showAlways && zoom < minZoom) {
-		// At low zoom: hide the unvisited grid, but still show tiles that have been
-		// visited or enclosed (level > 0) so the user can see their overall progress.
-		const features: H3GeoJsonFeature[] = [];
-		for (const [cell, record] of Object.entries(hexTileRecords)) {
-			if (record.level <= 0) continue;
-			if (features.length >= H3_MAX_CELLS) break;
-			try {
-				const boundary = cellToBoundary(cell, H3_GEOJSON_ORDER);
-				if (boundary.length > 0) {
-					features.push({
-						type: 'Feature',
-						geometry: { type: 'Polygon', coordinates: [boundary as number[][]] },
-						properties: { h3Index: cell, level: record.level },
-					});
-				}
-			} catch {
-				// Skip invalid cells
+/**
+ * Build the low-zoom H3 feature set: hides the unvisited grid, but still shows
+ * tiles that have been visited or enclosed (level > 0) so the user can see
+ * their overall progress.
+ */
+function buildLowZoomH3Features(hexTileRecords: Record<string, HexTileRecord>): H3GeoJsonFeature[] {
+	const features: H3GeoJsonFeature[] = [];
+	for (const [cell, record] of Object.entries(hexTileRecords)) {
+		if (record.level <= 0) continue;
+		if (features.length >= H3_MAX_CELLS) break;
+		try {
+			const boundary = cellToBoundary(cell, H3_GEOJSON_ORDER);
+			if (boundary.length > 0) {
+				features.push({
+					type: 'Feature',
+					geometry: { type: 'Polygon', coordinates: [boundary as number[][]] },
+					properties: { h3Index: cell, level: record.level },
+				});
 			}
+		} catch {
+			// Skip invalid cells
 		}
-		return { type: 'FeatureCollection', features };
 	}
+	return features;
+}
 
-	// Fractional resolutions (e.g. 10.5) use the floor as the base integer
-	// resolution and visually subdivide each parent cell into its children at
-	// the next resolution level.  Whole-number resolutions use the existing
-	// behaviour (round to nearest integer so e.g. 10.9 still maps to res 11).
-	const isHalfResolution = resolution % 1 !== 0;
-	const h3Res = Math.max(
-		H3_RESOLUTION_MIN,
-		Math.min(H3_RESOLUTION_MAX, isHalfResolution ? Math.floor(resolution) : Math.round(resolution)),
-	);
-
-	const centerLat = (bounds.north + bounds.south) / 2;
-	const centerLng = (bounds.east + bounds.west) / 2;
-	const centerCell = latLngToCell(centerLat, centerLng, h3Res);
-
-	// Determine how many grid rings are needed to cover all four viewport corners.
+/** Determine how many grid rings are needed to cover all four viewport corners. */
+function computeMaxGridDistanceToCorners(bounds: ViewportBounds, h3Res: number, centerCell: string): number {
 	const corners: Array<[number, number]> = [
 		[bounds.north, bounds.east],
 		[bounds.north, bounds.west],
@@ -425,68 +408,116 @@ function buildH3GeoJson(
 			console.warn('[H3] gridDistance failed for corner cell:', err);
 		}
 	}
+	return maxK;
+}
 
+/**
+ * For fractional resolutions (e.g. 10.5) compute child hexes at the next
+ * integer resolution and color them in 7 colors: the center child gets white
+ * (colorIndex 0) and the 6 ring children get red, yellow, green, blue,
+ * purple, orange (colorIndex 1–6) in ring order.
+ */
+function buildHalfResolutionH3Features(
+	parentCells: string[],
+	h3Res: number,
+	hexTileRecords: Record<string, HexTileRecord>,
+): H3GeoJsonFeature[] {
+	const features: H3GeoJsonFeature[] = [];
+	const childRes = Math.min(H3_RESOLUTION_MAX, h3Res + 1);
+	for (const parentCell of parentCells) {
+		if (features.length >= H3_MAX_CELLS) break;
+		const parentLevel = hexTileRecords[parentCell]?.level ?? 0;
+		const centerChild = cellToCenterChild(parentCell, childRes);
+		if (!centerChild) continue;
+
+		// Center child → colorIndex 0 (white)
+		const centerBoundary = cellToBoundary(centerChild, H3_GEOJSON_ORDER);
+		if (centerBoundary.length > 0) {
+			features.push({
+				type: 'Feature',
+				geometry: { type: 'Polygon', coordinates: [centerBoundary as number[][]] },
+				properties: { h3Index: parentCell, level: parentLevel, colorIndex: 0 },
+			});
+		}
+
+		// Ring children → colorIndex 1–6
+		let ringChildren: string[] = [];
+		try {
+			ringChildren = gridRingUnsafe(centerChild, 1).filter(
+				(c) => cellToParent(c, h3Res) === parentCell,
+			);
+		} catch (err) {
+			// gridRingUnsafe can throw for pentagon cells; skip ring for those
+			console.warn('[H3] gridRingUnsafe failed for centerChild', centerChild, err);
+		}
+		for (let i = 0; i < ringChildren.length; i++) {
+			if (features.length >= H3_MAX_CELLS) break;
+			const child = ringChildren[i];
+			const boundary = cellToBoundary(child, H3_GEOJSON_ORDER);
+			if (boundary.length > 0) {
+				features.push({
+					type: 'Feature',
+					geometry: { type: 'Polygon', coordinates: [boundary as number[][]] },
+					properties: { h3Index: parentCell, level: parentLevel, colorIndex: i + 1 },
+				});
+			}
+		}
+	}
+	return features;
+}
+
+/** Whole-number resolutions: one feature per parent cell at the base resolution. */
+function buildWholeResolutionH3Features(
+	parentCells: string[],
+	hexTileRecords: Record<string, HexTileRecord>,
+): H3GeoJsonFeature[] {
+	const features: H3GeoJsonFeature[] = [];
+	for (const cell of parentCells) {
+		if (features.length >= H3_MAX_CELLS) break;
+		const boundary = cellToBoundary(cell, H3_GEOJSON_ORDER);
+		// H3_GEOJSON_ORDER=true already closes the ring; no need to append boundary[0] again.
+		features.push({
+			type: 'Feature',
+			geometry: { type: 'Polygon', coordinates: [boundary as number[][]] },
+			properties: { h3Index: cell, level: hexTileRecords[cell]?.level ?? 0 },
+		});
+	}
+	return features;
+}
+
+function buildH3GeoJson(
+	bounds: ViewportBounds,
+	zoom: number,
+	resolution: number,
+	showAlways: boolean,
+	hexTileRecords: Record<string, HexTileRecord>,
+	minZoom: number = H3_MIN_ZOOM_DEFAULT,
+): H3FeatureCollection {
+	if (!showAlways && zoom < minZoom) {
+		return { type: 'FeatureCollection', features: buildLowZoomH3Features(hexTileRecords) };
+	}
+
+	// Fractional resolutions (e.g. 10.5) use the floor as the base integer
+	// resolution and visually subdivide each parent cell into its children at
+	// the next resolution level.  Whole-number resolutions use the existing
+	// behaviour (round to nearest integer so e.g. 10.9 still maps to res 11).
+	const isHalfResolution = resolution % 1 !== 0;
+	const h3Res = Math.max(
+		H3_RESOLUTION_MIN,
+		Math.min(H3_RESOLUTION_MAX, isHalfResolution ? Math.floor(resolution) : Math.round(resolution)),
+	);
+
+	const centerLat = (bounds.north + bounds.south) / 2;
+	const centerLng = (bounds.east + bounds.west) / 2;
+	const centerCell = latLngToCell(centerLat, centerLng, h3Res);
+
+	const maxK = computeMaxGridDistanceToCorners(bounds, h3Res, centerCell);
 	const k = Math.min(maxK + 1, 30);
 	const parentCells = gridDisk(centerCell, k);
 
-	const features: H3GeoJsonFeature[] = [];
-	if (isHalfResolution) {
-		// For fractional resolutions (e.g. 10.5) we compute child hexes at the
-		// next integer resolution and color them in 7 colors: the center child
-		// gets white (colorIndex 0) and the 6 ring children get red, yellow,
-		// green, blue, purple, orange (colorIndex 1–6) in ring order.
-		const childRes = Math.min(H3_RESOLUTION_MAX, h3Res + 1);
-		for (const parentCell of parentCells) {
-			if (features.length >= H3_MAX_CELLS) break;
-			const parentLevel = hexTileRecords[parentCell]?.level ?? 0;
-			const centerChild = cellToCenterChild(parentCell, childRes);
-			if (!centerChild) continue;
-
-			// Center child → colorIndex 0 (white)
-			const centerBoundary = cellToBoundary(centerChild, H3_GEOJSON_ORDER);
-			if (centerBoundary.length > 0) {
-				features.push({
-					type: 'Feature',
-					geometry: { type: 'Polygon', coordinates: [centerBoundary as number[][]] },
-					properties: { h3Index: parentCell, level: parentLevel, colorIndex: 0 },
-				});
-			}
-
-			// Ring children → colorIndex 1–6
-			let ringChildren: string[] = [];
-			try {
-				ringChildren = gridRingUnsafe(centerChild, 1).filter(
-					(c) => cellToParent(c, h3Res) === parentCell,
-				);
-			} catch (err) {
-				// gridRingUnsafe can throw for pentagon cells; skip ring for those
-				console.warn('[H3] gridRingUnsafe failed for centerChild', centerChild, err);
-			}
-			for (let i = 0; i < ringChildren.length; i++) {
-				if (features.length >= H3_MAX_CELLS) break;
-				const child = ringChildren[i];
-				const boundary = cellToBoundary(child, H3_GEOJSON_ORDER);
-				if (boundary.length > 0) {
-					features.push({
-						type: 'Feature',
-						geometry: { type: 'Polygon', coordinates: [boundary as number[][]] },
-						properties: { h3Index: parentCell, level: parentLevel, colorIndex: i + 1 },
-					});
-				}
-			}
-		}
-	} else {
-		for (const cell of parentCells) {
-			if (features.length >= H3_MAX_CELLS) break;
-			const boundary = cellToBoundary(cell, H3_GEOJSON_ORDER);
-			// H3_GEOJSON_ORDER=true already closes the ring; no need to append boundary[0] again.
-			features.push({
-				type: 'Feature',
-				geometry: { type: 'Polygon', coordinates: [boundary as number[][]] },
-				properties: { h3Index: cell, level: hexTileRecords[cell]?.level ?? 0 },
-			});
-		}
-	}
+	const features: H3GeoJsonFeature[] = isHalfResolution
+		? buildHalfResolutionH3Features(parentCells, h3Res, hexTileRecords)
+		: buildWholeResolutionH3Features(parentCells, hexTileRecords);
 
 	return { type: 'FeatureCollection', features };
 }
@@ -1011,30 +1042,25 @@ function generateMeasureRoutePoints(
 	return points;
 }
 
-function computeStats(points: RoutePoint[]): RunStats {
-	if (points.length < 2) {
-		const durationSeconds = points.length === 1 ? (Date.now() - points[0].timestamp) / 1000 : 0;
-		return {
-			distanceKm: 0,
-			durationSeconds,
-			paceMinPerKm: 0,
-			maxSpeedKmh: 0,
-			minSpeedKmh: 0,
-			avgSpeedKmh: 0,
-			medianSpeedKmh: 0,
-			kcal: 0,
-			steps: 0,
-			elevationGainM: 0,
-			elevationLossM: 0,
-			fluidNeedsMl: 0,
-		};
-	}
+type RouteSegmentAccumulation = {
+	distanceKm: number;
+	elevationGainM: number;
+	elevationLossM: number;
+	speedsKmh: number[];
+	speedDistanceKm: number;
+	speedDurationSeconds: number;
+};
 
+/**
+ * Walk consecutive route points accumulating total distance, elevation
+ * gain/loss, and the per-segment speed samples (once the GPS warm-up period
+ * has elapsed) used for the max/min/avg/median speed stats.
+ */
+function accumulateRouteSegments(points: RoutePoint[], startTimestamp: number): RouteSegmentAccumulation {
 	let distanceKm = 0;
 	let elevationGainM = 0;
 	let elevationLossM = 0;
 	const speedsKmh: number[] = [];
-	const startTimestamp = points[0].timestamp;
 	let speedDistanceKm = 0;
 	let speedDurationSeconds = 0;
 
@@ -1063,8 +1089,11 @@ function computeStats(points: RoutePoint[]): RunStats {
 		}
 	}
 
-	const durationSeconds = (points.at(-1)!.timestamp - points[0].timestamp) / 1000;
-	const paceMinPerKm = distanceKm > 0 ? durationSeconds / 60 / distanceKm : 0;
+	return { distanceKm, elevationGainM, elevationLossM, speedsKmh, speedDistanceKm, speedDurationSeconds };
+}
+
+/** Smooths raw per-segment speeds with a trailing moving-average window. */
+function computeWindowedSpeeds(speedsKmh: number[]): number[] {
 	const windowedSpeeds: number[] = [];
 	let windowSum = 0;
 	for (let i = 0; i < speedsKmh.length; i++) {
@@ -1072,15 +1101,47 @@ function computeStats(points: RoutePoint[]): RunStats {
 		if (i >= SPEED_WINDOW_SIZE) windowSum -= speedsKmh[i - SPEED_WINDOW_SIZE];
 		windowedSpeeds.push(windowSum / Math.min(i + 1, SPEED_WINDOW_SIZE));
 	}
+	return windowedSpeeds;
+}
+
+/** Median of the raw (non-windowed) per-segment speeds. */
+function computeMedianSpeed(speedsKmh: number[]): number {
+	if (speedsKmh.length === 0) return 0;
+	const sorted = [...speedsKmh].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function computeStats(points: RoutePoint[]): RunStats {
+	if (points.length < 2) {
+		const durationSeconds = points.length === 1 ? (Date.now() - points[0].timestamp) / 1000 : 0;
+		return {
+			distanceKm: 0,
+			durationSeconds,
+			paceMinPerKm: 0,
+			maxSpeedKmh: 0,
+			minSpeedKmh: 0,
+			avgSpeedKmh: 0,
+			medianSpeedKmh: 0,
+			kcal: 0,
+			steps: 0,
+			elevationGainM: 0,
+			elevationLossM: 0,
+			fluidNeedsMl: 0,
+		};
+	}
+
+	const startTimestamp = points[0].timestamp;
+	const { distanceKm, elevationGainM, elevationLossM, speedsKmh, speedDistanceKm, speedDurationSeconds } =
+		accumulateRouteSegments(points, startTimestamp);
+
+	const durationSeconds = (points.at(-1)!.timestamp - points[0].timestamp) / 1000;
+	const paceMinPerKm = distanceKm > 0 ? durationSeconds / 60 / distanceKm : 0;
+	const windowedSpeeds = computeWindowedSpeeds(speedsKmh);
 	const maxSpeedKmh = windowedSpeeds.length > 0 ? Math.max(...windowedSpeeds) : 0;
 	const minSpeedKmh = windowedSpeeds.length > 0 ? Math.min(...windowedSpeeds) : 0;
 	const avgSpeedKmh = speedDurationSeconds > 0 ? (speedDistanceKm / speedDurationSeconds) * 3600 : 0;
-	const medianSpeedKmh = (() => {
-		if (speedsKmh.length === 0) return 0;
-		const sorted = [...speedsKmh].sort((a, b) => a - b);
-		const mid = Math.floor(sorted.length / 2);
-		return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-	})();
+	const medianSpeedKmh = computeMedianSpeed(speedsKmh);
 	const kcal = Math.round(distanceKm * DEFAULT_RUNNER_WEIGHT_KG * KCAL_PER_KG_PER_KM);
 	const steps = Math.round((distanceKm * 1000) / AVERAGE_STRIDE_LENGTH_METERS);
 	const fluidNeedsMl = Math.round((durationSeconds / FLUID_BASELINE_DURATION_SECONDS) * FLUID_BASELINE_ML);
@@ -2892,6 +2953,1186 @@ function InterruptedRecoveryContent({
 	);
 }
 
+// ─── RecordScreen: loadAndSendCustomizations helpers ──────────────────────────
+
+/** Image overlay entry sent to the map for a customized hex tile's terrain texture. */
+type TileImageOverlay = {
+	id: string;
+	url: string;
+	coordinates: [[number, number], [number, number], [number, number], [number, number]];
+	opacity: number;
+	// Actual H3 hex vertices in [lng, lat] order for precise canvas clipping.
+	polygonCoords: [number, number][];
+	// Bearing from hex center to its first vertex (radians, 0 = North, CW positive).
+	// Used to rotate the texture so it aligns with the H3 hex orientation.
+	rotation: number;
+};
+
+/**
+ * Build the tile-image overlays (per customized hex tile) sent to the map as
+ * MapLibre image sources, one per tile that has a `tileImage` customization.
+ */
+async function buildTileImageOverlays(
+	records: Record<string, HexTileRecord>,
+	textureAnchors: RootState['hexTextureConfig']['spriteAnchors'],
+	currentHexTextureOpacity: number,
+	loadAssetUrl: (cacheKey: string, moduleId: number, mimeType: string) => Promise<string | null>,
+): Promise<TileImageOverlay[]> {
+	// Flat lookup: terrain asset key → { moduleId, mimeType }
+	const terrainLookup = new Map<string, { moduleId: number; mimeType: string }>();
+	for (const assets of Object.values(TERRAIN_ASSETS)) {
+		for (const entry of assets) {
+			terrainLookup.set(entry.key, { moduleId: entry.source as number, mimeType: entry.mimeType ?? 'image/svg+xml' });
+		}
+	}
+
+	const imageOverlays: TileImageOverlay[] = [];
+
+	for (const [h3Index, record] of Object.entries(records)) {
+		// ── Tile image overlay ──────────────────────────────────────────────
+		if (record.tileImage) {
+			const terrainEntry = terrainLookup.get(record.tileImage);
+			if (terrainEntry !== undefined) {
+				const url = await loadAssetUrl(`terrain:${record.tileImage}`, terrainEntry.moduleId, terrainEntry.mimeType);
+				if (url) {
+					// Compute the bounding box of the hexagon in [lng, lat] GeoJSON order.
+					const boundary = cellToBoundary(h3Index); // [[lat, lng], ...]
+					if (boundary.length >= 3) {
+						let minLat = Infinity, maxLat = -Infinity;
+						let minLng = Infinity, maxLng = -Infinity;
+						for (const [lat, lng] of boundary) {
+							if (lat < minLat) minLat = lat;
+							if (lat > maxLat) maxLat = lat;
+							if (lng < minLng) minLng = lng;
+							if (lng > maxLng) maxLng = lng;
+						}
+						// Compute the geographic bearing (azimuth) from the hex center to its first
+						// vertex. Math.cos(centerLat) corrects the longitude delta for the fact that
+						// 1° of longitude covers less ground at higher latitudes. atan2(x, y) with
+						// (dlng, dlat) gives the angle measured clockwise from North, which is the
+						// standard geographic convention (0 = North, π/2 = East).
+						const centerLat = (minLat + maxLat) / 2;
+						const centerLng = (minLng + maxLng) / 2;
+						const v0 = boundary[0];
+						const dlat = v0[0] - centerLat;
+						const dlng = (v0[1] - centerLng) * Math.cos(centerLat * Math.PI / 180);
+						const rotation = Math.atan2(dlng, dlat); // radians CW from North
+
+						// Apply per-terrain anchor/scale overrides from hex texture config.
+						const terrainOverride = textureAnchors[record.tileImage];
+						const texAnchorX = terrainOverride?.anchorX ?? 0.5;
+						const texAnchorY = terrainOverride?.anchorY ?? 0.5;
+						const texScale = terrainOverride?.scaleMultiplier ?? 1.0;
+						const bboxW = maxLng - minLng;
+						const bboxH = maxLat - minLat;
+						// Scale > 1 enlarges the image overlay so the hex clips a zoomed-in
+						// portion of the texture (matching the HexFieldPreview behaviour).
+						const scaledW = bboxW * texScale;
+						const scaledH = bboxH * texScale;
+						// Pin the anchor fraction of the image to the hex center.
+						// This keeps the texture centred at scale 1 and lets the anchor
+						// shift which part of the image is visible at other scales.
+						// centerLng/centerLat are already computed above for the rotation calc.
+						const adjMinLng = centerLng - texAnchorX * scaledW;
+						const adjMaxLng = centerLng + (1 - texAnchorX) * scaledW;
+						const adjMinLat = centerLat - texAnchorY * scaledH;
+						const adjMaxLat = centerLat + (1 - texAnchorY) * scaledH;
+
+						imageOverlays.push({
+							id: `tile-img-${h3Index}`,
+							url,
+							// MapLibre image source format: top-left, top-right, bottom-right, bottom-left
+							coordinates: [
+								[adjMinLng, adjMaxLat],
+								[adjMaxLng, adjMaxLat],
+								[adjMaxLng, adjMinLat],
+								[adjMinLng, adjMinLat],
+							],
+							opacity: currentHexTextureOpacity,
+							// Actual hex vertices in [lng, lat] for canvas polygon clipping.
+							polygonCoords: boundary.map(([lat, lng]) => [lng, lat] as [number, number]),
+							rotation,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	return imageOverlays;
+}
+
+type BillboardFeature = {
+	type: 'Feature';
+	geometry: { type: 'Point'; coordinates: [number, number] };
+	properties: { iconKey: string; iconSizeAtRefZoom: number; anchorX: number; anchorY: number; flat: boolean };
+};
+
+type BillboardOverlaysResult = {
+	images: Record<string, { url: string }>;
+	features: BillboardFeature[];
+};
+
+/**
+ * Build the billboard GeoJSON symbol-layer data (images + point features) sent
+ * to the map: Hex Texture Adaptions (always flat) and Hex Objects (face-camera
+ * by default, with legacy per-anchor flat flag support).
+ *
+ * Billboards are rendered as a MapLibre symbol layer whose icon-size is set to
+ * a fixed value per feature. The zoom-based exponential expression in the
+ * MapLibre HTML ensures the icon scales proportionally with the map so that
+ * each billboard occupies a constant geographic area. Billboard size also
+ * scales with the H3 edge length: larger on bigger hexagons, smaller on
+ * smaller ones.
+ *
+ * Each unique billboard SVG is rasterized at 4× resolution (512×512 actual pixels
+ * for a 128×128 logical icon) via canvas + pixelRatio, keeping SVGs crisp when
+ * zoomed in or on high-DPI screens. Features carry an iconSizeAtRefZoom property
+ * (= desiredPixelSize / BILLBOARD_STANDARD_ICON_SIZE at zoom 14) so the layer's
+ * icon-size zoom expression scales it correctly at all zoom levels.
+ * NOTE: Keep this value in sync with BILLBOARD_ICON_SIZE in the MapLibre HTML.
+ */
+async function buildBillboardOverlays(
+	records: Record<string, HexTileRecord>,
+	spriteAnchors: RootState['billboardConfig']['spriteAnchors'],
+	billboardScaleRef: React.MutableRefObject<number>,
+	currentHexTextureAdaptionOpacity: number,
+	currentHexObjectOpacity: number,
+	loadAssetUrl: (cacheKey: string, moduleId: number, mimeType: string) => Promise<string | null>,
+): Promise<BillboardOverlaysResult> {
+	// Billboard pixel size is determined by the sprite's scaleFactor, the
+	// user-adjustable billboard scale multiplier, AND the H3 edge length ratio
+	// relative to the reference resolution (10). This makes billboards larger on
+	// bigger hexagons and smaller on smaller ones.
+	// townhall (scaleFactor 7.0) renders at 7 × BILLBOARD_UNIT_PX ≈ 48 px at zoom 14
+	// at the reference resolution.
+	const BILLBOARD_STANDARD_ICON_SIZE = 128;
+
+	const billboardImages: Record<string, { url: string }> = {};
+	const billboardFeatures: BillboardFeature[] = [];
+
+	for (const [h3Index, record] of Object.entries(records)) {
+		// Build effective billboard maps for Hex Objects and Hex Texture Adaptions.
+		const effectiveBillboards = getEffectiveBillboards(record);
+		const effectiveBillboardsTexture = getEffectiveBillboardsTexture(record);
+		// Per-anchor flat flags (legacy; used only for old `billboards` data).
+		const effectiveFlat = getEffectiveBillboardsFlat(record);
+
+		const hasBillboards = Object.keys(effectiveBillboards).length > 0;
+		const hasTextureAdaptions = Object.keys(effectiveBillboardsTexture).length > 0;
+		if (!hasBillboards && !hasTextureAdaptions) continue;
+
+		// Compute hex boundary (centroid + vertices) once per tile.
+		const boundary = cellToBoundary(h3Index, H3_GEOJSON_ORDER); // [[lng, lat], ...]
+		let sumLng = 0, sumLat = 0;
+		const n = boundary.length - 1;
+		if (n <= 0) continue;
+		for (let j = 0; j < n; j++) {
+			const [bLng, bLat] = boundary[j] as [number, number];
+			sumLng += bLng;
+			sumLat += bLat;
+		}
+		const centerLng = sumLng / n;
+		const centerLat = sumLat / n;
+
+		// Size constants for this tile's resolution (shared across all anchors).
+		const cellRes = getResolution(h3Index);
+		const clampedRes = Math.max(0, Math.min(cellRes, H3_EDGE_LENGTH_KM.length - 1));
+		const edgeLengthRatio = H3_EDGE_LENGTH_KM[clampedRes] / H3_EDGE_LENGTH_KM[BILLBOARD_REFERENCE_RESOLUTION];
+
+		// ── Hex Texture Adaptions (always flat on the map surface) ────────────
+		for (const [anchorColor, billboardKey] of Object.entries(effectiveBillboardsTexture)) {
+			const parsed = parseBillboardKey(billboardKey);
+			if (!parsed) continue;
+			const { sprite, idx } = parsed;
+			const url = await loadAssetUrl(billboardKey, sprite.source as number, 'image/svg+xml');
+			if (!url) continue;
+
+			const iconKey = `billboard-${billboardKey}`;
+			const anchorOverride = spriteAnchors[idx];
+			const anchorX = anchorOverride?.anchorX ?? sprite.anchorX;
+			const anchorY = anchorOverride?.anchorY ?? sprite.anchorY;
+			const [lng, lat] = resolveAnchorPosition(anchorColor, boundary, n, centerLng, centerLat);
+			const perSpriteScale = anchorOverride?.scaleMultiplier ?? 1.0;
+			const billboardSizePx = Math.max(BILLBOARD_MIN_SIZE_PX, Math.round(
+				BILLBOARD_UNIT_PX * sprite.scaleFactor * billboardScaleRef.current * perSpriteScale * edgeLengthRatio,
+			));
+			const iconSizeAtRefZoom = billboardSizePx / BILLBOARD_STANDARD_ICON_SIZE;
+
+			if (!billboardImages[iconKey]) {
+				billboardImages[iconKey] = { url };
+			}
+			// Hex Texture Adaptions are always flat and rotated by the position angle.
+			const textureRotation = getAnchorAngleDeg(anchorColor);
+			billboardFeatures.push({
+				type: 'Feature',
+				geometry: { type: 'Point', coordinates: [lng, lat] },
+				properties: { iconKey, iconSizeAtRefZoom, anchorX, anchorY, flat: true, opacity: currentHexTextureAdaptionOpacity, textureRotation },
+			});
+		}
+
+		// ── Hex Objects (face-camera; legacy billboardsFlat flag still respected) ──
+		for (const [anchorColor, billboardKey] of Object.entries(effectiveBillboards)) {
+			const parsed = parseBillboardKey(billboardKey);
+			if (!parsed) continue;
+			const { sprite, idx } = parsed;
+			const url = await loadAssetUrl(billboardKey, sprite.source as number, 'image/svg+xml');
+			if (!url) continue;
+
+			const iconKey = `billboard-${billboardKey}`;
+			const anchorOverride = spriteAnchors[idx];
+			const anchorX = anchorOverride?.anchorX ?? sprite.anchorX;
+			const anchorY = anchorOverride?.anchorY ?? sprite.anchorY;
+			const [lng, lat] = resolveAnchorPosition(anchorColor, boundary, n, centerLng, centerLat);
+			const perSpriteScale = anchorOverride?.scaleMultiplier ?? 1.0;
+			const billboardSizePx = Math.max(BILLBOARD_MIN_SIZE_PX, Math.round(
+				BILLBOARD_UNIT_PX * sprite.scaleFactor * billboardScaleRef.current * perSpriteScale * edgeLengthRatio,
+			));
+			const iconSizeAtRefZoom = billboardSizePx / BILLBOARD_STANDARD_ICON_SIZE;
+
+			// Hex Objects are face-camera by default; legacy per-anchor flat flag
+			// is still respected for backward compatibility with existing data.
+			const flat = effectiveFlat[anchorColor] === true;
+
+			if (!billboardImages[iconKey]) {
+				billboardImages[iconKey] = { url };
+			}
+			billboardFeatures.push({
+				type: 'Feature',
+				geometry: { type: 'Point', coordinates: [lng, lat] },
+				properties: { iconKey, iconSizeAtRefZoom, anchorX, anchorY, flat, opacity: currentHexObjectOpacity },
+			});
+		}
+	}
+
+	return { images: billboardImages, features: billboardFeatures };
+}
+
+// ─── RecordScreen: handleMapMessage helpers ────────────────────────────────────
+
+/** Handles the 'MapComponentMounted' map message: activates the hex tile
+ * layer, resends the current route (if any) and player position, and
+ * (re)sends the current tile/billboard customizations. */
+function handleMapComponentMounted(
+	mapRef: React.MutableRefObject<MyMapHandle | null>,
+	routePointsRef: React.MutableRefObject<RoutePoint[]>,
+	debugPlayerPositionRef: React.MutableRefObject<{ lat: number; lng: number } | null>,
+	sendRouteToMap: (points: RoutePoint[]) => void,
+	centerMapOnPosition: (pos: { lat: number; lng: number }, zoom?: number) => void,
+	loadAndSendCustomizations: () => void,
+): void {
+	// Activate hex tile layer. strokeColor is intentionally omitted so that
+	// the default gray value defined in hexTileScript.ts is preserved.
+	const { hexLineOpacity: initHexLineOpacity, hexLineWidth: initHexLineWidth } = store.getState().displaySettings;
+	mapRef.current?.sendToMap({
+		hexTileLayer: { color: 'rgba(0, 0, 0, 0)', opacityMax: 0, lineOpacity: initHexLineOpacity, lineWidth: initHexLineWidth },
+	});
+	if (routePointsRef.current.length > 0) {
+		sendRouteToMap(routePointsRef.current);
+	}
+	const pos = debugPlayerPositionRef.current;
+	if (pos) {
+		centerMapOnPosition(pos);
+	}
+	// Send any already-selected tile images to the map.
+	loadAndSendCustomizations();
+}
+
+/** Handles the 'MapViewportChanged' map message: shows the selected route's
+ * preview tiles/walk-path when a route is selected pre-recording, otherwise
+ * refreshes the normal (global) tile display for the new viewport. */
+function handleMapViewportChanged(
+	vp: { bounds: ViewportBounds; zoom: number },
+	selectedRouteRef: React.MutableRefObject<SavedRoute | null>,
+	isRecordingRef: React.MutableRefObject<boolean>,
+	debugViewportRef: React.MutableRefObject<DebugViewportInfo | null>,
+	mapRef: React.MutableRefObject<MyMapHandle | null>,
+	refreshNormalTileDisplay: (vp: { bounds: ViewportBounds; zoom: number }) => void,
+): void {
+	debugViewportRef.current = { bounds: vp.bounds, zoom: vp.zoom, tileCount: 0 };
+
+	// When a route is selected (pre-recording), show only the route's tiles
+	// and walk path instead of the full global tile set.
+	if (selectedRouteRef.current && !isRecordingRef.current) {
+		try {
+			const { hexTileGeoJson, hexWalkPathGeoJson } = buildRouteDisplayData(
+				selectedRouteRef.current,
+				store.getState().hexTiles.records,
+			);
+			debugViewportRef.current.tileCount = hexTileGeoJson.features.length;
+			mapRef.current?.sendToMap({ hexTileGeoJson });
+			mapRef.current?.sendToMap({ hexWalkPathGeoJson });
+		} catch (err) {
+			console.warn('[RecordScreen] Route preview viewport update failed:', err);
+		}
+	} else {
+		refreshNormalTileDisplay(vp);
+	}
+}
+
+/** Handles the 'HexTileClicked' map message: dispatches to whichever click
+ * mode (set-home, coloring, magnify, or default tile-info) is currently active. */
+function handleHexTileClicked(
+	clickedMsg: { h3Index?: string; mapFeatures?: MapFeatureInfo[] },
+	isSettingHomeRef: React.MutableRefObject<boolean>,
+	setIsSettingHome: (val: boolean) => void,
+	coloringTileImageRef: React.MutableRefObject<string | null>,
+	isMagnifyModeRef: React.MutableRefObject<boolean>,
+	showMagnifyHexTileModal: (h3Index: string) => void,
+	showHexTileModal: (h3Index: string) => void,
+	dispatch: AppDispatch,
+): void {
+	if (clickedMsg.h3Index) {
+		if (isSettingHomeRef.current) {
+			// Set-home mode: place castle2 at the center of the selected tile
+			// and store it as the player's home.
+			const newHomeHex = clickedMsg.h3Index;
+			dispatch(setBillboardAtAnchor({
+				h3Index: newHomeHex,
+				anchorColor: BillboardAnchorPosition.CENTER,
+				billboard: BILLBOARD_CASTLE2_KEY,
+			}));
+			dispatch(setHomeHexTile(newHomeHex));
+			isSettingHomeRef.current = false;
+			setIsSettingHome(false);
+		} else if (coloringTileImageRef.current !== null) {
+			// Coloring mode active: directly apply the selected tile image.
+			dispatch(setHexTileCustomization({ h3Index: clickedMsg.h3Index, tileImage: coloringTileImageRef.current }));
+		} else if (isMagnifyModeRef.current) {
+			// Magnify mode active: show detailed map info modal.
+			showMagnifyHexTileModal(clickedMsg.h3Index);
+		} else {
+			showHexTileModal(clickedMsg.h3Index);
+		}
+	}
+}
+
+/** Handles the 'MapMeasurePoint' map message: appends the tapped point to the
+ * in-progress measure route while measure mode is active. */
+function handleMapMeasurePoint(
+	ptMsg: { lat: number; lng: number },
+	isMeasureModeRef: React.MutableRefObject<boolean>,
+	measureWaypointsRef: React.MutableRefObject<Array<{ lat: number; lng: number }>>,
+	mapRef: React.MutableRefObject<MyMapHandle | null>,
+): void {
+	if (isMeasureModeRef.current) {
+		const newWaypoints = [...measureWaypointsRef.current, { lat: ptMsg.lat, lng: ptMsg.lng }];
+		measureWaypointsRef.current = newWaypoints;
+		const coords = newWaypoints.map((w) => [w.lng, w.lat]);
+		mapRef.current?.sendToMap({ measureRouteCoords: coords });
+		mapRef.current?.sendToMap({ measurePoints: coords });
+	}
+}
+
+// ─── RecordScreen: handleLocationUpdate helpers ────────────────────────────────
+
+/** Handles a location update while a recording is paused: updates the visual
+ * player marker (without recording GPS points or marking hex tiles) and keeps
+ * the GPS speed-filter reference in sync. */
+function applyPausedLocationUpdate(
+	point: RoutePoint,
+	fromJoystick: boolean,
+	appActive: boolean,
+	movedPlayerManuallyRef: React.MutableRefObject<boolean>,
+	debugPlayerPositionRef: React.MutableRefObject<{ lat: number; lng: number } | null>,
+	lastAcceptedGpsPointRef: React.MutableRefObject<RoutePoint | null>,
+	mapRef: React.MutableRefObject<MyMapHandle | null>,
+	centerMapOnPosition: (pos: { lat: number; lng: number }, zoom?: number) => void,
+): void {
+	// For real GPS: skip if the user already overrode the position with the
+	// joystick before pausing – this mirrors the active-recording behaviour and
+	// prevents GPS from snapping the marker back while the user navigates
+	// virtually during the pause.
+	const shouldUpdate = fromJoystick || !movedPlayerManuallyRef.current;
+	if (shouldUpdate) {
+		debugPlayerPositionRef.current = { lat: point.lat, lng: point.lng };
+		if (appActive) {
+			mapRef.current?.sendToMap({ userLocation: { lat: point.lat, lng: point.lng } });
+			centerMapOnPosition({ lat: point.lat, lng: point.lng });
+		}
+		// Advance the accepted-point ref for real GPS so the speed filter works
+		// correctly on the first GPS point recorded after resume.
+		if (!fromJoystick) {
+			lastAcceptedGpsPointRef.current = point;
+		}
+	}
+}
+
+/**
+ * GPS speed/interval filter applied to real (non-joystick) GPS fixes.
+ * Returns true when the point should be discarded as noise/glitch/too-frequent;
+ * otherwise records it as the last accepted GPS point (matching the original
+ * inline behaviour) and returns false.
+ */
+function maybeFilterGpsPoint(
+	fromJoystick: boolean,
+	point: RoutePoint,
+	isRecordingRef: React.MutableRefObject<boolean>,
+	joystickActiveRef: React.MutableRefObject<boolean>,
+	movedPlayerManuallyRef: React.MutableRefObject<boolean>,
+	lastAcceptedGpsPointRef: React.MutableRefObject<RoutePoint | null>,
+	selectedSportTypeRef: React.MutableRefObject<SportType>,
+): boolean {
+	if (fromJoystick) return false;
+
+	// While the joystick is actively held during a recording, skip GPS
+	// route points entirely. The joystick is providing the authoritative
+	// position; adding a real GPS fix would create a visible jump in the
+	// recorded route from the virtual joystick position back to the
+	// physical GPS location.
+	if (isRecordingRef.current && (joystickActiveRef.current || movedPlayerManuallyRef.current)) {
+		return true;
+	}
+
+	const lastAccepted = lastAcceptedGpsPointRef.current;
+	if (lastAccepted) {
+		const dtSec = (point.timestamp - lastAccepted.timestamp) / 1000;
+
+		// ── GPS time-interval filter ──────────────────────────────────────────
+		// During recording, skip this point if the elapsed time since the last
+		// accepted GPS fix is less than 95 % of the configured GPS interval.
+		// This prevents the platform from delivering points more frequently than
+		// the user-selected accuracy setting, which would result in too many
+		// recorded GPS points.
+		if (isRecordingRef.current) {
+			const gpsIntervalSeconds = store.getState().gpsInterval.intervalSeconds;
+			const minElapsedSec = gpsIntervalSeconds * 0.95;
+			if (dtSec < minElapsedSec) {
+				return true;
+			}
+		}
+
+		if (dtSec > 0) {
+			const distKm = haversineKm(lastAccepted.lat, lastAccepted.lng, point.lat, point.lng);
+			const impliedSpeedKmh = (distKm / dtSec) * 3600;
+			const activeSportDef = SPORT_TYPES.find((s) => s.type === selectedSportTypeRef.current);
+			const maxSpeedKmh = activeSportDef?.maxSpeedKmh ?? 250;
+			if (impliedSpeedKmh > maxSpeedKmh) {
+				console.warn(
+					`[RecordScreen] GPS point filtered: implied speed ${impliedSpeedKmh.toFixed(1)} km/h` +
+					` exceeds max ${maxSpeedKmh} km/h for sport "${selectedSportTypeRef.current}".`,
+				);
+				return true;
+			}
+		}
+	}
+	lastAcceptedGpsPointRef.current = point;
+	return false;
+}
+
+/** Tracks the H3 cell (and finer red-line cell) visited by this GPS/joystick
+ * point: fills in gap cells across GPS dropouts, dispatches markVisited for
+ * newly-visited cells, and records walked edges for both the standard and
+ * red-line resolutions. */
+function trackVisitedHexCells(
+	point: RoutePoint,
+	h3ResolutionRef: React.MutableRefObject<number>,
+	lastCellRef: React.MutableRefObject<string | null>,
+	visitedHexIdsRef: React.MutableRefObject<Set<string>>,
+	orderedHexTilesRef: React.MutableRefObject<string[]>,
+	lastRedLineCellRef: React.MutableRefObject<string | null>,
+	dispatch: AppDispatch,
+): void {
+	if (isH3Available()) {
+		try {
+			// Use the same base integer resolution as buildH3GeoJson so that the
+			// visited cell ID matches the keys in the GeoJSON and the Redux records.
+			// For fractional resolutions (e.g. 10.5) buildH3GeoJson uses Math.floor
+			// as the base and subdivides into children; visits are tracked at the base
+			// (parent) resolution so the colour update propagates to all sub-tiles.
+			const h3Res = Math.max(H3_RESOLUTION_MIN, Math.min(H3_RESOLUTION_MAX, Math.floor(h3ResolutionRef.current)));
+			const cell = latLngToCell(point.lat, point.lng, h3Res);
+			if (cell) {
+				// ── GPS gap interpolation ─────────────────────────────────────────
+				// When moving from lastCellRef to the new cell, fill in all H3 cells
+				// on the straight-line path between them. This handles GPS dropouts
+				// where the device had no signal for several updates: tiles the user
+				// actually passed through are still counted as visited.
+				if (lastCellRef.current && cell !== lastCellRef.current) {
+					try {
+						const pathCells = gridPathCells(lastCellRef.current, cell);
+						// pathCells[0] is lastCellRef (already visited), pathCells[last] is
+						// `cell` which will be processed below. Only fill when the gap is
+						// within a reasonable bound to avoid marking thousands of tiles on a
+						// very long GPS outage.
+						// pathCells.length - 2 is the number of intermediate cells (excludes
+						// first and last), so `<= GPS_PATH_INTERPOLATION_MAX_CELLS` allows
+						// exactly that many intermediate cells at most.
+						if (pathCells.length - 2 <= GPS_PATH_INTERPOLATION_MAX_CELLS) {
+							const newEdges: string[] = [];
+							for (let i = 0; i < pathCells.length - 1; i++) {
+								const a = pathCells[i];
+								const b = pathCells[i + 1];
+								newEdges.push(a < b ? `${a}:${b}` : `${b}:${a}`);
+								if (i > 0) {
+									// Intermediate cell (not pathCells[0] which is lastCellRef, already visited)
+									if (!visitedHexIdsRef.current.has(pathCells[i])) {
+										visitedHexIdsRef.current.add(pathCells[i]);
+										orderedHexTilesRef.current.push(pathCells[i]);
+										dispatch(markVisited({ h3Indices: [pathCells[i]], timestamp: point.timestamp }));
+									}
+								}
+							}
+							if (newEdges.length > 0) {
+								dispatch(addWalkedEdges(newEdges));
+							}
+						}
+					} catch (pathErr) {
+						// gridPathCells can throw when the two cells are on different
+						// icosahedron faces – log at warn level for diagnosability and continue.
+						console.warn('[RecordScreen] gridPathCells failed during gap interpolation:', pathErr);
+					}
+				}
+
+				// Only count each tile once per run so the level can rise by at most
+				// one step during a single activity.
+				if (!visitedHexIdsRef.current.has(cell)) {
+					visitedHexIdsRef.current.add(cell);
+					orderedHexTilesRef.current.push(cell);
+					dispatch(markVisited({ h3Indices: [cell], timestamp: point.timestamp }));
+				}
+				if (cell !== lastCellRef.current) {
+					lastCellRef.current = cell;
+				}
+
+				// ── Red-line walk-path edge tracking ────────────────────────────────
+				// Track finer red-line cell transitions for the red walk-path line.
+				try {
+					const redLineCell = latLngToCell(point.lat, point.lng, RED_LINE_GRID_RESOLUTION);
+					if (redLineCell && redLineCell !== lastRedLineCellRef.current) {
+						if (lastRedLineCellRef.current) {
+							const newRedLineEdges: string[] = [];
+							try {
+								const redLinePathCells = gridPathCells(lastRedLineCellRef.current, redLineCell);
+								if (redLinePathCells.length - 2 <= GPS_PATH_INTERPOLATION_MAX_CELLS) {
+									for (let i = 0; i < redLinePathCells.length - 1; i++) {
+										const a = redLinePathCells[i];
+										const b = redLinePathCells[i + 1];
+										newRedLineEdges.push(a < b ? `${a}:${b}` : `${b}:${a}`);
+									}
+								}
+							} catch {
+								const a = lastRedLineCellRef.current;
+								const b = redLineCell;
+								newRedLineEdges.push(a < b ? `${a}:${b}` : `${b}:${a}`);
+							}
+							if (newRedLineEdges.length > 0) {
+								dispatch(addWalkedEdgesRedLine(newRedLineEdges));
+							}
+						}
+						lastRedLineCellRef.current = redLineCell;
+					}
+				} catch {
+					// latLngToCell can throw for invalid coordinates; skip silently
+				}
+			}
+		} catch (err) {
+			console.warn('[RecordScreen] latLngToCell failed for visited hex tracking:', err);
+		}
+	}
+}
+
+/** Announces a whole-km distance milestone via TTS when the runner crosses one
+ * during this update, respecting the user's speech settings. */
+function announceKmMilestoneIfNeeded(
+	liveDistanceKm: number,
+	speechSettingsRef: React.MutableRefObject<SpeechSettingsState>,
+	lastAnnouncedKmRef: React.MutableRefObject<number>,
+	startTimeRef: React.MutableRefObject<number>,
+	accumulatedSecondsRef: React.MutableRefObject<number>,
+): void {
+	if (!speechSettingsRef.current.enabled) return;
+	const crossedKm = Math.floor(liveDistanceKm);
+	if (crossedKm > 0 && crossedKm > lastAnnouncedKmRef.current) {
+		lastAnnouncedKmRef.current = crossedKm;
+		const elapsedSec = startTimeRef.current > 0
+				? (Date.now() - startTimeRef.current) / 1000 + accumulatedSecondsRef.current
+				: accumulatedSecondsRef.current;
+		const paceMinPerKm = elapsedSec > 0 && liveDistanceKm > 0 ? elapsedSec / 60 / liveDistanceKm : null;
+		const locale = getLocales()[0]?.languageTag ?? 'en-US';
+		const langCode = locale.split('-')[0].toLowerCase();
+		const curSs = speechSettingsRef.current;
+		const text = buildKmAnnouncement(crossedKm, paceMinPerKm, locale, {
+			announcePace: curSs.announcePace,
+			announceSpeedKmh: curSs.announceSpeed,
+		});
+		try {
+			speakAnnouncement(text, langCode, {
+				rate: speechRateToNumber(curSs.speechRate),
+			}, 'km_milestone');
+		} catch (err) {
+			console.warn('[RecordScreen] Km milestone announcement failed:', err);
+		}
+	}
+}
+
+/** Evaluates and (if needed) speaks a pace-hint transition announcement
+ * ("too fast" / "too slow" / back to on-target), with hysteresis thresholds
+ * and a cooldown between announcements. */
+function evaluatePaceHintAnnouncement(
+	point: RoutePoint,
+	liveDistanceKm: number,
+	speechSettingsRef: React.MutableRefObject<SpeechSettingsState>,
+	startTimeRef: React.MutableRefObject<number>,
+	accumulatedSecondsRef: React.MutableRefObject<number>,
+	paceHintStateRef: React.MutableRefObject<PaceHintState>,
+	lastPaceHintTimeRef: React.MutableRefObject<number>,
+	paceHintCooldownMs: number,
+): void {
+	if (!speechSettingsRef.current.enabled || liveDistanceKm <= 0) return;
+	const curSs = speechSettingsRef.current;
+	if (!curSs.paceTargetEnabled) return;
+
+	// Use instantaneous GPS speed for comparison so the hint reflects
+	// the runner's current speed rather than the session average.
+	// Fall back to the average pace when GPS speed is unavailable.
+	const elapsedSec = startTimeRef.current > 0
+		? (Date.now() - startTimeRef.current) / 1000 + accumulatedSecondsRef.current
+		: accumulatedSecondsRef.current;
+	let currentPace: number | null = null;
+	if (point.speed != null && point.speed > 0.5) {
+		currentPace = 1000 / (point.speed * 60); // instantaneous pace: min/km from m/s
+	} else if (elapsedSec > 0) {
+		currentPace = elapsedSec / 60 / liveDistanceKm; // average fallback
+	}
+	if (currentPace != null) {
+		const targetPace = curSs.paceTargetMinutes + curSs.paceTargetSeconds / 60;
+		const fasterThreshold = curSs.paceHintFasterMinutes + curSs.paceHintFasterSeconds / 60;
+		const slowerThreshold = curSs.paceHintSlowerMinutes + curSs.paceHintSlowerSeconds / 60;
+
+		// Lower pace value = faster running.  Thresholds are subtracted/added
+		// from the target to define the acceptable range boundaries.
+		const fasterBound = targetPace - fasterThreshold;
+		const slowerBound = targetPace + slowerThreshold;
+
+		const prev = paceHintStateRef.current;
+		let next: PaceHintState = 'on_target';
+
+		if (curSs.paceHintFasterEnabled && currentPace < fasterBound) {
+			next = 'too_fast';
+		} else if (curSs.paceHintSlowerEnabled && currentPace > slowerBound) {
+			next = 'too_slow';
+		}
+
+		const now = Date.now();
+		const locale = getLocales()[0]?.languageTag ?? 'en-US';
+		const langCode = locale.split('-')[0].toLowerCase();
+
+		// Announce "too fast" / "too slow" only on transition from on_target.
+		if (
+			next !== 'on_target' &&
+			prev === 'on_target' &&
+			now - lastPaceHintTimeRef.current >= paceHintCooldownMs
+		) {
+			const text = buildPaceHintAnnouncement(next, currentPace, targetPace, locale);
+			try {
+				speakAnnouncement(text, langCode, {
+					volume: curSs.volume,
+					rate: speechRateToNumber(curSs.speechRate),
+					useApplicationAudioSession: curSs.duckMusicDuringTTS,
+				}, 'pace_hint');
+			} catch (err) {
+				console.warn('[RecordScreen] Pace hint announcement failed:', err);
+			}
+			lastPaceHintTimeRef.current = now;
+		}
+
+		// Announce "Zielgeschwindigkeit erreicht" when returning to on_target
+		// after a warning state.
+		if (next === 'on_target' && prev !== 'on_target') {
+			const text = buildOnTargetAnnouncement(locale);
+			try {
+				speakAnnouncement(text, langCode, {
+					volume: curSs.volume,
+					rate: speechRateToNumber(curSs.speechRate),
+					useApplicationAudioSession: curSs.duckMusicDuringTTS,
+				}, 'pace_hint_on_target');
+			} catch (err) {
+				console.warn('[RecordScreen] On-target announcement failed:', err);
+			}
+		}
+
+		paceHintStateRef.current = next;
+	}
+}
+
+/** Refreshes the H3 hex-tile and walk-path GeoJSON (plus the search highlight
+ * layer) sent to the map so newly-visited tiles are reflected without waiting
+ * for a full viewport-change event. No-ops while backgrounded. */
+function refreshHexDisplayForViewport(
+	appActive: boolean,
+	debugViewportRef: React.MutableRefObject<DebugViewportInfo | null>,
+	mapRef: React.MutableRefObject<MyMapHandle | null>,
+	h3ResolutionRef: React.MutableRefObject<number>,
+	showGridAlwaysRef: React.MutableRefObject<boolean>,
+	h3MinZoomRef: React.MutableRefObject<number>,
+	refreshSearchHighlight: (cells: string[]) => void,
+): void {
+	const vp = debugViewportRef.current;
+	if (appActive && vp && mapRef.current) {
+		let geoJson: H3FeatureCollection = { type: 'FeatureCollection', features: [] };
+		try {
+			geoJson = buildH3GeoJson(vp.bounds, vp.zoom, h3ResolutionRef.current, showGridAlwaysRef.current, store.getState().hexTiles.records, h3MinZoomRef.current);
+		} catch (err) {
+			console.warn('[RecordScreen] buildH3GeoJson failed during location update:', err);
+		}
+		debugViewportRef.current = { ...vp, tileCount: geoJson.features.length };
+		const viewportCells = [...new Set(geoJson.features.map((f) => f.properties.h3Index))];
+		const walkPathGeoJson = buildWalkPathGeoJson(viewportCells, store.getState().hexTiles.walkedEdges, store.getState().hexTiles.walkedEdgesRedLine);
+		mapRef.current.sendToMap({ hexTileGeoJson: geoJson });
+		mapRef.current.sendToMap({ hexWalkPathGeoJson: walkPathGeoJson });
+		refreshSearchHighlight(viewportCells);
+	}
+}
+
+/** Persists a recording snapshot for crash recovery, throttled to at most once
+ * every 10 seconds while actively (non-paused) recording. */
+function persistRecordingSnapshotIfDue(
+	isRecordingRef: React.MutableRefObject<boolean>,
+	isPausedRef: React.MutableRefObject<boolean>,
+	lastSnapshotSaveRef: React.MutableRefObject<number>,
+	startTimeRef: React.MutableRefObject<number>,
+	accumulatedSecondsRef: React.MutableRefObject<number>,
+	routePointsRef: React.MutableRefObject<RoutePoint[]>,
+	orderedHexTilesRef: React.MutableRefObject<string[]>,
+	h3ResolutionRef: React.MutableRefObject<number>,
+	selectedSportTypeRef: React.MutableRefObject<SportType>,
+	selectedRouteRef: React.MutableRefObject<SavedRoute | null>,
+): void {
+	if (isRecordingRef.current && !isPausedRef.current) {
+		const now = Date.now();
+		// Save a snapshot at most every 10 seconds to limit I/O.
+		if (now - lastSnapshotSaveRef.current >= 10_000) {
+			lastSnapshotSaveRef.current = now;
+			saveRecordingSnapshot({
+				startedAt: startTimeRef.current,
+				accumulatedSeconds: accumulatedSecondsRef.current,
+				segmentStart: startTimeRef.current,
+				routePoints: routePointsRef.current,
+				hexTilesOrdered: orderedHexTilesRef.current,
+				h3Resolution: Math.floor(h3ResolutionRef.current),
+				sportType: selectedSportTypeRef.current,
+				routeId: selectedRouteRef.current?.id ?? null,
+				savedAt: now,
+			});
+		}
+	}
+}
+
+// ─── RecordScreen: render helpers ──────────────────────────────────────────────
+
+/** Home button icon color: white while placing home, green when a home tile is set. */
+function resolveHomeButtonIconColor(isSettingHome: boolean, homeHexTile: string | null): string {
+	if (isSettingHome) return '#ffffff';
+	if (homeHexTile !== null) return STATUS_SUCCESS_COLOR;
+	return '#555555';
+}
+
+/** Central record button action: start when idle, resume when paused, otherwise pause. */
+function resolveRecordButtonAction(
+	isRecording: boolean,
+	isPaused: boolean,
+	pauseRecording: () => void,
+	handleRecordButtonPress: () => Promise<void>,
+	resumeRecording: () => void,
+): () => void | Promise<void> {
+	if (!isRecording) return handleRecordButtonPress;
+	if (isPaused) return resumeRecording;
+	return pauseRecording;
+}
+
+type MapOverlayButtonsProps = Readonly<{
+	mapRef: React.MutableRefObject<MyMapHandle | null>;
+	isHeadingMode: boolean;
+	handleCompassPress: () => void;
+	isFollowing: boolean;
+	setFollowMode: (val: boolean) => void;
+	movedPlayerManuallyRef: React.MutableRefObject<boolean>;
+	isRecording: boolean;
+	isSettingHome: boolean;
+	homeHexTile: string | null;
+	homeButtonIconColor: string;
+	isSettingHomeRef: React.MutableRefObject<boolean>;
+	setIsSettingHome: (val: boolean) => void;
+	searchState: RootState['mapSearch']['searchState'];
+	openSearchModal: () => Promise<void>;
+	isDebugMode: boolean;
+	coloringTileImage: string | null;
+	openColoringModal: () => void;
+	isMeasureMode: boolean;
+	cancelMeasureMode: () => void;
+	startMeasureMode: () => void;
+	showDebugModal: () => void;
+	finishMeasurement: () => Promise<void>;
+	undoMeasurePoint: () => void;
+}>;
+
+/** Top-right map overlay button cluster: compass, locate-me, set-home, search,
+ * and (in debug mode) coloring / measure / debug-menu / measure-confirm buttons. */
+function MapOverlayButtons({
+	mapRef,
+	isHeadingMode,
+	handleCompassPress,
+	isFollowing,
+	setFollowMode,
+	movedPlayerManuallyRef,
+	isRecording,
+	isSettingHome,
+	homeHexTile,
+	homeButtonIconColor,
+	isSettingHomeRef,
+	setIsSettingHome,
+	searchState,
+	openSearchModal,
+	isDebugMode,
+	coloringTileImage,
+	openColoringModal,
+	isMeasureMode,
+	cancelMeasureMode,
+	startMeasureMode,
+	showDebugModal,
+	finishMeasurement,
+	undoMeasurePoint,
+}: MapOverlayButtonsProps) {
+	return (
+		<View style={styles.mapOverlayButtons} pointerEvents="box-none">
+			{/* Compass / heading-mode toggle button */}
+			<TouchableOpacity
+				style={[
+					styles.compassButton,
+					isHeadingMode && { backgroundColor: PRIMARY_COLOR },
+				]}
+				onPress={handleCompassPress}
+				activeOpacity={0.8}
+			>
+				<MaterialIcons
+					name={isHeadingMode ? 'navigation' : 'explore'}
+					size={26}
+					color={isHeadingMode ? '#ffffff' : '#555555'}
+				/>
+			</TouchableOpacity>
+			<View style={styles.buttonSpacer} />
+			<MapLocationButton
+				mapRef={mapRef}
+				backgroundColor="#ffffff"
+				iconColor="#555555"
+				activeColor={PRIMARY_COLOR}
+				isFollowing={isFollowing}
+				zoom={17}
+				onLocationFound={() => {
+					movedPlayerManuallyRef.current = false;
+					setFollowMode(true);
+				}}
+			/>
+			<View style={styles.buttonSpacer} />
+			{/* Set Home button – always visible when not recording */}
+			{!isRecording && (
+				<>
+					<TouchableOpacity
+						style={[
+							styles.debugButton,
+							isSettingHome && { backgroundColor: STATUS_WARNING_COLOR },
+							!isSettingHome && homeHexTile !== null && { backgroundColor: STATUS_SUCCESS_COLOR + '22' },
+						]}
+						onPress={() => {
+							if (!isSettingHome && homeHexTile !== null) {
+								const [lat, lng] = cellToLatLng(homeHexTile);
+								mapRef.current?.sendToMap({
+									mapCenterPosition: { lat, lng },
+									zoom: 17,
+								});
+							} else {
+								isSettingHomeRef.current = !isSettingHome;
+								setIsSettingHome(!isSettingHome);
+							}
+						}}
+						activeOpacity={0.8}
+					>
+						<MaterialIcons
+							name="home"
+							size={20}
+							color={homeButtonIconColor}
+						/>
+					</TouchableOpacity>
+					<View style={styles.buttonSpacer} />
+				</>
+			)}
+			{/* Search highlight button – always visible in RecordScreen */}
+			<TouchableOpacity
+				style={[
+					styles.debugButton,
+					searchState !== null && searchState.enabledKeys.length > 0 && { backgroundColor: '#ef4444' },
+				]}
+				onPress={() => { void openSearchModal(); }}
+				activeOpacity={0.8}
+			>
+				<MaterialIcons
+					name="search"
+					size={20}
+					color={searchState !== null && searchState.enabledKeys.length > 0 ? '#ffffff' : '#555555'}
+				/>
+			</TouchableOpacity>
+			<View style={styles.buttonSpacer} />
+			{isDebugMode && !isRecording && (
+				<>
+					<TouchableOpacity
+						style={[
+							styles.debugButton,
+							coloringTileImage !== null && { backgroundColor: PRIMARY_COLOR },
+						]}
+						onPress={openColoringModal}
+						activeOpacity={0.8}
+					>
+						<MaterialIcons name="format-paint" size={20} color={coloringTileImage !== null ? '#ffffff' : '#555555'} />
+					</TouchableOpacity>
+					<View style={styles.buttonSpacer} />
+					<TouchableOpacity
+						style={[
+							styles.debugButton,
+							isMeasureMode && { backgroundColor: '#f97316' },
+						]}
+						onPress={isMeasureMode ? cancelMeasureMode : startMeasureMode}
+						activeOpacity={0.8}
+					>
+						<MaterialIcons name="straighten" size={20} color={isMeasureMode ? '#ffffff' : '#555555'} />
+					</TouchableOpacity>
+					<View style={styles.buttonSpacer} />
+				</>
+			)}
+			{isDebugMode && !isRecording && !isMeasureMode && (
+					<TouchableOpacity
+						style={styles.debugButton}
+						onPress={showDebugModal}
+						activeOpacity={0.8}
+					>
+						<MaterialIcons name="bug-report" size={20} color="#555555" />
+					</TouchableOpacity>
+			)}
+			{isDebugMode && isMeasureMode && (
+				<>
+					<TouchableOpacity
+						style={[styles.debugButton, { backgroundColor: '#43a047' }]}
+						onPress={finishMeasurement}
+						activeOpacity={0.8}
+					>
+						<MaterialIcons name="check" size={20} color="#ffffff" />
+					</TouchableOpacity>
+					<View style={styles.buttonSpacer} />
+					<TouchableOpacity
+						style={styles.debugButton}
+						onPress={undoMeasurePoint}
+						activeOpacity={0.8}
+					>
+						<MaterialIcons name="undo" size={20} color="#555555" />
+					</TouchableOpacity>
+				</>
+			)}
+		</View>
+	);
+}
+
+type LiveControlPanelProps = Readonly<{
+	isPanelCollapsed: boolean;
+	setIsPanelCollapsed: (val: boolean) => void;
+	theme: ReturnType<typeof useTheme>['theme'];
+	isRecording: boolean;
+	liveDistanceValue: string;
+	liveDistanceKm: number;
+	livePaceMinPerKm: number | null;
+	liveAvgSpeedKmh: number;
+	selectedRoute: SavedRoute | null;
+	setSelectedRoute: (route: SavedRoute | null) => void;
+	isDebugMode: boolean;
+	debugReplayActivity: SavedActivity | null;
+	setDebugReplayActivity: (activity: SavedActivity | null) => void;
+	stopRecording: () => Promise<void>;
+	activeSport: SportTypeDefinition;
+	showActivityTypeModal: () => void;
+	recordButtonColor: string;
+	recordButtonAction: () => void | Promise<void>;
+	recordButtonIcon: 'play-arrow' | 'pause';
+	showRouteSelectionModal: () => Promise<void>;
+}>;
+
+/** Bottom control panel: live stats row, selected-route/replay indicators, and
+ * the stop/record-pause/route-picker controls row. Collapses to just a chevron
+ * while recording if the user collapses it. */
+function LiveControlPanel({
+	isPanelCollapsed,
+	setIsPanelCollapsed,
+	theme,
+	isRecording,
+	liveDistanceValue,
+	liveDistanceKm,
+	livePaceMinPerKm,
+	liveAvgSpeedKmh,
+	selectedRoute,
+	setSelectedRoute,
+	isDebugMode,
+	debugReplayActivity,
+	setDebugReplayActivity,
+	stopRecording,
+	activeSport,
+	showActivityTypeModal,
+	recordButtonColor,
+	recordButtonAction,
+	recordButtonIcon,
+	showRouteSelectionModal,
+}: LiveControlPanelProps) {
+	return (
+		<View style={[styles.liveBar, { backgroundColor: theme.screen.background }]}>
+			{isPanelCollapsed && (
+				/* Collapsed: only show expand chevron – aligned right to match expanded position */
+				<View style={styles.liveBarCollapsedRow}>
+					<View style={styles.liveBarSideSlot}>
+						<TouchableOpacity
+							style={styles.chevronButton}
+							onPress={() => setIsPanelCollapsed(false)}
+							activeOpacity={0.7}
+						>
+							<MaterialIcons name="expand-less" size={24} color={theme.screen.icon} />
+						</TouchableOpacity>
+					</View>
+				</View>
+			)}
+			{!isPanelCollapsed && (
+				<>
+					{/* Stats row */}
+					<View style={styles.liveBarStatsRow}>
+						<View style={styles.liveStatCard}>
+							<MaterialIcons name="straighten" size={20} color={PRIMARY_COLOR} />
+							<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
+								{isRecording ? liveDistanceValue : '--'}
+							</Text>
+							<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>
+								{isRecording && liveDistanceKm < 1 ? 'm' : 'km'}
+							</Text>
+						</View>
+						<View style={[styles.liveVerticalDivider, { backgroundColor: theme.screen.text + '33' }]} />
+						<View style={styles.liveStatCard}>
+							<MaterialIcons name="speed" size={20} color={PRIMARY_COLOR} />
+							<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
+								{isRecording && livePaceMinPerKm != null ? formatPace(livePaceMinPerKm) : '--:--'}
+							</Text>
+							<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>min/km</Text>
+						</View>
+						<View style={[styles.liveVerticalDivider, { backgroundColor: theme.screen.text + '33' }]} />
+						<View style={styles.liveStatCard}>
+							<MaterialIcons name="directions-run" size={20} color={theme.screen.icon} />
+							<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
+								{isRecording ? liveAvgSpeedKmh.toFixed(1) : '--'}
+							</Text>
+							<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>km/h</Text>
+						</View>
+					</View>
+
+					{/* Selected route indicator (shown only before recording starts) */}
+					{!isRecording && selectedRoute && (
+						<View style={styles.selectedRouteRow}>
+							<MaterialIcons name="route" size={14} color={PRIMARY_COLOR} />
+							<Text style={[styles.selectedRouteText, { color: theme.screen.text }]} numberOfLines={1}>
+								{selectedRoute.name}
+							</Text>
+							<TouchableOpacity onPress={() => setSelectedRoute(null)} activeOpacity={0.7} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+								<MaterialIcons name="close" size={16} color={theme.screen.icon} />
+							</TouchableOpacity>
+						</View>
+					)}
+
+					{/* Debug replay indicator (shown in debug mode before recording starts) */}
+					{isDebugMode && !isRecording && debugReplayActivity && (
+						<View style={styles.selectedRouteRow}>
+							<MaterialIcons name="replay" size={14} color="#f97316" />
+							<Text style={[styles.selectedRouteText, { color: '#f97316' }]} numberOfLines={1}>
+								{'🔄 Replay: ' + new Date(debugReplayActivity.startedAt).toLocaleDateString() + ' ' + new Date(debugReplayActivity.startedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+							</Text>
+							<TouchableOpacity onPress={() => setDebugReplayActivity(null)} activeOpacity={0.7} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+								<MaterialIcons name="close" size={16} color={theme.screen.icon} />
+							</TouchableOpacity>
+						</View>
+					)}
+
+
+					{/* Controls row: [stop?] [record/pause – centred] [chevron-down] */}
+					<View style={styles.liveBarControlsRow}>
+						{/* Left side: stop button when recording, activity type picker otherwise */}
+						<View style={styles.liveBarSideSlot}>
+							{isRecording && (
+								<TouchableOpacity
+									style={[styles.stopButton, { backgroundColor: '#e53935' }]}
+									onPress={stopRecording}
+									activeOpacity={0.8}
+								>
+									<MaterialIcons name="stop" size={32} color="white" />
+								</TouchableOpacity>
+							)}
+							{!isRecording && (
+								<TouchableOpacity
+									style={[styles.activityTypeButton, { backgroundColor: activeSport.color + '22' }]}
+									onPress={showActivityTypeModal}
+									activeOpacity={0.8}
+								>
+									{activeSport.iconLibrary === 'MaterialCommunityIcons' ? (
+										<MaterialCommunityIcons
+											name={activeSport.iconName as React.ComponentProps<typeof MaterialCommunityIcons>['name']}
+											size={28}
+											color={activeSport.color}
+										/>
+									) : (
+										<MaterialIcons
+											name={activeSport.iconName as React.ComponentProps<typeof MaterialIcons>['name']}
+											size={28}
+											color={activeSport.color}
+										/>
+									)}
+								</TouchableOpacity>
+							)}
+						</View>
+
+						{/* Central record / pause button */}
+						<TouchableOpacity
+							style={[
+								styles.mainRecordButton,
+								{ backgroundColor: recordButtonColor },
+							]}
+							onPress={recordButtonAction}
+							activeOpacity={0.8}
+						>
+							<MaterialIcons
+								name={recordButtonIcon}
+								size={32}
+								color="white"
+							/>
+						</TouchableOpacity>
+
+						{/* Chevron-down collapse button – right side */}
+						<View style={styles.liveBarSideSlot}>
+							{!isRecording && (
+								<TouchableOpacity
+									style={[styles.routeButton, selectedRoute ? { backgroundColor: PRIMARY_COLOR + '22' } : {}]}
+									onPress={showRouteSelectionModal}
+									activeOpacity={0.8}
+								>
+									<MaterialIcons name="route" size={24} color={selectedRoute ? PRIMARY_COLOR : theme.screen.icon} />
+								</TouchableOpacity>
+							)}
+							{isRecording && (
+								<TouchableOpacity
+									style={styles.chevronButton}
+									onPress={() => setIsPanelCollapsed(true)}
+									activeOpacity={0.7}
+								>
+									<MaterialIcons name="expand-more" size={24} color={theme.screen.icon} />
+								</TouchableOpacity>
+							)}
+						</View>
+					</View>
+				</>
+			)}
+		</View>
+	);
+}
+
 export default function RecordScreen() {
 	const { theme } = useTheme();
 	const { show: showModal, close: closeModal } = useMyScrollViewModal();
@@ -3046,7 +4287,7 @@ export default function RecordScreen() {
 	// True while the joystick is being actively used; suppresses compass updates.
 	const joystickActiveRef = useRef(false);
 
-	const dispatch = useDispatch();
+	const dispatch = useDispatch<AppDispatch>();
 
 	// ── Tile image / model overlay sync ────────────────────────────────────────
 
@@ -3115,223 +4356,15 @@ export default function RecordScreen() {
 		const currentHexTextureAdaptionOpacity = store.getState().displaySettings.hexTextureAdaptionOpacity;
 		const currentHexObjectOpacity = store.getState().displaySettings.hexObjectOpacity;
 
-		// Flat lookup: terrain asset key → { moduleId, mimeType }
-		const terrainLookup = new Map<string, { moduleId: number; mimeType: string }>();
-		for (const assets of Object.values(TERRAIN_ASSETS)) {
-			for (const entry of assets) {
-				terrainLookup.set(entry.key, { moduleId: entry.source as number, mimeType: entry.mimeType ?? 'image/svg+xml' });
-			}
-		}
-
-		type ImageOverlay = {
-			id: string;
-			url: string;
-			coordinates: [[number, number], [number, number], [number, number], [number, number]];
-			opacity: number;
-			// Actual H3 hex vertices in [lng, lat] order for precise canvas clipping.
-			polygonCoords: [number, number][];
-			// Bearing from hex center to its first vertex (radians, 0 = North, CW positive).
-			// Used to rotate the texture so it aligns with the H3 hex orientation.
-			rotation: number;
-		};
-
-		const imageOverlays: ImageOverlay[] = [];
-
-		for (const [h3Index, record] of Object.entries(records)) {
-			// ── Tile image overlay ──────────────────────────────────────────────
-			if (record.tileImage) {
-				const terrainEntry = terrainLookup.get(record.tileImage);
-				if (terrainEntry !== undefined) {
-					const url = await loadAssetUrl(`terrain:${record.tileImage}`, terrainEntry.moduleId, terrainEntry.mimeType);
-					if (url) {
-						// Compute the bounding box of the hexagon in [lng, lat] GeoJSON order.
-						const boundary = cellToBoundary(h3Index); // [[lat, lng], ...]
-						if (boundary.length >= 3) {
-							let minLat = Infinity, maxLat = -Infinity;
-							let minLng = Infinity, maxLng = -Infinity;
-							for (const [lat, lng] of boundary) {
-								if (lat < minLat) minLat = lat;
-								if (lat > maxLat) maxLat = lat;
-								if (lng < minLng) minLng = lng;
-								if (lng > maxLng) maxLng = lng;
-							}
-							// Compute the geographic bearing (azimuth) from the hex center to its first
-							// vertex. Math.cos(centerLat) corrects the longitude delta for the fact that
-							// 1° of longitude covers less ground at higher latitudes. atan2(x, y) with
-							// (dlng, dlat) gives the angle measured clockwise from North, which is the
-							// standard geographic convention (0 = North, π/2 = East).
-							const centerLat = (minLat + maxLat) / 2;
-							const centerLng = (minLng + maxLng) / 2;
-							const v0 = boundary[0];
-							const dlat = v0[0] - centerLat;
-							const dlng = (v0[1] - centerLng) * Math.cos(centerLat * Math.PI / 180);
-							const rotation = Math.atan2(dlng, dlat); // radians CW from North
-
-							// Apply per-terrain anchor/scale overrides from hex texture config.
-							const terrainOverride = textureAnchors[record.tileImage];
-							const texAnchorX = terrainOverride?.anchorX ?? 0.5;
-							const texAnchorY = terrainOverride?.anchorY ?? 0.5;
-							const texScale = terrainOverride?.scaleMultiplier ?? 1.0;
-							const bboxW = maxLng - minLng;
-							const bboxH = maxLat - minLat;
-							// Scale > 1 enlarges the image overlay so the hex clips a zoomed-in
-							// portion of the texture (matching the HexFieldPreview behaviour).
-							const scaledW = bboxW * texScale;
-							const scaledH = bboxH * texScale;
-							// Pin the anchor fraction of the image to the hex center.
-							// This keeps the texture centred at scale 1 and lets the anchor
-							// shift which part of the image is visible at other scales.
-							// centerLng/centerLat are already computed above for the rotation calc.
-							const adjMinLng = centerLng - texAnchorX * scaledW;
-							const adjMaxLng = centerLng + (1 - texAnchorX) * scaledW;
-							const adjMinLat = centerLat - texAnchorY * scaledH;
-							const adjMaxLat = centerLat + (1 - texAnchorY) * scaledH;
-
-							imageOverlays.push({
-								id: `tile-img-${h3Index}`,
-								url,
-								// MapLibre image source format: top-left, top-right, bottom-right, bottom-left
-								coordinates: [
-									[adjMinLng, adjMaxLat],
-									[adjMaxLng, adjMaxLat],
-									[adjMaxLng, adjMinLat],
-									[adjMinLng, adjMinLat],
-								],
-								opacity: currentHexTextureOpacity,
-								// Actual hex vertices in [lng, lat] for canvas polygon clipping.
-								polygonCoords: boundary.map(([lat, lng]) => [lng, lat] as [number, number]),
-								rotation,
-							});
-						}
-					}
-				}
-			}
-		}
-
-		// ── Billboard GeoJSON symbol layer ───────────────────────────────────────────
-		// Billboards are rendered as a MapLibre symbol layer whose icon-size is set to
-		// a fixed value per feature. The zoom-based exponential expression in the
-		// MapLibre HTML ensures the icon scales proportionally with the map so that
-		// each billboard occupies a constant geographic area. Billboard size also
-		// scales with the H3 edge length: larger on bigger hexagons, smaller on
-		// smaller ones.
-		//
-		// Each unique billboard SVG is rasterized at 4× resolution (512×512 actual pixels
-		// for a 128×128 logical icon) via canvas + pixelRatio, keeping SVGs crisp when
-		// zoomed in or on high-DPI screens. Features carry an iconSizeAtRefZoom property
-		// (= desiredPixelSize / BILLBOARD_STANDARD_ICON_SIZE at zoom 14) so the layer's
-		// icon-size zoom expression scales it correctly at all zoom levels.
-		// NOTE: Keep this value in sync with BILLBOARD_ICON_SIZE in the MapLibre HTML.
-		const BILLBOARD_STANDARD_ICON_SIZE = 128;
-
-		// Billboard pixel size is determined by the sprite's scaleFactor, the
-		// user-adjustable billboard scale multiplier, AND the H3 edge length ratio
-		// relative to the reference resolution (10). This makes billboards larger on
-		// bigger hexagons and smaller on smaller ones.
-		// townhall (scaleFactor 7.0) renders at 7 × BILLBOARD_UNIT_PX ≈ 48 px at zoom 14
-		// at the reference resolution.
-
-		const billboardImages: Record<string, { url: string }> = {};
-		type BillboardFeature = {
-			type: 'Feature';
-			geometry: { type: 'Point'; coordinates: [number, number] };
-			properties: { iconKey: string; iconSizeAtRefZoom: number; anchorX: number; anchorY: number; flat: boolean };
-		};
-		const billboardFeatures: BillboardFeature[] = [];
-
-		for (const [h3Index, record] of Object.entries(records)) {
-			// Build effective billboard maps for Hex Objects and Hex Texture Adaptions.
-			const effectiveBillboards = getEffectiveBillboards(record);
-			const effectiveBillboardsTexture = getEffectiveBillboardsTexture(record);
-			// Per-anchor flat flags (legacy; used only for old `billboards` data).
-			const effectiveFlat = getEffectiveBillboardsFlat(record);
-
-			const hasBillboards = Object.keys(effectiveBillboards).length > 0;
-			const hasTextureAdaptions = Object.keys(effectiveBillboardsTexture).length > 0;
-			if (!hasBillboards && !hasTextureAdaptions) continue;
-
-			// Compute hex boundary (centroid + vertices) once per tile.
-			const boundary = cellToBoundary(h3Index, H3_GEOJSON_ORDER); // [[lng, lat], ...]
-			let sumLng = 0, sumLat = 0;
-			const n = boundary.length - 1;
-			if (n <= 0) continue;
-			for (let j = 0; j < n; j++) {
-				const [bLng, bLat] = boundary[j] as [number, number];
-				sumLng += bLng;
-				sumLat += bLat;
-			}
-			const centerLng = sumLng / n;
-			const centerLat = sumLat / n;
-
-			// Size constants for this tile's resolution (shared across all anchors).
-			const cellRes = getResolution(h3Index);
-			const clampedRes = Math.max(0, Math.min(cellRes, H3_EDGE_LENGTH_KM.length - 1));
-			const edgeLengthRatio = H3_EDGE_LENGTH_KM[clampedRes] / H3_EDGE_LENGTH_KM[BILLBOARD_REFERENCE_RESOLUTION];
-
-			// ── Hex Texture Adaptions (always flat on the map surface) ────────────
-			for (const [anchorColor, billboardKey] of Object.entries(effectiveBillboardsTexture)) {
-				const parsed = parseBillboardKey(billboardKey);
-				if (!parsed) continue;
-				const { sprite, idx } = parsed;
-				const url = await loadAssetUrl(billboardKey, sprite.source as number, 'image/svg+xml');
-				if (!url) continue;
-
-				const iconKey = `billboard-${billboardKey}`;
-				const anchorOverride = spriteAnchors[idx];
-				const anchorX = anchorOverride?.anchorX ?? sprite.anchorX;
-				const anchorY = anchorOverride?.anchorY ?? sprite.anchorY;
-				const [lng, lat] = resolveAnchorPosition(anchorColor, boundary, n, centerLng, centerLat);
-				const perSpriteScale = anchorOverride?.scaleMultiplier ?? 1.0;
-				const billboardSizePx = Math.max(BILLBOARD_MIN_SIZE_PX, Math.round(
-					BILLBOARD_UNIT_PX * sprite.scaleFactor * billboardScaleRef.current * perSpriteScale * edgeLengthRatio,
-				));
-				const iconSizeAtRefZoom = billboardSizePx / BILLBOARD_STANDARD_ICON_SIZE;
-
-				if (!billboardImages[iconKey]) {
-					billboardImages[iconKey] = { url };
-				}
-				// Hex Texture Adaptions are always flat and rotated by the position angle.
-				const textureRotation = getAnchorAngleDeg(anchorColor);
-				billboardFeatures.push({
-					type: 'Feature',
-					geometry: { type: 'Point', coordinates: [lng, lat] },
-					properties: { iconKey, iconSizeAtRefZoom, anchorX, anchorY, flat: true, opacity: currentHexTextureAdaptionOpacity, textureRotation },
-				});
-			}
-
-			// ── Hex Objects (face-camera; legacy billboardsFlat flag still respected) ──
-			for (const [anchorColor, billboardKey] of Object.entries(effectiveBillboards)) {
-				const parsed = parseBillboardKey(billboardKey);
-				if (!parsed) continue;
-				const { sprite, idx } = parsed;
-				const url = await loadAssetUrl(billboardKey, sprite.source as number, 'image/svg+xml');
-				if (!url) continue;
-
-				const iconKey = `billboard-${billboardKey}`;
-				const anchorOverride = spriteAnchors[idx];
-				const anchorX = anchorOverride?.anchorX ?? sprite.anchorX;
-				const anchorY = anchorOverride?.anchorY ?? sprite.anchorY;
-				const [lng, lat] = resolveAnchorPosition(anchorColor, boundary, n, centerLng, centerLat);
-				const perSpriteScale = anchorOverride?.scaleMultiplier ?? 1.0;
-				const billboardSizePx = Math.max(BILLBOARD_MIN_SIZE_PX, Math.round(
-					BILLBOARD_UNIT_PX * sprite.scaleFactor * billboardScaleRef.current * perSpriteScale * edgeLengthRatio,
-				));
-				const iconSizeAtRefZoom = billboardSizePx / BILLBOARD_STANDARD_ICON_SIZE;
-
-				// Hex Objects are face-camera by default; legacy per-anchor flat flag
-				// is still respected for backward compatibility with existing data.
-				const flat = effectiveFlat[anchorColor] === true;
-
-				if (!billboardImages[iconKey]) {
-					billboardImages[iconKey] = { url };
-				}
-				billboardFeatures.push({
-					type: 'Feature',
-					geometry: { type: 'Point', coordinates: [lng, lat] },
-					properties: { iconKey, iconSizeAtRefZoom, anchorX, anchorY, flat, opacity: currentHexObjectOpacity },
-				});
-			}
-		}
+		const imageOverlays = await buildTileImageOverlays(records, textureAnchors, currentHexTextureOpacity, loadAssetUrl);
+		const { images: billboardImages, features: billboardFeatures } = await buildBillboardOverlays(
+			records,
+			spriteAnchors,
+			billboardScaleRef,
+			currentHexTextureAdaptionOpacity,
+			currentHexObjectOpacity,
+			loadAssetUrl,
+		);
 
 		mapRef.current.sendToMap({
 			imageOverlays,
@@ -4068,78 +5101,18 @@ export default function RecordScreen() {
 		const msg = data as { tag?: string };
 		if (msg.tag === 'MapComponentMounted') {
 			mapWebViewReadyRef.current = true;
-			// Activate hex tile layer. strokeColor is intentionally omitted so that
-			// the default gray value defined in hexTileScript.ts is preserved.
-			const { hexLineOpacity: initHexLineOpacity, hexLineWidth: initHexLineWidth } = store.getState().displaySettings;
-			mapRef.current?.sendToMap({
-				hexTileLayer: { color: 'rgba(0, 0, 0, 0)', opacityMax: 0, lineOpacity: initHexLineOpacity, lineWidth: initHexLineWidth },
-			});
-			if (routePointsRef.current.length > 0) {
-				sendRouteToMap(routePointsRef.current);
-			}
-			const pos = debugPlayerPositionRef.current;
-			if (pos) {
-				centerMapOnPosition(pos);
-			}
-			// Send any already-selected tile images to the map.
-			loadAndSendCustomizations();
+			handleMapComponentMounted(mapRef, routePointsRef, debugPlayerPositionRef, sendRouteToMap, centerMapOnPosition, loadAndSendCustomizations);
 		} else if (msg.tag === 'MapInteracted') {
 			setFollowMode(false);
 		} else if (msg.tag === 'MapViewportChanged') {
 			const vp = msg as { bounds: ViewportBounds; zoom: number };
-			debugViewportRef.current = { bounds: vp.bounds, zoom: vp.zoom, tileCount: 0 };
-
-			// When a route is selected (pre-recording), show only the route's tiles
-			// and walk path instead of the full global tile set.
-			if (selectedRouteRef.current && !isRecordingRef.current) {
-				try {
-					const { hexTileGeoJson, hexWalkPathGeoJson } = buildRouteDisplayData(
-						selectedRouteRef.current,
-						store.getState().hexTiles.records,
-					);
-					debugViewportRef.current.tileCount = hexTileGeoJson.features.length;
-					mapRef.current?.sendToMap({ hexTileGeoJson });
-					mapRef.current?.sendToMap({ hexWalkPathGeoJson });
-				} catch (err) {
-					console.warn('[RecordScreen] Route preview viewport update failed:', err);
-				}
-			} else {
-				refreshNormalTileDisplay(vp);
-			}
+			handleMapViewportChanged(vp, selectedRouteRef, isRecordingRef, debugViewportRef, mapRef, refreshNormalTileDisplay);
 		} else if (msg.tag === 'HexTileClicked') {
 			const clickedMsg = msg as { h3Index?: string; mapFeatures?: MapFeatureInfo[] };
-			if (clickedMsg.h3Index) {
-				if (isSettingHomeRef.current) {
-					// Set-home mode: place castle2 at the center of the selected tile
-					// and store it as the player's home.
-					const newHomeHex = clickedMsg.h3Index;
-					dispatch(setBillboardAtAnchor({
-						h3Index: newHomeHex,
-						anchorColor: BillboardAnchorPosition.CENTER,
-						billboard: BILLBOARD_CASTLE2_KEY,
-					}));
-					dispatch(setHomeHexTile(newHomeHex));
-					isSettingHomeRef.current = false;
-					setIsSettingHome(false);
-				} else if (coloringTileImageRef.current !== null) {
-					// Coloring mode active: directly apply the selected tile image.
-					dispatch(setHexTileCustomization({ h3Index: clickedMsg.h3Index, tileImage: coloringTileImageRef.current }));
-				} else if (isMagnifyModeRef.current) {
-					// Magnify mode active: show detailed map info modal.
-					showMagnifyHexTileModal(clickedMsg.h3Index);
-				} else {
-					showHexTileModal(clickedMsg.h3Index);
-				}
-			}
+			handleHexTileClicked(clickedMsg, isSettingHomeRef, setIsSettingHome, coloringTileImageRef, isMagnifyModeRef, showMagnifyHexTileModal, showHexTileModal, dispatch);
 		} else if (msg.tag === 'MapMeasurePoint') {
 			const ptMsg = msg as { lat: number; lng: number };
-			if (isMeasureModeRef.current) {
-				const newWaypoints = [...measureWaypointsRef.current, { lat: ptMsg.lat, lng: ptMsg.lng }];
-				measureWaypointsRef.current = newWaypoints;
-				const coords = newWaypoints.map((w) => [w.lng, w.lat]);
-				mapRef.current?.sendToMap({ measureRouteCoords: coords });
-				mapRef.current?.sendToMap({ measurePoints: coords });
-			}
+			handleMapMeasurePoint(ptMsg, isMeasureModeRef, measureWaypointsRef, mapRef);
 		}
 	}, [centerMapOnPosition, sendRouteToMap, setFollowMode, showHexTileModal, showMagnifyHexTileModal, loadAndSendCustomizations, dispatch, refreshNormalTileDisplay]);
 
@@ -4280,27 +5253,7 @@ export default function RecordScreen() {
 		// AppState 'active' handler re-syncs the display on return.
 		const appActive = AppState.currentState === 'active';
 		if (isPausedRef.current) {
-			// During pause: update the visual player position but do NOT record GPS points
-			// or mark hex tiles. Both real GPS and joystick movement are allowed so the
-			// player marker stays live while the run is paused.
-			//
-			// For real GPS: skip if the user already overrode the position with the
-			// joystick before pausing – this mirrors the active-recording behaviour and
-			// prevents GPS from snapping the marker back while the user navigates
-			// virtually during the pause.
-			const shouldUpdate = fromJoystick || !movedPlayerManuallyRef.current;
-			if (shouldUpdate) {
-				debugPlayerPositionRef.current = { lat: point.lat, lng: point.lng };
-				if (appActive) {
-					mapRef.current?.sendToMap({ userLocation: { lat: point.lat, lng: point.lng } });
-					centerMapOnPosition({ lat: point.lat, lng: point.lng });
-				}
-				// Advance the accepted-point ref for real GPS so the speed filter works
-				// correctly on the first GPS point recorded after resume.
-				if (!fromJoystick) {
-					lastAcceptedGpsPointRef.current = point;
-				}
-			}
+			applyPausedLocationUpdate(point, fromJoystick, appActive, movedPlayerManuallyRef, debugPlayerPositionRef, lastAcceptedGpsPointRef, mapRef, centerMapOnPosition);
 			return;
 		}
 
@@ -4308,49 +5261,8 @@ export default function RecordScreen() {
 		// If the implied speed between the last accepted GPS fix and this one is
 		// unrealistically high for the selected sport, discard the point as a GPS
 		// glitch / noise spike.
-		if (!fromJoystick) {
-			// While the joystick is actively held during a recording, skip GPS
-			// route points entirely. The joystick is providing the authoritative
-			// position; adding a real GPS fix would create a visible jump in the
-			// recorded route from the virtual joystick position back to the
-			// physical GPS location.
-			if (isRecordingRef.current && (joystickActiveRef.current || movedPlayerManuallyRef.current)) {
-				return;
-			}
-
-			const lastAccepted = lastAcceptedGpsPointRef.current;
-			if (lastAccepted) {
-				const dtSec = (point.timestamp - lastAccepted.timestamp) / 1000;
-
-				// ── GPS time-interval filter ──────────────────────────────────────────
-				// During recording, skip this point if the elapsed time since the last
-				// accepted GPS fix is less than 95 % of the configured GPS interval.
-				// This prevents the platform from delivering points more frequently than
-				// the user-selected accuracy setting, which would result in too many
-				// recorded GPS points.
-				if (isRecordingRef.current) {
-					const gpsIntervalSeconds = store.getState().gpsInterval.intervalSeconds;
-					const minElapsedSec = gpsIntervalSeconds * 0.95;
-					if (dtSec < minElapsedSec) {
-						return;
-					}
-				}
-
-				if (dtSec > 0) {
-					const distKm = haversineKm(lastAccepted.lat, lastAccepted.lng, point.lat, point.lng);
-					const impliedSpeedKmh = (distKm / dtSec) * 3600;
-					const activeSportDef = SPORT_TYPES.find((s) => s.type === selectedSportTypeRef.current);
-					const maxSpeedKmh = activeSportDef?.maxSpeedKmh ?? 250;
-					if (impliedSpeedKmh > maxSpeedKmh) {
-						console.warn(
-							`[RecordScreen] GPS point filtered: implied speed ${impliedSpeedKmh.toFixed(1)} km/h` +
-							` exceeds max ${maxSpeedKmh} km/h for sport "${selectedSportTypeRef.current}".`,
-						);
-						return;
-					}
-				}
-			}
-			lastAcceptedGpsPointRef.current = point;
+		if (maybeFilterGpsPoint(fromJoystick, point, isRecordingRef, joystickActiveRef, movedPlayerManuallyRef, lastAcceptedGpsPointRef, selectedSportTypeRef)) {
+			return;
 		}
 
 		const next = [...routePointsRef.current, point];
@@ -4363,103 +5275,7 @@ export default function RecordScreen() {
 		}
 
 		// Track the visited H3 cell and dispatch to Redux for persistent storage
-		if (isH3Available()) {
-			try {
-				// Use the same base integer resolution as buildH3GeoJson so that the
-				// visited cell ID matches the keys in the GeoJSON and the Redux records.
-				// For fractional resolutions (e.g. 10.5) buildH3GeoJson uses Math.floor
-				// as the base and subdivides into children; visits are tracked at the base
-				// (parent) resolution so the colour update propagates to all sub-tiles.
-				const h3Res = Math.max(H3_RESOLUTION_MIN, Math.min(H3_RESOLUTION_MAX, Math.floor(h3ResolutionRef.current)));
-				const cell = latLngToCell(point.lat, point.lng, h3Res);
-				if (cell) {
-					// ── GPS gap interpolation ─────────────────────────────────────────
-					// When moving from lastCellRef to the new cell, fill in all H3 cells
-					// on the straight-line path between them. This handles GPS dropouts
-					// where the device had no signal for several updates: tiles the user
-					// actually passed through are still counted as visited.
-					if (lastCellRef.current && cell !== lastCellRef.current) {
-						try {
-							const pathCells = gridPathCells(lastCellRef.current, cell);
-							// pathCells[0] is lastCellRef (already visited), pathCells[last] is
-							// `cell` which will be processed below. Only fill when the gap is
-							// within a reasonable bound to avoid marking thousands of tiles on a
-							// very long GPS outage.
-							// pathCells.length - 2 is the number of intermediate cells (excludes
-							// first and last), so `<= GPS_PATH_INTERPOLATION_MAX_CELLS` allows
-							// exactly that many intermediate cells at most.
-							if (pathCells.length - 2 <= GPS_PATH_INTERPOLATION_MAX_CELLS) {
-								const newEdges: string[] = [];
-								for (let i = 0; i < pathCells.length - 1; i++) {
-									const a = pathCells[i];
-									const b = pathCells[i + 1];
-									newEdges.push(a < b ? `${a}:${b}` : `${b}:${a}`);
-									if (i > 0) {
-										// Intermediate cell (not pathCells[0] which is lastCellRef, already visited)
-										if (!visitedHexIdsRef.current.has(pathCells[i])) {
-											visitedHexIdsRef.current.add(pathCells[i]);
-											orderedHexTilesRef.current.push(pathCells[i]);
-											dispatch(markVisited({ h3Indices: [pathCells[i]], timestamp: point.timestamp }));
-										}
-									}
-								}
-								if (newEdges.length > 0) {
-									dispatch(addWalkedEdges(newEdges));
-								}
-							}
-						} catch (pathErr) {
-							// gridPathCells can throw when the two cells are on different
-							// icosahedron faces – log at warn level for diagnosability and continue.
-							console.warn('[RecordScreen] gridPathCells failed during gap interpolation:', pathErr);
-						}
-					}
-
-					// Only count each tile once per run so the level can rise by at most
-					// one step during a single activity.
-					if (!visitedHexIdsRef.current.has(cell)) {
-						visitedHexIdsRef.current.add(cell);
-						orderedHexTilesRef.current.push(cell);
-						dispatch(markVisited({ h3Indices: [cell], timestamp: point.timestamp }));
-					}
-					if (cell !== lastCellRef.current) {
-						lastCellRef.current = cell;
-					}
-
-					// ── Red-line walk-path edge tracking ────────────────────────────────
-					// Track finer red-line cell transitions for the red walk-path line.
-					try {
-						const redLineCell = latLngToCell(point.lat, point.lng, RED_LINE_GRID_RESOLUTION);
-						if (redLineCell && redLineCell !== lastRedLineCellRef.current) {
-							if (lastRedLineCellRef.current) {
-								const newRedLineEdges: string[] = [];
-								try {
-									const redLinePathCells = gridPathCells(lastRedLineCellRef.current, redLineCell);
-									if (redLinePathCells.length - 2 <= GPS_PATH_INTERPOLATION_MAX_CELLS) {
-										for (let i = 0; i < redLinePathCells.length - 1; i++) {
-											const a = redLinePathCells[i];
-											const b = redLinePathCells[i + 1];
-											newRedLineEdges.push(a < b ? `${a}:${b}` : `${b}:${a}`);
-										}
-									}
-								} catch {
-									const a = lastRedLineCellRef.current;
-									const b = redLineCell;
-									newRedLineEdges.push(a < b ? `${a}:${b}` : `${b}:${a}`);
-								}
-								if (newRedLineEdges.length > 0) {
-									dispatch(addWalkedEdgesRedLine(newRedLineEdges));
-								}
-							}
-							lastRedLineCellRef.current = redLineCell;
-						}
-					} catch {
-						// latLngToCell can throw for invalid coordinates; skip silently
-					}
-				}
-			} catch (err) {
-				console.warn('[RecordScreen] latLngToCell failed for visited hex tracking:', err);
-			}
-		}
+		trackVisitedHexCells(point, h3ResolutionRef, lastCellRef, visitedHexIdsRef, orderedHexTilesRef, lastRedLineCellRef, dispatch);
 
 		// If heading mode is active, rotate the map smoothly to face movement direction.
 		if (appActive && isHeadingModeRef.current && next.length >= 2) {
@@ -4480,108 +5296,10 @@ export default function RecordScreen() {
 		}
 
 		// Announce each whole-km milestone via TTS when enabled.
-		if (speechSettingsRef.current.enabled) {
-			const crossedKm = Math.floor(d);
-			if (crossedKm > 0 && crossedKm > lastAnnouncedKmRef.current) {
-				lastAnnouncedKmRef.current = crossedKm;
-				const elapsedSec = startTimeRef.current > 0
-						? (Date.now() - startTimeRef.current) / 1000 + accumulatedSecondsRef.current
-						: accumulatedSecondsRef.current;
-				const paceMinPerKm = elapsedSec > 0 && d > 0 ? elapsedSec / 60 / d : null;
-				const locale = getLocales()[0]?.languageTag ?? 'en-US';
-				const langCode = locale.split('-')[0].toLowerCase();
-				const curSs = speechSettingsRef.current;
-				const text = buildKmAnnouncement(crossedKm, paceMinPerKm, locale, {
-					announcePace: curSs.announcePace,
-					announceSpeedKmh: curSs.announceSpeed,
-				});
-				try {
-					speakAnnouncement(text, langCode, {
-						rate: speechRateToNumber(curSs.speechRate),
-					}, 'km_milestone');
-				} catch (err) {
-					console.warn('[RecordScreen] Km milestone announcement failed:', err);
-				}
-			}
-		}
+		announceKmMilestoneIfNeeded(d, speechSettingsRef, lastAnnouncedKmRef, startTimeRef, accumulatedSecondsRef);
 
 		// ── Pace hint announcements with hysteresis threshold ────────────
-		if (speechSettingsRef.current.enabled && d > 0) {
-			const curSs = speechSettingsRef.current;
-			if (curSs.paceTargetEnabled) {
-				// Use instantaneous GPS speed for comparison so the hint reflects
-				// the runner's current speed rather than the session average.
-				// Fall back to the average pace when GPS speed is unavailable.
-				const elapsedSec = startTimeRef.current > 0
-					? (Date.now() - startTimeRef.current) / 1000 + accumulatedSecondsRef.current
-					: accumulatedSecondsRef.current;
-				let currentPace: number | null = null;
-				if (point.speed != null && point.speed > 0.5) {
-					currentPace = 1000 / (point.speed * 60); // instantaneous pace: min/km from m/s
-				} else if (elapsedSec > 0) {
-					currentPace = elapsedSec / 60 / d; // average fallback
-				}
-				if (currentPace != null) {
-					const targetPace = curSs.paceTargetMinutes + curSs.paceTargetSeconds / 60;
-					const fasterThreshold = curSs.paceHintFasterMinutes + curSs.paceHintFasterSeconds / 60;
-					const slowerThreshold = curSs.paceHintSlowerMinutes + curSs.paceHintSlowerSeconds / 60;
-
-					// Lower pace value = faster running.  Thresholds are subtracted/added
-					// from the target to define the acceptable range boundaries.
-					const fasterBound = targetPace - fasterThreshold;
-					const slowerBound = targetPace + slowerThreshold;
-
-					const prev = paceHintStateRef.current;
-					let next: PaceHintState = 'on_target';
-
-					if (curSs.paceHintFasterEnabled && currentPace < fasterBound) {
-						next = 'too_fast';
-					} else if (curSs.paceHintSlowerEnabled && currentPace > slowerBound) {
-						next = 'too_slow';
-					}
-
-					const now = Date.now();
-					const locale = getLocales()[0]?.languageTag ?? 'en-US';
-					const langCode = locale.split('-')[0].toLowerCase();
-
-					// Announce "too fast" / "too slow" only on transition from on_target.
-					if (
-						next !== 'on_target' &&
-						prev === 'on_target' &&
-						now - lastPaceHintTimeRef.current >= PACE_HINT_COOLDOWN_MS
-					) {
-						const text = buildPaceHintAnnouncement(next, currentPace, targetPace, locale);
-						try {
-							speakAnnouncement(text, langCode, {
-								volume: curSs.volume,
-								rate: speechRateToNumber(curSs.speechRate),
-								useApplicationAudioSession: curSs.duckMusicDuringTTS,
-							}, 'pace_hint');
-						} catch (err) {
-							console.warn('[RecordScreen] Pace hint announcement failed:', err);
-						}
-						lastPaceHintTimeRef.current = now;
-					}
-
-					// Announce "Zielgeschwindigkeit erreicht" when returning to on_target
-					// after a warning state.
-					if (next === 'on_target' && prev !== 'on_target') {
-						const text = buildOnTargetAnnouncement(locale);
-						try {
-							speakAnnouncement(text, langCode, {
-								volume: curSs.volume,
-								rate: speechRateToNumber(curSs.speechRate),
-								useApplicationAudioSession: curSs.duckMusicDuringTTS,
-							}, 'pace_hint_on_target');
-						} catch (err) {
-							console.warn('[RecordScreen] On-target announcement failed:', err);
-						}
-					}
-
-					paceHintStateRef.current = next;
-				}
-			}
-		}
+		evaluatePaceHintAnnouncement(point, d, speechSettingsRef, startTimeRef, accumulatedSecondsRef, paceHintStateRef, lastPaceHintTimeRef, PACE_HINT_COOLDOWN_MS);
 
 		if (appActive && point.speed != null && point.speed >= 0) {
 			setLiveSpeedKmh(point.speed * 3.6);
@@ -4601,41 +5319,10 @@ export default function RecordScreen() {
 		// Refresh hex GeoJSON to show updated tile levels (includes the just-dispatched
 		// visit). Skipped while backgrounded; the AppState 'active' handler rebuilds
 		// the full map display when the app returns to the foreground.
-		const vp = debugViewportRef.current;
-		if (appActive && vp && mapRef.current) {
-			let geoJson: H3FeatureCollection = { type: 'FeatureCollection', features: [] };
-			try {
-				geoJson = buildH3GeoJson(vp.bounds, vp.zoom, h3ResolutionRef.current, showGridAlwaysRef.current, store.getState().hexTiles.records, h3MinZoomRef.current);
-			} catch (err) {
-				console.warn('[RecordScreen] buildH3GeoJson failed during location update:', err);
-			}
-			debugViewportRef.current = { ...vp, tileCount: geoJson.features.length };
-			const viewportCells = [...new Set(geoJson.features.map((f) => f.properties.h3Index))];
-			const walkPathGeoJson = buildWalkPathGeoJson(viewportCells, store.getState().hexTiles.walkedEdges, store.getState().hexTiles.walkedEdgesRedLine);
-			mapRef.current.sendToMap({ hexTileGeoJson: geoJson });
-			mapRef.current.sendToMap({ hexWalkPathGeoJson: walkPathGeoJson });
-			refreshSearchHighlight(viewportCells);
-		}
+		refreshHexDisplayForViewport(appActive, debugViewportRef, mapRef, h3ResolutionRef, showGridAlwaysRef, h3MinZoomRef, refreshSearchHighlight);
 
 		// ── Periodically persist a recording snapshot for crash recovery ──
-		if (isRecordingRef.current && !isPausedRef.current) {
-			const now = Date.now();
-			// Save a snapshot at most every 10 seconds to limit I/O.
-			if (now - lastSnapshotSaveRef.current >= 10_000) {
-				lastSnapshotSaveRef.current = now;
-				saveRecordingSnapshot({
-					startedAt: startTimeRef.current,
-					accumulatedSeconds: accumulatedSecondsRef.current,
-					segmentStart: startTimeRef.current,
-					routePoints: routePointsRef.current,
-					hexTilesOrdered: orderedHexTilesRef.current,
-					h3Resolution: Math.floor(h3ResolutionRef.current),
-					sportType: selectedSportTypeRef.current,
-					routeId: selectedRouteRef.current?.id ?? null,
-					savedAt: now,
-				});
-			}
-		}
+		persistRecordingSnapshotIfDue(isRecordingRef, isPausedRef, lastSnapshotSaveRef, startTimeRef, accumulatedSecondsRef, routePointsRef, orderedHexTilesRef, h3ResolutionRef, selectedSportTypeRef, selectedRouteRef);
 	}, [centerMapOnPosition, sendRouteToMap, dispatch, refreshSearchHighlight]);
 
 	// Moves the player to a new position (used by the debug gamepad).
@@ -5255,12 +5942,7 @@ export default function RecordScreen() {
 	const liveAvgSpeedKmh = elapsedSeconds > 0 ? (liveDistanceKm / elapsedSeconds) * 3600 : 0;
 
 	// Home button icon: white while placing home, green when a home tile is set.
-	let homeButtonIconColor = '#555555';
-	if (isSettingHome) {
-		homeButtonIconColor = '#ffffff';
-	} else if (homeHexTile !== null) {
-		homeButtonIconColor = STATUS_SUCCESS_COLOR;
-	}
+	const homeButtonIconColor = resolveHomeButtonIconColor(isSettingHome, homeHexTile);
 
 	// Live distance: metres below 1 km, kilometres afterwards.
 	const liveDistanceValue = liveDistanceKm < 1 ? (liveDistanceKm * 1000).toFixed(0) : liveDistanceKm.toFixed(2);
@@ -5268,12 +5950,7 @@ export default function RecordScreen() {
 	// Central record button: green when idle or paused (start/resume), amber while recording (pause).
 	const recordButtonColor = !isRecording || isPaused ? '#43a047' : '#f59e0b';
 	const recordButtonIcon = !isRecording || isPaused ? 'play-arrow' : 'pause';
-	let recordButtonAction: () => void | Promise<void> = pauseRecording;
-	if (!isRecording) {
-		recordButtonAction = handleRecordButtonPress;
-	} else if (isPaused) {
-		recordButtonAction = resumeRecording;
-	}
+	const recordButtonAction = resolveRecordButtonAction(isRecording, isPaused, pauseRecording, handleRecordButtonPress, resumeRecording);
 
 	if (!osmConsent) {
 		return (
@@ -5292,139 +5969,31 @@ export default function RecordScreen() {
 				)}
 
 				{/* Map overlay buttons – top-right */}
-				<View style={styles.mapOverlayButtons} pointerEvents="box-none">
-					{/* Compass / heading-mode toggle button */}
-					<TouchableOpacity
-						style={[
-							styles.compassButton,
-							isHeadingMode && { backgroundColor: PRIMARY_COLOR },
-						]}
-						onPress={handleCompassPress}
-						activeOpacity={0.8}
-					>
-						<MaterialIcons
-							name={isHeadingMode ? 'navigation' : 'explore'}
-							size={26}
-							color={isHeadingMode ? '#ffffff' : '#555555'}
-						/>
-					</TouchableOpacity>
-					<View style={styles.buttonSpacer} />
-					<MapLocationButton
-						mapRef={mapRef}
-						backgroundColor="#ffffff"
-						iconColor="#555555"
-						activeColor={PRIMARY_COLOR}
-						isFollowing={isFollowing}
-						zoom={17}
-						onLocationFound={() => {
-							movedPlayerManuallyRef.current = false;
-							setFollowMode(true);
-						}}
-					/>
-					<View style={styles.buttonSpacer} />
-					{/* Set Home button – always visible when not recording */}
-					{!isRecording && (
-						<>
-							<TouchableOpacity
-								style={[
-									styles.debugButton,
-									isSettingHome && { backgroundColor: STATUS_WARNING_COLOR },
-									!isSettingHome && homeHexTile !== null && { backgroundColor: STATUS_SUCCESS_COLOR + '22' },
-								]}
-								onPress={() => {
-									if (!isSettingHome && homeHexTile !== null) {
-										const [lat, lng] = cellToLatLng(homeHexTile);
-										mapRef.current?.sendToMap({
-											mapCenterPosition: { lat, lng },
-											zoom: 17,
-										});
-									} else {
-										isSettingHomeRef.current = !isSettingHome;
-										setIsSettingHome(!isSettingHome);
-									}
-								}}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons
-									name="home"
-									size={20}
-									color={homeButtonIconColor}
-								/>
-							</TouchableOpacity>
-							<View style={styles.buttonSpacer} />
-						</>
-					)}
-					{/* Search highlight button – always visible in RecordScreen */}
-					<TouchableOpacity
-						style={[
-							styles.debugButton,
-							searchState !== null && searchState.enabledKeys.length > 0 && { backgroundColor: '#ef4444' },
-						]}
-						onPress={() => { void openSearchModal(); }}
-						activeOpacity={0.8}
-					>
-						<MaterialIcons
-							name="search"
-							size={20}
-							color={searchState !== null && searchState.enabledKeys.length > 0 ? '#ffffff' : '#555555'}
-						/>
-					</TouchableOpacity>
-					<View style={styles.buttonSpacer} />
-					{isDebugMode && !isRecording && (
-						<>
-							<TouchableOpacity
-								style={[
-									styles.debugButton,
-									coloringTileImage !== null && { backgroundColor: PRIMARY_COLOR },
-								]}
-								onPress={openColoringModal}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons name="format-paint" size={20} color={coloringTileImage !== null ? '#ffffff' : '#555555'} />
-							</TouchableOpacity>
-							<View style={styles.buttonSpacer} />
-							<TouchableOpacity
-								style={[
-									styles.debugButton,
-									isMeasureMode && { backgroundColor: '#f97316' },
-								]}
-								onPress={isMeasureMode ? cancelMeasureMode : startMeasureMode}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons name="straighten" size={20} color={isMeasureMode ? '#ffffff' : '#555555'} />
-							</TouchableOpacity>
-							<View style={styles.buttonSpacer} />
-						</>
-					)}
-					{isDebugMode && !isRecording && !isMeasureMode && (
-							<TouchableOpacity
-								style={styles.debugButton}
-								onPress={showDebugModal}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons name="bug-report" size={20} color="#555555" />
-							</TouchableOpacity>
-					)}
-					{isDebugMode && isMeasureMode && (
-						<>
-							<TouchableOpacity
-								style={[styles.debugButton, { backgroundColor: '#43a047' }]}
-								onPress={finishMeasurement}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons name="check" size={20} color="#ffffff" />
-							</TouchableOpacity>
-							<View style={styles.buttonSpacer} />
-							<TouchableOpacity
-								style={styles.debugButton}
-								onPress={undoMeasurePoint}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons name="undo" size={20} color="#555555" />
-							</TouchableOpacity>
-						</>
-					)}
-				</View>
+				<MapOverlayButtons
+					mapRef={mapRef}
+					isHeadingMode={isHeadingMode}
+					handleCompassPress={handleCompassPress}
+					isFollowing={isFollowing}
+					setFollowMode={setFollowMode}
+					movedPlayerManuallyRef={movedPlayerManuallyRef}
+					isRecording={isRecording}
+					isSettingHome={isSettingHome}
+					homeHexTile={homeHexTile}
+					homeButtonIconColor={homeButtonIconColor}
+					isSettingHomeRef={isSettingHomeRef}
+					setIsSettingHome={setIsSettingHome}
+					searchState={searchState}
+					openSearchModal={openSearchModal}
+					isDebugMode={isDebugMode}
+					coloringTileImage={coloringTileImage}
+					openColoringModal={openColoringModal}
+					isMeasureMode={isMeasureMode}
+					cancelMeasureMode={cancelMeasureMode}
+					startMeasureMode={startMeasureMode}
+					showDebugModal={showDebugModal}
+					finishMeasurement={finishMeasurement}
+					undoMeasurePoint={undoMeasurePoint}
+				/>
 
 				{/* Joystick controller – bottom-left overlay */}
 				{isDebugMode && (
@@ -5445,156 +6014,28 @@ export default function RecordScreen() {
 				</View>
 
 			{/* Bottom control panel */}
-			<View style={[styles.liveBar, { backgroundColor: theme.screen.background }]}>
-				{isPanelCollapsed && (
-					/* Collapsed: only show expand chevron – aligned right to match expanded position */
-					<View style={styles.liveBarCollapsedRow}>
-						<View style={styles.liveBarSideSlot}>
-							<TouchableOpacity
-								style={styles.chevronButton}
-								onPress={() => setIsPanelCollapsed(false)}
-								activeOpacity={0.7}
-							>
-								<MaterialIcons name="expand-less" size={24} color={theme.screen.icon} />
-							</TouchableOpacity>
-						</View>
-					</View>
-				)}
-				{!isPanelCollapsed && (
-					<>
-						{/* Stats row */}
-						<View style={styles.liveBarStatsRow}>
-							<View style={styles.liveStatCard}>
-								<MaterialIcons name="straighten" size={20} color={PRIMARY_COLOR} />
-								<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
-									{isRecording ? liveDistanceValue : '--'}
-								</Text>
-								<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>
-									{isRecording && liveDistanceKm < 1 ? 'm' : 'km'}
-								</Text>
-							</View>
-							<View style={[styles.liveVerticalDivider, { backgroundColor: theme.screen.text + '33' }]} />
-							<View style={styles.liveStatCard}>
-								<MaterialIcons name="speed" size={20} color={PRIMARY_COLOR} />
-								<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
-									{isRecording && livePaceMinPerKm != null ? formatPace(livePaceMinPerKm) : '--:--'}
-								</Text>
-								<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>min/km</Text>
-							</View>
-							<View style={[styles.liveVerticalDivider, { backgroundColor: theme.screen.text + '33' }]} />
-							<View style={styles.liveStatCard}>
-								<MaterialIcons name="directions-run" size={20} color={theme.screen.icon} />
-								<Text style={[styles.liveStatBigValue, { color: theme.screen.text }]}>
-									{isRecording ? liveAvgSpeedKmh.toFixed(1) : '--'}
-								</Text>
-								<Text style={[styles.liveStatUnit, { color: theme.screen.icon }]}>km/h</Text>
-							</View>
-						</View>
-
-						{/* Selected route indicator (shown only before recording starts) */}
-						{!isRecording && selectedRoute && (
-							<View style={styles.selectedRouteRow}>
-								<MaterialIcons name="route" size={14} color={PRIMARY_COLOR} />
-								<Text style={[styles.selectedRouteText, { color: theme.screen.text }]} numberOfLines={1}>
-									{selectedRoute.name}
-								</Text>
-								<TouchableOpacity onPress={() => setSelectedRoute(null)} activeOpacity={0.7} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
-									<MaterialIcons name="close" size={16} color={theme.screen.icon} />
-								</TouchableOpacity>
-							</View>
-						)}
-
-						{/* Debug replay indicator (shown in debug mode before recording starts) */}
-						{isDebugMode && !isRecording && debugReplayActivity && (
-							<View style={styles.selectedRouteRow}>
-								<MaterialIcons name="replay" size={14} color="#f97316" />
-								<Text style={[styles.selectedRouteText, { color: '#f97316' }]} numberOfLines={1}>
-									{'🔄 Replay: ' + new Date(debugReplayActivity.startedAt).toLocaleDateString() + ' ' + new Date(debugReplayActivity.startedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-								</Text>
-								<TouchableOpacity onPress={() => setDebugReplayActivity(null)} activeOpacity={0.7} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
-									<MaterialIcons name="close" size={16} color={theme.screen.icon} />
-								</TouchableOpacity>
-							</View>
-						)}
-
-
-						{/* Controls row: [stop?] [record/pause – centred] [chevron-down] */}
-						<View style={styles.liveBarControlsRow}>
-							{/* Left side: stop button when recording, activity type picker otherwise */}
-							<View style={styles.liveBarSideSlot}>
-								{isRecording && (
-									<TouchableOpacity
-										style={[styles.stopButton, { backgroundColor: '#e53935' }]}
-										onPress={stopRecording}
-										activeOpacity={0.8}
-									>
-										<MaterialIcons name="stop" size={32} color="white" />
-									</TouchableOpacity>
-								)}
-								{!isRecording && (
-									<TouchableOpacity
-										style={[styles.activityTypeButton, { backgroundColor: activeSport.color + '22' }]}
-										onPress={showActivityTypeModal}
-										activeOpacity={0.8}
-									>
-										{activeSport.iconLibrary === 'MaterialCommunityIcons' ? (
-											<MaterialCommunityIcons
-												name={activeSport.iconName as React.ComponentProps<typeof MaterialCommunityIcons>['name']}
-												size={28}
-												color={activeSport.color}
-											/>
-										) : (
-											<MaterialIcons
-												name={activeSport.iconName as React.ComponentProps<typeof MaterialIcons>['name']}
-												size={28}
-												color={activeSport.color}
-											/>
-										)}
-									</TouchableOpacity>
-								)}
-							</View>
-
-							{/* Central record / pause button */}
-							<TouchableOpacity
-								style={[
-									styles.mainRecordButton,
-									{ backgroundColor: recordButtonColor },
-								]}
-								onPress={recordButtonAction}
-								activeOpacity={0.8}
-							>
-								<MaterialIcons
-									name={recordButtonIcon}
-									size={32}
-									color="white"
-								/>
-							</TouchableOpacity>
-
-							{/* Chevron-down collapse button – right side */}
-							<View style={styles.liveBarSideSlot}>
-								{!isRecording && (
-									<TouchableOpacity
-										style={[styles.routeButton, selectedRoute ? { backgroundColor: PRIMARY_COLOR + '22' } : {}]}
-										onPress={showRouteSelectionModal}
-										activeOpacity={0.8}
-									>
-										<MaterialIcons name="route" size={24} color={selectedRoute ? PRIMARY_COLOR : theme.screen.icon} />
-									</TouchableOpacity>
-								)}
-								{isRecording && (
-									<TouchableOpacity
-										style={styles.chevronButton}
-										onPress={() => setIsPanelCollapsed(true)}
-										activeOpacity={0.7}
-									>
-										<MaterialIcons name="expand-more" size={24} color={theme.screen.icon} />
-									</TouchableOpacity>
-								)}
-							</View>
-						</View>
-					</>
-				)}
-			</View>
+			<LiveControlPanel
+				isPanelCollapsed={isPanelCollapsed}
+				setIsPanelCollapsed={setIsPanelCollapsed}
+				theme={theme}
+				isRecording={isRecording}
+				liveDistanceValue={liveDistanceValue}
+				liveDistanceKm={liveDistanceKm}
+				livePaceMinPerKm={livePaceMinPerKm}
+				liveAvgSpeedKmh={liveAvgSpeedKmh}
+				selectedRoute={selectedRoute}
+				setSelectedRoute={setSelectedRoute}
+				isDebugMode={isDebugMode}
+				debugReplayActivity={debugReplayActivity}
+				setDebugReplayActivity={setDebugReplayActivity}
+				stopRecording={stopRecording}
+				activeSport={activeSport}
+				showActivityTypeModal={showActivityTypeModal}
+				recordButtonColor={recordButtonColor}
+				recordButtonAction={recordButtonAction}
+				recordButtonIcon={recordButtonIcon}
+				showRouteSelectionModal={showRouteSelectionModal}
+			/>
 		</SafeAreaView>
 	);
 }

--- a/apps/geonexia/frontend/app/routes/[id].tsx
+++ b/apps/geonexia/frontend/app/routes/[id].tsx
@@ -91,6 +91,66 @@ function buildAggregatedFeatures(featureMap: Record<string, MapFeatureInfo[]>): 
 	return aggregated;
 }
 
+// Queries tile features for a list of hex cell ids, warning (and falling back
+// to an empty feature list) for any cell whose query fails. `isCancelled` is
+// polled between requests so an in-flight query loop can be abandoned early.
+async function queryFeaturesForHexTiles(
+	hexIds: string[],
+	isCancelled: () => boolean,
+	warnLabel: string,
+): Promise<Record<string, MapFeatureInfo[]>> {
+	const featureMap: Record<string, MapFeatureInfo[]> = {};
+	for (const hexId of hexIds) {
+		if (isCancelled()) return featureMap;
+		try {
+			const features = await queryTileFeaturesForHexCell(
+				hexId,
+				undefined,
+				{ nameNullAllowList: ROUTE_NAME_LANDMARK_NAME_NULL_ALLOW },
+			);
+			featureMap[hexId] = features;
+		} catch (err) {
+			console.warn(`[RouteDetailScreen] Failed to query features for ${warnLabel}`, hexId, err);
+			featureMap[hexId] = [];
+		}
+	}
+	return featureMap;
+}
+
+// Computes the hex tiles enclosed by the route's loop: builds a closed ring
+// from the ordered tile center points and fills it with polygonToCells, then
+// excludes the route tiles themselves. See the call site for why this approach
+// (rather than cellsToMultiPolygon + polygonToCells) is needed.
+function computeEnclosedTilesForRoute(route: SavedRoute): string[] {
+	const tiles: string[] = [];
+	try {
+		const firstTile = route.hexTiles[0];
+		const lastTile = route.hexTiles[route.hexTiles.length - 1];
+		if (firstTile && lastTile && route.hexTiles.length >= 3) {
+			const res = getResolution(firstTile);
+
+			// Check loop closure: first and last tiles must be adjacent (neighbors).
+			if (areNeighborCells(firstTile, lastTile)) {
+				// Build closed ring from ordered tile center points [lat, lng]
+				const ring: CoordPair[] = route.hexTiles.map((cell) => cellToLatLng(cell) as CoordPair);
+				ring.push(ring[0]); // close the ring
+
+				// Fill the polygon interior with H3 cells, then exclude the route tiles
+				const filledCells = polygonToCells([ring], res, false);
+				const routeSet = new Set(route.hexTiles);
+				for (const cell of filledCells) {
+					if (!routeSet.has(cell)) {
+						tiles.push(cell);
+					}
+				}
+			}
+		}
+	} catch (err) {
+		console.warn('[RouteDetailScreen] Failed to compute enclosed tiles:', err);
+	}
+	return tiles;
+}
+
 function formatDate(timestamp: number): string {
 	return new Date(timestamp).toLocaleDateString(undefined, {
 		weekday: 'long',
@@ -648,21 +708,7 @@ export default function RouteDetailScreen() {
 			setFeaturesLoading(true);
 
 			// 1. Build hex tile → features dict
-			const featureMap: Record<string, MapFeatureInfo[]> = {};
-			for (const hexId of route.hexTiles) {
-				if (cancelled) return;
-				try {
-					const features = await queryTileFeaturesForHexCell(
-						hexId,
-						undefined,
-						{ nameNullAllowList: ROUTE_NAME_LANDMARK_NAME_NULL_ALLOW },
-					);
-					featureMap[hexId] = features;
-				} catch (err) {
-					console.warn('[RouteDetailScreen] Failed to query features for hex tile', hexId, err);
-					featureMap[hexId] = [];
-				}
-			}
+			const featureMap = await queryFeaturesForHexTiles(route.hexTiles, () => cancelled, 'hex tile');
 
 			if (cancelled) return;
 			setHexTileFeatureMap(featureMap);
@@ -695,37 +741,10 @@ export default function RouteDetailScreen() {
 			if (route.enclosedTiles !== undefined) {
 				tiles = route.enclosedTiles;
 			} else {
-				// 1. Compute enclosed tiles using the same algorithm as the activity end screen:
-				//    build a polygon from the ordered tile center points and fill it with
-				//    polygonToCells.  cellsToMultiPolygon + polygonToCells does NOT work here
-				//    because for a ring of tiles it produces a donut, and filling a donut just
-				//    returns the ring tiles themselves (leaving 0 enclosed cells after exclusion).
-				tiles = [];
-				try {
-					const firstTile = route.hexTiles[0];
-					const lastTile = route.hexTiles[route.hexTiles.length - 1];
-					if (firstTile && lastTile && route.hexTiles.length >= 3) {
-						const res = getResolution(firstTile);
-
-						// Check loop closure: first and last tiles must be adjacent (neighbors).
-						if (areNeighborCells(firstTile, lastTile)) {
-							// Build closed ring from ordered tile center points [lat, lng]
-							const ring: CoordPair[] = route.hexTiles.map((cell) => cellToLatLng(cell) as CoordPair);
-							ring.push(ring[0]); // close the ring
-
-							// Fill the polygon interior with H3 cells, then exclude the route tiles
-							const filledCells = polygonToCells([ring], res, false);
-							const routeSet = new Set(route.hexTiles);
-							for (const cell of filledCells) {
-								if (!routeSet.has(cell)) {
-									tiles.push(cell);
-								}
-							}
-						}
-					}
-				} catch (err) {
-					console.warn('[RouteDetailScreen] Failed to compute enclosed tiles:', err);
-				}
+				// 1. Compute enclosed tiles using the same algorithm as the activity end screen
+				//    (see computeEnclosedTilesForRoute for why cellsToMultiPolygon + polygonToCells
+				//    does not work here).
+				tiles = computeEnclosedTilesForRoute(route);
 
 				if (cancelled) return;
 
@@ -754,21 +773,7 @@ export default function RouteDetailScreen() {
 			setEnclosedFeaturesLoading(true);
 
 			// 2. Query features for each enclosed tile
-			const featureMap: Record<string, MapFeatureInfo[]> = {};
-			for (const hexId of tiles) {
-				if (cancelled) return;
-				try {
-					const features = await queryTileFeaturesForHexCell(
-						hexId,
-						undefined,
-						{ nameNullAllowList: ROUTE_NAME_LANDMARK_NAME_NULL_ALLOW },
-					);
-					featureMap[hexId] = features;
-				} catch (err) {
-					console.warn('[RouteDetailScreen] Failed to query features for enclosed tile', hexId, err);
-					featureMap[hexId] = [];
-				}
-			}
+			const featureMap = await queryFeaturesForHexTiles(tiles, () => cancelled, 'enclosed tile');
 
 			if (cancelled) return;
 

--- a/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
+++ b/apps/geonexia/frontend/helpers/ActivityMapRebuildHelper.ts
@@ -549,24 +549,14 @@ function computeParentInfo(
  * @param distanceKm       Route distance in km (used to derive avg speed).
  * @returns Array of synthetic `RoutePoint` values tagged `interpolated: true`.
  */
-export function synthesizeManualActivityRoutePoints(
-	hexTilesOrdered: string[],
-	startedAt: number,
-	durationMs: number,
-	distanceKm: number,
-): RoutePoint[] {
-	if (hexTilesOrdered.length === 0 || durationMs <= 0 || !isH3Available()) return [];
-
-	const durationSeconds = durationMs / 1000;
-	const avgSpeedMps = distanceKm > 0 && durationSeconds > 0
-		? (distanceKm * 1000) / durationSeconds
-		: 0;
-
-	// Build a fine-grained red-line path:
-	//  1. Convert every h10 tile to its center-child at RED_LINE_GRID_RESOLUTION.
-	//  2. Between consecutive red-line cells, fill in intermediate cells using
-	//     gridPathCells so the synthetic route points follow the actual red-line
-	//     grid instead of jumping from h10 centre to h10 centre.
+/**
+ * Build a fine-grained red-line path from the ordered h10 hex tiles:
+ *  1. Convert every h10 tile to its center-child at RED_LINE_GRID_RESOLUTION.
+ *  2. Between consecutive red-line cells, fill in intermediate cells using
+ *     gridPathCells so the synthetic route points follow the actual red-line
+ *     grid instead of jumping from h10 centre to h10 centre.
+ */
+function buildRedLinePathFromHexTiles(hexTilesOrdered: string[]): string[] {
 	const redLinePath: string[] = [];
 	for (const hexTile of hexTilesOrdered) {
 		try {
@@ -591,10 +581,20 @@ export function synthesizeManualActivityRoutePoints(
 			// skip invalid cells
 		}
 	}
+	return redLinePath;
+}
 
-	if (redLinePath.length === 0) return [];
-
-	// Distribute timestamps evenly: first point at startedAt, last at startedAt + durationMs.
+/**
+ * Convert a red-line cell path into timestamped `RoutePoint`s, distributing
+ * timestamps evenly so the first point is at `startedAt` and the last is at
+ * `startedAt + durationMs`.
+ */
+function buildRoutePointsFromRedLinePath(
+	redLinePath: string[],
+	startedAt: number,
+	durationMs: number,
+	avgSpeedMps: number,
+): RoutePoint[] {
 	const step = redLinePath.length > 1 ? durationMs / (redLinePath.length - 1) : 0;
 
 	const points: RoutePoint[] = [];
@@ -614,6 +614,26 @@ export function synthesizeManualActivityRoutePoints(
 		}
 	}
 	return points;
+}
+
+export function synthesizeManualActivityRoutePoints(
+	hexTilesOrdered: string[],
+	startedAt: number,
+	durationMs: number,
+	distanceKm: number,
+): RoutePoint[] {
+	if (hexTilesOrdered.length === 0 || durationMs <= 0 || !isH3Available()) return [];
+
+	const durationSeconds = durationMs / 1000;
+	const avgSpeedMps = distanceKm > 0 && durationSeconds > 0
+		? (distanceKm * 1000) / durationSeconds
+		: 0;
+
+	const redLinePath = buildRedLinePathFromHexTiles(hexTilesOrdered);
+
+	if (redLinePath.length === 0) return [];
+
+	return buildRoutePointsFromRedLinePath(redLinePath, startedAt, durationMs, avgSpeedMps);
 }
 
 /**
@@ -701,6 +721,319 @@ export function computeActivityData(
  *          loaded into the Redux hex-tile slice via `loadPersistedState` /
  *          `loadWalkedEdgesState` / `loadWalkedEdgesRedLineState`.
  */
+/**
+ * Derive the ordered list of visited hex-tile entries for an activity.
+ * Prefers the pre-computed field; falls back to the raw ordered list for
+ * activities saved before the computed field was introduced.  For
+ * backward-compat, also accepts the legacy `orderedHexTiles` field name.
+ */
+function deriveOrderedHexTiles(activity: SavedActivity): ComputedHexTileEntry[] {
+	return (
+		activity.computed?.hexTilesVisited ??
+		(activity.computed as { orderedHexTiles?: ComputedHexTileEntry[] } | undefined)?.orderedHexTiles ??
+		(activity.hexTilesOrdered ?? []).map((hexId) => ({ hexId, avgSpeedKmh: 0 }))
+	);
+}
+
+/**
+ * Always recompute enclosed tiles from the route when enough walked tiles
+ * are available.  This ensures that stale stored values (e.g. an activity
+ * that was recorded with a closed loop but later the route was found to be
+ * open) are corrected: if the route does not form a closed loop, the
+ * recomputation returns [] and overrides the stored (now-incorrect) data.
+ * Include tiles derived from interpolated GPS points so that routes
+ * completed via route interpolation produce a properly closed polygon.
+ */
+function computeEnclosedHexTilesForActivity(activity: SavedActivity): string[] {
+	if ((activity.hexTilesOrdered?.length ?? 0) >= MIN_TILES_FOR_ENCLOSED_POLYGON) {
+		const visitedIds = activity.hexTilesOrdered ?? [];
+		const h3Res = activity.h3Resolution ?? H3_RESOLUTION_FALLBACK;
+		const fullRouteIds = buildFullRouteTileIds(visitedIds, activity.routePoints, h3Res);
+		return findEnclosedCellsFromHexTiles(fullRouteIds, h3Res);
+	}
+	// Not enough walked tiles to form a polygon; fall back to any stored
+	// value for legacy activities that pre-date hexTilesOrdered.
+	return (
+		activity.computed?.enclosedHexTiles ??
+		activity.enclosedHexTiles ??
+		activity.hexTilesEnclosed ??
+		[]
+	);
+}
+
+/** Pre-build a map for O(1) lookup of an activity's existing per-tile references. */
+function buildActivityReferenceMap(
+	records: Record<string, HexTileRecord>,
+	activityId: string,
+): Map<string, ActivityReference> {
+	const refByHexId = new Map<string, ActivityReference>();
+	for (const rec of Object.values(records)) {
+		if (!rec.activityReferences) continue;
+		const ref = rec.activityReferences.find(
+			(r: ActivityReference) => r.activityId === activityId,
+		);
+		if (ref) refByHexId.set(rec.h3Index, ref);
+	}
+	return refByHexId;
+}
+
+/**
+ * Process visited (walked) tiles for one activity: updates timestamps,
+ * merges activity references, and builds walked edges from consecutive tile
+ * pairs.  Mutates `records` and `edgeSet` in place.
+ */
+function processVisitedTiles(
+	orderedHexTiles: ComputedHexTileEntry[],
+	activityId: string,
+	endedAt: number,
+	records: Record<string, HexTileRecord>,
+	refByHexId: Map<string, ActivityReference>,
+	edgeSet: Set<string>,
+): void {
+	for (let i = 0; i < orderedHexTiles.length; i++) {
+		const { hexId } = orderedHexTiles[i];
+		const rec = getOrCreateRecord(records, hexId);
+
+		// Update timestamps
+		if (rec.lastVisitedAt === null || endedAt > rec.lastVisitedAt) {
+			rec.lastVisitedAt = endedAt;
+		}
+
+		// Add or merge the activity reference
+		rec.activityReferences ??= [];
+		const existingRef = refByHexId.get(hexId);
+		if (existingRef) {
+			existingRef.walkedIndex = i;
+		} else {
+			const newRef: ActivityReference = { activityId, walkedIndex: i };
+			rec.activityReferences.push(newRef);
+			refByHexId.set(hexId, newRef);
+		}
+
+		// Build walked edges from consecutive tile pairs
+		if (i > 0) {
+			const prev = orderedHexTiles[i - 1].hexId;
+			const edge = prev < hexId ? `${prev}:${hexId}` : `${hexId}:${prev}`;
+			edgeSet.add(edge);
+		}
+	}
+}
+
+/**
+ * Compute red-line walked edges for one activity, using GPS route points
+ * when available and synthesizing them for manual activities.  Mutates
+ * `edgeSetRedLine` in place.
+ */
+function computeRedLineEdgesForActivity(
+	activity: SavedActivity,
+	orderedHexTiles: ComputedHexTileEntry[],
+	edgeSetRedLine: Set<string>,
+): void {
+	if (!isH3Available()) return;
+	const hexTilesOrdered = orderedHexTiles.map((e) => e.hexId);
+	const routePoints = activity.routePoints.length > 0
+		? activity.routePoints
+		: synthesizeManualActivityRoutePoints(
+			hexTilesOrdered,
+			activity.startedAt,
+			activity.endedAt - activity.startedAt,
+			activity.distanceKm,
+		);
+	if (routePoints.length > 0) {
+		const redLineEdges = computeEdgesFromRoutePoints(routePoints, RED_LINE_GRID_RESOLUTION);
+		for (const edge of redLineEdges) edgeSetRedLine.add(edge);
+	}
+}
+
+/**
+ * Process enclosed tiles for one activity: updates timestamps and merges
+ * activity references.  Mutates `records` in place.
+ */
+function processEnclosedTiles(
+	enclosedHexTiles: string[],
+	activityId: string,
+	endedAt: number,
+	records: Record<string, HexTileRecord>,
+	refByHexId: Map<string, ActivityReference>,
+): void {
+	for (let i = 0; i < enclosedHexTiles.length; i++) {
+		const hexId = enclosedHexTiles[i];
+		const rec = getOrCreateRecord(records, hexId);
+
+		// Update timestamps
+		if (rec.lastEnclosedAt === null || endedAt > rec.lastEnclosedAt) {
+			rec.lastEnclosedAt = endedAt;
+		}
+
+		// Add or merge the activity reference
+		rec.activityReferences ??= [];
+		const existingRef = refByHexId.get(hexId);
+		if (existingRef) {
+			existingRef.enclosedIndex = i;
+		} else {
+			const newRef: ActivityReference = { activityId, enclosedIndex: i };
+			rec.activityReferences.push(newRef);
+			refByHexId.set(hexId, newRef);
+		}
+	}
+}
+
+/**
+ * Compute `visitCount`, `enclosedCount`, `walkedOn` and `level` for a single
+ * record from its accumulated `activityReferences`.
+ */
+function computeCountsAndLevelForRecord(rec: HexTileRecord): void {
+	const refs: ActivityReference[] = rec.activityReferences ?? [];
+
+	// Count distinct activities that visited / enclosed this tile.
+	const visitedActivities = new Set(
+		refs.filter((r) => r.walkedIndex !== undefined).map((r) => r.activityId),
+	);
+	const enclosedActivities = new Set(
+		refs.filter((r) => r.enclosedIndex !== undefined).map((r) => r.activityId),
+	);
+
+	rec.visitCount = visitedActivities.size;
+	rec.enclosedCount = enclosedActivities.size;
+	rec.walkedOn = rec.visitCount > 0;
+	rec.level = computeHexTileLevel(rec);
+}
+
+/**
+ * Compute `avenueCount` for every tile: the number of distinct activities
+ * that visited (i.e. walked on or enclosed) at least one immediately
+ * neighbouring tile (ring-1 H3 disk, excl. self).
+ *
+ * Must be called after `visitCount`/`enclosedCount` are fully populated on
+ * every record (via `computeCountsAndLevelForRecord`) so that the per-tile
+ * activity-ID sets are already available via `activityReferences`.  Mutates
+ * `records` in place, including creating neighbour records that did not
+ * previously exist.
+ */
+function computeAvenueCounts(records: Record<string, HexTileRecord>): void {
+	if (!isH3Available()) return;
+
+	// Build a map from hexId → set of activity IDs that walked on OR enclosed it.
+	const visitedActsMap = new Map<string, Set<string>>();
+	for (const [hexId, rec] of Object.entries(records)) {
+		if (rec.visitCount > 0 || rec.enclosedCount > 0) {
+			const refs: ActivityReference[] = rec.activityReferences ?? [];
+			visitedActsMap.set(
+				hexId,
+				new Set(refs.map((r) => r.activityId)),
+			);
+		}
+	}
+
+	// Ensure that every ring-1 neighbor of a visited tile has a record so
+	// that its avenueCount is computed and stored even when the tile itself
+	// was never walked or enclosed.
+	for (const hexId of visitedActsMap.keys()) {
+		const neighbors = gridDisk(hexId, 1).filter((n) => n !== hexId);
+		for (const neighbor of neighbors) {
+			getOrCreateRecord(records, neighbor);
+		}
+	}
+
+	// For every tile, union the activity sets of its walked neighbours.
+	for (const [hexId, rec] of Object.entries(records)) {
+		const neighbors = gridDisk(hexId, 1).filter((n) => n !== hexId);
+		const avenueActivities = new Set<string>();
+		for (const neighbor of neighbors) {
+			const neighborActs = visitedActsMap.get(neighbor);
+			if (neighborActs) {
+				for (const actId of neighborActs) {
+					avenueActivities.add(actId);
+				}
+			}
+		}
+		rec.avenueCount = avenueActivities.size;
+	}
+}
+
+/**
+ * Apply automatic tile-image and billboard assignments to a single record.
+ * Must be called after all counts (`visitCount`/`enclosedCount`) are fully
+ * computed, so it is safe to query neighbour tiles' state when deciding
+ * whether to place trees / path billboards.
+ */
+function applyTileImageAndBillboardsForRecord(
+	hexId: string,
+	rec: HexTileRecord,
+	edgeSet: Set<string>,
+	hexTileFeatureCache: HexTileFeatureCache,
+): void {
+	if (rec.visitCount > 0) {
+		// Visited tile → dirt terrain
+		rec.tileImage = TILE_IMAGE_DIRT;
+
+		// Place a path object (flat) at each MIDDLE ring anchor that faces a
+		// walked neighbor tile, indicating the route direction.
+		if (isH3Available()) {
+			const neighbors = gridDisk(hexId, 1).filter((n) => n !== hexId);
+			for (const neighbor of neighbors) {
+				const edgeStr = hexId < neighbor ? `${hexId}:${neighbor}` : `${neighbor}:${hexId}`;
+				if (!edgeSet.has(edgeStr)) continue;
+				const edgeIdx = getEdgeIndexTowardNeighbor(hexId, neighbor);
+				if (edgeIdx < 0 || edgeIdx >= EDGE_INDEX_TO_ANCHOR.length) continue;
+				const anchorPosition = EDGE_INDEX_TO_ANCHOR[edgeIdx];
+				rec.billboardsTexture ??= {};
+				rec.billboardsTexture[anchorPosition] = BILLBOARD_PATH_ROUNDED;
+			}
+		}
+	} else if (rec.enclosedCount > 0) {
+		// Enclosed but not visited → grass terrain; forest
+		// trees only when the feature cache confirms a forest / wooded area.
+		rec.tileImage = TILE_IMAGE_GRASS;
+		checkAndApplyForest(hexId, rec, hexTileFeatureCache[hexId]);
+		// Override tileImage to stone when the feature cache confirms rocky
+		// ground (pebble-stone terrain).  This is a tileImage-level change only –
+		// not a billboard (hex object) and not a texture adaption (hex texture).
+		// Note: pebbleStone runs after forest so the stone terrain wins when
+		// both features are present.  In practice, ROCK and WOOD landcovers
+		// are mutually exclusive in OpenMapTiles data, so this scenario does
+		// not occur on real tiles.
+		checkAndApplyPebbleStone(rec, hexTileFeatureCache[hexId]);
+	}
+}
+
+/**
+ * Populate `parentH3Index` and `parentChildIndex` for every tile in
+ * `records`, and ensure ancestor records (up to resolution 0) also exist in
+ * `records` with their own parent info.  Ancestor records added here have
+ * level 0 and no visit/enclosure data; they serve purely as hierarchy
+ * metadata.  Mutates `records` in place.
+ */
+function populateParentChain(records: Record<string, HexTileRecord>): void {
+	if (!isH3Available()) return;
+
+	// Snapshot the keys so that newly created ancestor records are also
+	// processed (we iterate until no new keys are added).
+	let keysToProcess = Object.keys(records);
+	while (keysToProcess.length > 0) {
+		const nextKeys: string[] = [];
+		for (const h3Index of keysToProcess) {
+			const rec = records[h3Index];
+			// Skip tiles whose parent info is already set.
+			if (rec.parentH3Index !== undefined) continue;
+			const info = computeParentInfo(h3Index);
+			if (!info) {
+				rec.parentH3Index = null;
+				rec.parentChildIndex = null;
+				continue;
+			}
+			rec.parentH3Index = info.parentH3Index;
+			rec.parentChildIndex = info.parentChildIndex;
+			// Create the parent record if it does not yet exist.
+			if (!records[info.parentH3Index]) {
+				getOrCreateRecord(records, info.parentH3Index);
+				nextKeys.push(info.parentH3Index);
+			}
+		}
+		keysToProcess = nextKeys;
+	}
+}
+
 export function rebuildMapFromActivities(
 	activities: SavedActivity[],
 	hexTileFeatureCache: HexTileFeatureCache = {},
@@ -715,116 +1048,18 @@ export function rebuildMapFromActivities(
 		const endedAt = activity.endedAt;
 
 		// ── Derive the ordered and enclosed tile lists ────────────────────────
-		// Prefer the pre-computed field; fall back to the raw ordered list for
-		// activities saved before the computed field was introduced.
-		// For backward-compat, also accept the legacy `orderedHexTiles` field name.
-		const orderedHexTiles: ComputedHexTileEntry[] =
-			activity.computed?.hexTilesVisited ??
-			(activity.computed as { orderedHexTiles?: ComputedHexTileEntry[] } | undefined)?.orderedHexTiles ??
-			(activity.hexTilesOrdered ?? []).map((hexId) => ({ hexId, avgSpeedKmh: 0 }));
-
-		// Always recompute enclosed tiles from the route when enough walked tiles
-		// are available.  This ensures that stale stored values (e.g. an activity
-		// that was recorded with a closed loop but later the route was found to be
-		// open) are corrected: if the route does not form a closed loop, the
-		// recomputation returns [] and overrides the stored (now-incorrect) data.
-		// Include tiles derived from interpolated GPS points so that routes
-		// completed via route interpolation produce a properly closed polygon.
-		let enclosedHexTiles: string[];
-		if ((activity.hexTilesOrdered?.length ?? 0) >= MIN_TILES_FOR_ENCLOSED_POLYGON) {
-			const visitedIds = activity.hexTilesOrdered ?? [];
-			const h3Res = activity.h3Resolution ?? H3_RESOLUTION_FALLBACK;
-			const fullRouteIds = buildFullRouteTileIds(visitedIds, activity.routePoints, h3Res);
-			enclosedHexTiles = findEnclosedCellsFromHexTiles(fullRouteIds, h3Res);
-		} else {
-			// Not enough walked tiles to form a polygon; fall back to any stored
-			// value for legacy activities that pre-date hexTilesOrdered.
-			enclosedHexTiles =
-				activity.computed?.enclosedHexTiles ??
-				activity.enclosedHexTiles ??
-				activity.hexTilesEnclosed ??
-				[];
-		}
+		const orderedHexTiles = deriveOrderedHexTiles(activity);
+		const enclosedHexTiles = computeEnclosedHexTilesForActivity(activity);
 
 		// ── Process visited (walked) tiles ────────────────────────────────────
-		// Pre-build a map for O(1) lookup of existing references for this activity.
-		const refByHexId = new Map<string, ActivityReference>();
-		for (const rec of Object.values(records)) {
-			if (!rec.activityReferences) continue;
-			const ref = rec.activityReferences.find(
-				(r: ActivityReference) => r.activityId === activityId,
-			);
-			if (ref) refByHexId.set(rec.h3Index, ref);
-		}
-
-		for (let i = 0; i < orderedHexTiles.length; i++) {
-			const { hexId } = orderedHexTiles[i];
-			const rec = getOrCreateRecord(records, hexId);
-
-			// Update timestamps
-			if (rec.lastVisitedAt === null || endedAt > rec.lastVisitedAt) {
-				rec.lastVisitedAt = endedAt;
-			}
-
-			// Add or merge the activity reference
-			rec.activityReferences ??= [];
-			const existingRef = refByHexId.get(hexId);
-			if (existingRef) {
-				existingRef.walkedIndex = i;
-			} else {
-				const newRef: ActivityReference = { activityId, walkedIndex: i };
-				rec.activityReferences.push(newRef);
-				refByHexId.set(hexId, newRef);
-			}
-
-			// Build walked edges from consecutive tile pairs
-			if (i > 0) {
-				const prev = orderedHexTiles[i - 1].hexId;
-				const edge = prev < hexId ? `${prev}:${hexId}` : `${hexId}:${prev}`;
-				edgeSet.add(edge);
-			}
-		}
+		const refByHexId = buildActivityReferenceMap(records, activityId);
+		processVisitedTiles(orderedHexTiles, activityId, endedAt, records, refByHexId, edgeSet);
 
 		// ── Compute red-line walked edges for this activity ──────────────────
-		// Use GPS route points when available; synthesize them for manual activities.
-		if (isH3Available()) {
-			const hexTilesOrdered = orderedHexTiles.map((e) => e.hexId);
-			const routePoints = activity.routePoints.length > 0
-				? activity.routePoints
-				: synthesizeManualActivityRoutePoints(
-					hexTilesOrdered,
-					activity.startedAt,
-					activity.endedAt - activity.startedAt,
-					activity.distanceKm,
-				);
-			if (routePoints.length > 0) {
-				const redLineEdges = computeEdgesFromRoutePoints(routePoints, RED_LINE_GRID_RESOLUTION);
-				for (const edge of redLineEdges) edgeSetRedLine.add(edge);
-			}
-		}
+		computeRedLineEdgesForActivity(activity, orderedHexTiles, edgeSetRedLine);
 
 		// ── Process enclosed tiles ────────────────────────────────────────────
-		for (let i = 0; i < enclosedHexTiles.length; i++) {
-			const hexId = enclosedHexTiles[i];
-			const rec = getOrCreateRecord(records, hexId);
-
-			// Update timestamps
-			if (rec.lastEnclosedAt === null || endedAt > rec.lastEnclosedAt) {
-				rec.lastEnclosedAt = endedAt;
-			}
-
-			// Add or merge the activity reference
-			rec.activityReferences ??= [];
-			const existingRef = refByHexId.get(hexId);
-			if (existingRef) {
-				existingRef.enclosedIndex = i;
-			} else {
-				const newRef: ActivityReference = { activityId, enclosedIndex: i };
-				rec.activityReferences.push(newRef);
-				refByHexId.set(hexId, newRef);
-			}
-		}
-
+		processEnclosedTiles(enclosedHexTiles, activityId, endedAt, records, refByHexId);
 	}
 
 	// ── Second pass (2a): compute counts and levels for ALL tiles first ───────
@@ -832,105 +1067,15 @@ export function rebuildMapFromActivities(
 	// visitCount are fully populated before the terrain/tree assignment pass
 	// (2b) reads those values on neighbour tiles.
 	for (const rec of Object.values(records)) {
-		const refs: ActivityReference[] = rec.activityReferences ?? [];
-
-		// Count distinct activities that visited / enclosed this tile.
-		const visitedActivities = new Set(
-			refs.filter((r) => r.walkedIndex !== undefined).map((r) => r.activityId),
-		);
-		const enclosedActivities = new Set(
-			refs.filter((r) => r.enclosedIndex !== undefined).map((r) => r.activityId),
-		);
-
-		rec.visitCount = visitedActivities.size;
-		rec.enclosedCount = enclosedActivities.size;
-		rec.walkedOn = rec.visitCount > 0;
-		rec.level = computeHexTileLevel(rec);
+		computeCountsAndLevelForRecord(rec);
 	}
 
 	// ── Second pass (2a.5): compute avenueCount ───────────────────────────────
-	// avenueCount for a tile = number of distinct activities that visited (i.e.
-	// walked on or enclosed) at least one immediately neighbouring tile
-	// (ring-1 H3 disk, excl. self).
-	// This is computed after visitCount/enclosedCount are fully populated so
-	// that the per-tile activity-ID sets are already available via
-	// activityReferences.
-	if (isH3Available()) {
-		// Build a map from hexId → set of activity IDs that walked on OR enclosed it.
-		const visitedActsMap = new Map<string, Set<string>>();
-		for (const [hexId, rec] of Object.entries(records)) {
-			if (rec.visitCount > 0 || rec.enclosedCount > 0) {
-				const refs: ActivityReference[] = rec.activityReferences ?? [];
-				visitedActsMap.set(
-					hexId,
-					new Set(refs.map((r) => r.activityId)),
-				);
-			}
-		}
-
-		// Ensure that every ring-1 neighbor of a visited tile has a record so
-		// that its avenueCount is computed and stored even when the tile itself
-		// was never walked or enclosed.
-		for (const hexId of visitedActsMap.keys()) {
-			const neighbors = gridDisk(hexId, 1).filter((n) => n !== hexId);
-			for (const neighbor of neighbors) {
-				getOrCreateRecord(records, neighbor);
-			}
-		}
-
-		// For every tile, union the activity sets of its walked neighbours.
-		for (const [hexId, rec] of Object.entries(records)) {
-			const neighbors = gridDisk(hexId, 1).filter((n) => n !== hexId);
-			const avenueActivities = new Set<string>();
-			for (const neighbor of neighbors) {
-				const neighborActs = visitedActsMap.get(neighbor);
-				if (neighborActs) {
-					for (const actId of neighborActs) {
-						avenueActivities.add(actId);
-					}
-				}
-			}
-			rec.avenueCount = avenueActivities.size;
-		}
-	}
+	computeAvenueCounts(records);
 
 	// ── Second pass (2b): apply tile-image and billboard assignments ──────────
-	// All counts are now fully computed, so it is safe to query neighbour
-	// tiles' enclosedCount when deciding whether to place trees.
 	for (const [hexId, rec] of Object.entries(records)) {
-		// Apply automatic tile-image and billboard assignments.
-		if (rec.visitCount > 0) {
-			// Visited tile → dirt terrain
-			rec.tileImage = TILE_IMAGE_DIRT;
-
-			// Place a path object (flat) at each MIDDLE ring anchor that faces a
-			// walked neighbor tile, indicating the route direction.
-			if (isH3Available()) {
-				const neighbors = gridDisk(hexId, 1).filter((n) => n !== hexId);
-				for (const neighbor of neighbors) {
-					const edgeStr = hexId < neighbor ? `${hexId}:${neighbor}` : `${neighbor}:${hexId}`;
-					if (!edgeSet.has(edgeStr)) continue;
-					const edgeIdx = getEdgeIndexTowardNeighbor(hexId, neighbor);
-					if (edgeIdx < 0 || edgeIdx >= EDGE_INDEX_TO_ANCHOR.length) continue;
-					const anchorPosition = EDGE_INDEX_TO_ANCHOR[edgeIdx];
-					rec.billboardsTexture ??= {};
-					rec.billboardsTexture[anchorPosition] = BILLBOARD_PATH_ROUNDED;
-				}
-			}
-		} else if (rec.enclosedCount > 0) {
-			// Enclosed but not visited → grass terrain; forest
-			// trees only when the feature cache confirms a forest / wooded area.
-			rec.tileImage = TILE_IMAGE_GRASS;
-			checkAndApplyForest(hexId, rec, hexTileFeatureCache[hexId]);
-			// Override tileImage to stone when the feature cache confirms rocky
-			// ground (pebble-stone terrain).  This is a tileImage-level change only –
-			// not a billboard (hex object) and not a texture adaption (hex texture).
-			// Note: pebbleStone runs after forest so the stone terrain wins when
-			// both features are present.  In practice, ROCK and WOOD landcovers
-			// are mutually exclusive in OpenMapTiles data, so this scenario does
-			// not occur on real tiles.
-			checkAndApplyPebbleStone(rec, hexTileFeatureCache[hexId]);
-		}
+		applyTileImageAndBillboardsForRecord(hexId, rec, edgeSet, hexTileFeatureCache);
 	}
 
 	// Apply home tile castle2 billboard if a home tile is set.
@@ -941,37 +1086,7 @@ export function rebuildMapFromActivities(
 	}
 
 	// ── Fourth pass: populate parent chain for all tiles ─────────────────────
-	// For every tile in `records`, set `parentH3Index` and `parentChildIndex`,
-	// and ensure ancestor records (up to resolution 0) also exist in `records`
-	// with their own parent info.  Ancestor records added here have level 0 and
-	// no visit/enclosure data; they serve purely as hierarchy metadata.
-	if (isH3Available()) {
-		// Snapshot the keys so that newly created ancestor records are also
-		// processed (we iterate until no new keys are added).
-		let keysToProcess = Object.keys(records);
-		while (keysToProcess.length > 0) {
-			const nextKeys: string[] = [];
-			for (const h3Index of keysToProcess) {
-				const rec = records[h3Index];
-				// Skip tiles whose parent info is already set.
-				if (rec.parentH3Index !== undefined) continue;
-				const info = computeParentInfo(h3Index);
-				if (!info) {
-					rec.parentH3Index = null;
-					rec.parentChildIndex = null;
-					continue;
-				}
-				rec.parentH3Index = info.parentH3Index;
-				rec.parentChildIndex = info.parentChildIndex;
-				// Create the parent record if it does not yet exist.
-				if (!records[info.parentH3Index]) {
-					getOrCreateRecord(records, info.parentH3Index);
-					nextKeys.push(info.parentH3Index);
-				}
-			}
-			keysToProcess = nextKeys;
-		}
-	}
+	populateParentChain(records);
 
 	return { records, walkedEdges: Array.from(edgeSet), walkedEdgesRedLine: Array.from(edgeSetRedLine) };
 }
@@ -1003,6 +1118,67 @@ const BENCH_MAX_ACTIVITIES_PER_ROUTE = 5;
  * @param activities All saved activities (used to look up route membership).
  * @param routes     All saved routes.
  */
+/**
+ * Accumulate per-hex average-speed totals across a route's qualifying
+ * activities, excluding each activity's first/last visited tile and the
+ * route-level excluded tiles.  Skips activities without speed data (legacy
+ * activities) and activities with fewer than 3 visited tiles.
+ */
+function accumulateRouteHexSpeedTotals(
+	routeActivities: SavedActivity[],
+	routeExcluded: Set<string>,
+): { hexSpeedSum: Record<string, number>; hexActivityCount: Record<string, number> } {
+	const hexSpeedSum: Record<string, number> = {};
+	const hexActivityCount: Record<string, number> = {};
+
+	for (const activity of routeActivities) {
+		// Skip activities without speed data – a zero-speed fallback would
+		// artificially rank tiles from legacy activities as the slowest.
+		if (!activity.computed?.hexTilesVisited) continue;
+		const hexTilesVisited = activity.computed.hexTilesVisited;
+
+		// Need at least 3 tiles so there is at least one tile remaining after
+		// excluding the first and last.
+		if (hexTilesVisited.length < 3) continue;
+
+		// Exclude first and last tiles of this activity's visited sequence.
+		const activityExcluded = new Set<string>([
+			hexTilesVisited[0].hexId,
+			hexTilesVisited[hexTilesVisited.length - 1].hexId,
+		]);
+
+		for (const { hexId, avgSpeedKmh } of hexTilesVisited) {
+			if (activityExcluded.has(hexId)) continue;
+			if (routeExcluded.has(hexId)) continue;
+			hexSpeedSum[hexId] = (hexSpeedSum[hexId] ?? 0) + avgSpeedKmh;
+			hexActivityCount[hexId] = (hexActivityCount[hexId] ?? 0) + 1;
+		}
+	}
+
+	return { hexSpeedSum, hexActivityCount };
+}
+
+/**
+ * Place a bench billboard on the first candidate (already sorted
+ * slowest-first) that is a dirt tile with no existing CENTER billboard.
+ * Mutates `records` in place.
+ */
+function placeBenchOnSlowestDirtTile(
+	candidates: Array<{ hexId: string; meanSpeed: number }>,
+	records: Record<string, HexTileRecord>,
+): void {
+	for (const { hexId } of candidates) {
+		const rec = records[hexId];
+		if (!rec) continue;
+		if (rec.tileImage !== TILE_IMAGE_DIRT) continue;
+		if (rec.billboards?.[BillboardAnchorPosition.CENTER]) continue;
+
+		rec.billboards ??= {};
+		rec.billboards[BillboardAnchorPosition.CENTER] = BILLBOARD_BENCH;
+		break;
+	}
+}
+
 export function applyRouteBenches(
 	records: Record<string, HexTileRecord>,
 	activities: SavedActivity[],
@@ -1027,32 +1203,7 @@ export function applyRouteBenches(
 		if (routeActivities.length === 0) continue;
 
 		// Accumulate average speed per hex tile across activities.
-		const hexSpeedSum: Record<string, number> = {};
-		const hexActivityCount: Record<string, number> = {};
-
-		for (const activity of routeActivities) {
-			// Skip activities without speed data – a zero-speed fallback would
-			// artificially rank tiles from legacy activities as the slowest.
-			if (!activity.computed?.hexTilesVisited) continue;
-			const hexTilesVisited = activity.computed.hexTilesVisited;
-
-			// Need at least 3 tiles so there is at least one tile remaining after
-			// excluding the first and last.
-			if (hexTilesVisited.length < 3) continue;
-
-			// Exclude first and last tiles of this activity's visited sequence.
-			const activityExcluded = new Set<string>([
-				hexTilesVisited[0].hexId,
-				hexTilesVisited[hexTilesVisited.length - 1].hexId,
-			]);
-
-			for (const { hexId, avgSpeedKmh } of hexTilesVisited) {
-				if (activityExcluded.has(hexId)) continue;
-				if (routeExcluded.has(hexId)) continue;
-				hexSpeedSum[hexId] = (hexSpeedSum[hexId] ?? 0) + avgSpeedKmh;
-				hexActivityCount[hexId] = (hexActivityCount[hexId] ?? 0) + 1;
-			}
-		}
+		const { hexSpeedSum, hexActivityCount } = accumulateRouteHexSpeedTotals(routeActivities, routeExcluded);
 
 		// Sort eligible tiles by mean speed ascending (slowest first).
 		const candidates = Object.keys(hexSpeedSum)
@@ -1063,15 +1214,6 @@ export function applyRouteBenches(
 			.sort((a, b) => a.meanSpeed - b.meanSpeed);
 
 		// Place bench on the first dirt tile that has no CENTER billboard yet.
-		for (const { hexId } of candidates) {
-			const rec = records[hexId];
-			if (!rec) continue;
-			if (rec.tileImage !== TILE_IMAGE_DIRT) continue;
-			if (rec.billboards?.[BillboardAnchorPosition.CENTER]) continue;
-
-			rec.billboards ??= {};
-			rec.billboards[BillboardAnchorPosition.CENTER] = BILLBOARD_BENCH;
-			break;
-		}
+		placeBenchOnSlowestDirtTile(candidates, records);
 	}
 }

--- a/apps/geonexia/frontend/helpers/RoadMatchHelper.ts
+++ b/apps/geonexia/frontend/helpers/RoadMatchHelper.ts
@@ -334,6 +334,76 @@ function graphNodeIndex(graph: RoadGraph, pt: [number, number]): number | undefi
 /** A candidate entry/exit point into the graph: a node plus the extra distance to reach it from off-graph. */
 type WeightedNode = { nodeIndex: number; extraDist: number };
 
+/** One entry in `findConnectingPath`'s array-scan priority queue. */
+type PathQueueEntry = { nodeIndex: number; dist: number };
+
+/** Maps each target node to the smallest `extraDist` among (possibly duplicate) targets sharing that node. */
+function buildTargetExtraMap(targets: WeightedNode[]): Map<number, number> {
+	const targetExtra = new Map<number, number>();
+	for (const t of targets) {
+		const prevExtra = targetExtra.get(t.nodeIndex);
+		if (prevExtra === undefined || t.extraDist < prevExtra) targetExtra.set(t.nodeIndex, t.extraDist);
+	}
+	return targetExtra;
+}
+
+/** Seeds the Dijkstra `dist` map and priority queue from the search's starting nodes. */
+function seedSourceQueue(sources: WeightedNode[]): { dist: Map<number, number>; queue: PathQueueEntry[] } {
+	const dist = new Map<number, number>();
+	const queue: PathQueueEntry[] = [];
+	for (const s of sources) {
+		if (!dist.has(s.nodeIndex) || s.extraDist < dist.get(s.nodeIndex)!) {
+			dist.set(s.nodeIndex, s.extraDist);
+			queue.push({ nodeIndex: s.nodeIndex, dist: s.extraDist });
+		}
+	}
+	return { dist, queue };
+}
+
+/** Removes and returns the queue entry with the smallest `dist` (simple array-scan priority queue). */
+function popNearestQueueEntry(queue: PathQueueEntry[]): PathQueueEntry {
+	let minIdx = 0;
+	for (let i = 1; i < queue.length; i++) {
+		if (queue[i].dist < queue[minIdx].dist) minIdx = i;
+	}
+	return queue.splice(minIdx, 1)[0];
+}
+
+/** Walks `prev` back from `endNode` to a source, returning the node-index path in source → target order. */
+function reconstructPathFromPrev(prev: Map<number, number>, endNode: number): number[] {
+	const path: number[] = [endNode];
+	let node = endNode;
+	while (prev.has(node)) {
+		node = prev.get(node)!;
+		path.push(node);
+	}
+	path.reverse();
+	return path;
+}
+
+/** Relaxes `current`'s outgoing edges, updating `dist`/`prev` and enqueueing any improved neighbours. */
+function relaxOutgoingEdges(
+	graph: RoadGraph,
+	current: PathQueueEntry,
+	maxTotalDistDeg: number,
+	visited: Set<number>,
+	dist: Map<number, number>,
+	prev: Map<number, number>,
+	queue: PathQueueEntry[],
+): void {
+	for (const edge of graph.adjacency[current.nodeIndex]) {
+		if (visited.has(edge.to)) continue;
+		const newDist = current.dist + edge.dist;
+		if (newDist > maxTotalDistDeg) continue;
+		const existing = dist.get(edge.to);
+		if (existing === undefined || newDist < existing) {
+			dist.set(edge.to, newDist);
+			prev.set(edge.to, current.nodeIndex);
+			queue.push({ nodeIndex: edge.to, dist: newDist });
+		}
+	}
+}
+
 /**
  * Dijkstra search from any of `sources` to the nearest of `targets`, capped at
  * `maxTotalDistDeg` total distance (including the sources'/targets' extra
@@ -351,31 +421,13 @@ function findConnectingPath(
 ): { path: number[]; distance: number } | null {
 	if (sources.length === 0 || targets.length === 0) return null;
 
-	const targetExtra = new Map<number, number>();
-	for (const t of targets) {
-		const prevExtra = targetExtra.get(t.nodeIndex);
-		if (prevExtra === undefined || t.extraDist < prevExtra) targetExtra.set(t.nodeIndex, t.extraDist);
-	}
-
-	const dist = new Map<number, number>();
+	const targetExtra = buildTargetExtraMap(targets);
+	const { dist, queue } = seedSourceQueue(sources);
 	const prev = new Map<number, number>();
-	const queue: { nodeIndex: number; dist: number }[] = [];
-
-	for (const s of sources) {
-		if (!dist.has(s.nodeIndex) || s.extraDist < dist.get(s.nodeIndex)!) {
-			dist.set(s.nodeIndex, s.extraDist);
-			queue.push({ nodeIndex: s.nodeIndex, dist: s.extraDist });
-		}
-	}
-
 	const visited = new Set<number>();
 
 	while (queue.length > 0) {
-		let minIdx = 0;
-		for (let i = 1; i < queue.length; i++) {
-			if (queue[i].dist < queue[minIdx].dist) minIdx = i;
-		}
-		const current = queue.splice(minIdx, 1)[0];
+		const current = popNearestQueueEntry(queue);
 		if (visited.has(current.nodeIndex)) continue;
 		visited.add(current.nodeIndex);
 
@@ -383,29 +435,12 @@ function findConnectingPath(
 		if (extra !== undefined) {
 			const totalDist = current.dist + extra;
 			if (totalDist > maxTotalDistDeg) return null;
-			const path: number[] = [current.nodeIndex];
-			let node = current.nodeIndex;
-			while (prev.has(node)) {
-				node = prev.get(node)!;
-				path.push(node);
-			}
-			path.reverse();
-			return { path, distance: totalDist };
+			return { path: reconstructPathFromPrev(prev, current.nodeIndex), distance: totalDist };
 		}
 
 		if (current.dist > maxTotalDistDeg) continue;
 
-		for (const edge of graph.adjacency[current.nodeIndex]) {
-			if (visited.has(edge.to)) continue;
-			const newDist = current.dist + edge.dist;
-			if (newDist > maxTotalDistDeg) continue;
-			const existing = dist.get(edge.to);
-			if (existing === undefined || newDist < existing) {
-				dist.set(edge.to, newDist);
-				prev.set(edge.to, current.nodeIndex);
-				queue.push({ nodeIndex: edge.to, dist: newDist });
-			}
-		}
+		relaxOutgoingEdges(graph, current, maxTotalDistDeg, visited, dist, prev, queue);
 	}
 
 	return null;
@@ -440,6 +475,73 @@ export type RoadMatchJunctionMode = 'direct' | 'network';
 export const DEFAULT_ROAD_MATCH_JUNCTION_MODE: RoadMatchJunctionMode = 'network';
 
 // ─── Main matching ──────────────────────────────────────────────────────────
+
+/**
+ * Isolated-point correction: point i differs from both neighbours, which
+ * agree with each other - and point i is close enough to the neighbours'
+ * way to plausibly be a noisy reading of the same way, not a real detour.
+ * Mutates `matches` in place.
+ */
+function applyIsolatedPointCorrection(
+	points: [number, number][],
+	matches: (PointMatch | null)[],
+	ways: RoadWay[],
+	noiseDegSq: number,
+): void {
+	for (let i = 1; i < matches.length - 1; i++) {
+		const prev = matches[i - 1];
+		const next = matches[i + 1];
+		if (!prev || !next || prev.wayIndex !== next.wayIndex) continue;
+		const curr = matches[i];
+		if (curr?.wayIndex === prev.wayIndex) continue;
+
+		const alt = findBestMatchOnWay(points[i], ways[prev.wayIndex], prev.wayIndex, noiseDegSq);
+		if (alt) matches[i] = alt;
+	}
+}
+
+/**
+ * Connects `prevMatch` and `currMatch` (matched to the same way) by
+ * appending the way's own vertices between the two projections, instead of
+ * cutting a straight line, in whichever direction the walk went.
+ */
+function connectSameWaySegment(
+	result: [number, number][],
+	wayPoints: [number, number][],
+	prevMatch: PointMatch,
+	currMatch: PointMatch,
+): void {
+	for (const pt of extractWaySubPath(wayPoints, prevMatch.segIndex, prevMatch.t, currMatch.segIndex, currMatch.t)) {
+		pushDistinct(result, pt);
+	}
+	pushDistinct(result, currMatch.point);
+}
+
+/**
+ * Connects `prevMatch` and `currMatch` (matched to different ways) via a
+ * `findConnectingPath` network search, lazily building `graph` from `ways`
+ * on first use (`graph` may already be built from an earlier call). Falls
+ * back to a direct connect when no path is found within `maxConnectDistDeg`.
+ * Returns the (possibly newly built) graph so the caller can reuse it.
+ */
+function connectViaNetworkSearch(
+	result: [number, number][],
+	graph: RoadGraph | null,
+	ways: RoadWay[],
+	prevMatch: PointMatch,
+	currMatch: PointMatch,
+	maxConnectDistDeg: number,
+): RoadGraph {
+	const resolvedGraph = graph ?? buildRoadGraph(ways);
+	const sources = segmentEndpointsAsWeightedNodes(resolvedGraph, ways[prevMatch.wayIndex].points, prevMatch);
+	const targets = segmentEndpointsAsWeightedNodes(resolvedGraph, ways[currMatch.wayIndex].points, currMatch);
+	const connection = findConnectingPath(resolvedGraph, sources, targets, maxConnectDistDeg);
+	if (connection) {
+		for (const nodeIdx of connection.path) pushDistinct(result, resolvedGraph.nodeCoords[nodeIdx]);
+	}
+	pushDistinct(result, currMatch.point);
+	return resolvedGraph;
+}
 
 /**
  * Matches a raw GPS track onto the given road/path ways and returns the
@@ -481,19 +583,7 @@ export function matchRouteToRoads(
 
 	const matches: (PointMatch | null)[] = points.map((pt) => findBestMatch(pt, grid, maxDistDegSq));
 
-	// Isolated-point correction: point i differs from both neighbours, which
-	// agree with each other - and point i is close enough to the neighbours'
-	// way to plausibly be a noisy reading of the same way, not a real detour.
-	for (let i = 1; i < matches.length - 1; i++) {
-		const prev = matches[i - 1];
-		const next = matches[i + 1];
-		if (!prev || !next || prev.wayIndex !== next.wayIndex) continue;
-		const curr = matches[i];
-		if (curr?.wayIndex === prev.wayIndex) continue;
-
-		const alt = findBestMatchOnWay(points[i], ways[prev.wayIndex], prev.wayIndex, noiseDegSq);
-		if (alt) matches[i] = alt;
-	}
+	applyIsolatedPointCorrection(points, matches, ways, noiseDegSq);
 
 	// Built lazily - only needed once a way-to-way transition actually occurs.
 	let graph: RoadGraph | null = null;
@@ -508,24 +598,13 @@ export function matchRouteToRoads(
 		if (currMatch && prevMatch?.wayIndex === currMatch.wayIndex) {
 			// Follow the way's own vertices between the two projections instead of
 			// cutting a straight line, in whichever direction the walk went.
-			const wayPoints = ways[prevMatch.wayIndex].points;
-			for (const pt of extractWaySubPath(wayPoints, prevMatch.segIndex, prevMatch.t, currMatch.segIndex, currMatch.t)) {
-				pushDistinct(result, pt);
-			}
-			pushDistinct(result, currMatch.point);
+			connectSameWaySegment(result, ways[prevMatch.wayIndex].points, prevMatch, currMatch);
 		} else if (prevMatch && currMatch && junctionMode === 'direct') {
 			pushDistinct(result, currMatch.point);
 		} else if (prevMatch && currMatch) {
 			// 'network': search for a real road/path route between them instead of
 			// cutting a straight line across the corner.
-			graph ??= buildRoadGraph(ways);
-			const sources = segmentEndpointsAsWeightedNodes(graph, ways[prevMatch.wayIndex].points, prevMatch);
-			const targets = segmentEndpointsAsWeightedNodes(graph, ways[currMatch.wayIndex].points, currMatch);
-			const connection = findConnectingPath(graph, sources, targets, maxConnectDistDeg);
-			if (connection) {
-				for (const nodeIdx of connection.path) pushDistinct(result, graph.nodeCoords[nodeIdx]);
-			}
-			pushDistinct(result, currMatch.point);
+			graph = connectViaNetworkSearch(result, graph, ways, prevMatch, currMatch, maxConnectDistDeg);
 		} else {
 			pushDistinct(result, currMatch ? currMatch.point : points[i]);
 		}

--- a/apps/geonexia/frontend/helpers/RouteDisplayHelper.ts
+++ b/apps/geonexia/frontend/helpers/RouteDisplayHelper.ts
@@ -43,6 +43,52 @@ export function computeEdgesFromHexTiles(hexTiles: string[]): string[] {
 }
 
 /**
+ * Add edges for the H3 grid path between two adjacent cells visited in
+ * sequence, interpolating through any intermediate cells. Falls back to a
+ * direct edge when the two cells sit on different icosahedron faces (no
+ * valid grid path exists between them).
+ */
+function addInterpolatedRouteEdges(lastCell: string, cell: string, edges: Set<string>): void {
+	try {
+		const pathCells = gridPathCells(lastCell, cell);
+		if (pathCells.length - 2 <= GPS_PATH_INTERPOLATION_MAX_CELLS) {
+			for (let i = 0; i < pathCells.length - 1; i++) {
+				const a = pathCells[i];
+				const b = pathCells[i + 1];
+				edges.add(a < b ? `${a}:${b}` : `${b}:${a}`);
+			}
+		}
+	} catch {
+		// Different icosahedron faces – just add direct edge
+		edges.add(lastCell < cell ? `${lastCell}:${cell}` : `${cell}:${lastCell}`);
+	}
+}
+
+/**
+ * Convert a single GPS route point to its H3 cell and, if it differs from the
+ * previously visited cell, record the walked edge(s) between them. Returns
+ * the cell to use as `lastCell` for the next point (unchanged on failure).
+ */
+function processRoutePointForEdges(
+	point: { lat: number; lng: number },
+	h3Resolution: number,
+	lastCell: string | null,
+	edges: Set<string>,
+): string | null {
+	try {
+		const cell = latLngToCell(point.lat, point.lng, h3Resolution);
+		if (!cell) return lastCell;
+		if (lastCell && cell !== lastCell) {
+			addInterpolatedRouteEdges(lastCell, cell, edges);
+		}
+		return cell;
+	} catch {
+		// Skip invalid GPS points
+		return lastCell;
+	}
+}
+
+/**
  * Compute walked edges from raw GPS route points by converting each point to
  * its H3 cell and tracking hex-to-hex transitions (including gap
  * interpolation). This produces accurate edges based on the actual path taken.
@@ -55,28 +101,7 @@ export function computeEdgesFromRoutePoints(
 	let lastCell: string | null = null;
 
 	for (const point of routePoints) {
-		try {
-			const cell = latLngToCell(point.lat, point.lng, h3Resolution);
-			if (!cell) continue;
-			if (lastCell && cell !== lastCell) {
-				try {
-					const pathCells = gridPathCells(lastCell, cell);
-					if (pathCells.length - 2 <= GPS_PATH_INTERPOLATION_MAX_CELLS) {
-						for (let i = 0; i < pathCells.length - 1; i++) {
-							const a = pathCells[i];
-							const b = pathCells[i + 1];
-							edges.add(a < b ? `${a}:${b}` : `${b}:${a}`);
-						}
-					}
-				} catch {
-					// Different icosahedron faces – just add direct edge
-					edges.add(lastCell < cell ? `${lastCell}:${cell}` : `${cell}:${lastCell}`);
-				}
-			}
-			lastCell = cell;
-		} catch {
-			// Skip invalid GPS points
-		}
+		lastCell = processRoutePointForEdges(point, h3Resolution, lastCell, edges);
 	}
 
 	return Array.from(edges);

--- a/apps/geonexia/frontend/helpers/TTSHelper.ts
+++ b/apps/geonexia/frontend/helpers/TTSHelper.ts
@@ -216,6 +216,77 @@ function formatPaceForSpeech(
 }
 
 /**
+ * Format the distance part of a periodic announcement, localised for the
+ * given language code.
+ */
+function resolveDistanceAnnouncementPart(langCode: string, distanceKm: number): string {
+	if (langCode === 'de') {
+		return formatDistanceForSpeech(distanceKm, 'Kilometer', 'Meter');
+	}
+	return formatDistanceForSpeech(distanceKm, 'kilometers', 'meters');
+}
+
+/**
+ * Format the duration part of a periodic announcement, localised for the
+ * given language code.
+ */
+function resolveDurationAnnouncementPart(langCode: string, elapsedSeconds: number): string {
+	const totalSec = Math.round(elapsedSeconds);
+	const h = Math.floor(totalSec / 3600);
+	const m = Math.floor((totalSec % 3600) / 60);
+	const s = totalSec % 60;
+	if (langCode === 'de') {
+		if (h > 0) {
+			return `${h} Stunde${h > 1 ? 'n' : ''} ${m} Minuten ${s} Sekunden`;
+		}
+		return `${m} Minuten ${s} Sekunden`;
+	}
+	if (h > 0) {
+		return `${h} hour${h > 1 ? 's' : ''} ${m} minutes ${s} seconds`;
+	}
+	return `${m} minutes ${s} seconds`;
+}
+
+/**
+ * Format the current-speed part of a periodic announcement, localised for
+ * the given language code. Derives km/h from pace when available so both
+ * metrics share the same base; falls back to `speedKmh` from stats.
+ * Returns null when no speed value is available.
+ */
+function resolveSpeedAnnouncementPart(
+	langCode: string,
+	paceMinPerKm: number | null,
+	speedKmh: number | null,
+): string | null {
+	const derivedKmh = paceToKmh(paceMinPerKm) ?? speedKmh;
+	if (derivedKmh == null) {
+		return null;
+	}
+	const sp = formatSpeedForSpeech(derivedKmh);
+	if (langCode === 'de') {
+		return `${sp} Kilometer pro Stunde`;
+	}
+	return `${sp} kilometers per hour`;
+}
+
+/**
+ * Format the average-speed part of a periodic announcement, localised for
+ * the given language code. Average speed is always derived from avg pace
+ * (total distance / total time). Returns null when pace is unavailable.
+ */
+function resolveSpeedAvgAnnouncementPart(langCode: string, paceMinPerKm: number | null): string | null {
+	const avgKmh = paceToKmh(paceMinPerKm);
+	if (avgKmh == null) {
+		return null;
+	}
+	const sp = formatSpeedForSpeech(avgKmh);
+	if (langCode === 'de') {
+		return `Durchschnittliche Geschwindigkeit: ${sp} Kilometer pro Stunde`;
+	}
+	return `Average speed: ${sp} kilometers per hour`;
+}
+
+/**
  * Build a localised TTS announcement for periodic (time-based) updates during
  * recording.  Only the content toggles that are enabled are included.
  *
@@ -238,12 +309,7 @@ export function buildPeriodicAnnouncement(
 	const parts: string[] = [];
 
 	if (content.announceDistance) {
-		const d = stats.distanceKm;
-		if (langCode === 'de') {
-			parts.push(formatDistanceForSpeech(d, 'Kilometer', 'Meter'));
-		} else {
-			parts.push(formatDistanceForSpeech(d, 'kilometers', 'meters'));
-		}
+		parts.push(resolveDistanceAnnouncementPart(langCode, stats.distanceKm));
 	}
 
 	if (content.announcePace && stats.paceMinPerKm != null) {
@@ -255,46 +321,20 @@ export function buildPeriodicAnnouncement(
 	}
 
 	if (content.announceDuration) {
-		const totalSec = Math.round(stats.elapsedSeconds);
-		const h = Math.floor(totalSec / 3600);
-		const m = Math.floor((totalSec % 3600) / 60);
-		const s = totalSec % 60;
-		if (langCode === 'de') {
-			if (h > 0) {
-				parts.push(`${h} Stunde${h > 1 ? 'n' : ''} ${m} Minuten ${s} Sekunden`);
-			} else {
-				parts.push(`${m} Minuten ${s} Sekunden`);
-			}
-		} else if (h > 0) {
-			parts.push(`${h} hour${h > 1 ? 's' : ''} ${m} minutes ${s} seconds`);
-		} else {
-			parts.push(`${m} minutes ${s} seconds`);
-		}
+		parts.push(resolveDurationAnnouncementPart(langCode, stats.elapsedSeconds));
 	}
 
 	if (content.announceSpeed) {
-		// Derive km/h from pace when available so both metrics share the same base.
-		const derivedKmh = paceToKmh(stats.paceMinPerKm) ?? stats.speedKmh;
-		if (derivedKmh != null) {
-			const sp = formatSpeedForSpeech(derivedKmh);
-			if (langCode === 'de') {
-				parts.push(`${sp} Kilometer pro Stunde`);
-			} else {
-				parts.push(`${sp} kilometers per hour`);
-			}
+		const speedPart = resolveSpeedAnnouncementPart(langCode, stats.paceMinPerKm, stats.speedKmh);
+		if (speedPart != null) {
+			parts.push(speedPart);
 		}
 	}
 
 	if (content.announceSpeedAvg) {
-		// Average speed is always derived from avg pace (total distance / total time).
-		const avgKmh = paceToKmh(stats.paceMinPerKm);
-		if (avgKmh != null) {
-			const sp = formatSpeedForSpeech(avgKmh);
-			if (langCode === 'de') {
-				parts.push(`Durchschnittliche Geschwindigkeit: ${sp} Kilometer pro Stunde`);
-			} else {
-				parts.push(`Average speed: ${sp} kilometers per hour`);
-			}
+		const speedAvgPart = resolveSpeedAvgAnnouncementPart(langCode, stats.paceMinPerKm);
+		if (speedAvgPart != null) {
+			parts.push(speedAvgPart);
 		}
 	}
 

--- a/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
+++ b/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
@@ -10,7 +10,7 @@
  */
 
 import Pbf from 'pbf';
-import { VectorTile } from '@mapbox/vector-tile';
+import { VectorTile, VectorTileFeature } from '@mapbox/vector-tile';
 
 import type { MapFeatureInfo } from './RouteNameSuggestionHelper';
 import type { MapFeatureFilterOptions } from './OpenMapTilesSchema';
@@ -130,6 +130,36 @@ export function getTilesForBounds(
 const tileUrlCache: Record<string, string> = {};
 
 /**
+ * Find the first PBF tile URL (matching `{z}` placeholder or `.pbf` extension)
+ * in a list of candidate tile URL templates.
+ */
+function findPbfTileUrl(tiles: string[] | undefined): string | undefined {
+	if (!tiles) return undefined;
+	for (const url of tiles) {
+		if (url.includes('{z}') || url.includes('.pbf')) return url;
+	}
+	return undefined;
+}
+
+/**
+ * Fetch a TileJSON document from `url` and extract its first PBF tile URL
+ * template, if any. TileJSON fetch/parse errors are swallowed and treated as
+ * "no URL found" so the caller can keep looking at other sources.
+ */
+async function resolveTileUrlFromTileJson(url: string): Promise<string | undefined> {
+	try {
+		const tjRes = await fetch(url);
+		if (tjRes.ok) {
+			const tj = await tjRes.json();
+			return findPbfTileUrl(tj.tiles as string[] | undefined);
+		}
+	} catch {
+		// Ignore TileJSON fetch errors and continue.
+	}
+	return undefined;
+}
+
+/**
  * Fetch the MapLibre style JSON and extract the first `{z}/{x}/{y}` PBF tile
  * URL template from the `sources` section.
  */
@@ -148,34 +178,18 @@ export async function resolveTileUrl(styleUrl: string = DEFAULT_STYLE_URL): Prom
 		const source = src as Record<string, unknown>;
 		if (source.type !== 'vector') continue;
 
-		const tiles = source.tiles as string[] | undefined;
-		if (tiles) {
-			for (const url of tiles) {
-				if (url.includes('{z}') || url.includes('.pbf')) {
-					tileUrlCache[styleUrl] = url;
-					return url;
-				}
-			}
+		const directUrl = findPbfTileUrl(source.tiles as string[] | undefined);
+		if (directUrl) {
+			tileUrlCache[styleUrl] = directUrl;
+			return directUrl;
 		}
 
 		// Some styles use a TileJSON URL in the `url` field instead.
 		if (typeof source.url === 'string') {
-			try {
-				const tjRes = await fetch(source.url);
-				if (tjRes.ok) {
-					const tj = await tjRes.json();
-					const tjTiles = tj.tiles as string[] | undefined;
-					if (tjTiles) {
-						for (const url of tjTiles) {
-							if (url.includes('{z}') || url.includes('.pbf')) {
-								tileUrlCache[styleUrl] = url;
-								return url;
-							}
-						}
-					}
-				}
-			} catch {
-				// Ignore TileJSON fetch errors and continue.
+			const tileJsonUrl = await resolveTileUrlFromTileJson(source.url);
+			if (tileJsonUrl) {
+				tileUrlCache[styleUrl] = tileJsonUrl;
+				return tileJsonUrl;
 			}
 		}
 	}
@@ -257,6 +271,69 @@ function tileCacheKey(tileUrlTemplate: string, z: number, x: number, y: number):
 }
 
 /**
+ * Determine whether a feature's geographic bounding box (derived from its
+ * tile-relative geometry bbox) overlaps `filterBounds`.
+ */
+function featureOverlapsBounds(
+	feat: VectorTileFeature,
+	x: number,
+	y: number,
+	z: number,
+	filterBounds: { minLat: number; minLng: number; maxLat: number; maxLng: number },
+): boolean {
+	const [bx1, by1, bx2, by2] = feat.bbox();
+	const extent = feat.extent || 4096;
+
+	// Convert tile-relative coordinates to geographic lat/lng.
+	const featMinLng = tileXToLng(x + bx1 / extent, z);
+	const featMaxLng = tileXToLng(x + bx2 / extent, z);
+	// Tile Y increases downward: smaller py → further north.
+	const featMaxLat = tileYToLat(y + by1 / extent, z);
+	const featMinLat = tileYToLat(y + by2 / extent, z);
+
+	return boundsOverlap(
+		{ minLat: featMinLat, minLng: featMinLng, maxLat: featMaxLat, maxLng: featMaxLng },
+		filterBounds,
+	);
+}
+
+/** Build the `MapFeatureInfo` (minus `count`) for a raw tile feature, plus its dedup key. */
+function buildFeatureInfo(
+	layerName: string,
+	props: Record<string, number | string | boolean>,
+): { featureId: string; info: Omit<MapFeatureInfo, 'count'> } {
+	const name = (props.name as string) || (props['name:de'] as string) || null;
+	const cls = (props['class'] as string) || null;
+	const subclass = (props.subclass as string) || null;
+	const highway = (props.highway as string) || null;
+	const waterway = (props.waterway as string) || null;
+	const building = (props.building as string) || null;
+	const natural = (props.natural as string) || null;
+	const landuse = (props.landuse as string) || null;
+	const amenity = (props.amenity as string) || null;
+
+	// Deduplicate by synthetic feature ID: class|subclass|name.
+	// Duplicate occurrences increment the count instead of adding a new entry.
+	const featureId = (cls ?? '') + '|' + (subclass ?? '') + '|' + (name ?? '');
+
+	return {
+		featureId,
+		info: {
+			layerId: layerName,
+			name,
+			class: cls,
+			subclass,
+			highway,
+			waterway,
+			building,
+			natural,
+			landuse,
+			amenity,
+		},
+	};
+}
+
+/**
  * Fetch a single vector tile and parse it into an array of `MapFeatureInfo`.
  * Results are cached in-memory so repeated requests for the same tile
  * (e.g. overlapping H3 bounding boxes) are served instantly.
@@ -325,57 +402,18 @@ export async function fetchAndParseTile(
 			const props = feat.properties ?? {};
 
 			// ── Geographic filter ────────────────────────────────────
-			if (filterBounds) {
-				const [bx1, by1, bx2, by2] = feat.bbox();
-				const extent = feat.extent || 4096;
-
-				// Convert tile-relative coordinates to geographic lat/lng.
-				const featMinLng = tileXToLng(x + bx1 / extent, z);
-				const featMaxLng = tileXToLng(x + bx2 / extent, z);
-				// Tile Y increases downward: smaller py → further north.
-				const featMaxLat = tileYToLat(y + by1 / extent, z);
-				const featMinLat = tileYToLat(y + by2 / extent, z);
-
-				if (!boundsOverlap(
-					{ minLat: featMinLat, minLng: featMinLng, maxLat: featMaxLat, maxLng: featMaxLng },
-					filterBounds,
-				)) {
-					continue;
-				}
+			if (filterBounds && !featureOverlapsBounds(feat, x, y, z, filterBounds)) {
+				continue;
 			}
 
-			const name = (props.name as string) || (props['name:de'] as string) || null;
-			const cls = (props['class'] as string) || null;
-			const subclass = (props.subclass as string) || null;
-			const highway = (props.highway as string) || null;
-			const waterway = (props.waterway as string) || null;
-			const building = (props.building as string) || null;
-			const natural = (props.natural as string) || null;
-			const landuse = (props.landuse as string) || null;
-			const amenity = (props.amenity as string) || null;
-
-			// Deduplicate by synthetic feature ID: class|subclass|name.
-			// Duplicate occurrences increment the count instead of adding a new entry.
-			const featureId = (cls ?? '') + '|' + (subclass ?? '') + '|' + (name ?? '');
+			const { featureId, info } = buildFeatureInfo(layerName, props);
 			const existing = featureMap.get(featureId);
 			if (existing) {
 				existing.count += 1;
 				continue;
 			}
 
-			featureMap.set(featureId, {
-				layerId: layerName,
-				name,
-				class: cls,
-				subclass,
-				highway,
-				waterway,
-				building,
-				natural,
-				landuse,
-				amenity,
-				count: 1,
-			});
+			featureMap.set(featureId, { ...info, count: 1 });
 		}
 	}
 

--- a/apps/geonexia/frontend/store/store.ts
+++ b/apps/geonexia/frontend/store/store.ts
@@ -49,71 +49,61 @@ export const store = configureStore({
 
 // Auto-persist hex tile state to disk whenever it changes (debounced to avoid
 // excessive I/O during rapid consecutive GPS updates).
-let _saveTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedRecords: Record<string, HexTileRecord> | null = null;
-let _walkedEdgesTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedWalkedEdges: string[] | null = null;
-let _walkedEdgesRedLineTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedWalkedEdgesRedLine: string[] | null = null;
 
-// Auto-persist sport type to disk whenever the selected type changes.
-let _lastSavedSportType: SportType | null = null;
+// Generic ref shapes used by the persistence helpers below. Keeping the
+// mutable timer/last-saved-value pair together lets each helper receive it
+// as an explicit parameter instead of closing over module-local `let`s.
+type DebounceRef<T> = { timer: ReturnType<typeof setTimeout> | null; lastSaved: T | null };
+type ImmediateRef<T> = { lastSaved: T | null };
 
-// Auto-persist theme mode to disk whenever the selected mode changes.
-let _lastSavedThemeMode: ThemeMode | null = null;
+// Persists `value` immediately (no debounce) the first time it differs from
+// the last-saved value.
+function persistImmediate<T>(value: T, ref: ImmediateRef<T>, save: (value: T) => void): void {
+	if (value !== ref.lastSaved) {
+		ref.lastSaved = value;
+		save(value);
+	}
+}
 
-// Auto-persist billboard config to disk whenever anchor overrides change.
-let _bbConfigTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedBbConfig: BillboardConfigState | null = null;
+// Persists `value` after a debounce delay, resetting the pending timer on
+// every change so only the trailing value within the delay window is saved.
+function persistDebounced<T>(value: T, ref: DebounceRef<T>, save: (value: T) => void, delay = 500): void {
+	if (value !== ref.lastSaved) {
+		ref.lastSaved = value;
+		if (ref.timer) clearTimeout(ref.timer);
+		ref.timer = setTimeout(() => {
+			save(value);
+			ref.timer = null;
+		}, delay);
+	}
+}
 
-// Auto-persist hex texture config to disk whenever anchor overrides change.
-let _hexTextureConfigTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedHexTextureConfig: HexTextureConfigState | null = null;
-
-// Auto-persist GPS interval seconds to disk whenever it changes.
-let _lastSavedGpsIntervalSeconds: number | null = null;
-
-// Auto-persist TTS enabled flag to disk whenever it changes.
-let _lastSavedTTSEnabled: boolean | null = null;
-
-// Auto-persist speech settings to disk whenever they change.
-let _speechSettingsTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedSpeechSettings: SpeechSettingsState | null = null;
-
-// Auto-persist display settings to disk whenever they change.
-let _displaySettingsTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedDisplaySettings: DisplaySettingsState | null = null;
-
-// Auto-persist replay settings to disk whenever they change.
-let _replaySettingsTimer: ReturnType<typeof setTimeout> | null = null;
-let _lastSavedReplaySettings: ReplaySettingsState | null = null;
-
-// Auto-persist player information to disk whenever it changes.
-let _lastSavedPlayerInformation: PlayerInformation | null = null;
-
-store.subscribe(() => {
-	const state = store.getState();
-
-	const { records } = state.hexTiles;
-	if (records !== _lastSavedRecords) {
-		_lastSavedRecords = records;
-		if (_saveTimer) clearTimeout(_saveTimer);
-		_saveTimer = setTimeout(() => {
+// Persists hex tile records, choosing the dev/non-dev storage target based on
+// the freshest isDevMode value at the time the debounce fires (not at the
+// time the change was detected).
+function persistHexTileRecords(records: Record<string, HexTileRecord>, ref: DebounceRef<Record<string, HexTileRecord>>): void {
+	if (records !== ref.lastSaved) {
+		ref.lastSaved = records;
+		if (ref.timer) clearTimeout(ref.timer);
+		ref.timer = setTimeout(() => {
 			const currentIsDevMode = store.getState().hexTiles.isDevMode;
 			if (currentIsDevMode) {
 				saveDevHexTileState(records);
 			} else {
 				saveHexTileState(records);
 			}
-			_saveTimer = null;
+			ref.timer = null;
 		}, 500);
 	}
+}
 
-	const { walkedEdges } = state.hexTiles;
-	if (walkedEdges !== _lastSavedWalkedEdges) {
-		_lastSavedWalkedEdges = walkedEdges;
-		if (_walkedEdgesTimer) clearTimeout(_walkedEdgesTimer);
-		_walkedEdgesTimer = setTimeout(() => {
+// Persists walked edges, re-reading both isDevMode and the current edges from
+// the store when the debounce fires so the freshest values are saved.
+function persistWalkedEdges(walkedEdges: string[], ref: DebounceRef<string[]>): void {
+	if (walkedEdges !== ref.lastSaved) {
+		ref.lastSaved = walkedEdges;
+		if (ref.timer) clearTimeout(ref.timer);
+		ref.timer = setTimeout(() => {
 			const currentIsDevMode = store.getState().hexTiles.isDevMode;
 			const currentEdges = store.getState().hexTiles.walkedEdges;
 			if (currentIsDevMode) {
@@ -121,15 +111,17 @@ store.subscribe(() => {
 			} else {
 				saveWalkedEdges(currentEdges);
 			}
-			_walkedEdgesTimer = null;
+			ref.timer = null;
 		}, 500);
 	}
+}
 
-	const { walkedEdgesRedLine: currentWalkedEdgesRedLine } = state.hexTiles;
-	if (currentWalkedEdgesRedLine !== _lastSavedWalkedEdgesRedLine) {
-		_lastSavedWalkedEdgesRedLine = currentWalkedEdgesRedLine;
-		if (_walkedEdgesRedLineTimer) clearTimeout(_walkedEdgesRedLineTimer);
-		_walkedEdgesRedLineTimer = setTimeout(() => {
+// Same as persistWalkedEdges but for the red-line walked edges variant.
+function persistWalkedEdgesRedLine(walkedEdgesRedLine: string[], ref: DebounceRef<string[]>): void {
+	if (walkedEdgesRedLine !== ref.lastSaved) {
+		ref.lastSaved = walkedEdgesRedLine;
+		if (ref.timer) clearTimeout(ref.timer);
+		ref.timer = setTimeout(() => {
 			const currentIsDevMode = store.getState().hexTiles.isDevMode;
 			const currentEdgesRedLine = store.getState().hexTiles.walkedEdgesRedLine;
 			if (currentIsDevMode) {
@@ -137,89 +129,69 @@ store.subscribe(() => {
 			} else {
 				saveWalkedEdgesRedLine(currentEdgesRedLine);
 			}
-			_walkedEdgesRedLineTimer = null;
+			ref.timer = null;
 		}, 500);
 	}
+}
 
-	const { selectedType } = state.sportType;
-	if (selectedType !== _lastSavedSportType) {
-		_lastSavedSportType = selectedType;
-		saveSportType(selectedType);
-	}
+const hexTileRecordsRef: DebounceRef<Record<string, HexTileRecord>> = { timer: null, lastSaved: null };
+const walkedEdgesRef: DebounceRef<string[]> = { timer: null, lastSaved: null };
+const walkedEdgesRedLineRef: DebounceRef<string[]> = { timer: null, lastSaved: null };
 
-	const { selectedMode } = state.theme;
-	if (selectedMode !== _lastSavedThemeMode) {
-		_lastSavedThemeMode = selectedMode;
-		saveThemeMode(selectedMode);
-	}
+// Auto-persist sport type to disk whenever the selected type changes.
+const sportTypeRef: ImmediateRef<SportType> = { lastSaved: null };
 
-	const { spriteAnchors } = state.billboardConfig;
-	if (spriteAnchors !== _lastSavedBbConfig) {
-		_lastSavedBbConfig = spriteAnchors;
-		if (_bbConfigTimer) clearTimeout(_bbConfigTimer);
-		_bbConfigTimer = setTimeout(() => {
-			saveBillboardConfig(spriteAnchors);
-			_bbConfigTimer = null;
-		}, 500);
-	}
+// Auto-persist theme mode to disk whenever the selected mode changes.
+const themeModeRef: ImmediateRef<ThemeMode> = { lastSaved: null };
 
-	const { spriteAnchors: textureAnchors } = state.hexTextureConfig;
-	if (textureAnchors !== _lastSavedHexTextureConfig) {
-		_lastSavedHexTextureConfig = textureAnchors;
-		if (_hexTextureConfigTimer) clearTimeout(_hexTextureConfigTimer);
-		_hexTextureConfigTimer = setTimeout(() => {
-			saveHexTextureConfig(textureAnchors);
-			_hexTextureConfigTimer = null;
-		}, 500);
-	}
+// Auto-persist billboard config to disk whenever anchor overrides change.
+const billboardConfigRef: DebounceRef<BillboardConfigState> = { timer: null, lastSaved: null };
 
-	const { intervalSeconds: gpsSeconds } = state.gpsInterval;
-	if (gpsSeconds !== _lastSavedGpsIntervalSeconds) {
-		_lastSavedGpsIntervalSeconds = gpsSeconds;
-		saveGpsIntervalSeconds(gpsSeconds);
-	}
+// Auto-persist hex texture config to disk whenever anchor overrides change.
+const hexTextureConfigRef: DebounceRef<HexTextureConfigState> = { timer: null, lastSaved: null };
 
-	const { ttsEnabled } = state.tts;
-	if (ttsEnabled !== _lastSavedTTSEnabled) {
-		_lastSavedTTSEnabled = ttsEnabled;
-		saveTTSEnabled(ttsEnabled);
-	}
+// Auto-persist GPS interval seconds to disk whenever it changes.
+const gpsIntervalRef: ImmediateRef<number> = { lastSaved: null };
 
-	const speechSettings = state.speechSettings;
-	if (speechSettings !== _lastSavedSpeechSettings) {
-		_lastSavedSpeechSettings = speechSettings;
-		if (_speechSettingsTimer) clearTimeout(_speechSettingsTimer);
-		_speechSettingsTimer = setTimeout(() => {
-			saveSpeechSettings(speechSettings);
-			_speechSettingsTimer = null;
-		}, 500);
-	}
+// Auto-persist TTS enabled flag to disk whenever it changes.
+const ttsEnabledRef: ImmediateRef<boolean> = { lastSaved: null };
 
-	const displaySettings = state.displaySettings;
-	if (displaySettings !== _lastSavedDisplaySettings) {
-		_lastSavedDisplaySettings = displaySettings;
-		if (_displaySettingsTimer) clearTimeout(_displaySettingsTimer);
-		_displaySettingsTimer = setTimeout(() => {
-			saveDisplaySettings(displaySettings);
-			_displaySettingsTimer = null;
-		}, 500);
-	}
+// Auto-persist speech settings to disk whenever they change.
+const speechSettingsRef: DebounceRef<SpeechSettingsState> = { timer: null, lastSaved: null };
 
-	const { homeHexTile } = state.playerInformation;
-	if (state.playerInformation !== _lastSavedPlayerInformation) {
-		_lastSavedPlayerInformation = state.playerInformation;
-		savePlayerInformation({ homeHexTile });
-	}
+// Auto-persist display settings to disk whenever they change.
+const displaySettingsRef: DebounceRef<DisplaySettingsState> = { timer: null, lastSaved: null };
 
-	const replaySettings = state.replaySettings;
-	if (replaySettings !== _lastSavedReplaySettings) {
-		_lastSavedReplaySettings = replaySettings;
-		if (_replaySettingsTimer) clearTimeout(_replaySettingsTimer);
-		_replaySettingsTimer = setTimeout(() => {
-			saveReplaySettings(replaySettings);
-			_replaySettingsTimer = null;
-		}, 500);
-	}
+// Auto-persist replay settings to disk whenever they change.
+const replaySettingsRef: DebounceRef<ReplaySettingsState> = { timer: null, lastSaved: null };
+
+// Auto-persist player information to disk whenever it changes.
+const playerInformationRef: ImmediateRef<PlayerInformation> = { lastSaved: null };
+
+store.subscribe(() => {
+	const state = store.getState();
+
+	persistHexTileRecords(state.hexTiles.records, hexTileRecordsRef);
+	persistWalkedEdges(state.hexTiles.walkedEdges, walkedEdgesRef);
+	persistWalkedEdgesRedLine(state.hexTiles.walkedEdgesRedLine, walkedEdgesRedLineRef);
+
+	persistImmediate(state.sportType.selectedType, sportTypeRef, saveSportType);
+	persistImmediate(state.theme.selectedMode, themeModeRef, saveThemeMode);
+
+	persistDebounced(state.billboardConfig.spriteAnchors, billboardConfigRef, saveBillboardConfig);
+	persistDebounced(state.hexTextureConfig.spriteAnchors, hexTextureConfigRef, saveHexTextureConfig);
+
+	persistImmediate(state.gpsInterval.intervalSeconds, gpsIntervalRef, saveGpsIntervalSeconds);
+	persistImmediate(state.tts.ttsEnabled, ttsEnabledRef, saveTTSEnabled);
+
+	persistDebounced(state.speechSettings, speechSettingsRef, saveSpeechSettings);
+	persistDebounced(state.displaySettings, displaySettingsRef, saveDisplaySettings);
+
+	persistImmediate(state.playerInformation, playerInformationRef, (playerInformation) => {
+		savePlayerInformation({ homeHexTile: playerInformation.homeHexTile });
+	});
+
+	persistDebounced(state.replaySettings, replaySettingsRef, saveReplaySettings);
 });
 
 // ─── Type helpers ─────────────────────────────────────────────────────────────

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -973,6 +973,175 @@ Runden:** die übrigen ca. 58 Cognitive-Complexity-Funde (Komplexität 22 bis
 201, siehe Liste weiter oben in der fünften Runde) sowie das 51-Case-`switch`
 in `settingsReducer.ts`.
 
+## Am 2026-07-21 (siebte Runde): kompletter Cognitive-Complexity-Rest + 51-Case-`switch`
+
+Ausgangspunkt war die aktuelle CSV mit 112 Vorkommen: 58x „Cognitive
+Complexity" (Komplexität 22–201, alle bislang offenen Funde aus der fünften/
+sechsten Runde), 16x Argument-Reihenfolge (`hashHelper.ts`, `NOSONAR`-Fall,
+weiterhin unverändert bestätigt), 15x „Array index in keys" (weiterhin
+bewusst unverändert, siehe fünfte Runde), 12x „ist deprecated"
+(`hexTilesEnclosed`/`billboardsFlat`/`billboardAnchorColor`, weiterhin
+bewusst unverändert, siehe fünfte Runde), 3x „Signatur ... ist deprecated",
+2x „node:buffer", je 1x „redundant assignment" (`CardWithText`), „Simplify
+this regular expression" (`1_fix_viewbox.py`), `Object.hasOwn()`
+(`DateHelper.ts`), „Move this component definition" (`FoodItem.tsx:324`)
+und „Prefer `structuredClone(…)`" (`animationHelper.ts`) — alle neun
+kleineren Kategorien wurden Stelle für Stelle gegen die in der fünften Runde
+dokumentierten Begründungen geprüft und entsprechen exakt denselben
+Dateien/Zeilen; keine davon wurde in dieser Runde angefasst.
+
+Diese Runde hat die **restlichen 58 Cognitive-Complexity-Funde sowie das
+51-Case-`switch` in `settingsReducer.ts`** vollständig abgearbeitet — damit
+sind erstmals seit Beginn dieses Workflows alle bekannten „braucht
+individuelles Refactoring"-Funde durchgegangen.
+
+### Vorgehen: 43 parallele, dateigebundene Agenten
+
+Um Merge-Konflikte auszuschließen, wurde die Arbeit strikt nach Datei
+aufgeteilt: 43 unabhängige Agenten liefen parallel, je einer pro betroffener
+Datei (Dateien mit mehreren Funden, z. B. `geonexia/app/index.tsx` mit 6
+Funktionen oder `activities/[id].tsx` mit 4, bekamen einen einzigen Agenten,
+der alle Funde der Datei in einem Durchgang bearbeitet hat). Jeder Agent
+durfte ausschließlich seine zugewiesene Datei anfassen, keine Git-Befehle
+ausführen und musste einen strukturierten Bericht zurückgeben.
+
+**Wichtiger Zwischenfall:** Beim ersten Durchlauf meldeten 4 der 43 Agenten
+(`CustomMarkdown.tsx`, `RoadMatchHelper.ts`, `accessibilityTester/report.ts`,
+`geonexia/activities/index.tsx`) einen erfolgreichen Fix mit plausibel
+klingenden Details (konkrete Namen extrahierter Hilfsfunktionen, Zeilenzahlen
+etc.) — tatsächlich hatte `git diff` für alle vier Dateien **keinerlei
+Änderung** gezeigt (Halluzination, keine reale Editierung). Das wurde durch
+einen Abgleich „gemeldete Datei-Liste vs. tatsächlich von `git status`
+geänderte Dateien" aufgedeckt (nicht durch Vertrauen in die
+Agenten-Zusammenfassung). Alle vier wurden mit frischen, einzeln
+beauftragten Agenten wiederholt, die diesmal ihren eigenen `git diff` vor
+der Erfolgsmeldung selbst prüfen mussten; alle vier zeigen jetzt reale,
+verifizierte Diffs. Lehre für künftige Runden: bei automatisiertem
+Multi-Agent-Fan-out **immer** die tatsächlichen Dateiänderungen gegen die
+Agenten-Berichte verifizieren, nie den Berichten allein vertrauen.
+
+### Verifizierung
+
+- **Typecheck-Baseline-Diff** für alle betroffenen Workspaces (`git stash`/
+  `tsc --noEmit`-Vergleich vor/nach): `apps/frontend/app` (293 Zeilen
+  vorbestehende, unabhängige Fehler — identisch vor/nach bis auf
+  Zeilennummern-Verschiebungen), `apps/geonexia/frontend` (35 Zeilen,
+  ebenso identisch), `apps/score-tracker/frontend` (66 Zeilen, **exakt
+  unverändert**, da kein Score-Tracker-File in dieser Runde angefasst
+  wurde), `apps/accessibilityTester` (0 Fehler, weiterhin sauber) sowie
+  `yarn typecheck` für die Backend-Extension (weiterhin 0 Fehler).
+- Dabei einen echten, durch die Extraktion neu eingeführten Typfehler
+  gefunden und behoben: `form-queue/index.tsx`s neu extrahierte
+  `resolveUpdatedValueFields` hatte `customType: string` statt `customType:
+  string | undefined` typisiert (der destrukturierte `custom_type` aus
+  `formDataEntry` ist optional) — zu `string | undefined` korrigiert, reine
+  Typannotation, keine Laufzeitänderung.
+- **Adversarielle Diff-Reviews:** zusätzlich zur Typecheck-Verifizierung
+  wurden 7 unabhängige Review-Agenten eingesetzt, die die kompletten Diffs
+  aller 43 Dateien gegen das Kriterium „reine Code-Verschiebung, keine
+  Verhaltensänderung" geprüft haben (Parameterbindung, Mutations- vs.
+  Kopie-Semantik, Ref-Aktualität bei `async`/`useEffect`, Reihenfolge von
+  Datei-Upload/-Löschung, Vollständigkeit der `settingsReducer.ts`-Tabelle).
+  Besonders geprüft: die höchsten Einzelfunde (`handleLocationUpdate` in
+  `geonexia/app/index.tsx`, Komplexität 201; `rebuildMapFromActivities` in
+  `ActivityMapRebuildHelper.ts`, Komplexität 120; die Mail-Sync-Funktion in
+  `forms-sync-hook/index.ts`, Komplexität 93) sowie die 45-Einträge-Tabelle
+  in `settingsReducer.ts` (programmatisch gegen die Original-Switch-Cases
+  abgeglichen, alle 51 Action-Types nachweislich erhalten). Ergebnis: keine
+  bestätigten Verhaltensänderungen in allen 43 Dateien.
+
+### Ergebnis pro Datei
+
+**Backend-Extension** (12 Dateien, 15 Funde, alle behoben oder
+best-effort-partiell bei extrem hoher Ausgangskomplexität):
+`food-sync-hook/ParseSchedule.ts` (61→.., 41→.., 10 neue Hilfsmethoden),
+`forms-sync-hook/index.ts` (26→.., sowie die zweithöchste Einzelkomplexität
+im gesamten Repo, 93→.., bewusst schichtweise statt in einem Zug zerlegt,
+9 Hilfsfunktionen), `forms-sync-hook/FormImportSyncWorkflow.ts` (32→..),
+`workflows-runs-hook/index.ts` (36→.., 35→..),
+`auto-translation-hook/DirectusCollectionTranslator.ts` (22→..),
+`foods-translation-fix-missing-schedule/index.ts` (38→..),
+`app-reviews-pull-hook/index.ts` (26→..), `helpers/MarkingFilterHelper.ts`
+(24→..), `helpers/TranslationHelper.ts` (31→.., als „partial" markiert —
+Original-Typisierung `any` für `remaining_translationsFromParsing` bewusst
+beibehalten, siehe Dateikommentar), `mails-hook/index.ts` (39→..),
+`redirect-with-token-endpoint/index.ts` (36→..),
+`washingmachines-sync-hook/index.ts` (24→..). Alle Extraktionen mit
+expliziten Parametern statt Closures, `yarn typecheck` weiterhin bei 0
+Fehlern.
+
+**Geonexia** (12 Dateien, 24 Funde): `app/index.tsx` (alle 6 Funde,
+darunter die höchste Einzelkomplexität im gesamten Repo — `handleLocationUpdate`,
+201→.., in 7 in sich geschlossene Blöcke zerlegt: Pause-Handling,
+GPS-Filterung, H3-Zellen-Tracking, Kilometer-Ansage, Pace-Hinweis,
+Hex-Display-Refresh, Crash-Snapshot), `app/activities/[id].tsx` (alle 4
+Funde), `helpers/ActivityMapRebuildHelper.ts` (25→.., 35→.., sowie die
+zweithöchste Einzelkomplexität, `rebuildMapFromActivities` 120→.., in 10
+Hilfsfunktionen zerlegt — als „partial" markiert, da die tatsächliche
+Ziffer ohne echten Sonar-Rescan nicht bestätigt werden kann),
+`helpers/RoadMatchHelper.ts` (36→.., 31→.., Dijkstra-Suche und
+Streckenanpassung aufgeteilt), `app/activities/index.tsx` (34→..),
+`app/_layout.tsx` (37→.., Forst-Billboard-Startup-Block), `app/challenges/index.tsx`
+(23→.., 4 Wochentyp-Handler extrahiert), `app/routes/[id].tsx` (32→.., als
+„partial" markiert, gleiche Begründung wie bei `ActivityMapRebuildHelper.ts`),
+`helpers/TileFeatureHelper.ts` (37→.., 26→..), `helpers/TTSHelper.ts` (38→..,
+als „partial" markiert — 4 Textbaustein-Helper extrahiert, aber 6
+Top-Level-`if`-Zweige bleiben strukturell bestehen, absichtlich konservativ
+belassen um die gesprochene TTS-Logik nicht zu riskieren),
+`helpers/RouteDisplayHelper.ts` (27→..), `store/store.ts` (29→.., 13
+unabhängige Debounce-/Immediate-Persistenz-Blöcke auf 5 generische/spezielle
+Hilfsfunktionen reduziert, jedes Feld mit eigenem Timer-Objekt — per Review
+bestätigt, keine geteilten Zustände zwischen Feldern).
+
+**Frontend** (16 Dateien, 15 Cognitive-Complexity-Funde + 1 `switch`-Fund):
+`components/CustomMarkdown/CustomMarkdown.tsx` (31→..),
+`app/(app)/form-submission/index.tsx` (29→.., sowie die dritthöchste
+Einzelkomplexität, 65→.., der Custom-Type-Dispatch für Datei-/Bild-Upload
+inkl. Lösch-vor-Upload-Reihenfolge unverändert erhalten),
+`app/(app)/form-queue/index.tsx` (49→.., analoges Custom-Type-Dispatch-Muster),
+`app/(app)/form-submissions/index.tsx` (25→..),
+`app/(app)/image-full-screen/index.tsx` (22→..), `app/(app)/map/index.tsx`
+(25→.., inkl. Deduplizierung einer zuvor doppelten POI-Icon-Override-Berechnung),
+`app/(monitor)/bigScreen/index.tsx` (25→.., als „partial" markiert — 7 reine
+Hilfsfunktionen aus Hook-Callbacks extrahiert, die große JSX-Return-Struktur
+bewusst unangetastet gelassen), `components/MyImage/index.tsx` (29→..),
+`components/DropdownInput/DropdownSheet.tsx` (25→.., 4 Zeilen-Render-Helper),
+`components/MarkingLabels/MarkingLabels.tsx` (22→..),
+`components/SettingsListMarkingLabel/SettingsListMarkingLabel.tsx` (22→..,
+strukturell ähnlich zu `MarkingLabels.tsx`, aber unabhängig geprüft und
+verifiziert), `components/TimeTable/TimeTableList.tsx` (30→.., 6 vormals
+kopierte Zeilen-Blöcke auf einen gemeinsamen Renderer reduziert),
+`components/ManagmentFoodPlan/FoodPlan.tsx` (23→..),
+`app/(app)/foodoffers/details/hooks/useFoodDetails.ts` (23→..),
+`app/(app)/foodoffers/details/components/FoodHeader.tsx` (22→.., als
+„partial" markiert — nur die doppelte Bewertungs-Badge dedupliziert, die
+großen Web-/Mobile-JSX-Bäume mit ihren Layout-Ternaries bewusst
+unangetastet), `redux/reducer/settingsReducer.ts` (51→30 Switch-Cases: 45
+uniforme „Feld = Payload"-Fälle in eine `SIMPLE_FIELD_ASSIGNMENTS`-Lookup-Tabelle
+konsolidiert, 6 strukturell abweichende Fälle als explizite Cases belassen —
+Endstand 6 Cases, deutlich unter dem Ziel von 30).
+
+**Common-UI / accessibilityTester** (3 Dateien): `MyAvatarEditor/index.tsx`
+(40→.., `handleRandomize` in 5 Hilfsfunktionen zerlegt),
+`SettingsList/SettingsList.tsx` (28→..), `accessibilityTester/src/report.ts`
+(35→.., 8 Hilfsfunktionen für den Markdown-Report-Aufbau).
+
+**Bilanz dieser Runde:** 58 Cognitive-Complexity-Funde + 1 `switch`-Case-Fund
+= 59 neu bearbeitete Fundstellen über 43 Dateien, davon 5 bewusst als
+„partial" markiert (`ActivityMapRebuildHelper.ts`, `routes/[id].tsx`,
+`TTSHelper.ts`, `bigScreen/index.tsx`, `FoodHeader.tsx` — jeweils aus
+Sicherheitsgründen konservativ nur teilweise zerlegt, siehe Begründung
+oben; Kandidaten für eine erneute Prüfung nach dem nächsten SonarCloud-Scan).
+Alle neun kleineren, bereits in früheren Runden dokumentierten Kategorien
+(Array-Index-Keys, Deprecations, `hashHelper`-Argumentreihenfolge,
+`node:buffer`, `CardWithText`-Redundanz, Regex-Komplexität,
+`Object.hasOwn()`, `FoodItem.tsx`-Komponente, `structuredClone`) wurden
+erneut geprüft und bleiben aus denselben, weiterhin gültigen Gründen
+unverändert. **Noch offen:** nichts Bekanntes — nach dieser Runde sollte
+der nächste SonarCloud-Scan zeigen, ob einzelne der als „partial" markierten
+Funde noch über der 15er-Schwelle liegen; falls ja, sind das gezielte
+Kandidaten für eine achte Runde statt eines erneuten Komplett-Durchlaufs.
+
 ## Hinweise
 
 - Die CSV-Reports werden per CI aktualisiert (Commits `chore: update sonarcloud reports`).

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -666,6 +666,109 @@ function stripHashPrefix(color: string): string {
 }
 
 /** Position of an item within a visually grouped settings list. */
+function randomizeComponentOptions(
+	style: AvatarStyle,
+	componentOptions: Record<string, string[]>,
+	probabilityKeys: Record<string, string>,
+): Record<string, string[]> {
+	const randomOptions: Record<string, string[]> = {};
+	for (const [key, values] of Object.entries(componentOptions)) {
+		const realValues = values.filter((v) => v !== NONE_OPTION);
+		if (realValues.length === 0) continue;
+		// For openPeeps, mask is always none (key absent = renderer sets probability=0)
+		if (style === AvatarStyle.OPEN_PEEPS && key === 'mask' && probabilityKeys[key]) {
+			continue;
+		}
+		// For optional components, include "none" as a possible random selection
+		if (probabilityKeys[key]) {
+			const allValues = [NONE_OPTION, ...realValues];
+			const randomValue = allValues[Math.floor(Math.random() * allValues.length)];
+			if (randomValue !== NONE_OPTION) {
+				randomOptions[key] = [randomValue];
+			}
+			// Probability not stored – renderer derives it from key presence.
+		} else {
+			randomOptions[key] = [realValues[Math.floor(Math.random() * realValues.length)]];
+		}
+	}
+	return randomOptions;
+}
+
+function randomizeColorOptions(
+	style: AvatarStyle,
+	colorKeys: string[],
+	hiddenPropKeys: Set<string>,
+): Record<string, string[]> {
+	const randomOptions: Record<string, string[]> = {};
+	for (const key of colorKeys) {
+		// Skip hidden prop keys – they are always pinned to a fixed value
+		if (hiddenPropKeys.has(key)) continue;
+		// For Micah, eyebrowsColor and facialHairColor are derived from hairColor below
+		if (style === AvatarStyle.MICAH && (key === 'eyebrowsColor' || key === 'facialHairColor')) continue;
+		const presetColors = getPresetColorsForKey(key, style);
+		const randomColor = presetColors[Math.floor(Math.random() * presetColors.length)];
+		randomOptions[key] = [stripHashPrefix(randomColor)];
+	}
+	return randomOptions;
+}
+
+// For Micah: coordinate eyebrowsColor (= hairColor) and facialHairColor (one step lighter).
+// Mutates randomOptions in place, matching the calling convention of the other randomize* helpers.
+function applyMicahColorCoordination(
+	style: AvatarStyle,
+	randomOptions: Record<string, string[] | boolean | number>,
+	hiddenPropKeys: Set<string>,
+): void {
+	if (style !== AvatarStyle.MICAH) return;
+	const hairColorValue = randomOptions['hairColor']?.[0] as string | undefined;
+	if (hairColorValue === undefined) return;
+	if (!hiddenPropKeys.has('eyebrowsColor')) {
+		randomOptions['eyebrowsColor'] = [hairColorValue];
+	}
+	if (!hiddenPropKeys.has('facialHairColor')) {
+		// MICAH_HAIR_COLORS is ordered dark→light (index 0=Black … index 8=Light Gray),
+		// so index + 1 yields one step lighter.
+		const hairIndex = MICAH_HAIR_COLORS.findIndex((c) => stripHashPrefix(c) === hairColorValue);
+		const lighterIndex = hairIndex !== -1 ? Math.min(hairIndex + 1, MICAH_HAIR_COLORS.length - 1) : 0;
+		randomOptions['facialHairColor'] = [stripHashPrefix(MICAH_HAIR_COLORS[lighterIndex])];
+	}
+}
+
+// Preserve boolean flags (flip, clip) and numeric options (scale, translateX, translateY, rotate)
+// so that user-set positioning/orientation is not lost on randomize. Mutates randomOptions in place.
+function preservePositioningOptions(
+	config: AvatarConfig,
+	randomOptions: Record<string, string[] | boolean | number>,
+): void {
+	const preserveKeys: string[] = [
+		AvatarPropKey.OpenPeeps.FLIP,
+		AvatarPropKey.OpenPeeps.CLIP,
+		AvatarPropKey.OpenPeeps.SCALE,
+		AvatarPropKey.OpenPeeps.TRANSLATE_X,
+		AvatarPropKey.OpenPeeps.TRANSLATE_Y,
+		AvatarPropKey.OpenPeeps.ROTATE,
+	];
+	for (const key of preserveKeys) {
+		if (config.options?.[key] !== undefined) {
+			randomOptions[key] = config.options[key]!;
+		}
+	}
+}
+
+// Preserve hidden prop values so they are never lost during randomize,
+// even in debug mode where applyHiddenProps is skipped. Mutates randomOptions in place.
+function applyHiddenPropsToRandomOptions(
+	hiddenProps: Record<string, string | undefined> | undefined,
+	randomOptions: Record<string, string[] | boolean | number>,
+): void {
+	if (!hiddenProps) return;
+	for (const [key, value] of Object.entries(hiddenProps)) {
+		if (value !== undefined) {
+			randomOptions[key] = [value];
+		}
+	}
+}
+
 function getGroupPosition(length: number, index: number): 'single' | 'top' | 'bottom' | 'middle' {
 	if (length === 1) return 'single';
 	if (index === 0) return 'top';
@@ -1173,79 +1276,13 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 		const newComponentOptions = getStyleComponentOptions(config.style);
 		const newColorKeys = getStyleColorKeys(config.style);
 		const newProbabilityKeys = getStyleProbabilityKeys(config.style);
-		const randomOptions: Record<string, string[] | boolean | number> = {};
-		for (const [key, values] of Object.entries(newComponentOptions)) {
-			const realValues = values.filter((v) => v !== NONE_OPTION);
-			if (realValues.length === 0) continue;
-			// For openPeeps, mask is always none (key absent = renderer sets probability=0)
-			if (config.style === AvatarStyle.OPEN_PEEPS && key === 'mask' && newProbabilityKeys[key]) {
-				continue;
-			}
-			// For optional components, include "none" as a possible random selection
-			if (newProbabilityKeys[key]) {
-				const allValues = [NONE_OPTION, ...realValues];
-				const randomValue = allValues[Math.floor(Math.random() * allValues.length)];
-				if (randomValue !== NONE_OPTION) {
-					randomOptions[key] = [randomValue];
-				}
-				// Probability not stored – renderer derives it from key presence.
-			} else {
-				randomOptions[key] = [realValues[Math.floor(Math.random() * realValues.length)]];
-			}
-		}
-		for (const key of newColorKeys) {
-			// Skip hidden prop keys – they are always pinned to a fixed value
-			if (hiddenPropKeys.has(key)) continue;
-			// For Micah, eyebrowsColor and facialHairColor are derived from hairColor below
-			if (config.style === AvatarStyle.MICAH && (key === 'eyebrowsColor' || key === 'facialHairColor')) continue;
-			const presetColors = getPresetColorsForKey(key, config.style);
-			const randomColor = presetColors[Math.floor(Math.random() * presetColors.length)];
-			randomOptions[key] = [stripHashPrefix(randomColor)];
-		}
-		// For Micah: coordinate eyebrowsColor (= hairColor) and facialHairColor (one step lighter)
-		if (config.style === AvatarStyle.MICAH) {
-			const hairColorValue = randomOptions['hairColor']?.[0] as string | undefined;
-			if (hairColorValue !== undefined) {
-				if (!hiddenPropKeys.has('eyebrowsColor')) {
-					randomOptions['eyebrowsColor'] = [hairColorValue];
-				}
-				if (!hiddenPropKeys.has('facialHairColor')) {
-					// MICAH_HAIR_COLORS is ordered dark→light (index 0=Black … index 8=Light Gray),
-					// so index + 1 yields one step lighter.
-					const hairIndex = MICAH_HAIR_COLORS.findIndex(
-						(c) => stripHashPrefix(c) === hairColorValue,
-					);
-					const lighterIndex = hairIndex !== -1
-						? Math.min(hairIndex + 1, MICAH_HAIR_COLORS.length - 1)
-						: 0;
-					randomOptions['facialHairColor'] = [stripHashPrefix(MICAH_HAIR_COLORS[lighterIndex])];
-				}
-			}
-		}
-		// Preserve boolean flags (flip, clip) and numeric options (scale, translateX, translateY, rotate)
-		// so that user-set positioning/orientation is not lost on randomize.
-		const preserveKeys: string[] = [
-			AvatarPropKey.OpenPeeps.FLIP,
-			AvatarPropKey.OpenPeeps.CLIP,
-			AvatarPropKey.OpenPeeps.SCALE,
-			AvatarPropKey.OpenPeeps.TRANSLATE_X,
-			AvatarPropKey.OpenPeeps.TRANSLATE_Y,
-			AvatarPropKey.OpenPeeps.ROTATE,
-		];
-		for (const key of preserveKeys) {
-			if (config.options?.[key] !== undefined) {
-				randomOptions[key] = config.options[key]!;
-			}
-		}
-		// Preserve hidden prop values so they are never lost during randomize,
-		// even in debug mode where applyHiddenProps is skipped.
-		if (hiddenProps) {
-			for (const [key, value] of Object.entries(hiddenProps)) {
-				if (value !== undefined) {
-					randomOptions[key] = [value];
-				}
-			}
-		}
+		const randomOptions: Record<string, string[] | boolean | number> = {
+			...randomizeComponentOptions(config.style, newComponentOptions, newProbabilityKeys),
+			...randomizeColorOptions(config.style, newColorKeys, hiddenPropKeys),
+		};
+		applyMicahColorCoordination(config.style, randomOptions, hiddenPropKeys);
+		preservePositioningOptions(config, randomOptions);
+		applyHiddenPropsToRandomOptions(hiddenProps, randomOptions);
 		handleChange({ ...config, options: randomOptions });
 	};
 

--- a/packages/common-ui/src/components/SettingsList/SettingsList.tsx
+++ b/packages/common-ui/src/components/SettingsList/SettingsList.tsx
@@ -13,6 +13,63 @@ import { SettingsListProps } from './types';
 const padding = 0;
 const basePaddingVertical = 10;
 
+function computeGroupPositionStyles(
+	groupPosition: SettingsListProps['groupPosition'],
+): { groupContainerStyle: ViewStyle | null; wrapperBorderRadius: ViewStyle } {
+	if (groupPosition === 'top') {
+		return {
+			groupContainerStyle: {
+				borderTopLeftRadius: borderRadiusContainer,
+				borderTopRightRadius: borderRadiusContainer,
+				paddingTop: basePaddingVertical + padding,
+			},
+			wrapperBorderRadius: { borderTopLeftRadius: borderRadiusContainer, borderTopRightRadius: borderRadiusContainer },
+		};
+	} else if (groupPosition === 'bottom') {
+		return {
+			groupContainerStyle: {
+				borderBottomLeftRadius: borderRadiusContainer,
+				borderBottomRightRadius: borderRadiusContainer,
+				paddingBottom: basePaddingVertical + padding,
+			},
+			wrapperBorderRadius: { borderBottomLeftRadius: borderRadiusContainer, borderBottomRightRadius: borderRadiusContainer },
+		};
+	} else if (groupPosition === 'single') {
+		return {
+			groupContainerStyle: {
+				borderRadius: borderRadiusContainer,
+				paddingTop: basePaddingVertical + padding,
+				paddingBottom: basePaddingVertical + padding,
+			},
+			wrapperBorderRadius: { borderRadius: borderRadiusContainer },
+		};
+	}
+	return { groupContainerStyle: null, wrapperBorderRadius: {} };
+}
+
+function computeLeftIconContent(
+	showIconWrapper: boolean,
+	hasIcon: boolean,
+	leftIconComponent: React.ReactNode,
+	iconWrapperStyles: ViewStyle[],
+	renderedLeftIcon: React.ReactNode,
+): React.ReactNode {
+	if (showIconWrapper) {
+		return leftIconComponent || <View style={iconWrapperStyles}>{renderedLeftIcon}</View>;
+	} else if (hasIcon) {
+		return leftIconComponent || renderedLeftIcon;
+	}
+	return null;
+}
+
+function resolveAccountRequiredBorderStyle(
+	accountRequiredPosition: SettingsListProps['groupPosition'],
+): ViewStyle {
+	return accountRequiredPosition === 'middle' || accountRequiredPosition === 'bottom'
+		? { borderLeftWidth: 2, borderRightWidth: 2, borderBottomWidth: 2 }
+		: { borderWidth: 2 };
+}
+
 const SettingsList: React.FC<SettingsListProps> = ({
 	leftIcon,
 	leftIconComponent,
@@ -79,41 +136,22 @@ const SettingsList: React.FC<SettingsListProps> = ({
 		iconWrapperStyles.push(styles.transparentIconWrapper);
 	}
 
-	let wrapperBorderRadius: ViewStyle = {};
-
-	if (groupPosition === 'top') {
-		containerStyles.push({
-			borderTopLeftRadius: borderRadiusContainer,
-			borderTopRightRadius: borderRadiusContainer,
-			paddingTop: basePaddingVertical + padding,
-		});
-		wrapperBorderRadius = { borderTopLeftRadius: borderRadiusContainer, borderTopRightRadius: borderRadiusContainer };
-	} else if (groupPosition === 'bottom') {
-		containerStyles.push({
-			borderBottomLeftRadius: borderRadiusContainer,
-			borderBottomRightRadius: borderRadiusContainer,
-			paddingBottom: basePaddingVertical + padding,
-		});
-		wrapperBorderRadius = { borderBottomLeftRadius: borderRadiusContainer, borderBottomRightRadius: borderRadiusContainer };
-	} else if (groupPosition === 'single') {
-		containerStyles.push({
-			borderRadius: borderRadiusContainer,
-			paddingTop: basePaddingVertical + padding,
-			paddingBottom: basePaddingVertical + padding,
-		});
-		wrapperBorderRadius = { borderRadius: borderRadiusContainer };
+	const { groupContainerStyle, wrapperBorderRadius } = computeGroupPositionStyles(groupPosition);
+	if (groupContainerStyle) {
+		containerStyles.push(groupContainerStyle);
 	}
 
 	const valueContainerStyle = stackedValue ? styles.valueContainerStacked : styles.valueContainer;
 	const valueStackedStyle = stackedValue ? styles.valueStacked : null;
 	const valueFontSizeStyle = valueFontSize ? { fontSize: valueFontSize } : null;
 
-	let leftIconContent: React.ReactNode = null;
-	if (showIconWrapper) {
-		leftIconContent = leftIconComponent || <View style={iconWrapperStyles}>{renderedLeftIcon}</View>;
-	} else if (hasIcon) {
-		leftIconContent = leftIconComponent || renderedLeftIcon;
-	}
+	const leftIconContent: React.ReactNode = computeLeftIconContent(
+		showIconWrapper,
+		hasIcon,
+		leftIconComponent,
+		iconWrapperStyles,
+		renderedLeftIcon,
+	);
 
 	const inner = (
 		<Container onPress={pressHandler} style={containerStyles} nativeID={nativeID}>
@@ -159,10 +197,7 @@ const SettingsList: React.FC<SettingsListProps> = ({
 	const separator = showSeparator ? <View style={[styles.separator, { backgroundColor: theme.screen.background, marginLeft: separatorMarginLeft }]} /> : null;
 
 	const accountRequiredPosition = accountRequiredGroupPosition ?? groupPosition;
-	const accountRequiredBorderStyle: ViewStyle =
-		accountRequiredPosition === 'middle' || accountRequiredPosition === 'bottom'
-			? { borderLeftWidth: 2, borderRightWidth: 2, borderBottomWidth: 2 }
-			: { borderWidth: 2 };
+	const accountRequiredBorderStyle: ViewStyle = resolveAccountRequiredBorderStyle(accountRequiredPosition);
 
 	if (isAccountRequired) {
 		return (


### PR DESCRIPTION
## Summary

This is round 7 of the recurring SonarCloud maintainability cleanup (see `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md`). It resolves **all 58 remaining "Cognitive Complexity" findings** (complexity 22–201) plus the **"Reduce non-empty switch cases from 51 to at most 30"** finding in `settingsReducer.ts`, across 43 files. These were the last two issue types documented as "needs individual refactoring instead of mechanical fixes" in the workflow doc — every previous round's smaller/mechanical categories were re-checked and confirmed still intentionally unchanged (documented in the doc, not part of this PR's diff).

- Each flagged function was decomposed by extracting cohesive inner blocks into **named helper functions with explicit parameters** (no closures over outer state, except stable module-level constants) — pure code motion, no behavior changes.
- **5 sites left partially resolved** due to extreme starting complexity or risk of altering render/business logic: `ActivityMapRebuildHelper.ts`'s `rebuildMapFromActivities` (120→..), `routes/[id].tsx` (32→..), `TTSHelper.ts` (38→..), `bigScreen/index.tsx` (25→..), `FoodHeader.tsx` (22→..). Flagged as candidates for a follow-up round if the next SonarCloud scan still reports them.
- `settingsReducer.ts`: consolidated 45 uniform `{...state, field: payload}` switch cases into a `SIMPLE_FIELD_ASSIGNMENTS` lookup table, keeping the 6 structurally different cases explicit (51 → 6 non-empty cases).

Full per-file breakdown of what was extracted (and why some fixes are partial) is in `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` under "siebte Runde".

## Process notes

- Work was split strictly **one agent per file** (43 parallel agents) to avoid merge conflicts, since some files (e.g. `geonexia/app/index.tsx` with 6 flagged functions, including the repo's highest single complexity at 201) had multiple findings.
- **Caught and fixed a real problem during verification:** 4 of the 43 agents initially reported "fixed" with plausible-sounding details but had made **zero actual file changes** (verified via `git diff`, not by trusting the agent summaries). All 4 were redone with fresh agents that verified their own diff before reporting success.
- 7 independent adversarial review agents then re-read every diff checking for parameter mismatches, mutation/copy bugs, ref-staleness in async code, and dropped logic. One genuinely new TypeScript error was found (`form-queue/index.tsx`, an overly strict parameter type) and fixed.
- The `settingsReducer.ts` consolidation was independently, programmatically cross-checked: all 51 original action types are still handled (45 in the table + 6 explicit cases), field names verified 1:1 against the original case bodies.

## Test plan

- [x] `tsc --noEmit` baseline diff (before/after) for `apps/frontend/app` (293 pre-existing unrelated errors, unchanged), `apps/geonexia/frontend` (35, unchanged), `apps/score-tracker/frontend` (66, exactly unchanged — untouched by this PR), `apps/accessibilityTester` (0, still clean)
- [x] `yarn typecheck` for the backend extension (0 errors, unchanged)
- [x] 7 adversarial diff-review passes across all 43 files, no confirmed behavior-changing issues remaining
- [ ] Next SonarCloud scan to confirm the 5 partial-fix sites and re-verify nothing regressed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016dtp7EAVaatvDDURftioiR)_