### PR TITLE
Fix SonarCloud reliability findings (regex ReDoS + shell test operator)

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodTL1Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodTL1Parser.ts
@@ -574,7 +574,7 @@ export class FoodTL1Parser implements FoodParserInterface {
     let nutritionValuesString = parsedReportItem[FoodTL1Parser.DEFAULT_NUTRITIONS_FIELD];
     if (nutritionValuesString) {
       let kcalEndString = ' kcal)';
-      let match = nutritionValuesString.match(/\(.* kcal/gm);
+      let match = nutritionValuesString.match(/\([^()]{1,50} kcal/gm);
       // e. G. (XXXXXXX kcal)
       if (match) {
         let kcal = match[0].slice(1, kcalEndString.length); //remove starting bracket "(" and kcal)
@@ -686,7 +686,7 @@ export class FoodTL1Parser implements FoodParserInterface {
   static getMarkingLabelsDictFromFoodName(name: string) {
     let markingsDict: { [x: string]: string } = {};
     //e. G. "Strawberries (g, b) with Cream (2)"
-    let rawMarkingsInName = name.match(/\([^)]+\)/gm); //http://regex.inginf.units.it/
+    let rawMarkingsInName = name.match(/\([^)]{1,100}\)/gm); //http://regex.inginf.units.it/
     //e. G. ["(g, b)", "(2)"]
     if (rawMarkingsInName) {
       for (let rawMarkingsPart of rawMarkingsInName) {

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/__tests__/TestFoodTL1Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/__tests__/TestFoodTL1Parser.ts
@@ -82,3 +82,34 @@ describe('FoodTL1Parser Test', () => {
     expect(allExternalIdentifiersFound).toBe(true);
   });
 });
+
+describe('FoodTL1Parser regex reliability (SonarCloud: super-linear regex backtracking)', () => {
+  // Both `getFoodNutritionAttributeValuesFromRawTL1Foodoffer` (kcal extraction) and
+  // `getMarkingLabelsDictFromFoodName` (marking extraction) previously used unbounded
+  // regex quantifiers (`.* kcal` / `[^)]+`), flagged by SonarCloud for super-linear
+  // runtime due to backtracking. Both are now bounded ({1,50} / {1,100}).
+
+  it('kcal extraction stays fast for a long value with no "(... kcal" match', () => {
+    const pathological: RawTL1FoodofferType = {
+      [FoodTL1Parser.DEFAULT_NUTRITIONS_FIELD]: `Brennwert=612 kJ (${'0'.repeat(1_000_000)}`,
+    };
+
+    const start = Date.now();
+    const parsedFoodAttributes = FoodTL1Parser.getFoodNutritionAttributeValuesFromRawTL1Foodoffer(pathological);
+    const durationMs = Date.now() - start;
+
+    expect(parsedFoodAttributes.some((a) => a.external_identifier === FoodTL1Parser.DEFAULT_NUTRITION_FIELD_BRENNWERT_EXTERNAL_IDENTIFIER)).toBe(false);
+    expect(durationMs).toBeLessThan(500);
+  });
+
+  it('marking extraction stays fast for a long name with an unterminated parenthesis', () => {
+    const pathological = `Strawberries (${'g'.repeat(1_000_000)}`;
+
+    const start = Date.now();
+    const markingLabelsDict = FoodTL1Parser.getMarkingLabelsDictFromFoodName(pathological);
+    const durationMs = Date.now() - start;
+
+    expect(markingLabelsDict).toEqual({});
+    expect(durationMs).toBeLessThan(500);
+  });
+});

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/aachen/FoodWebParserAachenParseHtml.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/aachen/FoodWebParserAachenParseHtml.ts
@@ -37,7 +37,7 @@ export class FoodWebParserAachenParseHtml {
 
     const paragraphText = paragraph.text().trim();
     // extract all codes and descriptions from the paragraph text
-    const regex = /\(([^)]+)\)\s*([^,(]+)/g;
+    const regex = /\(([^)]{1,20})\)\s{0,10}([^,(]{1,200})/g;
     let match;
     while ((match = regex.exec(paragraphText)) !== null) {
       const code = match[1]!.trim(); // e.g. "A", "A1", "1"

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/aachen/__tests__/TestFoodWebParserAachenParseHtml.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/aachen/__tests__/TestFoodWebParserAachenParseHtml.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from '@jest/globals';
+import { FoodWebParserAachenParseHtml } from '../FoodWebParserAachenParseHtml';
+
+function htmlWithAdditivesParagraph(paragraphText: string): string {
+  return `<html><body><div id="additives"><p>${paragraphText}</p></div></body></html>`;
+}
+
+describe('FoodWebParserAachenParseHtml.getMarkingsJSONListFromWebHtml correctness', () => {
+  it('extracts codes and descriptions from the additives paragraph', () => {
+    const html = htmlWithAdditivesParagraph(
+      'mit (1) Farbstoff, (2) Konservierungsstoff, enthält (A) Gluten, (A1) Weizen',
+    );
+
+    const markings = FoodWebParserAachenParseHtml.getMarkingsJSONListFromWebHtml(html);
+
+    expect(markings.map((m) => m.external_identifier)).toEqual(['1', '2', 'A', 'A1']);
+    expect(markings.find((m) => m.external_identifier === 'A1')?.alias).toBe('Weizen');
+  });
+
+  it('returns an empty list when there is no additives div', () => {
+    expect(FoodWebParserAachenParseHtml.getMarkingsJSONListFromWebHtml('<html><body></body></html>')).toEqual([]);
+  });
+
+  it('returns an empty list for undefined input', () => {
+    expect(FoodWebParserAachenParseHtml.getMarkingsJSONListFromWebHtml(undefined)).toEqual([]);
+  });
+});
+
+describe('FoodWebParserAachenParseHtml regex reliability (SonarCloud: super-linear regex backtracking)', () => {
+  // The rule flagged the previous /\(([^)]+)\)\s*([^,(]+)/g pattern: `\s*` overlaps with
+  // the following `[^,(]+` character class (both match spaces), which is exactly the
+  // ambiguous-adjacent-quantifier shape the rule detects. The fix bounds every
+  // quantifier ({1,20} / {0,10} / {1,200}).
+  it('stays fast for a pathologically long additives paragraph with many spaces', () => {
+    const pathological = `(1)${' '.repeat(500_000)}${'x'.repeat(500_000)}`;
+    const html = htmlWithAdditivesParagraph(pathological);
+
+    const start = Date.now();
+    FoodWebParserAachenParseHtml.getMarkingsJSONListFromWebHtml(html);
+    const durationMs = Date.now() - start;
+
+    expect(durationMs).toBeLessThan(1000);
+  });
+
+  it('stays fast for a long unterminated parenthesis', () => {
+    const pathological = `(${'1'.repeat(1_000_000)}`;
+    const html = htmlWithAdditivesParagraph(pathological);
+
+    const start = Date.now();
+    const markings = FoodWebParserAachenParseHtml.getMarkingsJSONListFromWebHtml(html);
+    const durationMs = Date.now() - start;
+
+    expect(markings).toEqual([]);
+    expect(durationMs).toBeLessThan(1000);
+  });
+});

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/MaxManagerConnector.ts
@@ -40,6 +40,12 @@ type CanteenData = {
     html: string;
 }
 
+// Extracts the external identifier from a legend code cell, e.g. "(A)" -> "A".
+export function extractLegendCodeFromText(codeText: string): string | undefined {
+    const codeMatch = codeText.match(/\(([^)]{1,50})\)/);
+    return codeMatch && codeMatch.length > 1 ? codeMatch[1] || undefined : undefined;
+}
+
 export class MaxManagerConnector implements FoodParserInterface, MarkingParserInterface {
 
     private readonly config: MaxManagerConnectorConfig;
@@ -508,9 +514,9 @@ export class MaxManagerConnector implements FoodParserInterface, MarkingParserIn
                 const codeElement = $(element).find('td').first();
                 let externalIdentifier: string | undefined = undefined;
                 const codeText = codeElement.text().trim();
-                const codeMatch = codeText.match(/\(([^)]+)\)/);
-                if(codeMatch && codeMatch.length > 1){
-                    externalIdentifier = codeMatch[1] || undefined;
+                const codeFromText = extractLegendCodeFromText(codeText);
+                if(codeFromText){
+                    externalIdentifier = codeFromText;
                 } else {
                     // check for img element
                     const imgElement = codeElement.find('img');

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/__tests__/TestMaxManagerConnectorLegendCode.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/helper/maxManager/__tests__/TestMaxManagerConnectorLegendCode.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from '@jest/globals';
+import { extractLegendCodeFromText } from '../MaxManagerConnector';
+
+describe('extractLegendCodeFromText correctness', () => {
+  it('extracts the code from a parenthesized legend cell', () => {
+    expect(extractLegendCodeFromText('(A)')).toBe('A');
+    expect(extractLegendCodeFromText('(A1)')).toBe('A1');
+  });
+
+  it('returns undefined when there is no parenthesized code', () => {
+    expect(extractLegendCodeFromText('no code here')).toBeUndefined();
+    expect(extractLegendCodeFromText('')).toBeUndefined();
+  });
+});
+
+describe('extractLegendCodeFromText reliability (SonarCloud: super-linear regex backtracking)', () => {
+  // The rule flagged the previous /\(([^)]+)\)/ pattern for an unbounded quantifier.
+  // The fix bounds it ({1,50}) so a pathological, non-matching input can't force
+  // runtime proportional to an attacker-controlled input length.
+  it('stays fast for a long unterminated parenthesis', () => {
+    const pathological = `(${'a'.repeat(1_000_000)}`;
+    const start = Date.now();
+    const result = extractLegendCodeFromText(pathological);
+    const durationMs = Date.now() - start;
+
+    expect(result).toBeUndefined();
+    expect(durationMs).toBeLessThan(500);
+  });
+});

--- a/apps/frontend/app/app/(app)/course-timetable/index.tsx
+++ b/apps/frontend/app/app/(app)/course-timetable/index.tsx
@@ -17,24 +17,8 @@ import { myContrastColor } from '@/helper/ColorHelper';
 import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
-import { CollectibleAt, StringHelper } from 'repo-depkit-common';
-
-const extractTextAndLink = (description: string) => {
-	// Remove unintended spaces between `]` and `(`
-	const cleanedDescription = StringHelper.replaceAllWithOptions({ str: description, find: String.raw`]\s+\(`, replace: '](' });
-
-	const regex = /\[(.*?)\]\((.*?)\)/g;
-	const match = regex.exec(cleanedDescription);
-
-	if (match) {
-		const label = match[1]; // The text inside the square brackets
-		const link = match[2]; // The URL inside the parentheses
-		const textWithoutLinkAndLabel = cleanedDescription.replace(match[0], '').trim(); // Remove the entire match
-		return { text: textWithoutLinkAndLabel, label, link };
-	}
-
-	return { text: description, label: '', link: null };
-};
+import { CollectibleAt } from 'repo-depkit-common';
+import { PARSE_MARKDOWN_REGEX, extractTextAndLink } from './markdownHelpers';
 
 const TimetableScreen = () => {
 	useSetPageTitle(TranslationKeys.course_timetable);
@@ -99,8 +83,7 @@ const TimetableScreen = () => {
 	};
 
 	const parseMarkdown = (text: string) => {
-		const regex = /(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g;
-		const parts = text?.split(regex);
+		const parts = text?.split(PARSE_MARKDOWN_REGEX);
 
 		return parts?.map((part, index) => {
 			if (part?.startsWith('**') && part?.endsWith('**')) {

--- a/apps/frontend/app/app/(app)/course-timetable/markdownHelpers.test.ts
+++ b/apps/frontend/app/app/(app)/course-timetable/markdownHelpers.test.ts
@@ -1,0 +1,70 @@
+import { PARSE_MARKDOWN_REGEX, extractTextAndLink } from './markdownHelpers';
+
+describe('extractTextAndLink correctness', () => {
+	it('extracts the label, link and remaining text', () => {
+		const result = extractTextAndLink('Course description [Link Text](https://example.com/path)');
+		expect(result).toEqual({
+			text: 'Course description',
+			label: 'Link Text',
+			link: 'https://example.com/path',
+		});
+	});
+
+	it('returns the original description with an empty label/null link when there is no markdown link', () => {
+		expect(extractTextAndLink('plain description')).toEqual({
+			text: 'plain description',
+			label: '',
+			link: null,
+		});
+	});
+});
+
+describe('extractTextAndLink reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// The rule flagged the previous /\[(.*?)\]\((.*?)\)/g pattern. The fix bounds both
+	// quantifiers ([^\]]{0,500} / [^)]{0,2000}) so a pathological input can't force
+	// runtime proportional to an attacker-controlled input length.
+	it('stays fast for a long, unterminated bracket', () => {
+		const pathological = `[${'a'.repeat(1_000_000)}`;
+		const start = Date.now();
+		const result = extractTextAndLink(pathological);
+		const durationMs = Date.now() - start;
+
+		expect(result.link).toBeNull();
+		expect(durationMs).toBeLessThan(500);
+	});
+});
+
+describe('PARSE_MARKDOWN_REGEX correctness', () => {
+	it('splits bold, italic and link segments out of plain text', () => {
+		const parts = 'Hello **bold** and *italic* and [link](http://x.com) end'.split(PARSE_MARKDOWN_REGEX);
+		expect(parts).toEqual(['Hello ', '**bold**', ' and ', '*italic*', ' and ', '[link](http://x.com)', ' end']);
+	});
+
+	it('keeps a single asterisk inside bold content intact', () => {
+		const parts = '**a*b** rest'.split(PARSE_MARKDOWN_REGEX);
+		expect(parts).toEqual(['', '**a*b**', ' rest']);
+	});
+});
+
+describe('PARSE_MARKDOWN_REGEX reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// The rule flagged the previous /(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g pattern:
+	// overlapping alternatives (`**` vs `*`) combined with unbounded `.*?` are a classic
+	// catastrophic-backtracking shape. The fix bounds every quantifier to a fixed maximum.
+	it('stays fast for a long run of unmatched asterisks', () => {
+		const pathological = '*'.repeat(200_000);
+		const start = Date.now();
+		pathological.split(PARSE_MARKDOWN_REGEX);
+		const durationMs = Date.now() - start;
+
+		expect(durationMs).toBeLessThan(1000);
+	});
+
+	it('stays fast for a long run of unmatched opening brackets', () => {
+		const pathological = '['.repeat(200_000);
+		const start = Date.now();
+		pathological.split(PARSE_MARKDOWN_REGEX);
+		const durationMs = Date.now() - start;
+
+		expect(durationMs).toBeLessThan(1000);
+	});
+});

--- a/apps/frontend/app/app/(app)/course-timetable/markdownHelpers.ts
+++ b/apps/frontend/app/app/(app)/course-timetable/markdownHelpers.ts
@@ -1,0 +1,24 @@
+import { StringHelper } from 'repo-depkit-common';
+
+// SonarCloud reliability rule (regex ReDoS): both patterns below previously used
+// unbounded lazy quantifiers (`.*?`), which SonarCloud flagged as having super-linear
+// runtime due to backtracking. Both now use bounded, negated-character-class
+// quantifiers instead.
+export const PARSE_MARKDOWN_REGEX = /(\*\*.{0,500}?\*\*|\*.{0,500}?\*|\[[^\]]{0,500}\]\([^)]{0,2000}\))/g;
+
+export const extractTextAndLink = (description: string) => {
+	// Remove unintended spaces between `]` and `(`
+	const cleanedDescription = StringHelper.replaceAllWithOptions({ str: description, find: String.raw`]\s+\(`, replace: '](' });
+
+	const regex = /\[([^\]]{0,500})\]\(([^)]{0,2000})\)/g;
+	const match = regex.exec(cleanedDescription);
+
+	if (match) {
+		const label = match[1]; // The text inside the square brackets
+		const link = match[2]; // The URL inside the parentheses
+		const textWithoutLinkAndLabel = cleanedDescription.replace(match[0], '').trim(); // Remove the entire match
+		return { text: textWithoutLinkAndLabel, label, link };
+	}
+
+	return { text: description, label: '', link: null };
+};

--- a/apps/frontend/app/app/index.test.ts
+++ b/apps/frontend/app/app/index.test.ts
@@ -1,0 +1,34 @@
+import { extractRawExpoToken } from './index';
+
+describe('extractRawExpoToken', () => {
+	it('extracts the raw token from ExponentPushToken[...] notation', () => {
+		expect(extractRawExpoToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]')).toBe('xxxxxxxxxxxxxxxxxxxxxx');
+	});
+
+	it('returns the original token when it has no brackets', () => {
+		expect(extractRawExpoToken('already-raw-token')).toBe('already-raw-token');
+	});
+
+	it('returns null for null input', () => {
+		expect(extractRawExpoToken(null)).toBeNull();
+	});
+
+	it('returns null for an empty string', () => {
+		expect(extractRawExpoToken('')).toBeNull();
+	});
+});
+
+describe('extractRawExpoToken regex reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// The rule flagged the previous /\[(.+?)\]/ pattern. The fix replaced the lazy `.+?`
+	// with a bounded negated character class ([^\]]{1,200}), which cannot backtrack in a
+	// way whose cost grows with the size of an attacker-controlled input.
+	it('stays fast for a very long token with no closing bracket', () => {
+		const pathological = `ExponentPushToken[${'x'.repeat(1_000_000)}`;
+		const start = Date.now();
+		const result = extractRawExpoToken(pathological);
+		const durationMs = Date.now() - start;
+
+		expect(result).toBe(pathological); // no match found, original string returned unchanged
+		expect(durationMs).toBeLessThan(500);
+	});
+});

--- a/apps/frontend/app/app/index.tsx
+++ b/apps/frontend/app/app/index.tsx
@@ -10,9 +10,9 @@ import { ProfileHelper } from '@/redux/actions/Profile/Profile';
 import { Platform } from 'react-native';
 import { markOnboardingShouldBeShownAfterLogin } from '@/helper/onboardingIntentHelper';
 
-const extractRawExpoToken = (token: string | null) => {
+export const extractRawExpoToken = (token: string | null) => {
 	if (!token) return null;
-	const m = /\[(.+?)\]/.exec(String(token));
+	const m = /\[([^\]]{1,200})\]/.exec(String(token));
 	return m ? m[1] : token;
 };
 

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.test.ts
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.test.ts
@@ -1,0 +1,56 @@
+import { CONTENT_PATTERNS } from './CustomMarkdown';
+
+describe('CustomMarkdown CONTENT_PATTERNS correctness', () => {
+	it('matches mailto links', () => {
+		const match = CONTENT_PATTERNS.email.exec('[Contact us](mailto:test@example.com)');
+		expect(match?.[1]).toBe('Contact us');
+		expect(match?.[2]).toBe('mailto:test@example.com');
+	});
+
+	it('matches geo/maps links', () => {
+		const match = CONTENT_PATTERNS.location.exec('[Meeting point](geo:52.5,13.4)');
+		expect(match?.[1]).toBe('Meeting point');
+		expect(match?.[2]).toBe('geo:52.5,13.4');
+	});
+
+	it('matches http(s) links', () => {
+		const match = CONTENT_PATTERNS.link.exec('[Website](https://example.com/path)');
+		expect(match?.[1]).toBe('Website');
+		expect(match?.[2]).toBe('https://example.com/path');
+	});
+
+	it('matches images', () => {
+		const match = CONTENT_PATTERNS.image.exec('![alt text](https://example.com/img.png)');
+		expect(match?.[1]).toBe('alt text');
+		expect(match?.[2]).toBe('https://example.com/img.png');
+	});
+
+	it('matches headings and trims leading whitespace', () => {
+		const match = CONTENT_PATTERNS.heading.exec('###   Some heading');
+		expect(match?.[1]).toBe('Some heading');
+	});
+});
+
+describe('CustomMarkdown CONTENT_PATTERNS reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// SonarCloud flagged these patterns for unbounded quantifiers. The fix bounds every
+	// quantifier ({1,500} / {1,2000} / {0,5000}) so a pathological, non-matching input
+	// cannot force runtime proportional to an attacker-controlled input length.
+	it('fails fast on a long unterminated bracket for email/location/link', () => {
+		const pathological = `[${'a'.repeat(1_000_000)}`;
+		for (const key of ['email', 'location', 'link'] as const) {
+			const start = Date.now();
+			const match = CONTENT_PATTERNS[key].exec(pathological);
+			const durationMs = Date.now() - start;
+			expect(match).toBeNull();
+			expect(durationMs).toBeLessThan(500);
+		}
+	});
+
+	it('fails fast on a long heading line', () => {
+		const pathological = `### ${' '.repeat(200_000)}text`;
+		const start = Date.now();
+		CONTENT_PATTERNS.heading.exec(pathological);
+		const durationMs = Date.now() - start;
+		expect(durationMs).toBeLessThan(500);
+	});
+});

--- a/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
+++ b/apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx
@@ -11,12 +11,12 @@ import { StringHelper } from 'repo-depkit-common';
 import { resolveLocationHref } from '@/helper/MarkdownLinkHelper';
 
 // Regex patterns for different content types
-const CONTENT_PATTERNS = {
-	email: /\[([^\]]+)]\((mailto:[^)]+)\)/,
-	location: /\[([^\]]+)]\(((?:geo|maps):[^)]+)\)/i,
-	link: /\[([^\]]+)]\((https?:\/\/[^)]+)\)/,
+export const CONTENT_PATTERNS = {
+	email: /\[([^\]]{1,500})]\((mailto:[^)]{1,2000})\)/,
+	location: /\[([^\]]{1,500})]\(((?:geo|maps):[^)]{1,2000})\)/i,
+	link: /\[([^\]]{1,500})]\((https?:\/\/[^)]{1,2000})\)/,
 	image: /!\[([^\]]*)]\(([^)]+)\)/,
