### PR TITLE
refactor: fix data clumps flagged by data-clumps-doctor

### DIFF
--- a/apps/accessibilityTester/src/report.ts
+++ b/apps/accessibilityTester/src/report.ts
@@ -148,13 +148,9 @@ function buildScreenSummaryTableRow(screen: ScreenResult): string {
   return `| ${escapeMarkdownTableCell(screen.screen)} | ${byImpact.critical} | ${byImpact.serious} | ${byImpact.moderate} | ${byImpact.minor} | ${total} | ${screen.passCount} |`;
 }
 
-interface RuleCountInfo {
-  impact: ImpactLevel;
-  help: string;
-  helpUrl: string;
-  nodeCount: number;
+type RuleCountInfo = Pick<ViolationSummary, 'impact' | 'help' | 'helpUrl' | 'nodeCount'> & {
   screenCount: number;
-}
+};
 
 function computeRuleCounts(screens: ScreenResult[]): Map<string, RuleCountInfo> {
   const ruleCounts = new Map<string, RuleCountInfo>();

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/DirectusCollectionTranslator.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/auto-translation-hook/DirectusCollectionTranslator.ts
@@ -299,13 +299,14 @@ export class DirectusCollectionTranslator {
    * Translates each field in fieldsToTranslate from sourceTranslation using the given translator,
    * for the given destination language_code. Logs and skips fields that fail to translate.
    */
-  private static async translateFields(
-    translator: Translator,
-    fieldsToTranslate: string[],
-    sourceTranslation: any,
-    sourceLanguageCode: string | undefined,
-    language_code: string
-  ): Promise<any> {
+  private static async translateFields(options: {
+    translator: Translator;
+    fieldsToTranslate: string[];
+    sourceTranslation: any;
+    sourceLanguageCode: string | undefined;
+    language_code: string;
+  }): Promise<any> {
+    const { translator, fieldsToTranslate, sourceTranslation, sourceLanguageCode, language_code } = options;
     const translatedItem: any = {};
     for (const field of fieldsToTranslate) {
       const fieldValue = sourceTranslation[field];
@@ -332,7 +333,7 @@ export class DirectusCollectionTranslator {
         console.warn('Translator is not ready - skipping translation for language: ' + language_code);
         // Skip translation attempts since translator cannot translate
       } else {
-        translatedItem = await DirectusCollectionTranslator.translateFields(translator, fieldsToTranslate, sourceTranslation, sourceLanguageCode, language_code);
+        translatedItem = await DirectusCollectionTranslator.translateFields({translator, fieldsToTranslate, sourceTranslation, sourceLanguageCode, language_code});
       }
     }
 

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -33,6 +33,17 @@ export type FoodCreationHelperObject = {
   foodofferCategoryExternalIdentifiersToFoodofferCategoriesDict: DictFoodofferCategoriesExternalIdentifiersToFoodofferCategories;
 };
 
+/**
+ * Groups the report data for a single canteen together with the shared creation helper
+ * object, so it can be passed as one parameter object into the per-canteen sync methods.
+ */
+export type CanteenFoodofferSyncGroup = {
+  canteen: DatabaseTypes.Canteens;
+  canteenExternalIdentifier: string;
+  canteenFoodoffers: FoodoffersTypeForParser[];
+  helperObject: FoodCreationHelperObject;
+};
+
 export class ParseSchedule {
   private readonly context: WorkflowRunContext;
   private readonly foodParser: FoodParserInterface | null;
@@ -349,11 +360,12 @@ export class ParseSchedule {
       if (!canteen) continue;
 
       const canteenFoodoffers = foodoffersForParserGroupedByCanteen[canteenExternalIdentifier] || [];
+      const canteenFoodofferSyncGroup: CanteenFoodofferSyncGroup = {canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject};
 
       if (canteen.foodoffers_import_without_date) {
-        await this.syncFoodOffersForCanteenWithoutDate(canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject);
+        await this.syncFoodOffersForCanteenWithoutDate(canteenFoodofferSyncGroup);
       } else {
-        await this.syncFoodOffersForCanteenByDate(canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject);
+        await this.syncFoodOffersForCanteenByDate(canteenFoodofferSyncGroup);
       }
     }
 
@@ -389,7 +401,8 @@ export class ParseSchedule {
    * Syncs foodoffers for an "import without date" canteen: all offers have date=null and are
    * processed as a single group via result_hash diffing.
    */
-  async syncFoodOffersForCanteenWithoutDate(canteen: DatabaseTypes.Canteens, canteenExternalIdentifier: string, canteenFoodoffers: FoodoffersTypeForParser[], helperObject: FoodCreationHelperObject): Promise<void> {
+  async syncFoodOffersForCanteenWithoutDate(canteenFoodofferSyncGroup: CanteenFoodofferSyncGroup): Promise<void> {
+    const {canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject} = canteenFoodofferSyncGroup;
     const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
 
     // Import-without-date canteen: all offers have date=null, process as a single group.
@@ -444,7 +457,8 @@ export class ParseSchedule {
    * Syncs foodoffers for a regular (dated) canteen: diffs are computed and applied per date
    * to minimize the deletion window.
    */
-  async syncFoodOffersForCanteenByDate(canteen: DatabaseTypes.Canteens, canteenExternalIdentifier: string, canteenFoodoffers: FoodoffersTypeForParser[], helperObject: FoodCreationHelperObject): Promise<void> {
+  async syncFoodOffersForCanteenByDate(canteenFoodofferSyncGroup: CanteenFoodofferSyncGroup): Promise<void> {
+    const {canteen, canteenExternalIdentifier, canteenFoodoffers, helperObject} = canteenFoodofferSyncGroup;
     const foodoffersHelper = this.context.myDatabaseHelper.getFoodoffersHelper();
 
     // Regular canteen: process diffs per date

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/foods-translation-fix-missing-schedule/index.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/foods-translation-fix-missing-schedule/index.ts
@@ -199,12 +199,13 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
   }
 
   /** Logs each source field's value once per food (aids diagnosing DeepL translation issues). */
-  private async logSourceFieldValues(
-    food: DatabaseTypes.Foods,
-    sourceTranslation: DatabaseTypes.FoodsTranslations,
-    fieldsToTranslate: string[],
-    context: WorkflowRunContext,
-  ): Promise<void> {
+  private async logSourceFieldValues(options: {
+    food: DatabaseTypes.Foods;
+    sourceTranslation: DatabaseTypes.FoodsTranslations;
+    fieldsToTranslate: string[];
+    context: WorkflowRunContext;
+  }): Promise<void> {
+    const {food, sourceTranslation, fieldsToTranslate, context} = options;
     for (const field of fieldsToTranslate) {
       const value = (sourceTranslation as any)[field];
       await context.logger.appendLog(
@@ -288,9 +289,9 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
     translatedItem[DirectusCollectionTranslator.FIELD_LET_BE_TRANSLATED] = true;
     translatedItem[DirectusCollectionTranslator.FIELD_BE_SOURCE_FOR_TRANSLATION] = false;
 
-    const wasSaved = await this.saveTranslatedItemIfNeeded(
+    const wasSaved = await this.saveTranslatedItemIfNeeded({
       food, translation, translatedItem, fieldsToTranslate, languageCode, context
-    );
+    });
     return {fixed: wasSaved, attempted: translateResult.attempted};
   }
 
@@ -350,7 +351,7 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
       ', languageField="' + FIELD_LANGUAGES_ID_OR_CODE + '"' +
       ', fieldsToTranslate=[' + fieldsToTranslate.join(', ') + ']'
     );
-    await this.logSourceFieldValues(food, sourceTranslation, fieldsToTranslate, context);
+    await this.logSourceFieldValues({food, sourceTranslation, fieldsToTranslate, context});
 
     let fixed = 0;
     let attempted = 0;
@@ -489,14 +490,15 @@ class FoodsTranslationFixMissingWorkflow extends SingleWorkflowRun {
    * Persists `translatedItem` onto the given translation if it contains any usable translated
    * field values; otherwise just logs that there was nothing to save. Returns whether it saved.
    */
-  private async saveTranslatedItemIfNeeded(
-    food: DatabaseTypes.Foods,
-    translation: DatabaseTypes.FoodsTranslations,
-    translatedItem: any,
-    fieldsToTranslate: string[],
-    languageCode: string,
-    context: WorkflowRunContext,
-  ): Promise<boolean> {
+  private async saveTranslatedItemIfNeeded(options: {
+    food: DatabaseTypes.Foods;
+    translation: DatabaseTypes.FoodsTranslations;
+    translatedItem: any;
+    fieldsToTranslate: string[];
+    languageCode: string;
+    context: WorkflowRunContext;
+  }): Promise<boolean> {
+    const {food, translation, translatedItem, fieldsToTranslate, languageCode, context} = options;
     if (fieldsToTranslate.some(field => translatedItem[field])) {
       const foodsUpdateHelper = context.myDatabaseHelper.getItemsServiceHelper<DatabaseTypes.Foods>(
         CollectionNames.FOODS

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -89,7 +89,12 @@ export class TranslationHelper {
     const { translationsFromParsing, items_primary_field_in_translation_table, itemsTablename, myDatabaseHelper } = config;
     const specificItemServiceReader = myDatabaseHelper.getItemsServiceHelper<T>(itemsTablename);
     if (itemWithTranslations) {
-      const { updateObject, updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations(itemWithTranslations, itemWithTranslations, translationsFromParsing, items_primary_field_in_translation_table);
+      const { updateObject, updateNeeded } = await TranslationHelper._getUpdateInformationForTranslations({
+        itemWithTranslations,
+        item: itemWithTranslations,
+        translationsFromParsing,
+        items_primary_field_in_translation_table,
+      });
 
       if (updateNeeded) {
         //const createTranslations = updateObject.translations.create;
@@ -146,12 +151,13 @@ export class TranslationHelper {
   static async _getUpdateInformationForTranslations<
     T extends ItemWithExistingTranslations, // T must have an id and translations field
     E extends ExistingTranslation, // the collection of the related translations
-  >(
-    itemWithTranslations: T, // the item we want to update the translations for
-    item: T, // the item we want to update the translations for
-    translationsFromParsing: TranslationsFromParsingType, // the translations we got from the parser
-    items_primary_field_in_translation_table: TranslationRelationField<E> // the primary field (to our item) in the translation table, e.g. "food_id" when translating foods
-  ) {
+  >(options: {
+    itemWithTranslations: T; // the item we want to update the translations for
+    item: T; // the item we want to update the translations for
+    translationsFromParsing: TranslationsFromParsingType; // the translations we got from the parser
+    items_primary_field_in_translation_table: TranslationRelationField<E>; // the primary field (to our item) in the translation table, e.g. "food_id" when translating foods
+  }) {
+    const { itemWithTranslations, item, translationsFromParsing, items_primary_field_in_translation_table } = options;
     /** translationsFromParsing is an object with the following structure:
          {
          [LanguageCodes.DE]: {
@@ -188,13 +194,13 @@ export class TranslationHelper {
     );
 
     //check remaining translationsFromParsing, then put into createTranslations
-    const newTranslationsFromParsing = TranslationHelper._collectCreateTranslationsFromRemaining(
+    const newTranslationsFromParsing = TranslationHelper._collectCreateTranslationsFromRemaining({
       remaining_translationsFromParsing,
       translationsFromParsing,
       items_primary_field_in_translation_table,
       item,
-      createTranslations
-    );
+      createTranslations,
+    });
 
     let updateObject = {
       translations: {
@@ -309,13 +315,14 @@ export class TranslationHelper {
    *
    * Mutates `createTranslations` in place, mirroring the original inline loop's behavior.
    */
-  static _collectCreateTranslationsFromRemaining<T extends ItemWithExistingTranslations, E extends ExistingTranslation>(
-    remaining_translationsFromParsing: TranslationsFromParsingType,
-    translationsFromParsing: TranslationsFromParsingType,
-    items_primary_field_in_translation_table: TranslationRelationField<E>,
-    item: T,
-    createTranslations: NewTranslationForCreation[]
-  ): boolean {
+  static _collectCreateTranslationsFromRemaining<T extends ItemWithExistingTranslations, E extends ExistingTranslation>(options: {
+    remaining_translationsFromParsing: TranslationsFromParsingType;
+    translationsFromParsing: TranslationsFromParsingType;
+    items_primary_field_in_translation_table: TranslationRelationField<E>;
+    item: T;
+    createTranslations: NewTranslationForCreation[];
+  }): boolean {
+    const { remaining_translationsFromParsing, translationsFromParsing, items_primary_field_in_translation_table, item, createTranslations } = options;
     let newTranslationsFromParsing = false;
 
     let remaining_languageKeys = Object.keys(remaining_translationsFromParsing);

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/__tests__/TestTranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/__tests__/TestTranslationHelper.ts
@@ -107,12 +107,12 @@ describe('TranslationHelper Test', () => {
 
   // Test case that should pass
   it('should detect updates needed when there is a significant change in translations', async () => {
-    const result = await TranslationHelper._getUpdateInformationForTranslations(
-      mockItemWithTranslations,
-      mockItemWithTranslations,
-      mockTranslationsFromParsing,
-      relationField // Use TestTranslationType for the relation field
-    );
+    const result = await TranslationHelper._getUpdateInformationForTranslations({
+      itemWithTranslations: mockItemWithTranslations,
+      item: mockItemWithTranslations,
+      translationsFromParsing: mockTranslationsFromParsing,
+      items_primary_field_in_translation_table: relationField, // Use TestTranslationType for the relation field
+    });
 
     expect(result.updateNeeded).toBe(true);
     expect(result.updateObject.translations.update).toHaveLength(1);
@@ -137,12 +137,12 @@ describe('TranslationHelper Test', () => {
       },
     };
 
-    const result = await TranslationHelper._getUpdateInformationForTranslations(
-      mockItemWithTranslations,
-      mockItemWithTranslations,
-      mockTranslationsWithoutChange,
-      relationField // Use TestTranslationType for the relation field
-    );
+    const result = await TranslationHelper._getUpdateInformationForTranslations({
+      itemWithTranslations: mockItemWithTranslations,
+      item: mockItemWithTranslations,
+      translationsFromParsing: mockTranslationsWithoutChange,
+      items_primary_field_in_translation_table: relationField, // Use TestTranslationType for the relation field
+    });
 
     expect(result.updateNeeded).toBe(false);
     expect(result.updateObject.translations.update).toHaveLength(0);

--- a/apps/frontend/app/components/DebugView/index.tsx
+++ b/apps/frontend/app/components/DebugView/index.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useMemo } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
+import type { LabeledAccentProps } from 'repo-depkit-common';
 import { useTheme } from '@/hooks/useTheme';
 import useDebugMode from '@/hooks/useDebugMode';
 import { useAppSelector } from '@/redux/hooks';
@@ -9,12 +10,9 @@ import styles from './styles';
 
 export type DebugLog = string | { message: string; timestamp?: string | Date };
 
-export type DebugAction = {
-        label: string;
+export type DebugAction = LabeledAccentProps & {
         onPress?: () => void;
         icon?: keyof typeof MaterialCommunityIcons.glyphMap;
-        backgroundColor?: string;
-        borderColor?: string;
         textColor?: string;
         disabled?: boolean;
 };

--- a/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/apps/frontend/app/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,16 +1,12 @@
 import React, { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '@/components/MyScrollViewModal';
 import { useModal } from './useModal';
-import type { ModalCloseReason } from 'repo-depkit-common-ui';
+import type { ModalOptions } from 'repo-depkit-common-ui';
 
 export type MyScrollViewModalConfig = MyScrollViewModalProps & { children?: ReactNode };
 
-type ScrollViewModalOptions = {
-	backgroundStyle?: any;
-	headerBackgroundColor?: string;
-	/** Forwarded to the global modal stack - see ModalOptions.onClosed in repo-depkit-common-ui. */
-	onClosed?: (reason: ModalCloseReason) => void;
-};
+/** The subset of the global modal stack's `ModalOptions` that a scroll-view modal forwards. */
+type ScrollViewModalOptions = Pick<ModalOptions, 'backgroundStyle' | 'headerBackgroundColor' | 'onClosed'>;
 
 export const useMyScrollViewModal = () => {
         const { show: showModal, close, showAndDiscardOthers: showAndDiscardOthersModal, closeAll, debug } = useModal();

--- a/apps/frontend/app/components/MyMap/model.ts
+++ b/apps/frontend/app/components/MyMap/model.ts
@@ -1,5 +1,6 @@
 import type { LatLngBoundsLiteral, LatLngLiteral, PointTuple } from 'leaflet';
 import { CircleMarkerProps, CircleProps, PolygonProps, PolylineProps, RectangleProps } from 'react-leaflet';
+import type { MapOverlayIdentity } from 'repo-depkit-common';
 
 export type Dimensions = [width: number, height: number];
 
@@ -28,20 +29,17 @@ export type MapMarker = {
 	title?: string;
 };
 
-export type MapLayer = {
+export type MapLayer = Partial<MapOverlayIdentity> & {
 	attribution?: string;
 	baseLayer?: boolean;
 	baseLayerIsChecked?: boolean;
 	baseLayerName?: string;
 	bounds?: LatLngBoundsLiteral;
-	id?: string;
 	layerType?: MapLayerType;
 	maxNativeZoom?: number;
 	maxZoom?: number;
-	opacity?: number;
 	pane?: string;
 	subLayer?: string;
-	url?: string;
 	zIndex?: number;
 };
 

--- a/apps/geonexia/frontend/app/index.tsx
+++ b/apps/geonexia/frontend/app/index.tsx
@@ -23,6 +23,7 @@ import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { MapLocationButton, MyMap, MyMapHandle, QrCode, useTheme, useMyScrollViewModal, SettingsListSelectOptionSingle, SettingsListGroupTitle, SettingsList, SettingsListTextInput, SettingsListBoolean, SettingsListNumberInput, MapStyleKey } from 'repo-depkit-common-ui';
 import { MathHelper } from 'repo-depkit-common';
+import type { MapOverlayIdentity } from 'repo-depkit-common';
 
 import { HEX_TILE_SCRIPT } from '../assets/hexTileScript';
 import { TERRAIN_ASSETS, TERRAIN_CATEGORIES, TerrainAssetEntry } from '../assets/terrainAssets';
@@ -2997,11 +2998,8 @@ function InterruptedRecoveryContent({
 // ─── RecordScreen: loadAndSendCustomizations helpers ──────────────────────────
 
 /** Image overlay entry sent to the map for a customized hex tile's terrain texture. */
-type TileImageOverlay = {
-	id: string;
-	url: string;
+type TileImageOverlay = MapOverlayIdentity & {
 	coordinates: [[number, number], [number, number], [number, number], [number, number]];
-	opacity: number;
 	// Actual H3 hex vertices in [lng, lat] order for precise canvas clipping.
 	polygonCoords: [number, number][];
 	// Bearing from hex center to its first vertex (radians, 0 = North, CW positive).

--- a/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
+++ b/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
@@ -62,8 +62,8 @@ function tileYToLat(yFrac: number, zoom: number): number {
 	return (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
 }
 
-/** Axis-aligned geographic bounding box. */
-type BoundingBox = { minLat: number; minLng: number; maxLat: number; maxLng: number };
+/** Axis-aligned geographic bounding box; same shape as {@link LatLngBounds}. */
+type BoundingBox = LatLngBounds;
 
 /** Simple axis-aligned bounding-box overlap check. */
 function boundsOverlap(a: BoundingBox, b: BoundingBox): boolean {

--- a/apps/score-tracker/frontend/helpers/GameRules.ts
+++ b/apps/score-tracker/frontend/helpers/GameRules.ts
@@ -67,16 +67,18 @@ export type GameRules = {
 	playerOrder?: PlayerOrderRule | null;
 };
 
-/** A shareable game template: everything needed to create a new game type. */
-export type GamePreset = {
+/** Rules/config fields shared between a shareable `GamePreset` and a stored `GameType`. */
+export type GameTypeDefinition = {
 	name: string;
+	/** Emoji shown as the game's "image" in lists and headers (e.g. 🎲). */
 	icon: string;
 	scoringMode: ScoringMode;
+	/** Maximum number of rounds per match. undefined/null = unlimited. */
 	maxRounds?: number | null;
+	/** Total score at which a match ends. undefined/null = unlimited. */
 	maxScore?: number | null;
+	/** Custom score-entry rules (e.g. a card picker instead of a plain number). undefined/null = plain numeric entry. */
 	rules?: GameRules | null;
-	/** How the starting player rotates each round. undefined/absent defaults to 'fixed'. */
-	startingPlayerMode?: StartingPlayerMode;
 	/**
 	 * Content version of this game definition (distinct from `rules.version`,
 	 * the fixed rule-schema version). Bump this yourself when sharing an
@@ -84,6 +86,12 @@ export type GamePreset = {
 	 * Undefined/absent defaults to 1.
 	 */
 	version?: number;
+};
+
+/** A shareable game template: everything needed to create a new game type. */
+export type GamePreset = GameTypeDefinition & {
+	/** How the starting player rotates each round. undefined/absent defaults to 'fixed'. */
+	startingPlayerMode?: StartingPlayerMode;
 };
 
 // ─── Evaluation ───────────────────────────────────────────────────────────────

--- a/apps/score-tracker/frontend/helpers/GameTypesStorage.ts
+++ b/apps/score-tracker/frontend/helpers/GameTypesStorage.ts
@@ -1,27 +1,15 @@
 import { getStorageItem, setStorageItem } from 'repo-depkit-common-ui';
-import type { GameRules, StartingPlayerMode } from './GameRules';
+import type { GameTypeDefinition, StartingPlayerMode } from './GameRules';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 /** Whether the highest or the lowest total score wins a match of this game. */
 export type ScoringMode = 'highWins' | 'lowWins';
 
-export type GameType = {
+export type GameType = GameTypeDefinition & {
 	id: string;
-	name: string;
-	/** Emoji shown as the game's "image" in lists and headers (e.g. 🎲). */
-	icon: string;
-	scoringMode: ScoringMode;
-	/** Maximum number of rounds per match. undefined/null = unlimited. */
-	maxRounds?: number | null;
-	/** Total score at which a match ends. undefined/null = unlimited. */
-	maxScore?: number | null;
-	/** Custom score-entry rules (e.g. a card picker instead of a plain number). undefined/null = plain numeric entry. */
-	rules?: GameRules | null;
 	/** How the starting player rotates each round. undefined/null = 'fixed' (seat 0 always starts). */
 	startingPlayerMode?: StartingPlayerMode | null;
-	/** Content version of this game's definition. undefined defaults to 1. */
-	version?: number;
 	createdAt: number;
 };
 

--- a/apps/score-tracker/frontend/store/gameSlice.ts
+++ b/apps/score-tracker/frontend/store/gameSlice.ts
@@ -10,16 +10,8 @@ export type { Player, Round, GameState, GameStatus };
 
 // ─── State type ───────────────────────────────────────────────────────────────
 
-export type GameSliceState = {
-	players: Player[];
-	rounds: Round[];
-	status: GameStatus;
-	currentRoundIndex: number;
-	/** Set when the current match is played as a specific game type. */
-	gameTypeId?: string;
-	/** Numeric state carried between rounds for a `startingPlayerMode: 'custom'` rule (see GameRules). */
-	playerOrderState?: number;
-};
+/** Redux slice state for the current match; identical shape to the persisted `GameState`. */
+export type GameSliceState = GameState;
 
 const initialState: GameSliceState = {
 	players: [],

--- a/packages/common-ui/src/components/Boxplot/Boxplot.tsx
+++ b/packages/common-ui/src/components/Boxplot/Boxplot.tsx
@@ -19,7 +19,8 @@ const DEFAULT_BOX_COLOR = '#22c55e';
 const DEFAULT_HIGH_COLOR = '#3b82f6';
 const DEFAULT_MEDIAN_COLOR = '#ef4444';
 
-export type BoxplotProps = {
+/** Boxplot styling/data props shared by `Boxplot` and `SettingsListBoxplot`. */
+export type BoxplotStyleProps = {
 	stats: BoxplotStats;
 	/** Color of the box (the "normal"/green range). Defaults to green. */
 	boxColor?: string;
@@ -38,6 +39,9 @@ export type BoxplotProps = {
 	medianBandValue?: number;
 	/** Formats a raw value for the min/median/max labels below the plot. Defaults to one decimal place. */
 	formatValue?: (value: number) => string;
+};
+
+export type BoxplotProps = BoxplotStyleProps & {
 	/** Hides the min/median/max labels below the plot when false. Defaults to true. */
 	showLabels?: boolean;
 };

--- a/packages/common-ui/src/components/Boxplot/index.ts
+++ b/packages/common-ui/src/components/Boxplot/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Boxplot';
-export type { BoxplotProps } from './Boxplot';
+export type { BoxplotProps, BoxplotStyleProps } from './Boxplot';

--- a/packages/common-ui/src/components/SettingsListAvatar/index.tsx
+++ b/packages/common-ui/src/components/SettingsListAvatar/index.tsx
@@ -3,10 +3,11 @@ import { StyleSheet, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import SettingsList from '../SettingsList';
 import type { SettingsListProps } from '../SettingsList/types';
+import type { LabeledAccentProps } from 'repo-depkit-common';
 import MyAvatar, { AvatarConfig, AvatarSize } from '../MyAvatar';
 import { useAvatarEditorModal, UseAvatarEditorModalOptions } from '../MyAvatarEditor';
 
-export type SettingsListAvatarProps = {
+export type SettingsListAvatarProps = LabeledAccentProps & {
 	/** Current avatar config, or null/undefined when no avatar has been set yet. */
 	config?: AvatarConfig | null;
 	/**
@@ -16,7 +17,6 @@ export type SettingsListAvatarProps = {
 	onChange?: (config: AvatarConfig) => void;
 	/** Called when the user confirms deletion. Only invoked when `options.allowDelete` is true. */
 	onDelete?: () => void;
-	label: string;
 	/** Optional value text shown on the right (e.g. a score). */
 	value?: string;
 	/** Preview size of the avatar shown in the row. Defaults to a compact row-sized preview. */
@@ -24,10 +24,6 @@ export type SettingsListAvatarProps = {
 	avatarBackgroundColor?: string;
 	/** Overrides the row's width (defaults to `'100%'`), e.g. for a multi-column layout. */
 	width?: number;
-	/** Overrides the row's background color (defaults to the theme's row background). */
-	backgroundColor?: string;
-	/** Optional border, e.g. to highlight the row. */
-	borderColor?: string;
 	borderWidth?: number;
 	borderStyle?: 'solid' | 'dashed';
 	/** Overrides the title text's font size. */

--- a/packages/common-ui/src/components/SettingsListBoxplot/SettingsListBoxplot.tsx
+++ b/packages/common-ui/src/components/SettingsListBoxplot/SettingsListBoxplot.tsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import { StyleSheet, Text, View, ViewStyle } from 'react-native';
 import type { PropsWithChildren } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import type { BoxplotStats } from 'repo-depkit-common';
 import { useTheme } from '../../context/ThemeContext';
 import SettingsList from '../SettingsList';
 import type { SettingsListProps } from '../SettingsList/types';
 import Boxplot from '../Boxplot';
+import type { BoxplotStyleProps } from '../Boxplot';
 import { borderRadiusContainer, horizontalScreenPadding } from '../../constants/ui';
 
 const ICON_WIDTH = 34;
@@ -20,26 +20,9 @@ function defaultBandDescription(format: (value: number) => string, medianBandVal
 	return `Die grüne Box zeigt den Bereich Median ± ${format(medianBandValue)}, der rote Strich ist der Median. Die Antennen an den Enden reichen bis zum kleinsten (rot) bzw. größten (blau) gemessenen Wert.`;
 }
 
-type SettingsListBoxplotOwnProps = {
-	stats: BoxplotStats;
+type SettingsListBoxplotOwnProps = BoxplotStyleProps & {
 	/** Explanation shown below the plot once expanded. Defaults to a generic "how to read a boxplot" text. */
 	description?: string;
-	formatValue?: (value: number) => string;
-	/** Color of the box (the "normal"/green range). Defaults to green. */
-	boxColor?: string;
-	/** Color of the median line inside the box. Defaults to red. */
-	medianColor?: string;
-	/** Color at the min end of the left whisker. Defaults to red. */
-	lowColor?: string;
-	/** Color at the max end of the right whisker. Defaults to blue. */
-	highColor?: string;
-	/**
-	 * When set, the box represents `median ± medianBandValue` instead of the
-	 * statistical `[q1, q3]` quartile range - see `BoxplotProps.medianBandValue`.
-	 * Also changes the expanded stats list to show the resulting green-zone
-	 * boundaries instead of Q1/Q3.
-	 */
-	medianBandValue?: number;
 	/** Whether the explanation is shown initially, without the user tapping the row. Defaults to false. */
 	initiallyExpanded?: boolean;
 };

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -27,4 +27,6 @@ export * from './src/CustomerAppStoreIds';
 export * from './src/AppleAppStoreConfig';
 export * from './src/DirectusItemStatus';
 export * from './src/GpsRouteTypes';
+export * from './src/MapOverlayTypes';
+export * from './src/UiAccentTypes';
 export * from './src/BoxplotHelper';

--- a/packages/common/src/MapOverlayTypes.ts
+++ b/packages/common/src/MapOverlayTypes.ts
@@ -1,0 +1,10 @@
+/**
+ * Minimal identity/opacity fields shared by tile/image overlay descriptors
+ * across apps (rocket-meals MyMap layers, geonexia hex-terrain overlays), so
+ * the field shapes stay in sync instead of being duplicated per app.
+ */
+export type MapOverlayIdentity = {
+	id: string;
+	url: string;
+	opacity: number;
+};

--- a/packages/common/src/UiAccentTypes.ts
+++ b/packages/common/src/UiAccentTypes.ts
@@ -1,0 +1,10 @@
+/**
+ * A labeled UI element with optional accent colors, shared by otherwise
+ * unrelated components (a debug action button, a settings-list avatar row)
+ * that each happen to expose the same label/background/border trio.
+ */
+export type LabeledAccentProps = {
+	label: string;
+	backgroundColor?: string;
+	borderColor?: string;
+};


### PR DESCRIPTION
## Summary

Fixes the 12 clusters listed in the recurring "chore: Refactor data clumps" issue (most recently [#4039](https://github.com/rocket-meals/rocket-meals/issues/4039)) generated by [data-clumps-doctor](https://github.com/NilsBaumgartner1994/data-clumps-doctor). Each clump was resolved by either introducing a parameter object or extracting a shared field type, reusing an existing type where one already fit.

- **Backend** (`apps/backend`):
  - `ParseSchedule`: introduced `CanteenFoodofferSyncGroup` parameter object shared by `syncFoodOffersForCanteenWithoutDate` / `syncFoodOffersForCanteenByDate`.
  - `FoodsTranslationFixMissingWorkflow`: converted `logSourceFieldValues` and `saveTranslatedItemIfNeeded` to take options objects.
  - `TranslationHelper`: converted `_getUpdateInformationForTranslations` and `_collectCreateTranslationsFromRemaining` to take options objects (and updated the corresponding unit tests).
  - `DirectusCollectionTranslator`: converted `translateFields` to take an options object instead of positional parameters matching `TranslationEntryOptions`.
- **Frontend / packages**:
  - `Boxplot` / `SettingsListBoxplot`: extracted shared `BoxplotStyleProps`.
  - `GameSliceState` now aliases `GameState` instead of redeclaring an identical shape.
  - `GamePreset` / `GameType`: extracted shared `GameTypeDefinition` base.
  - `RuleCountInfo` derived via `Pick<ViolationSummary, ...>` instead of duplicating fields.
  - `BoundingBox` now aliases the existing `LatLngBounds`.
  - `MapLayer` / `TileImageOverlay`: extracted shared `MapOverlayIdentity` into `repo-depkit-common` (already a shared dependency of both apps).
  - `DebugAction` / `SettingsListAvatarProps`: extracted shared `LabeledAccentProps` into `repo-depkit-common`.
  - `ScrollViewModalOptions` derived via `Pick<ModalOptions, ...>` instead of redeclaring it.

## Test plan

- [x] `yarn typecheck` passes for the backend extension (`apps/backend/.../directus-extension-rocket-meals-bundle`)
- [x] `yarn testOnly` passes for the backend extension (159 tests; the only failures are the pre-existing `NewsTestHannover` tests, which fail due to an external site returning HTTP 403 in this sandbox — unrelated to this change)
- [x] `tsc --noEmit` for `apps/frontend/app`, `apps/geonexia/frontend`, `apps/score-tracker/frontend`, and `apps/accessibilityTester` shows identical error output before/after this change (no new type errors introduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_018PfHeRZfdTfLu1y7KM2ngb)_