### PR TITLE
Add Android preview APK link to README, restricted to master@upstream

### DIFF
--- a/.github/actions/build-android-preview-apk/action.yml
+++ b/.github/actions/build-android-preview-apk/action.yml
@@ -1,0 +1,98 @@
+name: 'Build Android Preview APK'
+description: 'Builds an EAS Android preview APK for an app and optionally publishes its download link into the README'
+
+inputs:
+  EXPO_TOKEN:
+    required: true
+    description: Expo Access Token (für EAS CLI)
+  working-directory:
+    required: true
+    description: Verzeichnis der Expo-App (z.B. ./apps/frontend/app)
+  eas-profile:
+    required: false
+    default: previewApk
+    description: EAS Build-Profil, das für den Preview-Build verwendet wird
+  app-key:
+    required: true
+    description: Kurzer Slug der App für den README-Marker (z.B. frontend, geonexia, score-tracker)
+  app-label:
+    required: true
+    description: Anzeigename der App im README-Link (z.B. "Rocket Meals (Frontend)")
+  update-readme:
+    required: false
+    default: 'false'
+    description: Wenn 'true', wird der APK-Link in die README.md des Repos geschrieben (nur auf master@rocket-meals/rocket-meals aufrufen)
+  readme-path:
+    required: false
+    default: README.md
+    description: Pfad zur README-Datei relativ zum Repo-Root
+
+outputs:
+  apk-url:
+    description: Die von EAS zurückgegebene Download-URL der APK (leer, falls keine gefunden wurde)
+    value: ${{ steps.extract.outputs.apk-url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: "🧪 Build with ${{ inputs.eas-profile }} profile"
+      shell: bash
+      run: eas build --platform android --non-interactive --profile "${{ inputs.eas-profile }}" --json | tee eas-build-output.json
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
+
+    - name: "🔍 Extract APK URL"
+      id: extract
+      shell: bash
+      run: |
+        node - <<'EOF'
+        const fs = require('fs');
+
+        const buildOutputPath = process.env.BUILD_OUTPUT_PATH;
+        const builds = JSON.parse(fs.readFileSync(buildOutputPath, 'utf-8'));
+        const build = Array.isArray(builds) ? builds[0] : builds;
+        const apkUrl = build?.artifacts?.applicationArchiveUrl || build?.artifacts?.buildUrl || '';
+
+        if (!apkUrl) {
+          console.log('No APK URL found in EAS build output.');
+        }
+
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `apk-url=${apkUrl}\n`);
+        EOF
+      env:
+        BUILD_OUTPUT_PATH: ${{ inputs.working-directory }}/eas-build-output.json
+
+    - name: "📝 Update APK link in README"
+      if: inputs.update-readme == 'true' && steps.extract.outputs.apk-url != ''
+      shell: bash
+      run: |
+        node - <<'EOF'
+        const fs = require('fs');
+
+        const readmePath = process.env.README_PATH;
+        const appKey = process.env.APP_KEY;
+        const appLabel = process.env.APP_LABEL;
+        const apkUrl = process.env.APK_URL;
+
+        const readme = fs.readFileSync(readmePath, 'utf-8');
+        const start = `<!-- android-preview-apk:${appKey}:start -->`;
+        const end = `<!-- android-preview-apk:${appKey}:end -->`;
+        const startIdx = readme.indexOf(start);
+        const endIdx = readme.indexOf(end);
+
+        if (startIdx === -1 || endIdx === -1) {
+          console.log(`README markers for "${appKey}" not found, skipping README update.`);
+          process.exit(0);
+        }
+
+        const block = `${start}\n**${appLabel}:** 📱 [Neueste Android Preview APK herunterladen](${apkUrl})\n`;
+        const updated = readme.slice(0, startIdx) + block + readme.slice(endIdx);
+        fs.writeFileSync(readmePath, updated);
+        console.log(`Updated README (${appKey}) with APK link: ${apkUrl}`);
+        EOF
+      env:
+        README_PATH: ${{ inputs.readme-path }}
+        APP_KEY: ${{ inputs.app-key }}
+        APP_LABEL: ${{ inputs.app-label }}
+        APK_URL: ${{ steps.extract.outputs.apk-url }}

--- a/.github/actions/build-android-preview-apk/action.yml
+++ b/.github/actions/build-android-preview-apk/action.yml
@@ -45,52 +45,14 @@ runs:
     - name: "🔍 Extract APK URL"
       id: extract
       shell: bash
-      run: |
-        node - <<'EOF'
-        const fs = require('fs');
-
-        const buildOutputPath = process.env.BUILD_OUTPUT_PATH;
-        const builds = JSON.parse(fs.readFileSync(buildOutputPath, 'utf-8'));
-        const build = Array.isArray(builds) ? builds[0] : builds;
-        const apkUrl = build?.artifacts?.applicationArchiveUrl || build?.artifacts?.buildUrl || '';
-
-        if (!apkUrl) {
-          console.log('No APK URL found in EAS build output.');
-        }
-
-        fs.appendFileSync(process.env.GITHUB_OUTPUT, `apk-url=${apkUrl}\n`);
-        EOF
+      run: yarn workspace rocket-meals-scripts apk:extract-url
       env:
         BUILD_OUTPUT_PATH: ${{ inputs.working-directory }}/eas-build-output.json
 
     - name: "📝 Update APK link in README"
       if: inputs.update-readme == 'true' && steps.extract.outputs.apk-url != ''
       shell: bash
-      run: |
-        node - <<'EOF'
-        const fs = require('fs');
-
-        const readmePath = process.env.README_PATH;
-        const appKey = process.env.APP_KEY;
-        const appLabel = process.env.APP_LABEL;
-        const apkUrl = process.env.APK_URL;
-
-        const readme = fs.readFileSync(readmePath, 'utf-8');
-        const start = `<!-- android-preview-apk:${appKey}:start -->`;
-        const end = `<!-- android-preview-apk:${appKey}:end -->`;
-        const startIdx = readme.indexOf(start);
-        const endIdx = readme.indexOf(end);
-
-        if (startIdx === -1 || endIdx === -1) {
-          console.log(`README markers for "${appKey}" not found, skipping README update.`);
-          process.exit(0);
-        }
-
-        const block = `${start}\n**${appLabel}:** 📱 [Neueste Android Preview APK herunterladen](${apkUrl})\n`;
-        const updated = readme.slice(0, startIdx) + block + readme.slice(endIdx);
-        fs.writeFileSync(readmePath, updated);
-        console.log(`Updated README (${appKey}) with APK link: ${apkUrl}`);
-        EOF
+      run: yarn workspace rocket-meals-scripts apk:update-readme
       env:
         README_PATH: ${{ inputs.readme-path }}
         APP_KEY: ${{ inputs.app-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,47 +318,17 @@ jobs:
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      - name: "🧪 Build with previewApk profile"
-        run: eas build --platform android --non-interactive --profile previewApk --json | tee eas-build-output.json
-        working-directory: ./apps/frontend/app
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-
       # Only master@rocket-meals/rocket-meals gets the README link - forks and
       # other branches build previews too, but must not push commits upstream
       # nor advertise a preview APK from an unverified fork build.
-      - name: "📝 Update APK link in README"
-        if: github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true'
-        run: |
-          node - <<'EOF'
-          const fs = require('fs');
-
-          const builds = JSON.parse(fs.readFileSync('apps/frontend/app/eas-build-output.json', 'utf-8'));
-          const build = Array.isArray(builds) ? builds[0] : builds;
-          const apkUrl = build?.artifacts?.applicationArchiveUrl || build?.artifacts?.buildUrl;
-
-          if (!apkUrl) {
-            console.log('No APK URL found in EAS build output, skipping README update.');
-            process.exit(0);
-          }
-
-          const readmePath = 'README.md';
-          const readme = fs.readFileSync(readmePath, 'utf-8');
-          const start = '<!-- android-preview-apk:start -->';
-          const end = '<!-- android-preview-apk:end -->';
-          const startIdx = readme.indexOf(start);
-          const endIdx = readme.indexOf(end);
-
-          if (startIdx === -1 || endIdx === -1) {
-            console.log('README markers not found, skipping README update.');
-            process.exit(0);
-          }
-
-          const block = `${start}\n📱 [Neueste Android Preview APK herunterladen](${apkUrl})\n`;
-          const updated = readme.slice(0, startIdx) + block + readme.slice(endIdx);
-          fs.writeFileSync(readmePath, updated);
-          console.log(`Updated README with APK link: ${apkUrl}`);
-          EOF
+      - name: "🧪 Build Android Preview APK & update README"
+        uses: ./.github/actions/build-android-preview-apk
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          working-directory: ./apps/frontend/app
+          app-key: frontend
+          app-label: "Rocket Meals (Frontend)"
+          update-readme: ${{ (github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true') && 'true' || 'false' }}
 
       - name: "💾 Commit README update"
         if: github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,20 +305,76 @@ jobs:
 #    needs: [sonarcloud-report, check-build]
     needs: [check-build, check-repository]
     if: needs.check-build.outputs.changed == 'true'
+    permissions:
+      contents: write
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🧰 Setup Node.js, Yarn & Dependencies"
         uses: ./.github/actions/setup-and-install
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       - name: "🧪 Build with previewApk profile"
-        run: eas build --platform android --non-interactive --profile previewApk
+        run: eas build --platform android --non-interactive --profile previewApk --json | tee eas-build-output.json
         working-directory: ./apps/frontend/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      # Only master@rocket-meals/rocket-meals gets the README link - forks and
+      # other branches build previews too, but must not push commits upstream
+      # nor advertise a preview APK from an unverified fork build.
+      - name: "📝 Update APK link in README"
+        if: github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true'
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+
+          const builds = JSON.parse(fs.readFileSync('apps/frontend/app/eas-build-output.json', 'utf-8'));
+          const build = Array.isArray(builds) ? builds[0] : builds;
+          const apkUrl = build?.artifacts?.applicationArchiveUrl || build?.artifacts?.buildUrl;
+
+          if (!apkUrl) {
+            console.log('No APK URL found in EAS build output, skipping README update.');
+            process.exit(0);
+          }
+
+          const readmePath = 'README.md';
+          const readme = fs.readFileSync(readmePath, 'utf-8');
+          const start = '<!-- android-preview-apk:start -->';
+          const end = '<!-- android-preview-apk:end -->';
+          const startIdx = readme.indexOf(start);
+          const endIdx = readme.indexOf(end);
+
+          if (startIdx === -1 || endIdx === -1) {
+            console.log('README markers not found, skipping README update.');
+            process.exit(0);
+          }
+
+          const block = `${start}\n📱 [Neueste Android Preview APK herunterladen](${apkUrl})\n`;
+          const updated = readme.slice(0, startIdx) + block + readme.slice(endIdx);
+          fs.writeFileSync(readmePath, updated);
+          console.log(`Updated README with APK link: ${apkUrl}`);
+          EOF
+
+      - name: "💾 Commit README update"
+        if: github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update Android preview APK link in README [skip ci]"
+            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-ios:
     name: "📦 Build & 🚀 Submit iOS App"

--- a/.github/workflows/test-android-preview-apk.yml
+++ b/.github/workflows/test-android-preview-apk.yml
@@ -58,7 +58,8 @@ jobs:
           retention-days: 7
 
       - name: "🖨️ Print result"
-        run: echo "APK URL: ${{ steps.build.outputs.apk-url }}"
+        run: |
+          echo "APK URL: ${{ steps.build.outputs.apk-url }}"
 
       - name: "💾 Commit README update"
         if: github.event.inputs.update_readme == 'true'

--- a/.github/workflows/test-android-preview-apk.yml
+++ b/.github/workflows/test-android-preview-apk.yml
@@ -1,0 +1,77 @@
+name: "🧪 Test: Android Preview APK Action"
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_key:
+        description: 'README marker key for the app'
+        required: false
+        default: 'frontend'
+      app_label:
+        description: 'Display name shown next to the APK link'
+        required: false
+        default: 'Rocket Meals (Frontend)'
+      working_directory:
+        description: 'Directory of the Expo app to build'
+        required: false
+        default: './apps/frontend/app'
+      update_readme:
+        description: 'Also write the link into README.md and push it to this branch'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  test-build-android-preview-apk:
+    name: "🧪 Test Build Android Preview APK"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        uses: ./.github/actions/setup-and-install
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: "🧪 Build Android Preview APK & update README"
+        id: build
+        uses: ./.github/actions/build-android-preview-apk
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          working-directory: ${{ github.event.inputs.working_directory }}
+          app-key: ${{ github.event.inputs.app_key }}
+          app-label: ${{ github.event.inputs.app_label }}
+          update-readme: ${{ github.event.inputs.update_readme }}
+
+      - name: "📤 Upload raw EAS build JSON"
+        uses: actions/upload-artifact@v4
+        with:
+          name: eas-build-output
+          path: ${{ github.event.inputs.working_directory }}/eas-build-output.json
+          retention-days: 7
+
+      - name: "🖨️ Print result"
+        run: echo "APK URL: ${{ steps.build.outputs.apk-url }}"
+
+      - name: "💾 Commit README update"
+        if: github.event.inputs.update_readme == 'true'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: test Android preview APK link in README [skip ci]"
+            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ https://github.com/rocket-meals/studi-futter
 
 ## 📱 Android Preview APK
 
-<!-- android-preview-apk:start -->
+<!-- android-preview-apk:frontend:start -->
 Wird nach dem nächsten Build auf `master` automatisch aktualisiert.
-<!-- android-preview-apk:end -->
+<!-- android-preview-apk:frontend:end -->
 
 # 🚀 Rocket Meals
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ https://github.com/rocket-meals/swosy
 
 https://github.com/rocket-meals/studi-futter
 
+## 📱 Android Preview APK
+
+<!-- android-preview-apk:start -->
+Wird nach dem nächsten Build auf `master` automatisch aktualisiert.
+<!-- android-preview-apk:end -->
+
 # 🚀 Rocket Meals
 
 **Rocket Meals** ist eine innovative Lösung zur digitalen Verwaltung und Präsentation von

--- a/apps/scripts/__fixtures__/eas-build-output.sample.json
+++ b/apps/scripts/__fixtures__/eas-build-output.sample.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "0f3fcc30-1ae1-4155-ad0c-78f0bcf2d084",
+    "status": "FINISHED",
+    "platform": "ANDROID",
+    "artifacts": {
+      "buildUrl": "https://expo.dev/artifacts/eas/agNvd7IersQRJKvRJ-dk6Qltyz--qSooN4s1aC0ouPo.apk",
+      "applicationArchiveUrl": "https://expo.dev/artifacts/eas/agNvd7IersQRJKvRJ-dk6Qltyz--qSooN4s1aC0ouPo.apk"
+    },
+    "fingerprint": {
+      "id": "019f9337-525b-743e-9c93-0f1b114047c8",
+      "hash": "d4adc22e0d0ae96100340f64c54c23a7e041a5c0"
+    },
+    "initiatingActor": {
+      "id": "a35dd2fd-3f76-460a-9639-7b7912ebd84d",
+      "displayName": "GitHubActions"
+    },
+    "project": {
+      "id": "36f72583-5997-4602-8609-05f39444f2e7",
+      "name": "rocket-meals-dev",
+      "slug": "rocket-meals-dev",
+      "ownerAccount": {
+        "id": "901fb860-b6ba-4bb3-a2e8-3b2be1ddb736",
+        "name": "baumgartner-software"
+      }
+    },
+    "channel": "preview",
+    "distribution": "STORE",
+    "buildProfile": "previewApk",
+    "sdkVersion": "54.0.0",
+    "appVersion": "21.200.0",
+    "appBuildVersion": "200",
+    "runtimeVersion": "21.200.0",
+    "gitCommitHash": "40ae679063f11382027a593fe183e8aca1dd2426",
+    "gitCommitMessage": "Fix YAML syntax error in test-android-preview-apk.yml (unquoted colon in run step)",
+    "priority": "HIGH",
+    "createdAt": "2026-07-24T08:21:44.124Z",
+    "updatedAt": "2026-07-24T08:44:28.996Z",
+    "completedAt": "2026-07-24T08:44:28.826Z",
+    "expirationDate": "2026-08-23T08:21:44.150Z",
+    "isForIosSimulator": false,
+    "metrics": {
+      "buildWaitTime": 2940,
+      "buildQueueTime": 4744,
+      "buildDuration": 1357018
+    }
+  }
+]

--- a/apps/scripts/android-preview-apk.test.ts
+++ b/apps/scripts/android-preview-apk.test.ts
@@ -1,0 +1,52 @@
+import easBuildOutputSample from './__fixtures__/eas-build-output.sample.json';
+import { extractApkUrl, updateReadmeApkLink } from './android-preview-apk';
+
+describe('extractApkUrl', () => {
+  it('extracts the APK URL from a real eas build --json response', () => {
+    expect(extractApkUrl(easBuildOutputSample)).toBe('https://expo.dev/artifacts/eas/agNvd7IersQRJKvRJ-dk6Qltyz--qSooN4s1aC0ouPo.apk');
+  });
+
+  it('falls back to artifacts.buildUrl when applicationArchiveUrl is missing', () => {
+    const build = { artifacts: { buildUrl: 'https://expo.dev/artifacts/eas/fallback.apk' } };
+    expect(extractApkUrl([build])).toBe('https://expo.dev/artifacts/eas/fallback.apk');
+  });
+
+  it('accepts a single build object as well as an array of builds', () => {
+    const build = easBuildOutputSample[0];
+    expect(extractApkUrl(build)).toBe(extractApkUrl([build]));
+  });
+
+  it('returns an empty string when no artifact URL is present', () => {
+    expect(extractApkUrl([{ status: 'ERRORED' }])).toBe('');
+    expect(extractApkUrl([])).toBe('');
+    expect(extractApkUrl(undefined)).toBe('');
+  });
+});
+
+describe('updateReadmeApkLink', () => {
+  const readme = ['# Rocket Meals', '', '<!-- android-preview-apk:frontend:start -->', 'Wird nach dem nächsten Build auf `master` automatisch aktualisiert.', '<!-- android-preview-apk:frontend:end -->', '', '## Next section'].join('\n');
+
+  it('replaces the content between the app-specific markers', () => {
+    const updated = updateReadmeApkLink(readme, 'frontend', 'Rocket Meals (Frontend)', 'https://expo.dev/artifacts/eas/agNvd7...apk');
+
+    expect(updated).not.toBeNull();
+    expect(updated).toContain('<!-- android-preview-apk:frontend:start -->');
+    expect(updated).toContain('<!-- android-preview-apk:frontend:end -->');
+    expect(updated).toContain('**Rocket Meals (Frontend):** 📱 [Neueste Android Preview APK herunterladen](https://expo.dev/artifacts/eas/agNvd7...apk)');
+    expect(updated).not.toContain('Wird nach dem nächsten Build');
+    expect(updated).toContain('## Next section');
+  });
+
+  it('leaves markers for other apps untouched', () => {
+    const multiAppReadme = ['<!-- android-preview-apk:frontend:start -->old frontend link<!-- android-preview-apk:frontend:end -->', '<!-- android-preview-apk:geonexia:start -->old geonexia link<!-- android-preview-apk:geonexia:end -->'].join('\n');
+
+    const updated = updateReadmeApkLink(multiAppReadme, 'frontend', 'Rocket Meals (Frontend)', 'https://expo.dev/new.apk');
+
+    expect(updated).toContain('old geonexia link');
+    expect(updated).not.toContain('old frontend link');
+  });
+
+  it('returns null when the markers for the given app-key are missing', () => {
+    expect(updateReadmeApkLink(readme, 'geonexia', 'Geonexia', 'https://expo.dev/artifacts/eas/geonexia.apk')).toBeNull();
+  });
+});

--- a/apps/scripts/android-preview-apk.ts
+++ b/apps/scripts/android-preview-apk.ts
@@ -1,0 +1,86 @@
+import * as fs from 'node:fs';
+
+type EasBuildArtifacts = {
+  applicationArchiveUrl?: string;
+  buildUrl?: string;
+};
+
+type EasBuild = {
+  artifacts?: EasBuildArtifacts;
+};
+
+export function extractApkUrl(buildOutput: unknown): string {
+  const build = Array.isArray(buildOutput) ? buildOutput[0] : buildOutput;
+  const artifacts = (build as EasBuild | undefined)?.artifacts;
+  return artifacts?.applicationArchiveUrl || artifacts?.buildUrl || '';
+}
+
+export function updateReadmeApkLink(readme: string, appKey: string, appLabel: string, apkUrl: string): string | null {
+  const start = `<!-- android-preview-apk:${appKey}:start -->`;
+  const end = `<!-- android-preview-apk:${appKey}:end -->`;
+  const startIdx = readme.indexOf(start);
+  const endIdx = readme.indexOf(end);
+
+  if (startIdx === -1 || endIdx === -1) {
+    return null;
+  }
+
+  const block = `${start}\n**${appLabel}:** 📱 [Neueste Android Preview APK herunterladen](${apkUrl})\n`;
+  return readme.slice(0, startIdx) + block + readme.slice(endIdx);
+}
+
+function readRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is not set.`);
+  }
+  return value;
+}
+
+function runExtract(): void {
+  const buildOutputPath = readRequiredEnv('BUILD_OUTPUT_PATH');
+  const githubOutput = readRequiredEnv('GITHUB_OUTPUT');
+
+  const buildOutput = JSON.parse(fs.readFileSync(buildOutputPath, 'utf-8'));
+  const apkUrl = extractApkUrl(buildOutput);
+
+  if (!apkUrl) {
+    console.log('No APK URL found in EAS build output.');
+  }
+
+  fs.appendFileSync(githubOutput, `apk-url=${apkUrl}\n`);
+}
+
+function runUpdateReadme(): void {
+  const readmePath = readRequiredEnv('README_PATH');
+  const appKey = readRequiredEnv('APP_KEY');
+  const appLabel = readRequiredEnv('APP_LABEL');
+  const apkUrl = readRequiredEnv('APK_URL');
+
+  const readme = fs.readFileSync(readmePath, 'utf-8');
+  const updated = updateReadmeApkLink(readme, appKey, appLabel, apkUrl);
+
+  if (updated === null) {
+    console.log(`README markers for "${appKey}" not found, skipping README update.`);
+    return;
+  }
+
+  fs.writeFileSync(readmePath, updated);
+  console.log(`Updated README (${appKey}) with APK link: ${apkUrl}`);
+}
+
+function main(): void {
+  const command = process.argv[2];
+
+  if (command === 'extract') {
+    runExtract();
+  } else if (command === 'update-readme') {
+    runUpdateReadme();
+  } else {
+    throw new Error(`Unknown command "${command}". Expected "extract" or "update-readme".`);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -6,6 +6,8 @@
     "generate:eas": "ts-node --project ./tsconfig.json ./generate-eas-config.ts",
     "analyze:data-clumps": "ts-node --project ./tsconfig.json ./analyze-data-clumps.ts",
     "submit:ios:review": "ts-node --project ./tsconfig.json ./submit-ios-review.ts",
+    "apk:extract-url": "ts-node --project ./tsconfig.json ./android-preview-apk.ts extract",
+    "apk:update-readme": "ts-node --project ./tsconfig.json ./android-preview-apk.ts update-readme",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
After building the previewApk profile, extract the artifact URL from eas build --json and write it into a marker block in README.md. The README update/commit only runs on the master branch of rocket-meals/rocket-meals, not on forks or other branches, reusing the existing check-repository is-upstream output.