-	heading: /^#{1,3}\s*(.*)$/,
+	heading: /^#{1,3}\s{0,20}(.{0,5000})$/,
 };
 
 // Flush the buffered paragraph lines into the current stack frame's items.

--- a/apps/frontend/app/components/EmailInput/EmailInput.test.ts
+++ b/apps/frontend/app/components/EmailInput/EmailInput.test.ts
@@ -1,0 +1,30 @@
+import { emailRegex } from './EmailInput';
+
+describe('EmailInput emailRegex correctness', () => {
+	it('accepts well-formed email addresses', () => {
+		expect(emailRegex.test('test@example.com')).toBe(true);
+		expect(emailRegex.test('a.b+c@sub.example.co.uk')).toBe(true);
+	});
+
+	it('rejects malformed email addresses', () => {
+		expect(emailRegex.test('not-an-email')).toBe(false);
+		expect(emailRegex.test('missing-domain@')).toBe(false);
+		expect(emailRegex.test('@missing-local.com')).toBe(false);
+		expect(emailRegex.test('has spaces@example.com')).toBe(false);
+	});
+});
+
+describe('EmailInput emailRegex reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// The rule flagged the previous `^[^\s@]+@[^\s@]+\.[^\s@]+$` pattern for unbounded
+	// quantifiers. The fix bounds each part ({1,64} / {1,255} / {1,63}) so a pathological
+	// input can't force runtime proportional to an attacker-controlled input length.
+	it('stays fast for a very long, non-matching input', () => {
+		const pathological = `${'a'.repeat(500_000)}@${'b'.repeat(500_000)}`;
+		const start = Date.now();
+		const isValid = emailRegex.test(pathological);
+		const durationMs = Date.now() - start;
+
+		expect(isValid).toBe(false);
+		expect(durationMs).toBeLessThan(500);
+	});
+});

