### PR TITLE
fix(sonar): fix own NOSONAR syntax error, fix all 3 security findings

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -33,5 +33,5 @@ USER node
 
 RUN corepack enable && \
     corepack prepare pnpm@8.6.12 --activate && \
-    pnpm install directus-extension-sync@3.0.3 && \
-    pnpm install directus-extension-flow-manager@1.4.1
+    pnpm install --ignore-scripts directus-extension-sync@3.0.3 && \
+    pnpm install --ignore-scripts directus-extension-flow-manager@1.4.1

--- a/apps/geonexia/frontend/assets/objects/1_fix_viewbox.py
+++ b/apps/geonexia/frontend/assets/objects/1_fix_viewbox.py
@@ -25,11 +25,12 @@ PADDING = 10
 
 # ─── SVG path parser ──────────────────────────────────────────────────────────
 
-# NOSONAR: this is the SVG path 'd' attribute tokenizer (command letters + numbers,
+# This is the SVG path 'd' attribute tokenizer (command letters + numbers,
 # including exponential notation, leading/trailing decimal points, and adjacent
 # numbers without separators). A further structural simplification risks subtly
 # changing how those edge cases parse; verified equivalent to the previous, more
 # ambiguous version across 20,000 fuzzed inputs (see docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md).
+# Suppressed below rather than simplified further, for that reason.
 _TOKEN_RE = re.compile(r'([MmZzLlHhVvCcSsQqTtAa])|([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)')  # NOSONAR
 
 

--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -1658,6 +1658,77 @@ hatte). Verhalten unverändert, reine Umbenennung — erneut per `tsc --noEmit`
 für alle vier Workspaces sowie den drei bereits oben genannten Test-Suiten
 gegengeprüft.
 
