### PR TITLE
refactor: fix remaining data clumps and sonar maintainability issues

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -44,6 +44,17 @@ export type CanteenFoodofferSyncGroup = {
   helperObject: FoodCreationHelperObject;
 };
 
+/**
+ * Groups the data needed to build/apply attribute values for a single food or
+ * foodoffer, shared by `getFoodsOrFoodoffersWithOnlySetAttributesFields` and
+ * `buildAttributeValuesToCreate`.
+ */
+export type AttributeValuesSyncContext = {
+  new_attribute_values: FoodParseFoodAttributesType;
+  dictExternalIdentifierToFoodAttributes: DictFoodsAttributesExternalIdentifiersToFoodsAttributes;
+  typeHelper: { isFood: boolean; isFoodoffer: boolean };
+};
+
 export class ParseSchedule {
   private readonly context: WorkflowRunContext;
   private readonly foodParser: FoodParserInterface | null;
@@ -744,17 +755,17 @@ export class ParseSchedule {
   }
 
   async updateFoodsAttributesValues(food: DatabaseTypes.Foods, new_attribute_values: FoodParseFoodAttributesType, dictExternalIdentifierToFoodAttributes: DictFoodsAttributesExternalIdentifiersToFoodsAttributes) {
-    let foodWithOnlySetAttributesFields = this.getFoodsOrFoodoffersWithOnlySetAttributesFields(food, new_attribute_values, dictExternalIdentifierToFoodAttributes, { isFood: true, isFoodoffer: false });
+    let foodWithOnlySetAttributesFields = this.getFoodsOrFoodoffersWithOnlySetAttributesFields(food, { new_attribute_values, dictExternalIdentifierToFoodAttributes, typeHelper: { isFood: true, isFoodoffer: false } });
     await this.context.myDatabaseHelper.getFoodsHelper().updateOne(food.id, foodWithOnlySetAttributesFields, {
       disableEventEmit: true,
     });
   }
 
-  getFoodsOrFoodoffersWithOnlySetAttributesFields<T extends Partial<DatabaseTypes.Foods | DatabaseTypes.Foodoffers>>(foodOrFoodoffer: T, new_attribute_values: FoodParseFoodAttributesType, dictExternalIdentifierToFoodAttributes: DictFoodsAttributesExternalIdentifiersToFoodsAttributes, typeHelper: { isFood: boolean; isFoodoffer: boolean }): T {
+  getFoodsOrFoodoffersWithOnlySetAttributesFields<T extends Partial<DatabaseTypes.Foods | DatabaseTypes.Foodoffers>>(foodOrFoodoffer: T, attributeValuesSyncContext: AttributeValuesSyncContext): T {
     let delteAttributeValuesRaw = foodOrFoodoffer.attribute_values;
     let deleteAttributeValuesIds: any[] = this.resolveAttributeValueIdsToDelete(delteAttributeValuesRaw);
 
-    let createAttributeValues: any[] = this.buildAttributeValuesToCreate(new_attribute_values, dictExternalIdentifierToFoodAttributes, typeHelper, foodOrFoodoffer.id);
+    let createAttributeValues: any[] = this.buildAttributeValuesToCreate(attributeValuesSyncContext, foodOrFoodoffer.id);
     let foodOrFoodofferCopy: T = {} as T;
 
     foodOrFoodofferCopy.attribute_values = {
@@ -781,7 +792,8 @@ export class ParseSchedule {
     return deleteAttributeValuesIds;
   }
 
-  private buildAttributeValuesToCreate(new_attribute_values: FoodParseFoodAttributesType, dictExternalIdentifierToFoodAttributes: DictFoodsAttributesExternalIdentifiersToFoodsAttributes, typeHelper: { isFood: boolean; isFoodoffer: boolean }, itemId: any): any[] {
+  private buildAttributeValuesToCreate(attributeValuesSyncContext: AttributeValuesSyncContext, itemId: any): any[] {
+    const { new_attribute_values, dictExternalIdentifierToFoodAttributes, typeHelper } = attributeValuesSyncContext;
     let createAttributeValues: any[] = [];
     for (let new_attribute of new_attribute_values) {
       let external_identifier = new_attribute.external_identifier;
@@ -1033,7 +1045,11 @@ export class ParseSchedule {
       };
     });
 
-    let foodWithOnlySetAttributesFields = this.getFoodsOrFoodoffersWithOnlySetAttributesFields({} as DatabaseTypes.Foodoffers, foodofferForParser.attribute_values, helperObject.dictExternalIdentifierToFoodAttributes, { isFood: false, isFoodoffer: true });
+    let foodWithOnlySetAttributesFields = this.getFoodsOrFoodoffersWithOnlySetAttributesFields({} as DatabaseTypes.Foodoffers, {
+      new_attribute_values: foodofferForParser.attribute_values,
+      dictExternalIdentifierToFoodAttributes: helperObject.dictExternalIdentifierToFoodAttributes,
+      typeHelper: { isFood: false, isFoodoffer: true },
+    });
 
     let foodOfferToCreate: Partial<DatabaseTypes.Foodoffers> = {
       ...foodofferForParser.basicFoodofferData,

--- a/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
+++ b/apps/geonexia/frontend/helpers/TileFeatureHelper.ts
@@ -62,11 +62,8 @@ function tileYToLat(yFrac: number, zoom: number): number {
 	return (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
 }
 
-/** Axis-aligned geographic bounding box; same shape as {@link LatLngBounds}. */
-type BoundingBox = LatLngBounds;
-
 /** Simple axis-aligned bounding-box overlap check. */
-function boundsOverlap(a: BoundingBox, b: BoundingBox): boolean {
+function boundsOverlap(a: LatLngBounds, b: LatLngBounds): boolean {
 	return a.minLat <= b.maxLat && a.maxLat >= b.minLat &&
 		a.minLng <= b.maxLng && a.maxLng >= b.minLng;
 }

--- a/apps/score-tracker/frontend/helpers/FriendsStorage.ts
+++ b/apps/score-tracker/frontend/helpers/FriendsStorage.ts
@@ -1,13 +1,10 @@
 import { getStorageItem, setStorageItem } from 'repo-depkit-common-ui';
-import type { AvatarConfig } from 'repo-depkit-common-ui';
+import type { PlayerIdentity } from './PlayerIdentity';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type Friend = {
+export type Friend = PlayerIdentity & {
 	id: string;
-	name: string;
-	color: string;
-	avatarConfig?: AvatarConfig;
 	createdAt: number;
 };
 

--- a/apps/score-tracker/frontend/helpers/GameHistoryStorage.ts
+++ b/apps/score-tracker/frontend/helpers/GameHistoryStorage.ts
@@ -1,16 +1,13 @@
 import { getStorageItem, setStorageItem } from 'repo-depkit-common-ui';
-import type { AvatarConfig } from 'repo-depkit-common-ui';
+import type { PlayerIdentity } from './PlayerIdentity';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type GameHistoryPlayerEntry = {
+export type GameHistoryPlayerEntry = PlayerIdentity & {
 	/** The archived game's transient `Player.id` - the key into `finalScores`. */
 	playerId: string;
 	/** Present when this participant was a friend at the time the game was archived. */
 	friendId?: string;
-	name: string;
-	color: string;
-	avatarConfig?: AvatarConfig;
 };
 
 export type GameHistoryEntry = {

--- a/apps/score-tracker/frontend/helpers/GameStorage.ts
+++ b/apps/score-tracker/frontend/helpers/GameStorage.ts
@@ -1,14 +1,10 @@
 import { getStorageItem, setStorageItem } from 'repo-depkit-common-ui';
-import type { AvatarConfig } from 'repo-depkit-common-ui';
+import type { PlayerIdentity } from './PlayerIdentity';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type Player = {
+export type Player = PlayerIdentity & {
 	id: string;
-	name: string;
-	color: string;
-	/** Snapshot avatar, taken at the time the player was added to this game. */
-	avatarConfig?: AvatarConfig;
 	/** Set when this player was added from the friends roster. Absent = guest player. */
 	friendId?: string;
 };

--- a/apps/score-tracker/frontend/helpers/PlayerIdentity.ts
+++ b/apps/score-tracker/frontend/helpers/PlayerIdentity.ts
@@ -1,0 +1,12 @@
+import type { AvatarConfig } from 'repo-depkit-common-ui';
+
+/**
+ * Display identity shared by a friend, an in-game player, and an archived
+ * game-history participant (see FriendsStorage, GameStorage, GameHistoryStorage).
+ */
+export type PlayerIdentity = {
+	name: string;
+	color: string;
+	/** Snapshot avatar config, when one has been set. */
+	avatarConfig?: AvatarConfig;
+};

--- a/apps/score-tracker/frontend/store/gameSlice.ts
+++ b/apps/score-tracker/frontend/store/gameSlice.ts
@@ -6,7 +6,7 @@ import type { Friend } from '../helpers/FriendsStorage';
 import { renameFriend, setFriendColor, setFriendAvatar } from './friendsSlice';
 import { removeGameType } from './gameTypesSlice';
 import { generateId } from '../helpers/RandomHelper';
-export type { Player, Round, GameState, GameStatus };
+export type { Player, Round, GameState, GameStatus } from '../helpers/GameStorage';
 
 // ─── State type ───────────────────────────────────────────────────────────────
 

--- a/packages/common-ui/src/components/GlobalModal/ModalProvider.tsx
+++ b/packages/common-ui/src/components/GlobalModal/ModalProvider.tsx
@@ -27,12 +27,8 @@ export type ModalOptions = {
 	onClosed?: (reason: ModalCloseReason) => void;
 };
 
-type ModalStackItem = {
+type ModalStackItem = ModalOptions & {
 	content: ReactNode;
-	backgroundStyle: any;
-	overlayStyle: any;
-	headerBackgroundColor: string | undefined;
-	onClosed?: (reason: ModalCloseReason) => void;
 };
 
 type ModalContextType = {


### PR DESCRIPTION
## Summary

Follow-up to #4044: fixes the data clumps that surfaced in the next `data-clumps-doctor` run (10 clusters, 5 unique after deduping bidirectional pairs), plus the 3 SonarCloud maintainability findings in `reports/sonarCloud/`.

**Data clumps:**
- `ParseSchedule`: introduced an `AttributeValuesSyncContext` parameter object shared by `getFoodsOrFoodoffersWithOnlySetAttributesFields` and `buildAttributeValuesToCreate`.
- `Friend` / `Player` / `GameHistoryPlayerEntry` (score-tracker): extracted a shared `PlayerIdentity` base type (`name`, `color`, `avatarConfig`).
- `ModalStackItem` (common-ui `ModalProvider`): now intersects the existing `ModalOptions` instead of redeclaring the same fields.

**SonarCloud code smells:**
- `TileFeatureHelper.ts`: removed the redundant `BoundingBox` alias (flagged as "Remove this redundant type alias and replace its occurrences with `LatLngBounds`"), using `LatLngBounds` directly.
- `gameSlice.ts`: changed the bare `export type { Player, Round, GameState, GameStatus };` re-export into `export type {...} from '../helpers/GameStorage'` (flagged twice by Sonar for `Round` and `GameStatus`).

## Test plan

- [x] `yarn typecheck` passes for the backend extension
- [x] `yarn testOnly` passes for the backend extension (159 tests; the only failures are the pre-existing `NewsTestHannover` tests, which fail due to an external site returning HTTP 403 in this sandbox — unrelated to this change)
- [x] `tsc --noEmit` for `apps/frontend/app`, `apps/geonexia/frontend`, and `apps/score-tracker/frontend` shows identical error output before/after this change (no new type errors introduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_018PfHeRZfdTfLu1y7KM2ngb)_