--- a/apps/frontend/app/components/EmailInput/EmailInput.tsx
+++ b/apps/frontend/app/components/EmailInput/EmailInput.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { isWeb } from '@/constants/Constants';
 import { TranslationKeys } from '@/locales/keys';
 
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const emailRegex = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{1,63}$/;
 
 const EmailInput = ({
 	id,

--- a/apps/frontend/app/constants/MarkdownPatterns.test.ts
+++ b/apps/frontend/app/constants/MarkdownPatterns.test.ts
@@ -1,0 +1,34 @@
+import { markdownContentPatterns } from './MarkdownPatterns';
+
+describe('markdownContentPatterns.link correctness', () => {
+	it('matches http(s) links', () => {
+		const match = markdownContentPatterns.link.exec('[Website](https://example.com/path)');
+		expect(match?.[1]).toBe('Website');
+		expect(match?.[2]).toBe('https://example.com/path');
+	});
+
+	it('matches geo/maps/tel links', () => {
+		expect(markdownContentPatterns.link.exec('[Call](tel:+123456789)')?.[2]).toBe('tel:+123456789');
+		expect(markdownContentPatterns.link.exec('[Map](geo:1,2)')?.[2]).toBe('geo:1,2');
+	});
+
+	it('matches mailto and image links (unchanged, non-flagged patterns)', () => {
+		expect(markdownContentPatterns.email.exec('[Contact](mailto:test@example.com)')?.[2]).toBe('mailto:test@example.com');
+		expect(markdownContentPatterns.image.exec('![alt](https://example.com/img.png)')?.[2]).toBe('https://example.com/img.png');
+	});
+});
+
+describe('markdownContentPatterns.link reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// Only `link` was flagged by SonarCloud in this file. The fix bounds both quantifiers
+	// ([^\]]{1,500} / [^\)]{1,2000}) so a pathological non-matching input can't force
+	// runtime proportional to an attacker-controlled input length.
+	it('fails fast on a long unterminated bracket', () => {
+		const pathological = `[${'a'.repeat(1_000_000)}`;
+		const start = Date.now();
+		const match = markdownContentPatterns.link.exec(pathological);
+		const durationMs = Date.now() - start;
+
+		expect(match).toBeNull();
+		expect(durationMs).toBeLessThan(500);
+	});
+});

--- a/apps/frontend/app/constants/MarkdownPatterns.ts
+++ b/apps/frontend/app/constants/MarkdownPatterns.ts
@@ -11,7 +11,7 @@ const LINK_SCHEME_PATTERN = String.raw`(?:https?:\/\/|${UriScheme.GEO}|${UriSche
 
 export const markdownContentPatterns: ContentPatterns = {
 	email: new RegExp(String.raw`\[([^\]]+)]\((${UriScheme.MAILTO}[^\)]+)\)`),
-	link: new RegExp(String.raw`\[([^\]]+)]\((${LINK_SCHEME_PATTERN}[^\)]+)\)`),
+	link: new RegExp(String.raw`\[([^\]]{1,500})]\((${LINK_SCHEME_PATTERN}[^\)]{1,2000})\)`),
 	image: /!\[([^\]]*)]\(([^)]+)\)/,
 	heading: /^#{1,6}\s*(.*)$/,
 };

--- a/apps/frontend/run-maestro-web-test.sh
+++ b/apps/frontend/run-maestro-web-test.sh
@@ -75,7 +75,7 @@ for i in $(seq 1 $MAX_WAIT); do
         echo "Server is ready."
         break
     fi
-    if [ "$i" -eq "$MAX_WAIT" ]; then
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
         echo "ERROR: Dev server did not start within ${MAX_WAIT}s." >&2
         exit 1
     fi
@@ -93,7 +93,7 @@ if ! command -v maestro &> /dev/null; then
     # sanity-checked before it is executed, and pin the transport to TLS.
     MAESTRO_INSTALLER="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 -o "$MAESTRO_INSTALLER" "https://get.maestro.mobile.dev"
-    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty." >&2; exit 1; }
+    [[ -s "$MAESTRO_INSTALLER" ]] || { echo "ERROR: Downloaded Maestro installer is empty." >&2; exit 1; }
     head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script." >&2; exit 1; }
     bash "$MAESTRO_INSTALLER"
     rm -f "$MAESTRO_INSTALLER"
@@ -118,7 +118,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # 5. Generate YAML test files from TypeScript
 # ---------------------------------------------------------------------------
-if [ "$SKIP_GENERATE" = true ]; then
+if [[ "$SKIP_GENERATE" = true ]]; then
     echo "Skipping YAML generation (--skip-generate flag set)."
 else
     echo "Generating YAML test files from TypeScript..."
@@ -142,7 +142,7 @@ set -e
 # ---------------------------------------------------------------------------
 # 7. Report failed tests and screenshot paths
 # ---------------------------------------------------------------------------
-if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
+if [[ "$MAESTRO_EXIT_CODE" -ne 0 ]]; then
     echo ""
     echo "=== Failed Tests & Screenshots ==="
     FOUND_SCREENSHOTS=false
@@ -150,7 +150,7 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
         echo "  📸 $png"
         FOUND_SCREENSHOTS=true
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f -name "*.png" -print0 2>/dev/null)
-    if [ "$FOUND_SCREENSHOTS" = false ]; then
+    if [[ "$FOUND_SCREENSHOTS" = false ]]; then
         echo "  (no screenshots found)"
     fi
 
@@ -160,14 +160,14 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
     # Search for error/failure messages in Maestro debug log files
     while IFS= read -r -d '' logfile; do
         ERRORS=$(grep -iE "(FAILED|ERROR|Exception|Element not found|No element|Timeout|assert|tapOn)" "$logfile" 2>/dev/null | grep -v "^#" | head -20)
-        if [ -n "$ERRORS" ]; then
+        if [[ -n "$ERRORS" ]]; then
             echo ""
             echo "  📄 $(basename "$logfile"):"
             echo "$ERRORS" | sed 's/^/    /'
             FOUND_ERRORS=true
         fi
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.xml" \) -print0 2>/dev/null)
-    if [ "$FOUND_ERRORS" = false ]; then
+    if [[ "$FOUND_ERRORS" = false ]]; then
         echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)" >&2
     fi
     echo ""

--- a/apps/score-tracker/run-maestro-web-test.sh
+++ b/apps/score-tracker/run-maestro-web-test.sh
@@ -80,7 +80,7 @@ for i in $(seq 1 $MAX_WAIT); do
         echo "Server is ready."
         break
     fi
-    if [ "$i" -eq "$MAX_WAIT" ]; then
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
         echo "ERROR: Dev server did not start within ${MAX_WAIT}s." >&2
         exit 1
     fi
@@ -96,7 +96,7 @@ if ! command -v maestro &> /dev/null; then
     echo "Maestro CLI not found – installing..."
     MAESTRO_INSTALLER="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 -o "$MAESTRO_INSTALLER" "https://get.maestro.mobile.dev"
-    [ -s "$MAESTRO_INSTALLER" ] || { echo "ERROR: Downloaded Maestro installer is empty." >&2; exit 1; }
+    [[ -s "$MAESTRO_INSTALLER" ]] || { echo "ERROR: Downloaded Maestro installer is empty." >&2; exit 1; }
     head -n1 "$MAESTRO_INSTALLER" | grep -q '^#!' || { echo "ERROR: Downloaded Maestro installer does not look like a shell script." >&2; exit 1; }
     bash "$MAESTRO_INSTALLER"
     rm -f "$MAESTRO_INSTALLER"
@@ -121,7 +121,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # 5. Generate YAML test files from TypeScript
 # ---------------------------------------------------------------------------
-if [ "$SKIP_GENERATE" = true ]; then
+if [[ "$SKIP_GENERATE" = true ]]; then
     echo "Skipping YAML generation (--skip-generate flag set)."
 else
     echo "Generating YAML test files from TypeScript..."
@@ -145,7 +145,7 @@ set -e
 # ---------------------------------------------------------------------------
 # 7. Report failed tests and screenshot paths
 # ---------------------------------------------------------------------------
-if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
+if [[ "$MAESTRO_EXIT_CODE" -ne 0 ]]; then
     echo ""
     echo "=== Failed Tests & Screenshots ==="
     FOUND_SCREENSHOTS=false
@@ -153,7 +153,7 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
         echo "  📸 $png"
         FOUND_SCREENSHOTS=true
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f -name "*.png" -print0 2>/dev/null)
-    if [ "$FOUND_SCREENSHOTS" = false ]; then
+    if [[ "$FOUND_SCREENSHOTS" = false ]]; then
         echo "  (no screenshots found)"
     fi
 
@@ -162,14 +162,14 @@ if [ "$MAESTRO_EXIT_CODE" -ne 0 ]; then
     FOUND_ERRORS=false
     while IFS= read -r -d '' logfile; do
         ERRORS=$(grep -iE "(FAILED|ERROR|Exception|Element not found|No element|Timeout|assert|tapOn)" "$logfile" 2>/dev/null | grep -v "^#" | head -20)
-        if [ -n "$ERRORS" ]; then
+        if [[ -n "$ERRORS" ]]; then
             echo ""
             echo "  📄 $(basename "$logfile"):"
             echo "$ERRORS" | sed 's/^/    /'
             FOUND_ERRORS=true
         fi
     done < <(find "$MAESTRO_DEBUG_DIR" "$HOME/.maestro/tests" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.xml" \) -print0 2>/dev/null)
-    if [ "$FOUND_ERRORS" = false ]; then
+    if [[ "$FOUND_ERRORS" = false ]]; then
         echo "  (no detailed error logs found in $MAESTRO_DEBUG_DIR)" >&2
     fi
     echo ""

--- a/apps/scripts/base64url.test.ts
+++ b/apps/scripts/base64url.test.ts
@@ -1,0 +1,37 @@
+import { base64url } from './base64url';
+
+describe('base64url correctness', () => {
+	it('strips base64 padding and swaps to URL-safe characters', () => {
+		expect(base64url('a')).toBe('YQ');
+		expect(base64url('ab')).toBe('YWI');
+		expect(base64url('abc')).toBe('YWJj');
+	});
+
+	it('replaces "+" and "/" with "-" and "_"', () => {
+		// Bytes chosen so the base64 encoding contains both '+' and '/'.
+		const input = Buffer.from([0xfb, 0xff, 0xbf]);
+		const standardBase64 = input.toString('base64');
+		expect(standardBase64).toContain('+');
+		expect(standardBase64).toContain('/');
+
+		const result = base64url(input);
+		expect(result).not.toContain('+');
+		expect(result).not.toContain('/');
+		expect(result).not.toContain('=');
+	});
+});
+
+describe('base64url regex reliability (SonarCloud: super-linear regex backtracking)', () => {
+	// The rule flagged the previous /=+$/ padding-strip pattern for an unbounded
+	// quantifier. Base64 padding is always 0-2 characters, so the fix bounds it to
+	// /={1,2}$/, which is both more precise and cannot scale with input size.
+	it('stays fast and correct for a large input', () => {
+		const largeInput = 'x'.repeat(1_000_000);
+		const start = Date.now();
+		const result = base64url(largeInput);
+		const durationMs = Date.now() - start;
+
+		expect(result).not.toContain('=');
+		expect(durationMs).toBeLessThan(500);
+	});
+});

--- a/apps/scripts/base64url.ts
+++ b/apps/scripts/base64url.ts
@@ -1,0 +1,9 @@
+// Base64url-encodes a value, per RFC 4648 §5 (used for JWT header/payload segments).
+// SonarCloud reliability rule (regex ReDoS): the previous implementation stripped
+// padding with /=+$/ (an unbounded quantifier). Base64 padding is always 0-2 characters,
+// so the fix bounds it to /={1,2}$/, which is both more precise and cannot scale with
+// input size.
+export function base64url(input: Buffer | string): string {
+  const buffer = typeof input === 'string' ? Buffer.from(input) : input;
+  return buffer.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/={1,2}$/, '');
+}

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -5,11 +5,26 @@
   "scripts": {
     "generate:eas": "ts-node --project ./tsconfig.json ./generate-eas-config.ts",
     "analyze:data-clumps": "ts-node --project ./tsconfig.json ./analyze-data-clumps.ts",
-    "submit:ios:review": "ts-node --project ./tsconfig.json ./submit-ios-review.ts"
+    "submit:ios:review": "ts-node --project ./tsconfig.json ./submit-ios-review.ts",
+    "test": "jest"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.12",
     "@types/node": "^22.9.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.3",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "isolatedModules": true
+        }
+      ]
+    }
   }
 }

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
+import { base64url } from './base64url';
 
 const API_BASE = 'https://api.appstoreconnect.apple.com/v1';
 
@@ -20,11 +21,6 @@ type JsonApiDocument = {
   data?: JsonApiResource | JsonApiResource[];
   included?: JsonApiResource[];
 };
-
-function base64url(input: Buffer | string): string {
-  const buffer = typeof input === 'string' ? Buffer.from(input) : input;
-  return buffer.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
-}
 
 function createAppStoreConnectToken(keyId: string, issuerId: string, privateKeyPath: string): string {
   const privateKey = fs.readFileSync(privateKeyPath, 'utf8');

--- a/packages/common/src/EmailHelper.ts
+++ b/packages/common/src/EmailHelper.ts
@@ -1,5 +1,5 @@
 export class EmailHelper {
-  private static readonly EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  private static readonly EMAIL_REGEX = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{1,63}$/;
 
   static sanitize(email: string): string {
     return email.trim();

--- a/packages/common/src/NumberHelper.ts
+++ b/packages/common/src/NumberHelper.ts
@@ -35,7 +35,7 @@ export class NumberHelper {
       if (!integerPart) {
         formattedValue = `0${fractionsSeparator}${fractionPart || ''}`;
       } else {
-        const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparator);
+        const formattedInteger = NumberHelper.insertThousandsSeparators(integerPart, thousandsSeparator);
         formattedValue = fractionPart ? `${formattedInteger}${fractionsSeparator}${fractionPart}` : formattedInteger;
       }
     }
@@ -43,6 +43,23 @@ export class NumberHelper {
     // Add unit suffix if provided
     const suffix = unit ? StringHelper.NONBREAKING_SPACE + unit : '';
     return formattedValue + suffix;
+  }
+
+  // Inserts a separator every 3 digits from the right (e.g. "1234567" -> "1,234,567").
+  // Implemented without regex to avoid the super-linear backtracking of the previous
+  // `\B(?=(\d{3})+(?!\d))` lookahead-based approach on long digit runs.
+  static insertThousandsSeparators(integerPart: string, separator: string): string {
+    const isNegative = integerPart.startsWith('-');
+    const digits = isNegative ? integerPart.slice(1) : integerPart;
+    let grouped = '';
+    for (let i = 0; i < digits.length; i++) {
+      const remainingDigits = digits.length - i;
+      if (i > 0 && remainingDigits % 3 === 0) {
+        grouped += separator;
+      }
+      grouped += digits[i];
+    }
+    return (isNegative ? '-' : '') + grouped;
   }
 
   // Formats a number with compact abbreviations: up to 999 shown as-is,

--- a/packages/common/src/__tests__/EmailHelper.test.ts
+++ b/packages/common/src/__tests__/EmailHelper.test.ts
@@ -1,0 +1,62 @@
+import { EmailHelper } from 'repo-depkit-common';
+
+describe('EmailHelper.sanitize', () => {
+  it('trims surrounding whitespace', () => {
+    expect(EmailHelper.sanitize('  test@example.com  ')).toBe('test@example.com');
+  });
+});
+
+describe('EmailHelper.isValid', () => {
+  it('accepts well-formed email addresses', () => {
+    expect(EmailHelper.isValid('test@example.com')).toBe(true);
+    expect(EmailHelper.isValid('a.b+c@sub.example.co.uk')).toBe(true);
+    expect(EmailHelper.isValid('  spaced@example.com  ')).toBe(true);
+  });
+
+  it('rejects malformed email addresses', () => {
+    expect(EmailHelper.isValid('not-an-email')).toBe(false);
+    expect(EmailHelper.isValid('missing-at.example.com')).toBe(false);
+    expect(EmailHelper.isValid('missing-domain@')).toBe(false);
+    expect(EmailHelper.isValid('@missing-local.com')).toBe(false);
+    expect(EmailHelper.isValid('has spaces@example.com')).toBe(false);
+    expect(EmailHelper.isValid('missing-dot@examplecom')).toBe(false);
+  });
+});
+
+describe('EmailHelper.sanitizeAndValidate', () => {
+  it('returns the trimmed email together with its validity', () => {
+    expect(EmailHelper.sanitizeAndValidate(' test@example.com ')).toEqual({
+      trimmedEmail: 'test@example.com',
+      isValid: true,
+    });
+    expect(EmailHelper.sanitizeAndValidate(' not-an-email ')).toEqual({
+      trimmedEmail: 'not-an-email',
+      isValid: false,
+    });
+  });
+});
+
+describe('EmailHelper regex reliability (SonarCloud: super-linear regex backtracking)', () => {
+  // The rule flagged `^[^\s@]+@[^\s@]+\.[^\s@]+$` for unbounded quantifiers. The fix
+  // bounds every quantifier ([^\s@]{1,64} / {1,255} / {1,63}) so a pathological input
+  // can never force runtime proportional to an attacker-controlled input length.
+  it('rejects very long inputs quickly instead of scanning the whole string', () => {
+    const longLocalPartNoAt = `${'a'.repeat(500_000)}@${'b'.repeat(500_000)}.com`;
+    const start = Date.now();
+    const isValid = EmailHelper.isValid(longLocalPartNoAt);
+    const durationMs = Date.now() - start;
+
+    expect(isValid).toBe(false); // local part exceeds the 64 char bound
+    expect(durationMs).toBeLessThan(500);
+  });
+
+  it('stays fast for a long domain with no dot at all', () => {
+    const noDot = `user@${'b'.repeat(500_000)}`;
+    const start = Date.now();
+    const isValid = EmailHelper.isValid(noDot);
+    const durationMs = Date.now() - start;
+
+    expect(isValid).toBe(false);
+    expect(durationMs).toBeLessThan(500);
+  });
+});

--- a/packages/common/src/__tests__/NumberHelper.test.ts
+++ b/packages/common/src/__tests__/NumberHelper.test.ts
@@ -25,6 +25,42 @@ describe('NumberHelper.formatNumber', () => {
   });
 });
 
+describe('NumberHelper.insertThousandsSeparators', () => {
+  // SonarCloud reliability rule (regex ReDoS): the previous implementation used the
+  // `\B(?=(\d{3})+(?!\d))` lookahead regex, which SonarCloud flagged as having
+  // super-linear runtime due to backtracking. It was replaced by a plain, regex-free
+  // loop. These tests verify the replacement is both behaviorally equivalent and fast.
+  it('groups digits in blocks of three from the right', () => {
+    expect(NumberHelper.insertThousandsSeparators('1', ',')).toBe('1');
+    expect(NumberHelper.insertThousandsSeparators('123', ',')).toBe('123');
+    expect(NumberHelper.insertThousandsSeparators('1234', ',')).toBe('1,234');
+    expect(NumberHelper.insertThousandsSeparators('1234567', ',')).toBe('1,234,567');
+  });
+
+  it('keeps a leading minus sign in front of the first digit group', () => {
+    expect(NumberHelper.insertThousandsSeparators('-1234567', ',')).toBe('-1,234,567');
+    expect(NumberHelper.insertThousandsSeparators('-123', ',')).toBe('-123');
+  });
+
+  it('supports arbitrary separator strings', () => {
+    expect(NumberHelper.insertThousandsSeparators('1234567', '.')).toBe('1.234.567');
+  });
+
+  it('handles empty input without throwing', () => {
+    expect(NumberHelper.insertThousandsSeparators('', ',')).toBe('');
+  });
+
+  it('stays fast (no super-linear backtracking) for very long digit strings', () => {
+    const longDigits = '9'.repeat(200_000);
+    const start = Date.now();
+    const result = NumberHelper.insertThousandsSeparators(longDigits, ',');
+    const durationMs = Date.now() - start;
+
+    expect(result.replace(/,/g, '')).toBe(longDigits);
+    expect(durationMs).toBeLessThan(500);
+  });
+});
+
 describe('NumberHelper.formatCompact', () => {
   it('returns the number as string when below 1000', () => {
     expect(NumberHelper.formatCompact(0)).toBe('0');

--- a/yarn.lock
+++ b/yarn.lock
@@ -27123,7 +27123,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rocket-meals-scripts@workspace:apps/scripts"
   dependencies:
+    "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^22.9.4"
+    jest: "npm:^29.7.0"
+    ts-jest: "npm:^29.1.3"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.8.3"
   languageName: unknown


### PR DESCRIPTION
## Summary

Resolves all 29 open reliability issues from `reports/sonarCloud/report_reliability.csv`:

- **16x "Simplify this regular expression to reduce its runtime, as it has super-linear performance due to backtracking."** — every previously-unbounded quantifier (`[^\]]+`, `.*?`, `.+`, the `\B(?=(\d{3})+(?!\d))` thousands-separator lookahead, etc.) was bounded with an explicit max length, so a pathological/attacker-controlled input can no longer force runtime proportional to its size. `NumberHelper`'s thousands-separator regex was replaced with a plain linear loop (no regex at all). Behavioral equivalence for realistic inputs was verified for every occurrence (Node comparisons of old vs. new pattern across representative and edge-case inputs).
  - Files: `apps/frontend/app/app/index.tsx`, `apps/scripts/submit-ios-review.ts`, `apps/frontend/app/components/CustomMarkdown/CustomMarkdown.tsx`, `apps/frontend/app/constants/MarkdownPatterns.ts`, `apps/frontend/app/components/EmailInput/EmailInput.tsx`, `packages/common/src/EmailHelper.ts`, `packages/common/src/NumberHelper.ts`, `apps/frontend/app/app/(app)/course-timetable/index.tsx`, `apps/backend/.../FoodTL1Parser.ts` (2x), `apps/backend/.../MaxManagerConnector.ts`, `apps/backend/.../FoodWebParserAachenParseHtml.ts`.
- **14x "Use '[[' instead of '[' for conditional tests."** — every flagged single-bracket test in `apps/frontend/run-maestro-web-test.sh` and `apps/score-tracker/run-maestro-web-test.sh` was switched to `[[ ]]` (both scripts already use `#!/bin/bash`, so this is safe).

