### PR TITLE
fix(sonar): canonicalize path via realpathSync before validating

### DIFF
--- a/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
+++ b/docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md
@@ -1729,6 +1729,50 @@ wieder auf 0 bringen. Security: alle 3 aktuellen Funde behoben (2 echte
 Fixes ohne Funktionsverlust, 1 echter Fix mit neuer, für Agentic-/LLM-Nutzung
 relevanter Pfad-Validierung).
 
+## Am 2026-07-22 (fünfzehnte Runde): Pfad-Validierung um Symlink-Kanonisierung ergänzt
+
+Ausgangspunkt: Maintainability und Reliability beide bei **0**. Security
+zeigte 1 verbliebenen Fund — an derselben Stelle wie in der vierzehnten
+Runde (`scripts/count-sonar-maintainability-issues.js`), aber mit
+präziserer Meldung: „A path canonicalized from CLI-controlled data must be
+validated before use." Die vorherige Runde hatte `csvPath` per
+`path.resolve(...)` normalisiert und gegen die Repo-Wurzel geprüft — das
+entfernt zwar `.`/`..`-Segmente syntaktisch, löst aber **keine Symlinks**
+auf. Ein Symlink innerhalb des Repos, der auf eine Datei außerhalb zeigt
+(z. B. `reports/sonarCloud/evil.csv -> /etc/passwd`), hätte die Prüfung aus
+der vierzehnten Runde umgangen, da der syntaktisch normalisierte Pfad
+weiterhin innerhalb der Repo-Wurzel liegt — erst beim tatsächlichen Lesen
+löst das Betriebssystem den Symlink auf und liest die externe Datei.
+
+**Fix:** `repoRoot` und der angeforderte Pfad werden jetzt beide per
+`fs.realpathSync(...)` kanonisiert (Symlinks aufgelöst), **bevor** die
+Enthaltenssein-Prüfung läuft; der kanonisierte Pfad ist auch der, der
+anschließend tatsächlich gelesen wird (`fs.readFileSync(csvPath, ...)`),
+nicht nur der syntaktisch normalisierte.
+
+**Verifizierung:**
+- Normale Nutzung (Default-Pfad, expliziter gültiger Pfad innerhalb des
+  Repos) manuell erneut ausgeführt: unverändertes Verhalten.
+- Relative (`../../../../etc/passwd`) und absolute (`/etc/passwd`)
+  Traversal-Versuche: weiterhin mit Exit-Code 1 abgelehnt.
+- **Echter Symlink-Escape-Test:** `ln -sf /etc/passwd
+  reports/sonarCloud/evil-symlink.csv` innerhalb des Repos angelegt und mit
+  diesem Pfad aufgerufen — jetzt korrekt mit Exit-Code 1 abgelehnt (zuvor,
+  vor diesem Fix, hätte die reine `path.resolve`-Prüfung aus der
+  vierzehnten Runde das nicht erkannt, da der Symlink-Pfad selbst innerhalb
+  der Repo-Wurzel liegt). Ein erster Testversuch mit `cp` statt `ln -sf`
+  hatte fälschlich den Zielinhalt in eine echte Datei innerhalb des Repos
+  kopiert (kein tatsächlicher Symlink) und damit keine reale Sicherheitslücke
+  aufgedeckt — nach Korrektur des Testaufbaus (`ln -sf` statt `cp`) bestätigt
+  der Test den Fix wie beschrieben.
+- Nicht-existierender Pfad: wirft weiterhin (wie schon vor jeder dieser
+  Änderungen) eine unbehandelte `ENOENT`-Exception mit Stacktrace — keine
+  Verschlechterung ggü. dem Ausgangszustand, nur jetzt eine Stufe früher
+  (`realpathSync` statt `readFileSync`).
+
+**Bilanz:** Maintainability 0/0, Reliability 0/0, Security 0/0 (nach dem
+nächsten Scan) — alle drei SonarCloud-Kategorien für dieses Repo auf 0.
+
 ## Hinweise
 
 - Die CSV-Reports werden per CI aktualisiert (Commits `chore: update sonarcloud reports`).

--- a/scripts/count-sonar-maintainability-issues.js
+++ b/scripts/count-sonar-maintainability-issues.js
@@ -12,12 +12,15 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const repoRoot = path.resolve(__dirname, '..');
-const csvPath = path.resolve(process.argv[2] || path.join(repoRoot, 'reports', 'sonarCloud', 'report_maintainability.csv'));
+const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+const requestedPath = path.resolve(process.argv[2] || path.join(repoRoot, 'reports', 'sonarCloud', 'report_maintainability.csv'));
 const topN = Number.parseInt(process.argv[3] || '10', 10);
 
-// Reject any path (e.g. from a mistaken or malicious CLI argument) that resolves
-// outside the repository, before touching the file system.
+// Canonicalize (resolve symlinks) before validating, so a symlink inside the
+// repo that points outside it can't be used to bypass the containment check
+// below, then reject anything that resolves outside the repository - before
+// touching the file system any further.
+const csvPath = fs.realpathSync(requestedPath);
 if (csvPath !== repoRoot && !csvPath.startsWith(repoRoot + path.sep)) {
     console.error(`Refusing to read a path outside the repository: ${csvPath}`);
     process.exit(1);


### PR DESCRIPTION
## Summary

Maintainability and Reliability are both already at 0. Security had 1 remaining finding — at the same spot fixed in the previous round (`scripts/count-sonar-maintainability-issues.js`), but with a more precise message this time: "A path canonicalized from CLI-controlled data must be validated before use."

The previous round's fix (`path.resolve(...)` + a repo-root containment check) normalizes `.`/`..` segments syntactically, but doesn't resolve symlinks. A symlink placed inside the repo that points outside it (e.g. `reports/sonarCloud/evil.csv -> /etc/passwd`) would have passed that check, since the symlink's own path is inside the repo root — only the OS resolving the symlink at actual read time would reveal the real, external target.

**Fix:** both `repoRoot` and the requested path are now canonicalized via `fs.realpathSync(...)` *before* the containment check runs, and it's this canonicalized path that's actually passed to `fs.readFileSync`.

## Test plan

- [x] Normal usage (default path, an explicit valid in-repo path) — unchanged output.
- [x] Relative (`../../../../etc/passwd`) and absolute (`/etc/passwd`) traversal attempts — still correctly rejected.
- [x] **Real symlink-escape test**: created `ln -sf /etc/passwd reports/sonarCloud/evil-symlink.csv` inside the repo and ran the script against that path — now correctly rejected with exit code 1. (Before this fix, the previous round's `path.resolve`-only check would not have caught this, since the symlink path itself is inside the repo root.)
- [x] Non-existent path: still throws an unhandled `ENOENT` with a stack trace, same as before any of these changes — no regression, just one step earlier (`realpathSync` instead of `readFileSync`).
- [x] Updated `docs/SONARCLOUD_MAINTAINABILITY_WORKFLOW.md` with this round's summary — all three SonarCloud categories (Maintainability, Reliability, Security) should show 0 after the next scan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NTcNWDkCTRVqrVWyyRoz8B)_