### PR TITLE
Fix mojibake € sign in Speiseplan print preview, add Maestro regression test

### DIFF
--- a/apps/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
+++ b/apps/frontend/app/app/(monitor)/foodPlanWeek/index.tsx
@@ -12,6 +12,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { useAppSelector } from '@/redux/hooks';
 import { useMyScrollviewModalSelectWeekPlanCanteen } from '@/hooks/useMyScrollviewModalSelectWeekPlanCanteen';
+import { ComponentIds } from '@/constants/ComponentIds';
 
 const Index = () => {
 	useSetPageTitle(TranslationKeys.food_plan_week);
@@ -54,6 +55,7 @@ const Index = () => {
 				}}
 			>
 				<TouchableOpacity
+					nativeID={ComponentIds.MONITOR_FOODPLAN_WEEK_CANTEEN_BUTTON}
 					style={{
 						...styles.list,
 						backgroundColor: theme.screen.iconBg,
@@ -94,6 +96,7 @@ const Index = () => {
 					</View>
 				</View>
 				<TouchableOpacity
+					nativeID={ComponentIds.MONITOR_FOODPLAN_WEEK_BIGSCREEN_BUTTON}
 					style={{
 						...styles.button,
 						backgroundColor: theme.screen.iconBg,

--- a/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx
@@ -374,6 +374,7 @@ const Index = () => {
 			const html = `
       <html>
         <head>
+          <meta charset="utf-8">
           <style>
             ${stylesheets}
             @media print {
@@ -417,7 +418,7 @@ const Index = () => {
 			// opening the window directly at the Blob URL still runs the inline
 			// `window.print()` script once the document has loaded, since the window
 			// navigates to a full HTML document rather than having markup injected.
-			const blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+			const blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html;charset=utf-8' }));
 			const newWindow = window.open(blobUrl, '_blank');
 			newWindow?.addEventListener('load', () => URL.revokeObjectURL(blobUrl));
 		}

--- a/apps/frontend/app/app/(monitor)/list-week-screen/index.tsx
+++ b/apps/frontend/app/app/(monitor)/list-week-screen/index.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'expo-router';
 import { SET_WEEK_PLAN } from '@/redux/Types/types';
 import { myContrastColor } from '@/helper/ColorHelper';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { ComponentIds } from '@/constants/ComponentIds';
 
 const Index = () => {
 	useSetPageTitle('FoodPlan:Week');
@@ -113,6 +114,7 @@ const Index = () => {
 		<View style={[styles.container, { backgroundColor: theme.screen.background }]}>
 			<View style={[styles.header, { backgroundColor: theme.screen.background }]}>
 				<TouchableOpacity
+					nativeID={ComponentIds.MONITOR_LIST_WEEK_CURRENT_WEEK_BUTTON}
 					style={{
 						...styles.currentWeekButton,
 						backgroundColor: foods_area_color,

--- a/apps/frontend/app/components/ListWeekHeader/ListWeekHeader.tsx
+++ b/apps/frontend/app/components/ListWeekHeader/ListWeekHeader.tsx
@@ -4,6 +4,7 @@ import { Ionicons, MaterialCommunityIcons, MaterialIcons } from '@expo/vector-ic
 import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { isWeb } from '@/constants/Constants';
+import { ComponentIds } from '@/constants/ComponentIds';
 
 const FoodPlanHeader = ({ handlePrint }: any) => {
 	const { theme } = useTheme();
@@ -47,7 +48,7 @@ const FoodPlanHeader = ({ handlePrint }: any) => {
 								<MaterialIcons name="calendar-month" size={24} color={theme.screen.icon} />
 							</TouchableOpacity>
 							{isWeb && (
-								<TouchableOpacity onPress={handlePrint}>
+								<TouchableOpacity nativeID={ComponentIds.MONITOR_LIST_WEEK_PRINT_BUTTON} onPress={handlePrint}>
 									<Ionicons name="print-outline" size={24} color={theme.screen.icon} />
 								</TouchableOpacity>
 							)}

--- a/apps/frontend/app/constants/ComponentIds.ts
+++ b/apps/frontend/app/constants/ComponentIds.ts
@@ -90,6 +90,12 @@ export enum AppComponentIds {
 
 	// Feedback
 	FEEDBACK_AND_SUPPORT_TITLE = 'feedback-and-support-title',
+
+	// Monitor: Food Plan Week / print (Speiseplan)
+	MONITOR_FOODPLAN_WEEK_CANTEEN_BUTTON = 'monitor-foodplan-week-canteen-button',
+	MONITOR_FOODPLAN_WEEK_BIGSCREEN_BUTTON = 'monitor-foodplan-week-bigscreen-button',
+	MONITOR_LIST_WEEK_CURRENT_WEEK_BUTTON = 'monitor-list-week-current-week-button',
+	MONITOR_LIST_WEEK_PRINT_BUTTON = 'monitor-list-week-print-button',
 }
 
 /**

--- a/apps/frontend/maestro-tests/src/tests/speiseplan-print-euro-test.ts
+++ b/apps/frontend/maestro-tests/src/tests/speiseplan-print-euro-test.ts
@@ -1,0 +1,61 @@
+/**
+ * speiseplan-print-euro-test.ts – Regression test for a customer-reported bug:
+ * printing the "Speiseplan" (meal plan) week view corrupted the € sign into
+ * mojibake (e.g. "â‚¬") in the print-preview window, while the on-screen page
+ * rendered it correctly. Root cause: the print HTML built by `handlePrint()`
+ * (apps/frontend/app/app/(monitor)/list-week-screen/details/index.tsx) was
+ * opened via a Blob URL without any `<meta charset="utf-8">` / charset-tagged
+ * MIME type, so the browser had to guess the document's encoding.
+ *
+ * Flow: open the monitor "Food Plan: Week" settings → pick a canteen → open the
+ * week grid → open the current week's details → assert the € sign renders
+ * on-screen → tap the print icon → assert the € sign still renders correctly
+ * (and not as mojibake) in the print-preview document that opens in a new tab.
+ *
+ * NOTE: Maestro's web driver automatically switches its active window to a
+ * newly opened browser tab/window (e.g. from `window.open()`), so the
+ * assertions after tapping the print icon run against the print-preview
+ * document without any extra steps.
+ *
+ * IMPORTANT: Always use ComponentIds (from app/constants/ComponentIds.ts) with
+ * nativeID for element targeting so Maestro web tests can locate elements by
+ * their id attribute.
+ */
+
+import { MaestroTestCase } from 'repo-depkit-maestro-framework';
+import { ComponentIds } from '../../../app/constants/ComponentIds';
+
+const test = new MaestroTestCase({
+	appId: 'com.rocketmeals.web',
+	tags: ['web', 'print', 'regression'],
+	outputFileName: 'speiseplan-print-euro-test',
+});
+
+test
+	.openPage('http://localhost:8081/foodPlanWeek')
+	.waitForAnimationToEnd()
+
+	// Pick the first available canteen for the week monitor view
+	.tapOnId(ComponentIds.MONITOR_FOODPLAN_WEEK_CANTEEN_BUTTON)
+	.waitForAnimationToEnd()
+	.tapOnId(ComponentIds.CANTEEN_SELECT_BUTTON)
+	.waitForAnimationToEnd()
+
+	// Continue to the week grid, then open the current week's details (Speiseplan)
+	.tapOnId(ComponentIds.MONITOR_FOODPLAN_WEEK_BIGSCREEN_BUTTON)
+	.waitForAnimationToEnd()
+	.tapOnId(ComponentIds.MONITOR_LIST_WEEK_CURRENT_WEEK_BUTTON)
+	.waitForAnimationToEnd()
+	.takeScreenshot('speiseplan-week-onscreen')
+
+	// Sanity check: the on-screen meal plan renders prices with a correct € sign
+	.assertVisible('€')
+
+	// Regression check: printing must not corrupt the € sign into mojibake
+	.tapOnId(ComponentIds.MONITOR_LIST_WEEK_PRINT_BUTTON)
+	.waitForAnimationToEnd()
+	.takeScreenshot('speiseplan-print-preview')
+	.assertVisible('€')
+	.assertNotVisible('â‚¬');
+
+export default test;


### PR DESCRIPTION
The print icon on the monitor "Food Plan: Week" screen builds a standalone
HTML document from the on-screen content and opens it via a Blob URL. Without
a charset declared anywhere (no <meta charset> tag, no charset on the Blob's
MIME type), the browser had to guess the print document's encoding and
regularly picked a single-byte charset instead of UTF-8, turning € into
mojibake like "â‚¬" only in the print preview while the page itself rendered
correctly.

Add <meta charset="utf-8"> to the generated print HTML and tag the Blob as
text/html;charset=utf-8 so the browser decodes it correctly.

Add a Maestro web test (speiseplan-print-euro-test.ts) that opens the monitor
week view, prints it, and asserts the € sign renders correctly (and not as
mojibake) in the print-preview tab that Maestro's web driver automatically
switches focus to. Add the nativeIDs needed to drive that flow.