### PR TITLE
fix(frontend): default Android login back to the auth-session strategy

### DIFF
--- a/apps/frontend/app/helper/authHelper.test.ts
+++ b/apps/frontend/app/helper/authHelper.test.ts
@@ -172,17 +172,18 @@ describe('authHelper native login', () => {
 		expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
 	});
 
-	// Samsung Internet Custom Tabs never deliver the redirect deep link back to
-	// the app (and the same-task variant proved flaky), so Android defaults to
-	// the plain in-app browser, which relies on the redirect listener alone.
-	it('defaults to the in-app browser strategy on Android', async () => {
-		expect(authHelper.getSelectedLoginBrowserStrategy()).toBe(authHelper.LoginBrowserStrategy.IN_APP_BROWSER);
-		WebBrowser.openBrowserAsync.mockResolvedValue({ type: 'opened' });
+	// Android defaults to the same principle as iOS: the auth session in the
+	// preferred browser (native ASWebAuthenticationSession on iOS).
+	it('defaults to the preferred-browser auth session strategy on Android', async () => {
+		expect(authHelper.getSelectedLoginBrowserStrategy()).toBe(authHelper.LoginBrowserStrategy.AUTH_SESSION_PREFERRED_BROWSER);
+		WebBrowser.openAuthSessionAsync.mockResolvedValue({ type: 'success', url: `${REDIRECT_URL}?code=code-default` });
+		const getToken = jest.fn();
 
-		await authHelper.handleNativeLogin(LOGIN_URL, REDIRECT_URL, 'verifier-default', jest.fn());
+		await authHelper.handleNativeLogin(LOGIN_URL, REDIRECT_URL, 'verifier-default', getToken);
 
-		expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(LOGIN_URL);
-		expect(WebBrowser.openAuthSessionAsync).not.toHaveBeenCalled();
+		expect(WebBrowser.openAuthSessionAsync).toHaveBeenCalledWith(LOGIN_URL, REDIRECT_URL, expect.objectContaining({ browserPackage: 'com.android.chrome' }));
+		expect(WebBrowser.openBrowserAsync).not.toHaveBeenCalled();
+		expect(getToken).toHaveBeenCalledWith('verifier-default', 'code-default');
 	});
 
 	it('passes createTask=false for the same-task auth session strategy', async () => {

--- a/apps/frontend/app/helper/authHelper.ts
+++ b/apps/frontend/app/helper/authHelper.ts
@@ -28,16 +28,13 @@ const CODE_VERIFIER_STORAGE_KEY = 'pkce_pending_code_verifier';
 
 // Different ways of opening the provider login page, selectable from the
 // login screen's debug panel to find out what works reliably per device.
-// Device testing on Samsung devices (Samsung Internet as default browser)
-// showed: both regular auth session variants never deliver the redirect deep
-// link back to the app, and the same-task variant (createTask=false) is flaky
-// (worked once, then hung on the Google page - and Android offers no way to
-// close a Custom Tab programmatically). Only the plain in-app browser and the
-// system browser completed reliably.
+// Default on both platforms is the auth session in the preferred browser -
+// the same principle as iOS's native ASWebAuthenticationSession. The other
+// strategies stay available for debugging devices/browsers where that
+// doesn't complete reliably (e.g. some Samsung Internet setups).
 export enum LoginBrowserStrategy {
 	// Auth session in a Custom Tab of the preferred browser package.
-	// Default on iOS (native ASWebAuthenticationSession). On Android broken
-	// with Samsung Internet: the redirect deep link never reaches the app.
+	// Default on both platforms (matches iOS's native ASWebAuthenticationSession).
 	AUTH_SESSION_PREFERRED_BROWSER = 'auth_session_preferred_browser',
 	// Auth session, but let the system pick the browser (no explicit package).
 	// Same Samsung Internet problem as above when it is the default browser.
@@ -45,9 +42,8 @@ export enum LoginBrowserStrategy {
 	// Auth session with createTask=false: Custom Tab inside the app's own
 	// Android task. Flaky on Samsung Internet devices, see above.
 	AUTH_SESSION_SAME_TASK = 'auth_session_same_task',
-	// Default on Android: plain in-app browser (openBrowserAsync) without auth
-	// session semantics; relies entirely on the redirect listener / deep link
-	// fallback, which proved reliable on the affected devices.
+	// Plain in-app browser (openBrowserAsync) without auth session semantics;
+	// relies entirely on the redirect listener / deep link fallback.
 	IN_APP_BROWSER = 'in_app_browser',
 	// Full app switch to the system browser via Linking.openURL; return happens
 	// through the deep link only.
@@ -55,14 +51,16 @@ export enum LoginBrowserStrategy {
 }
 
 export const LOGIN_BROWSER_STRATEGY_LABELS: Record<LoginBrowserStrategy, string> = {
-	[LoginBrowserStrategy.AUTH_SESSION_PREFERRED_BROWSER]: 'Auth-Session, bevorzugter Browser (Standard iOS)',
+	[LoginBrowserStrategy.AUTH_SESSION_PREFERRED_BROWSER]: 'Auth-Session, bevorzugter Browser (Standard)',
 	[LoginBrowserStrategy.AUTH_SESSION_DEFAULT_BROWSER]: 'Auth-Session (System-Browser-Wahl)',
 	[LoginBrowserStrategy.AUTH_SESSION_SAME_TASK]: 'Auth-Session (gleicher App-Task)',
-	[LoginBrowserStrategy.IN_APP_BROWSER]: 'In-App-Browser (Standard Android)',
+	[LoginBrowserStrategy.IN_APP_BROWSER]: 'In-App-Browser',
 	[LoginBrowserStrategy.SYSTEM_BROWSER]: 'System-Browser (App-Wechsel)',
 };
 
-const defaultLoginBrowserStrategy = Platform.OS === 'android' ? LoginBrowserStrategy.IN_APP_BROWSER : LoginBrowserStrategy.AUTH_SESSION_PREFERRED_BROWSER;
+// Both platforms default to the auth session in the preferred browser - the
+// same principle as iOS's native ASWebAuthenticationSession.
+const defaultLoginBrowserStrategy = LoginBrowserStrategy.AUTH_SESSION_PREFERRED_BROWSER;
 
 let selectedLoginBrowserStrategy: LoginBrowserStrategy = defaultLoginBrowserStrategy;
 


### PR DESCRIPTION
## Summary
- Android's SSO login now defaults to `AUTH_SESSION_PREFERRED_BROWSER` again (the same principle as iOS's native `ASWebAuthenticationSession`), reverting the plain in-app-browser default from a few days ago.
- Updated comments/labels in `authHelper.ts` to reflect the shared default, and updated the corresponding unit test to assert the new default and its `openAuthSessionAsync` call with the preferred browser package.
- The other login browser strategies (same-task auth session, system browser, plain in-app browser, etc.) remain selectable from the login screen's debug panel for troubleshooting devices/browsers where the auth session doesn't complete reliably.

## Test plan
- [x] `yarn jest authHelper.test.ts` — all 15 tests pass
- [x] `tsc --noEmit` — no new type errors in `authHelper.ts`
- [ ] Manual verification on a real Android device that Google login completes reliably via the auth-session strategy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWkpBD9iMZC3idniDGn2xz)_