### PR TITLE
Add experimental avatar scroll list screen with paginated profile loading

### DIFF
--- a/apps/frontend/app/app/(app)/experimentell/avatar-scroll-list/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/avatar-scroll-list/index.tsx
@@ -1,0 +1,203 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Dimensions, DimensionValue, FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TranslationKeys } from '@/locales/keys';
+import useSetPageTitle from '@/hooks/useSetPageTitle';
+import { CollectionHelper } from '@/helper/collectionHelper';
+import { DatabaseTypes } from 'repo-depkit-common';
+import { MyAvatar } from 'repo-depkit-common-ui';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { parseProfileAvatar, AVATAR_BACKGROUND } from '@/hooks/useAvatarProfileEditor';
+
+const PAGE_SIZE = 24;
+const AVATAR_RENDER_SIZE = 80;
+const MIN_ITEM_WIDTH = 110;
+
+const profilesHelper = new CollectionHelper<DatabaseTypes.Profiles>('profiles');
+
+// Only the fields needed for the list are requested to keep each page small.
+// Sorted by id so that offset-based pagination stays stable while scrolling.
+async function fetchProfilesPage(offset: number): Promise<DatabaseTypes.Profiles[]> {
+	return await profilesHelper.readItems({
+		fields: ['id', 'nickname', 'avatar'],
+		sort: ['id'],
+		limit: PAGE_SIZE,
+		offset,
+	});
+}
+
+const AvatarScrollListScreen = () => {
+	useSetPageTitle(TranslationKeys.avatar_scroll_list);
+	const { theme } = useTheme();
+	const { translate } = useLanguage();
+
+	const [profiles, setProfiles] = useState<DatabaseTypes.Profiles[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [refreshing, setRefreshing] = useState(false);
+	const [loadingMore, setLoadingMore] = useState(false);
+	const [hasMore, setHasMore] = useState(true);
+	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
+	// Guards against parallel page loads (onEndReached can fire multiple times while scrolling).
+	const loadingMoreRef = useRef(false);
+
+	useEffect(() => {
+		const handleResize = () => setScreenWidth(Dimensions.get('window').width);
+		const subscription = Dimensions.addEventListener('change', handleResize);
+		return () => subscription?.remove();
+	}, []);
+
+	const numColumns = useMemo(() => {
+		return Math.max(2, Math.min(6, Math.floor(screenWidth / MIN_ITEM_WIDTH)));
+	}, [screenWidth]);
+
+	const appendUniqueProfiles = useCallback((prev: DatabaseTypes.Profiles[], page: DatabaseTypes.Profiles[]) => {
+		const knownIds = new Set(prev.map((p) => p.id));
+		return [...prev, ...page.filter((p) => !knownIds.has(p.id))];
+	}, []);
+
+	const loadInitial = useCallback(async () => {
+		try {
+			const page = await fetchProfilesPage(0);
+			setProfiles(page);
+			setHasMore(page.length === PAGE_SIZE);
+		} catch (e) {
+			console.error('[AvatarScrollList] Error loading profiles', e);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		loadInitial();
+	}, [loadInitial]);
+
+	const onRefresh = useCallback(async () => {
+		setRefreshing(true);
+		await loadInitial();
+		setRefreshing(false);
+	}, [loadInitial]);
+
+	const loadMore = useCallback(async () => {
+		if (loadingMoreRef.current || !hasMore || loading) return;
+		loadingMoreRef.current = true;
+		setLoadingMore(true);
+		try {
+			const page = await fetchProfilesPage(profiles.length);
+			setProfiles((prev) => appendUniqueProfiles(prev, page));
+			setHasMore(page.length === PAGE_SIZE);
+		} catch (e) {
+			console.error('[AvatarScrollList] Error loading more profiles', e);
+		} finally {
+			loadingMoreRef.current = false;
+			setLoadingMore(false);
+		}
+	}, [hasMore, loading, profiles.length, appendUniqueProfiles]);
+
+	const renderProfile = useCallback(
+		({ item }: { item: DatabaseTypes.Profiles }) => {
+			const avatarConfig = parseProfileAvatar(item.avatar);
+			const displayName = item.nickname || `#${String(item.id).slice(0, 8)}`;
+			return (
+				<View style={[styles.profileItem, { width: (100 / numColumns + '%') as DimensionValue }]}>
+					{avatarConfig ? (
+						<MyAvatar
+							style={avatarConfig.style}
+							options={avatarConfig.options}
+							size={AVATAR_RENDER_SIZE}
+							rounded={true}
+							backgroundColor={AVATAR_BACKGROUND}
+						/>
+					) : (
+						<View style={[styles.placeholderAvatar, { borderColor: theme.screen.text + '33' }]}>
+							<MaterialCommunityIcons name="account-outline" size={AVATAR_RENDER_SIZE / 2} color={theme.screen.text + '66'} />
+						</View>
+					)}
+					<Text style={[styles.profileName, { color: theme.screen.text }]} numberOfLines={1}>
+						{displayName}
+					</Text>
+				</View>
+			);
+		},
+		[numColumns, theme.screen.text]
+	);
+
+	if (loading) {
+		return (
+			<View style={[styles.loader, { backgroundColor: theme.screen.background }]}>
+				<ActivityIndicator />
+			</View>
+		);
+	}
+
+	return (
+		<FlatList
+			// Changing numColumns on the fly is not supported by FlatList, so remount on change.
+			key={`avatar-grid-${numColumns}`}
+			data={profiles}
+			keyExtractor={(item) => String(item.id)}
+			renderItem={renderProfile}
+			numColumns={numColumns}
+			onEndReached={loadMore}
+			onEndReachedThreshold={0.5}
+			refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+			scrollEventThrottle={16}
+			style={{ flex: 1, backgroundColor: theme.screen.background }}
+			contentContainerStyle={styles.listContent}
+			ListEmptyComponent={
+				<Text style={[styles.emptyText, { color: theme.screen.text }]}>
+					{translate(TranslationKeys.no_data_currently_calculating)}
+				</Text>
+			}
+			ListFooterComponent={
+				loadingMore ? (
+					<View style={styles.footerLoader}>
+						<ActivityIndicator />
+					</View>
+				) : null
+			}
+		/>
+	);
+};
+
+const styles = StyleSheet.create({
+	loader: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	listContent: {
+		paddingVertical: 16,
+		paddingHorizontal: 8,
+	},
+	profileItem: {
+		alignItems: 'center',
+		paddingVertical: 12,
+		paddingHorizontal: 4,
+	},
+	placeholderAvatar: {
+		width: AVATAR_RENDER_SIZE,
+		height: AVATAR_RENDER_SIZE,
+		borderRadius: AVATAR_RENDER_SIZE / 2,
+		borderWidth: 2,
+		borderStyle: 'dashed',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	profileName: {
+		marginTop: 8,
+		fontSize: 14,
+		textAlign: 'center',
+		maxWidth: '100%',
+	},
+	emptyText: {
+		textAlign: 'center',
+		paddingVertical: 32,
+	},
+	footerLoader: {
+		paddingVertical: 16,
+		alignItems: 'center',
+	},
+});
+
+export default AvatarScrollListScreen;

--- a/apps/frontend/app/app/(app)/experimentell/avatar-scroll-list/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/avatar-scroll-list/index.tsx
@@ -6,8 +6,7 @@ import { TranslationKeys } from '@/locales/keys';
 import useSetPageTitle from '@/hooks/useSetPageTitle';
 import { CollectionHelper } from '@/helper/collectionHelper';
 import { DatabaseTypes } from 'repo-depkit-common';
-import { MyAvatar } from 'repo-depkit-common-ui';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { AvatarConfig, MyAvatar } from 'repo-depkit-common-ui';
 import { parseProfileAvatar, AVATAR_BACKGROUND } from '@/hooks/useAvatarProfileEditor';
 
 const PAGE_SIZE = 24;
@@ -16,15 +15,37 @@ const MIN_ITEM_WIDTH = 110;
 
 const profilesHelper = new CollectionHelper<DatabaseTypes.Profiles>('profiles');
 
-// Only the fields needed for the list are requested to keep each page small.
-// Sorted by id so that offset-based pagination stays stable while scrolling.
+interface AvatarListItem {
+	id: string;
+	nickname: string | null;
+	config: AvatarConfig;
+}
+
+// Same query as the onboarding avatar carousel: only profiles that actually have
+// an avatar are loaded from the backend - no default/preset avatars are mixed in.
+// Paginated via limit/offset; the id tiebreaker keeps the order stable while
+// scrolling even when many profiles share the same (or no) date_updated.
 async function fetchProfilesPage(offset: number): Promise<DatabaseTypes.Profiles[]> {
 	return await profilesHelper.readItems({
+		filter: { avatar: { _nnull: true } },
+		sort: ['-date_updated', 'id'],
 		fields: ['id', 'nickname', 'avatar'],
-		sort: ['id'],
 		limit: PAGE_SIZE,
 		offset,
 	});
+}
+
+// Profiles whose avatar field cannot be parsed into a config are skipped -
+// the list only shows real, renderable server avatars.
+function toAvatarListItems(profiles: DatabaseTypes.Profiles[]): AvatarListItem[] {
+	const items: AvatarListItem[] = [];
+	for (const profile of profiles) {
+		const config = parseProfileAvatar(profile.avatar);
+		if (config) {
+			items.push({ id: String(profile.id), nickname: profile.nickname ?? null, config });
+		}
+	}
+	return items;
 }
 
 const AvatarScrollListScreen = () => {
@@ -32,12 +53,14 @@ const AvatarScrollListScreen = () => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 
-	const [profiles, setProfiles] = useState<DatabaseTypes.Profiles[]>([]);
+	const [items, setItems] = useState<AvatarListItem[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [refreshing, setRefreshing] = useState(false);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const [hasMore, setHasMore] = useState(true);
 	const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
+	// Offset counts fetched profiles (not rendered items), since unparseable avatars are skipped.
+	const offsetRef = useRef(0);
 	// Guards against parallel page loads (onEndReached can fire multiple times while scrolling).
 	const loadingMoreRef = useRef(false);
 
@@ -51,15 +74,16 @@ const AvatarScrollListScreen = () => {
 		return Math.max(2, Math.min(6, Math.floor(screenWidth / MIN_ITEM_WIDTH)));
 	}, [screenWidth]);
 
-	const appendUniqueProfiles = useCallback((prev: DatabaseTypes.Profiles[], page: DatabaseTypes.Profiles[]) => {
-		const knownIds = new Set(prev.map((p) => p.id));
-		return [...prev, ...page.filter((p) => !knownIds.has(p.id))];
+	const appendUniqueItems = useCallback((prev: AvatarListItem[], page: AvatarListItem[]) => {
+		const knownIds = new Set(prev.map((item) => item.id));
+		return [...prev, ...page.filter((item) => !knownIds.has(item.id))];
 	}, []);
 
 	const loadInitial = useCallback(async () => {
 		try {
 			const page = await fetchProfilesPage(0);
-			setProfiles(page);
+			offsetRef.current = page.length;
+			setItems(toAvatarListItems(page));
 			setHasMore(page.length === PAGE_SIZE);
 		} catch (e) {
 			console.error('[AvatarScrollList] Error loading profiles', e);
@@ -83,8 +107,9 @@ const AvatarScrollListScreen = () => {
 		loadingMoreRef.current = true;
 		setLoadingMore(true);
 		try {
-			const page = await fetchProfilesPage(profiles.length);
-			setProfiles((prev) => appendUniqueProfiles(prev, page));
+			const page = await fetchProfilesPage(offsetRef.current);
+			offsetRef.current += page.length;
+			setItems((prev) => appendUniqueItems(prev, toAvatarListItems(page)));
 			setHasMore(page.length === PAGE_SIZE);
 		} catch (e) {
 			console.error('[AvatarScrollList] Error loading more profiles', e);
@@ -92,27 +117,20 @@ const AvatarScrollListScreen = () => {
 			loadingMoreRef.current = false;
 			setLoadingMore(false);
 		}
-	}, [hasMore, loading, profiles.length, appendUniqueProfiles]);
+	}, [hasMore, loading, appendUniqueItems]);
 
-	const renderProfile = useCallback(
-		({ item }: { item: DatabaseTypes.Profiles }) => {
-			const avatarConfig = parseProfileAvatar(item.avatar);
-			const displayName = item.nickname || `#${String(item.id).slice(0, 8)}`;
+	const renderItem = useCallback(
+		({ item }: { item: AvatarListItem }) => {
+			const displayName = item.nickname || `#${item.id.slice(0, 8)}`;
 			return (
 				<View style={[styles.profileItem, { width: (100 / numColumns + '%') as DimensionValue }]}>
-					{avatarConfig ? (
-						<MyAvatar
-							style={avatarConfig.style}
-							options={avatarConfig.options}
-							size={AVATAR_RENDER_SIZE}
-							rounded={true}
-							backgroundColor={AVATAR_BACKGROUND}
-						/>
-					) : (
-						<View style={[styles.placeholderAvatar, { borderColor: theme.screen.text + '33' }]}>
-							<MaterialCommunityIcons name="account-outline" size={AVATAR_RENDER_SIZE / 2} color={theme.screen.text + '66'} />
-						</View>
-					)}
+					<MyAvatar
+						style={item.config.style}
+						options={item.config.options}
+						size={AVATAR_RENDER_SIZE}
+						rounded={true}
+						backgroundColor={AVATAR_BACKGROUND}
+					/>
 					<Text style={[styles.profileName, { color: theme.screen.text }]} numberOfLines={1}>
 						{displayName}
 					</Text>
@@ -134,9 +152,9 @@ const AvatarScrollListScreen = () => {
 		<FlatList
 			// Changing numColumns on the fly is not supported by FlatList, so remount on change.
 			key={`avatar-grid-${numColumns}`}
-			data={profiles}
-			keyExtractor={(item) => String(item.id)}
-			renderItem={renderProfile}
+			data={items}
+			keyExtractor={(item) => item.id}
+			renderItem={renderItem}
 			numColumns={numColumns}
 			onEndReached={loadMore}
 			onEndReachedThreshold={0.5}
@@ -174,15 +192,6 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		paddingVertical: 12,
 		paddingHorizontal: 4,
-	},
-	placeholderAvatar: {
-		width: AVATAR_RENDER_SIZE,
-		height: AVATAR_RENDER_SIZE,
-		borderRadius: AVATAR_RENDER_SIZE / 2,
-		borderWidth: 2,
-		borderStyle: 'dashed',
-		alignItems: 'center',
-		justifyContent: 'center',
 	},
 	profileName: {
 		marginTop: 8,

--- a/apps/frontend/app/app/(app)/experimentell/index.tsx
+++ b/apps/frontend/app/app/(app)/experimentell/index.tsx
@@ -152,6 +152,12 @@ const Index = () => {
 			leftIcon: <MaterialCommunityIcons name="account-circle" size={24} color={theme.screen.icon} />,
 			onPress: () => router.push('/experimentell/avatars'),
 		},
+		{
+			key: 'avatar-scroll-list',
+			label: translate(TranslationKeys.avatar_scroll_list),
+			leftIcon: <MaterialCommunityIcons name="account-group" size={24} color={theme.screen.icon} />,
+			onPress: () => router.push('/experimentell/avatar-scroll-list'),
+		},
 	];
 
 	return (

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -394,6 +394,7 @@ export enum TranslationKeys {
         canteen_visits = 'canteen_visits',
         avatar = 'avatar',
         avatars = 'avatars',
+        avatar_scroll_list = 'avatar_scroll_list',
         avatar_style = 'avatar_style',
         avatar_seed = 'avatar_seed',
         avatar_size = 'avatar_size',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -3607,6 +3607,16 @@
     "tr": "Avatarlar",
     "zh": "头像"
   },
+  "avatar_scroll_list": {
+    "de": "Avatar Scroll-Liste",
+    "en": "Avatar Scroll List",
+    "ar": "قائمة تمرير الصور الرمزية",
+    "es": "Lista de desplazamiento de avatares",
+    "fr": "Liste défilante d'avatars",
+    "ru": "Прокручиваемый список аватаров",
+    "tr": "Avatar Kaydırma Listesi",
+    "zh": "头像滚动列表"
+  },
   "avatar_style": {
     "de": "Avatar-Stil",
     "en": "Avatar Style",


### PR DESCRIPTION
New screen under Experimentell that loads profile avatars online from the
profiles collection as a scrollable grid (like the foodoffers list): pages
of 24 profiles are fetched via limit/offset and more are loaded lazily via
onEndReached, with pull-to-refresh. Each entry shows the avatar (or a
placeholder) with the profile nickname below it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011DQpw7ncpCpZALCaVccjQJ