### PR TITLE
fix(sonar): fix hashHelper.ts argument-order false positive at the root

### DIFF
--- a/apps/frontend/app/helper/hashHelper.ts
+++ b/apps/frontend/app/helper/hashHelper.ts
@@ -33,13 +33,19 @@ export class HashHelper {
 		const _H = (x: number, y: number, z: number) => x ^ y ^ z;
 		const _I = (x: number, y: number, z: number) => y ^ (x | ~z);
 
-		const _FF = (a: number, b: number, c: number, d: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(a, _F(b, c, d)), addUnsigned(x, ac)), s), b);
+		// Round-function parameters are intentionally named regA-regD (not a-d): each
+		// call site below passes the four MD5 state words in a rotated order, which
+		// previously matched these parameter names one-for-one just reordered. That
+		// coincidental name overlap is exactly what triggers SonarCloud's
+		// "arguments passed in the wrong order" check — renaming the parameters
+		// removes the false positive at its source instead of suppressing it.
+		const _FF = (regA: number, regB: number, regC: number, regD: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(regA, _F(regB, regC, regD)), addUnsigned(x, ac)), s), regB);
 
-		const _GG = (a: number, b: number, c: number, d: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(a, _G(b, c, d)), addUnsigned(x, ac)), s), b);
+		const _GG = (regA: number, regB: number, regC: number, regD: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(regA, _G(regB, regC, regD)), addUnsigned(x, ac)), s), regB);
 
-		const _HH = (a: number, b: number, c: number, d: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(a, _H(b, c, d)), addUnsigned(x, ac)), s), b);
+		const _HH = (regA: number, regB: number, regC: number, regD: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(regA, _H(regB, regC, regD)), addUnsigned(x, ac)), s), regB);
 