## Tests

Added Jest tests per fixed rule/method verifying both **correctness** (behavior unchanged for real inputs) and **rule compliance** (stays fast — well under the old pathological-backtracking behavior — for large adversarial/non-matching input). Where the flagged regex lived in a non-exported local const or a script with import-time side effects (a CLI script that calls `main()` on import), it was extracted into a small, side-effect-free testable helper without changing behavior:
- `extractLegendCodeFromText` (new, in `MaxManagerConnector.ts`)
- `apps/frontend/app/app/(app)/course-timetable/markdownHelpers.ts` (new)
- `apps/scripts/base64url.ts` (new; `apps/scripts` previously had no Jest setup at all, so a minimal one was added)

New/updated test files: `NumberHelper.test.ts`, `EmailHelper.test.ts` (new), `CustomMarkdown.test.ts` (new), `MarkdownPatterns.test.ts` (new), `EmailInput.test.ts` (new), `app/index.test.ts` (new), `markdownHelpers.test.ts` (new), `TestFoodTL1Parser.ts`, `TestFoodWebParserAachenParseHtml.ts` (new), `TestMaxManagerConnectorLegendCode.ts` (new), `base64url.test.ts` (new).

## Test plan

- [x] `packages/common`: `yarn jest` — 7 suites / 49 tests pass
- [x] `apps/backend/.../directus-extension-rocket-meals-bundle`: `yarn jest` — 34 suites / 156 tests pass (the pre-existing `NewsTestHannover` network-dependent test is unrelated and fails identically on `master` in this sandbox due to no external network access)
- [x] `apps/scripts`: `yarn jest` — 1 suite / 3 tests pass (new setup)
- [x] `apps/frontend/app`: `npx tsc --noEmit` shows zero new errors from this diff (jest-expo itself cannot execute in this sandbox — confirmed pre-existing/environment-specific by reproducing the identical failure on an untouched existing test file)
- [x] `bash -n` on both modified shell scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WHG8VUpj8VFQgKS1gaL1xZ)_