+## Am 2026-07-22 (vierzehnte Runde): eigener NOSONAR-Fehler behoben + erste Security-Runde
+
+Ausgangspunkt: frischer CSV-Stand — Reliability weiterhin 0. Maintainability
+nur noch **1 Fund**, verursacht durch die zwölfte Runde selbst. Zusätzlich
+auf Nutzerwunsch die **3 aktuellen Security-Funde** geprüft.
+
+**Maintainability (1 Fund, selbst verursacht):**
+- **`1_fix_viewbox.py:28`** („Fix the syntax of this issue suppression
+  comment."): der mehrzeilige Erklärkommentar aus der zwölften Runde begann
+  mit `# NOSONAR: this is the SVG path ...` — SonarPython interpretiert
+  **jede** Kommentarzeile, die das Wort „NOSONAR" enthält, als Versuch einer
+  Suppression-Direktive und validiert deren Syntax; `NOSONAR: <Freitext>` auf
+  einer eigenen Zeile (nicht auf der eigentlichen Code-Zeile) ist ungültige
+  Syntax. Behoben, indem das Wort „NOSONAR" aus dem Erklärkommentar entfernt
+  wurde — die tatsächliche, korrekt platzierte Suppression bleibt als
+  alleinstehendes `# NOSONAR` am Ende der Regex-Zeile bestehen. Zur Sicherheit
+  alle anderen `NOSONAR`-Kommentare im Repo (TS/JS: `DateHelper.ts`,
+  `FoodItem.tsx`, `MyBuffer.ts`, `MathHelper.ts`, `DeepCopyHelper.ts`, sowie
+  die bereits vorher bestehenden „X is currently unused"-Kommentare) auf
+  dasselbe Muster geprüft — keiner davon taucht im aktuellen CSV auf, das
+  Problem ist spezifisch für SonarPythons strengere Syntax-Prüfung.
+
+**Security (3 Funde, erste Runde für diese Kategorie):**
+- **`apps/backend/Dockerfile:36,37`** („Omitting '--ignore-scripts' allows
+  lifecycle scripts to run during package installation."): vor dem Fix
+  geprüft, ob die beiden `pnpm install`-Aufrufe (`directus-extension-sync@3.0.3`,
+  `directus-extension-flow-manager@1.4.1`) tatsächlich auf Install-Time-
+  Lifecycle-Scripts angewiesen sind — `npm view <pkg> scripts` zeigt für
+  beide Pakete nur Dev-Time-Scripts (`dev`, `link`, `test`/`build`, die
+  `pnpm install` nicht automatisch ausführt), keine `install`/`postinstall`/
+  `preinstall`/`prepare`-Scripts; `npm view <pkg> dependencies` zeigt für
+  beide Pakete **keine** Abhängigkeiten (keine transitive Dependency-Kette,
+  die auf Postinstall-Scripts angewiesen sein könnte). `--ignore-scripts` zu
+  beiden Aufrufen ergänzt — funktional folgenlos, aber schließt das
+  generische Risiko (kompromittiertes Paket mit bösartigem Postinstall) für
+  die Zukunft aus.
+- **`scripts/count-sonar-maintainability-issues.js:93`** („LLMs running
+  this code with faulty CLI arguments can escape file system restrictions."):
+  `csvPath` kam unvalidiert aus `process.argv[2]` direkt in
+  `fs.readFileSync(csvPath, ...)` — ein Aufrufer (menschlich oder ein
+  Agent mit einem fehlerhaften/böswilligen Pfad-Argument) konnte damit
+  beliebige Dateien außerhalb des Repos lesen (z. B. `../../../../etc/passwd`).
+  Fix: `csvPath` wird jetzt zu einem absoluten Pfad aufgelöst und vor dem
+  Dateizugriff gegen die aufgelöste Repo-Wurzel (`path.resolve(__dirname, '..')`)
+  geprüft; liegt der Pfad außerhalb, bricht das Skript mit Fehlermeldung und
+  Exit-Code 1 ab, **bevor** auf das Dateisystem zugegriffen wird. Die
+  bestehende Nutzung (kein Argument → Default-Pfad; expliziter Pfad zu einer
+  anderen CSV **innerhalb** des Repos, z. B. `report_security.csv`) bleibt
+  unverändert funktionsfähig — nur Pfade außerhalb der Repo-Wurzel werden
+  abgelehnt.
+
+**Verifizierung:**
+- `node scripts/count-sonar-maintainability-issues.js` (Default-Pfad) sowie
+  mit einem gültigen Pfad innerhalb des Repos (`reports/sonarCloud/report_security.csv`)
+  manuell ausgeführt: unverändertes Verhalten.
+- `../../../../etc/passwd` und `/etc/passwd` als Argument getestet: beide
+  werden mit Exit-Code 1 und Fehlermeldung abgelehnt, keine Dateisystem-
+  Zugriffe.
+- `1_fix_viewbox.py` erneut mit Beispiel-Pfaddaten ausgeführt (unverändertes
+  Verhalten, reine Kommentaränderung).
+- Docker-Datei nicht per echtem Docker-Build getestet (kein Docker in dieser
+  Sandbox verfügbar), aber die Risikobewertung (keine Lifecycle-Scripts, keine
+  Abhängigkeiten bei beiden betroffenen Paketen) macht einen Build-Bruch
+  extrem unwahrscheinlich.
+
+**Bilanz:** Reliability weiterhin 0/0. Maintainability: der eine (durch die
+vorherige Runde selbst verursachte) Fund behoben — sollte den nächsten Scan
+wieder auf 0 bringen. Security: alle 3 aktuellen Funde behoben (2 echte
+Fixes ohne Funktionsverlust, 1 echter Fix mit neuer, für Agentic-/LLM-Nutzung
+relevanter Pfad-Validierung).
+
 ## Hinweise
 
 - Die CSV-Reports werden per CI aktualisiert (Commits `chore: update sonarcloud reports`).

--- a/scripts/count-sonar-maintainability-issues.js
+++ b/scripts/count-sonar-maintainability-issues.js
@@ -12,8 +12,16 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const csvPath = process.argv[2] || path.join(__dirname, '..', 'reports', 'sonarCloud', 'report_maintainability.csv');
+const repoRoot = path.resolve(__dirname, '..');
+const csvPath = path.resolve(process.argv[2] || path.join(repoRoot, 'reports', 'sonarCloud', 'report_maintainability.csv'));
 const topN = Number.parseInt(process.argv[3] || '10', 10);
+
+// Reject any path (e.g. from a mistaken or malicious CLI argument) that resolves
+// outside the repository, before touching the file system.
+if (csvPath !== repoRoot && !csvPath.startsWith(repoRoot + path.sep)) {
+    console.error(`Refusing to read a path outside the repository: ${csvPath}`);
+    process.exit(1);
+}
 
 function parseCsvLine(line) {
     const fields = [];


### PR DESCRIPTION
## Summary

Reliability stays at 0. Maintainability was down to 1 finding — self-inflicted by the previous round. Also checked and fixed all 3 current Security findings, as requested.

### Maintainability (1 finding, self-inflicted)

- **`1_fix_viewbox.py:28`** ("Fix the syntax of this issue suppression comment."): the explanatory comment above the suppressed regex started with `# NOSONAR: this is the SVG path ...` on its own line. SonarPython treats *any* comment line containing the word "NOSONAR" as an attempted suppression directive and validates its syntax — `NOSONAR: <free text>` on a line that isn't the actual flagged code line is invalid syntax there. Fixed by removing the word from the explanation, keeping only the correctly-placed, bare `# NOSONAR` trailing the regex line itself. Checked every other `NOSONAR` comment in the repo for the same pattern (TS/JS: `DateHelper.ts`, `FoodItem.tsx`, `MyBuffer.ts`, `MathHelper.ts`, `DeepCopyHelper.ts`) — none of those are flagged, so this is specific to SonarPython's stricter check.

### Security (3 findings, first round for this category)

- **`apps/backend/Dockerfile:36,37`**: added `--ignore-scripts` to both `pnpm install` calls (`directus-extension-sync`, `directus-extension-flow-manager`). Verified via `npm view <pkg> scripts` that neither package declares any install-time lifecycle script (only dev-time `build`/`link`/`test` scripts, which `pnpm install` never runs automatically), and `npm view <pkg> dependencies` shows neither package has *any* dependencies — so this is functionally a no-op today, but closes off the generic risk of a compromised package's `postinstall` script running during the Docker build.
- **`scripts/count-sonar-maintainability-issues.js:93`**: `csvPath` came straight from an unvalidated CLI argument into `fs.readFileSync`, letting a caller (human or an agent given a wrong/malicious path) read arbitrary files outside the repo. Now resolves `csvPath` to an absolute path and rejects anything outside the repository root before touching the filesystem, while existing usage (default path, or an explicit path to another CSV inside the repo, e.g. `report_security.csv`) keeps working exactly as before.

## Test plan

- [x] Ran the script normally (default path, and an explicit valid in-repo path like `reports/sonarCloud/report_security.csv`) — unchanged output.
- [x] Tried both a relative traversal (`../../../../etc/passwd`) and an absolute path (`/etc/passwd`) as the argument — both correctly rejected with a clear error message and exit code 1, no filesystem access attempted.
- [x] Re-ran `1_fix_viewbox.py` on sample path data — unchanged behavior (comment-only change).
- [x] Dockerfile not build-tested (no Docker available in this sandbox), but the dependency/script analysis (see above) makes a build break very unlikely.
- [x] Updated `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` with this round's summary.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NTcNWDkCTRVqrVWyyRoz8B)_