-		const _II = (a: number, b: number, c: number, d: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(a, _I(b, c, d)), addUnsigned(x, ac)), s), b);
+		const _II = (regA: number, regB: number, regC: number, regD: number, x: number, s: number, ac: number) => addUnsigned(rotateLeft(addUnsigned(addUnsigned(regA, _I(regB, regC, regD)), addUnsigned(x, ac)), s), regB);
 
 		const convertToWordArray = (str: string) => {
 			let lWordCount: number;
@@ -79,10 +85,9 @@ export class HashHelper {
 		let c = 0x98badcfe;
 		let d = 0x10325476;
 
-		// NOSONAR: the (a, b, c, d) rotation below is the standard MD5 round structure
-		// (RSA reference algorithm) — each round intentionally passes the four state
-		// words in a rotated order, not the same order as the FF/GG/HH/II parameter
-		// names. Reordering would break the hash. See docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md.
+		// Each round below intentionally passes the four MD5 state words in a
+		// rotated order (standard MD5/RSA reference algorithm) — reordering would
+		// break the hash.
 		for (let k = 0; k < x.length; k += 16) {
 			const AA = a;
 			const BB = b;

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -606,7 +606,11 @@ exakt der bereits in früheren Runden dokumentierten Begründung):**
   `(a,b,c,d)`-Rotation ist die Standard-MD5-Rundenstruktur, kein
   Vertauschungs-Bug). Kommentar ist weiterhin vorhanden, Code unverändert —
   die 16 CSV-Einträge sind derselbe Stale-CSV-Effekt wie beim „Move
-  component"-Fund weiter oben.
+  component"-Fund weiter oben. **Update:** Diese Einschätzung war falsch —
+  der `NOSONAR`-Kommentar stand vor der Schleife, nicht auf den 16
+  konkret gemeldeten Zeilen, und hat SonarCloud daher nie tatsächlich
+  unterdrückt (kein Stale-CSV-Effekt). Siehe die spätere, neunte Runde für
+  den echten Fix.
 - **„Do not use Array index in keys" (15x)**: alle 15 Stellen einzeln erneut
   geöffnet und geprüft — sie entsprachen exakt den bereits weiter oben
   dokumentierten Fällen (Debug-Log-Anzeigen in `seaphara`,
@@ -1221,6 +1225,41 @@ dokumentiert und nicht über Text-Konkatenation im Key.
 
 Verifiziert per `tsc --noEmit`-Baseline-Diff (`git stash`/`git stash pop`)
 für `apps/frontend/app` und `apps/geonexia/frontend`: keine neuen Fehler.
+
+## Am 2026-07-22 (neunte Runde): `hashHelper.ts`-Argument-Reihenfolge korrekt behoben
+
+Der aktuelle CSV-Top-Fund war „Arguments 'X' and 'X' have the same names but
+not the same order as the function parameters" (16x), durchgehend
+`hashHelper.ts:93-153` (die `_FF`/`_GG`/`_HH`/`_II`-MD5-Rundenfunktionen).
+Frühere Runden (siehe fünfte Runde oben) hatten das als False Positive
+eingestuft und einen erklärenden `NOSONAR`-Kommentar **vor der Schleife**
+ergänzt — dieser Kommentar stand aber nie auf einer der 16 tatsächlich
+gemeldeten Zeilen, sondern mehrere Zeilen davor (vor `for (let k = ...)`),
+und hat SonarCloud dadurch nie wirklich unterdrückt. Das war also kein
+Stale-CSV-Effekt (wie fälschlich angenommen), sondern ein wirkungsloser
+Suppression-Kommentar.
+
+**Fix:** Statt eines Suppression-Kommentars wurde die eigentliche Ursache
+behoben — die vier Rundenfunktionen `_FF`/`_GG`/`_HH`/`_II` hatten
+Parameter namens `a, b, c, d`, exakt wie die äußeren MD5-Zustandsvariablen.
+Jede Rundenfunktion wird pro Aufruf mit den vier Zustandsvariablen in
+rotierter Reihenfolge aufgerufen (Standard-MD5-Algorithmus, z. B.
+`c = _FF(c, d, a, b, ...)`), was durch die identischen Namen wie ein
+Argument-Vertauschungsbug aussieht. Die Parameter wurden zu `regA, regB,
+regC, regD` umbenannt — dadurch gibt es keine Namensüberschneidung mit den
+äußeren `a/b/c/d` mehr, und SonarCloud hat keine Grundlage mehr, um einen
+Vertauschungsverdacht zu melden. Der alte, wirkungslose `NOSONAR`-Kommentar
+vor der Schleife wurde durch eine kürzere, sachliche Erklärung ersetzt
+(kein `NOSONAR` mehr nötig).
+
+**Verifizierung:** Das Verhalten ist durch die reine Parameter-Umbenennung
+unverändert (Aufrufstellen, Verschachtelung und Reihenfolge der Argumente
+bleiben exakt gleich). Zusätzlich empirisch geprüft: `HashHelper.md5(...)`
+liefert für mehrere Eingaben (leerer String, `"hello"`, Unicode, 1000
+Zeichen) exakt dieselben Hashes wie vor der Änderung (Bit-für-Bit-Vergleich
+Alt- vs. Neu-Implementierung) sowie korrekte MD5-Referenzwerte für
+`""`/`"hello"`/den bekannten Pangram-Testvektor. `tsc --noEmit` für
+`apps/frontend/app`: keine neuen Fehler.
 
 ## Hinweise
 


### PR DESCRIPTION
## Summary

Fixes the top remaining SonarCloud maintainability finding: "Arguments 'X' and 'X' have the same names but not the same order as the function parameters" (16x), all in `hashHelper.ts:93-153` (the `_FF`/`_GG`/`_HH`/`_II` MD5 round functions).

An earlier round had already identified this as a false positive (the `(a, b, c, d)` rotation is the standard MD5/RSA reference algorithm — reordering would break the hash) and added an explanatory `NOSONAR` comment. That comment, however, sat above the `for` loop rather than on any of the 16 actually-reported lines, so it never suppressed anything with SonarCloud — the issues kept reappearing in every scan.

**Fix:** instead of relying on a suppression comment, removed the actual cause of the false positive. The round functions' parameters were named `a, b, c, d` — identical to the outer MD5 state variables. Since each call site passes the state words in a rotated order (e.g. `c = _FF(c, d, a, b, ...)`), the identical names made it look like a swapped-argument bug. Renamed the parameters to `regA, regB, regC, regD`; the call sites and argument order are untouched, but there's no longer any name collision for SonarCloud's check to flag. The old, non-functional `NOSONAR` comment was replaced with a short explanatory comment (no suppression needed anymore).

## Test plan

- [x] Compiled the old and new implementations side by side and compared `HashHelper.md5(...)` output for several inputs (empty string, `"hello"`, `"rocket-meals"`, a long ASCII string, unicode, 1000-char string) — byte-for-byte identical results.
- [x] Verified against known MD5 test vectors (`""` → `d41d8cd9...`, `"hello"` → `5d41402a...`, the standard pangram test vector) — all correct.
- [x] `tsc --noEmit` for `apps/frontend/app`: no new errors.
- [x] Updated `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` to correct the earlier (mistaken) "stale CSV" explanation and record this round.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NTcNWDkCTRVqrVWyyRoz8B)_