### PR TITLE
fix(common-ui): Avatar speichern, wenn der Editor über einem anderen Modal liegt (+ Maestro-Test)

### DIFF
--- a/apps/score-tracker/frontend/app/players/index.tsx
+++ b/apps/score-tracker/frontend/app/players/index.tsx
@@ -184,6 +184,7 @@ function FriendEditContent({ friendId, onClose }: Readonly<{ friendId: string; o
 	return (
 		<View style={styles.modalContent}>
 			<SettingsListAvatar
+				nativeID={ComponentIds.PLAYER_DETAIL_AVATAR_ROW}
 				config={friend.avatarConfig}
 				onChange={(config) => {
 					logDebug(`players: avatar onChange friend=${friend.id} style=${config.style}`);

--- a/apps/score-tracker/frontend/constants/ComponentIds.ts
+++ b/apps/score-tracker/frontend/constants/ComponentIds.ts
@@ -70,6 +70,7 @@ export const ComponentIds = {
 	PLAYERS_OPTIONS_IMPORT_ROW: 'players-options-import-row',
 	PLAYER_DETAIL_EXPORT_ROW: 'player-detail-export-row',
 	PLAYER_DETAIL_IMPORT_ROW: 'player-detail-import-row',
+	PLAYER_DETAIL_AVATAR_ROW: 'player-detail-avatar-row',
 	PLAYER_DETAIL_DELETE_BUTTON: 'player-detail-delete-button',
 	PLAYER_DETAIL_ID_ROW: 'player-detail-id-row',
 

--- a/apps/score-tracker/maestro-tests/src/tests/players-avatar-test.ts
+++ b/apps/score-tracker/maestro-tests/src/tests/players-avatar-test.ts
@@ -1,0 +1,73 @@
+/**
+ * players-avatar-test.ts – Regression test for "the avatar of a friend isn't
+ * saved".
+ *
+ * The friend editor is itself a modal, so the avatar editor opens *stacked* on
+ * top of it. Closing it only pops back one level, which used to skip the
+ * editor's save-on-close entirely (the modal stack renders every item at the
+ * same tree position, so the popped content re-renders instead of unmounting -
+ * and the save hung off that unmount). The avatar was silently discarded.
+ *
+ * What proves it here: the avatar editor opens its quick-start preset grid
+ * only while no avatar exists yet, and jumps straight into the category editor
+ * once one is stored. So re-opening the editor after picking a preset must show
+ * the category list and must NOT show the preset grid again.
+ */
+
+import { MaestroTestCase } from 'repo-depkit-maestro-framework';
+import { CommonUiComponentIds } from 'repo-depkit-common-ui/src/constants/ComponentIds';
+import { ComponentIds } from '../../../frontend/constants/ComponentIds';
+
+const test = new MaestroTestCase({
+	appId: 'com.scoretracker.web',
+	tags: ['web', 'players-screen', 'avatar'],
+	outputFileName: 'players-avatar-test',
+});
+
+test
+	.openPage('http://localhost:8082/players')
+	.waitForAnimationToEnd()
+
+	// Create a friend - opens the friend edit modal right away
+	.tapOnId(ComponentIds.PLAYERS_SCREEN_ADD_BUTTON)
+	.waitForAnimationToEnd()
+	.assertVisibleId(ComponentIds.PLAYER_DETAIL_AVATAR_ROW)
+
+	// Open the avatar editor. A fresh friend has no avatar, so the quick-start
+	// preset grid is shown.
+	.tapOnId(ComponentIds.PLAYER_DETAIL_AVATAR_ROW)
+	.waitForAnimationToEnd()
+	.assertVisibleId(`${CommonUiComponentIds.AVATAR_EDITOR_PRESET_PREFIX}0`)
+	.takeScreenshot('avatar-quickstart')
+
+	// Pick a preset - this switches the editor into its category view
+	.tapOnId(`${CommonUiComponentIds.AVATAR_EDITOR_PRESET_PREFIX}0`)
+	.waitForAnimationToEnd()
+	.assertVisibleId(CommonUiComponentIds.AVATAR_EDITOR_CATEGORY_LIST)
+	.takeScreenshot('avatar-editor')
+
+	// Close the avatar editor - pops back to the friend edit modal, and this is
+	// the moment the avatar has to be saved.
+	.tapOnId(CommonUiComponentIds.MODAL_CLOSE_BUTTON)
+	.waitForAnimationToEnd()
+	.assertVisibleId(ComponentIds.PLAYER_DETAIL_DELETE_BUTTON)
+	.takeScreenshot('friend-after-avatar')
+
+	// Re-open the avatar editor: with the avatar stored it must open the
+	// category editor directly. If it falls back to the preset grid, nothing was
+	// saved - which is exactly the bug this test guards.
+	.tapOnId(ComponentIds.PLAYER_DETAIL_AVATAR_ROW)
+	.waitForAnimationToEnd()
+	.assertVisibleId(CommonUiComponentIds.AVATAR_EDITOR_CATEGORY_LIST)
+	.assertNotVisibleId(`${CommonUiComponentIds.AVATAR_EDITOR_PRESET_PREFIX}0`)
+	.takeScreenshot('avatar-editor-reopened')
+
+	// Clean up: back to the friend modal, then delete the friend so the friends
+	// list is empty again for the following tests.
+	.tapOnId(CommonUiComponentIds.MODAL_CLOSE_BUTTON)
+	.waitForAnimationToEnd()
+	.tapOnId(ComponentIds.PLAYER_DETAIL_DELETE_BUTTON)
+	.waitForAnimationToEnd()
+	.takeScreenshot('players-after-cleanup');
+
+export default test;

--- a/packages/common-ui/src/components/GlobalModal/useMyScrollViewModal.tsx
+++ b/packages/common-ui/src/components/GlobalModal/useMyScrollViewModal.tsx
@@ -1,10 +1,26 @@
 import React, { ReactNode } from 'react';
 import MyScrollViewModal, { MyScrollViewModalProps } from '../MyScrollViewModal';
 import { useModal } from './useModal';
+import type { ModalCloseReason } from './ModalProvider';
 
 export type MyScrollViewModalConfig = MyScrollViewModalProps & { children?: ReactNode };
 
-type ScrollViewModalOptions = { backgroundStyle?: any; headerBackgroundColor?: string };
+type ScrollViewModalOptions = {
+	backgroundStyle?: any;
+	headerBackgroundColor?: string;
+	/**
+	 * Called exactly once when this modal leaves the stack - including when it
+	 * is only popped back to the modal below it.
+	 *
+	 * Prefer this over `MyScrollViewModalProps.onClose` for anything that has
+	 * to happen on close (e.g. persisting what the user edited): `onClose`
+	 * fires from the content component's unmount, and the stack renders every
+	 * item at the same tree position inside one sheet - so popping back to the
+	 * parent modal re-renders that component instead of unmounting it, and
+	 * `onClose` never runs (see the SCROLL FIX 6 note in MyScrollViewModal).
+	 */
+	onClosed?: (reason: ModalCloseReason) => void;
+};
 
 export const useMyScrollViewModal = () => {
 	const { show: showModal, close, showAndDiscardOthers: showAndDiscardOthersModal, closeAll, debug } = useModal();

--- a/packages/common-ui/src/components/MyAvatarEditor/index.tsx
+++ b/packages/common-ui/src/components/MyAvatarEditor/index.tsx
@@ -136,6 +136,7 @@ import SettingsListGroupTitle from '../SettingsListGroupTitle';
 import SettingsList from '../SettingsList';
 import SettingsListLeftRight, { type SettingsListLeftRightItem } from '../SettingsListLeftRight/SettingsListLeftRight';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { CommonUiComponentIds } from '../../constants/ComponentIds';
 import { HAIR_COLORS, MICAH_HAIR_COLORS, SKIN_COLORS, PRESET_COLORS } from '../MyColorPicker';
 import MyCustomColorPicker from '../MyCustomColorPicker';
 import { myContrastColor } from '../../helpers/ColorHelper';
@@ -1459,6 +1460,10 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 			)}
 
 			<SettingsListGroupTitle title={translate ? translate('avatar_section_category') : 'Category'} />
+			{/* Marks "the editor is showing", as opposed to the quick-start grid -
+			    the two are mutually exclusive, which is what an E2E test can use to
+			    tell whether an avatar is already stored for the edited entity. */}
+			<View nativeID={CommonUiComponentIds.AVATAR_EDITOR_CATEGORY_LIST}>
 			{allCategories.map((cat, index) => {
 				const groupPosition = getGroupPosition(allCategories.length, index);
 				const rawColor = colorKeys.includes(cat) ? config.options?.[cat] : null;
@@ -1493,6 +1498,7 @@ const AvatarEditorModalContent: React.FC<AvatarEditorModalContentProps> = ({
 					/>
 				);
 			})}
+			</View>
 
 			<SettingsListGroupTitle title={translate ? translate('avatar_section_actions') : 'Actions'} />
 			<SettingsList
@@ -2430,6 +2436,7 @@ const QuickstartDebugSection: React.FC<QuickstartDebugSectionProps> = ({
 				{presets.map((presetConfig, index) => (
 					<TouchableOpacity
 						key={`${presetConfig.style}-${index}`}
+						nativeID={`${CommonUiComponentIds.AVATAR_EDITOR_DEBUG_PRESET_PREFIX}${index}`}
 						style={[styles.debugFallbackButton, { backgroundColor: buttonBg }]}
 						onPress={() => {
 							onDebugEvent?.(`debug:fallback-preset press index=${index}`);
@@ -2490,6 +2497,7 @@ const PresetSelectionModalContent: React.FC<PresetSelectionModalContentProps> = 
 				{presets.map((presetConfig, index) => (
 					<TouchableOpacity
 						key={`${presetConfig.style}-${index}`}
+						nativeID={`${CommonUiComponentIds.AVATAR_EDITOR_PRESET_PREFIX}${index}`}
 						// Debug: red border = the touchable's actual layout box (the touch target).
 						// If it doesn't line up with the yellow-bordered avatar view, hit-testing
 						// and visuals have drifted apart (the "tap only works at the bottom edge"
@@ -2559,6 +2567,7 @@ const PresetSelectionModalContent: React.FC<PresetSelectionModalContentProps> = 
 
 			<SettingsListGroupTitle title={translate ? translate('avatar_section_actions') : 'Actions'} />
 			<SettingsList
+				nativeID={CommonUiComponentIds.AVATAR_EDITOR_CUSTOMIZE_ROW}
 				title={translate ? translate('avatar_customize') : 'Customize'}
 				value={translate ? translate('avatar_customize_hint') : 'Customize avatar completely from scratch'}
 				onPress={() => {
@@ -2920,15 +2929,20 @@ export const useAvatarEditorModal = () => {
 
 			// Dirty tracking: only save when the user has actually made a change.
 			const isDirtyRef = { current: false };
+			// The editor saves on close, and "close" must also cover being popped
+			// back to the modal it was opened from (e.g. the friend edit sheet) -
+			// hence the stack-level `onClosed` below rather than the content's
+			// unmount-based `onClose`, which never fires for a pop. Guarded so the
+			// Apply button and the following close can't save twice.
+			const hasSavedRef = { current: false };
+			const saveIfDirty = () => {
+				if (hasSavedRef.current || !isDirtyRef.current) return;
+				hasSavedRef.current = true;
+				onDone(configRef.current);
+			};
 
 			show({
 				title: options?.title ?? 'Avatar Editor',
-				onClose: () => {
-					options?.onDebugEvent?.(`closed dirty=${isDirtyRef.current}`);
-					if (isDirtyRef.current) {
-						onDone(configRef.current);
-					}
-				},
 				stickyHeaderComponent: (
 					<AvatarStickyHeaderConditional
 						modeObservable={modeObservable}
@@ -2946,12 +2960,12 @@ export const useAvatarEditorModal = () => {
 						onApply={() => {
 							options?.onDebugEvent?.('apply');
 							isDirtyRef.current = true;
-							onDone(configRef.current);
+							saveIfDirty();
 							close();
 						}}
 						onChange={() => { isDirtyRef.current = true; }}
 						onReset={() => { isDirtyRef.current = false; }}
-						onDelete={onDelete ? () => { isDirtyRef.current = false; onDelete(); close(); } : undefined}
+						onDelete={onDelete ? () => { isDirtyRef.current = false; hasSavedRef.current = true; onDelete(); close(); } : undefined}
 						allowedStyles={allowedStyles}
 						size={size}
 						accentColor={options?.accentColor}
@@ -2963,6 +2977,11 @@ export const useAvatarEditorModal = () => {
 						onDebugEvent={options?.onDebugEvent}
 					/>
 				),
+			}, {
+				onClosed: (reason) => {
+					options?.onDebugEvent?.(`closed reason=${reason} dirty=${isDirtyRef.current}`);
+					saveIfDirty();
+				},
 			});
 		},
 		[show, close],

--- a/packages/common-ui/src/constants/ComponentIds.ts
+++ b/packages/common-ui/src/constants/ComponentIds.ts
@@ -9,4 +9,13 @@
 export enum CommonUiComponentIds {
 	// Modal
 	MODAL_CLOSE_BUTTON = 'modal-close-button',
+
+	// Avatar editor (see MyAvatarEditor). The quick-start grid is only shown
+	// while no avatar exists yet, so its presence/absence is what tells an E2E
+	// test whether an avatar was actually stored.
+	AVATAR_EDITOR_PRESET_PREFIX = 'avatar-editor-preset-',
+	/** Debug-only text fallback tiles, shown next to the grid in debug mode. */
+	AVATAR_EDITOR_DEBUG_PRESET_PREFIX = 'avatar-editor-debug-preset-',
+	AVATAR_EDITOR_CUSTOMIZE_ROW = 'avatar-editor-customize-row',
+	AVATAR_EDITOR_CATEGORY_LIST = 'avatar-editor-category-list',
 }


### PR DESCRIPTION
## Problem

Beim Bearbeiten eines Freundes im Score Tracker (**Spieler → Freund → Avatar**) wurde der geänderte Avatar nicht gespeichert.

## Ursache

Der Freund-Editor ist selbst ein Modal, der Avatar-Editor öffnet sich also **gestapelt** darüber — Schließen holt nur eine Ebene zurück.

Der Avatar-Editor speichert beim Schließen, ausgelöst bisher über `MyScrollViewModal.onClose`. Dieses hängt am **Unmount** der Inhaltskomponente. Der Modal-Stack rendert aber alle Einträge an derselben Stelle im Baum innerhalb *eines* BottomSheets (siehe „SCROLL FIX 6“-Kommentar in `MyScrollViewModal`): Beim Zurückspringen auf das darunterliegende Modal wird die Komponente nur **neu gerendert, nicht unmountet** — `onClose` lief also nie und die Änderung war verloren.

Ohne darunterliegendes Modal (z. B. Spieler im Spiel-Setup) unmountet das Sheet komplett, deshalb trat der Fehler nur bei den Freunden auf.

## Änderung

- `useMyScrollViewModal`: neue Option `onClosed`, die vom `ModalProvider` bedient wird und genau einmal feuert, wenn das Modal den Stack verlässt — auch beim Zurückspringen um eine Ebene. Inklusive Doku, warum sie `onClose` für „beim Schließen speichern“ vorzuziehen ist.
- `MyAvatarEditor`: speichert über diese Option statt über `onClose`, abgesichert gegen doppeltes Speichern durch den Apply-Button.
- Bestehende `onClose`-Nutzungen (`SettingsListTextInput`/`NumberInput`/`Date`) bleiben unverändert — die Semantik von `onClose` ist nicht angefasst.
- Test-IDs für Quick-Start-Kacheln, Kategorie-Liste und Customize-Zeile des Avatar-Editors sowie für die Avatar-Zeile im Freund-Editor.

## Testfall

Neuer Maestro-Test `players-avatar-test`: Freund anlegen → Avatar über eine Quick-Start-Kachel setzen → Editor schließen → Editor erneut öffnen.

Der Avatar-Editor zeigt die Quick-Start-Auswahl **nur solange kein Avatar existiert** und springt sonst direkt in die Kategorie-Liste. Genau das ist die Assertion:

```
assertVisible    avatar-editor-category-list
assertNotVisible avatar-editor-preset-0
```

Ohne den Fix erscheint beim erneuten Öffnen wieder die Quick-Start-Auswahl → Test schlägt fehl.

## Verifikation

Maestro selbst ließ sich in der Agent-Umgebung nicht ausführen (`get.maestro.mobile.dev` ist durch den Proxy geblockt, und zur vorhandenen Chromium-141-Binary fehlt der passende chromedriver — installiert ist 147). Die YAML-Generierung läuft durch; dieselbe Schrittfolge und dieselben Assertions wurden stattdessen per Playwright gegen den echten Web-Export (`expo export`) gefahren:

| | Avatar-Editor schließen → gespeichert? | Editor erneut geöffnet |
|---|---|---|
| vorher | `{"id":"…","name":"Freund 1","color":"#2563eb"}` — kein `avatarConfig` | Quick-Start-Auswahl |
| nachher | `…,"avatarConfig":{"style":"avataaars","options":{…}}` | Kategorie-Liste |

Zusätzlich geprüft, dass der nicht gestapelte Fall (Spieler-Avatar im Spiel-Setup) weiterhin speichert, und dass `tsc` keine neuen Fehler bringt.

Screenshots der Vorher-/Nachher-Zustände liegen im Task-Verlauf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UXihWg2BkauF13Lc9Xb4s

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXihWg2BkauF13Lc9Xb4s)_