### PR TITLE
feat(backend): reuse food translations when creating foodoffers to sa…

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/ParseSchedule.ts
@@ -1062,7 +1062,13 @@ export class ParseSchedule {
         },
       };
     }
-    const translationsCreate = translationsFromParsing ? TranslationHelper.getTranslationsCreateListForNewItem(translationsFromParsing) : [];
+    // Reuse the food's existing translations when the source name matches, so the
+    // auto-translation hook does not machine-translate the same text again for every
+    // newly created foodoffer (keeps translation costs down).
+    const existingFoodTranslations = (food.translations as DatabaseTypes.FoodsTranslations[]) || [];
+    const translationsCreate = translationsFromParsing
+      ? TranslationHelper.getTranslationsCreateListForNewItemReusingExistingTranslations(translationsFromParsing, existingFoodTranslations, ['name'])
+      : [];
 
     let foodOfferToCreate: Partial<DatabaseTypes.Foodoffers> = {
       ...foodofferForParser.basicFoodofferData,
@@ -1185,7 +1191,9 @@ export class ParseSchedule {
   }
 
   /**
-   * Looks up the food record for each food_id referenced by the given foodoffers.
+   * Looks up the food record (including its translations) for each food_id referenced
+   * by the given foodoffers. The translations are needed so that foodoffers can reuse
+   * the already existing food translations instead of triggering new auto-translations.
    */
   async resolveFoodsForFoodofferList(foodofferListForParser: FoodoffersTypeForParser[]): Promise<Record<string, DatabaseTypes.Foods | null>> {
     // dict foodsFound
@@ -1198,7 +1206,7 @@ export class ParseSchedule {
     const foodsService = await this.getFoodsService();
     const foodIds = Object.keys(dictFoodsFound);
     for (let foodId of foodIds) {
-      let food = await foodsService.readOne(foodId);
+      let food = await foodsService.readOneWithTranslations(foodId);
       if (food) {
         dictFoodsFound[foodId] = food;
       }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/TranslationHelper.ts
@@ -334,6 +334,80 @@ export class TranslationHelper {
   }
 
   /**
+   * Builds the nested-create translation list for a new item, additionally reusing
+   * already existing translations of a related item (e.g. the food of a foodoffer)
+   * when the source translation text matches.
+   *
+   * Reused translations are created with `let_be_translated: false`, so the
+   * auto-translation hook does not machine-translate the same text again for every
+   * new item (keeps translation costs down). When the source texts differ, only the
+   * parsed translations are returned and the remaining languages are left to the
+   * auto-translation hook as usual.
+   *
+   * Only the given `fieldsToReuse` (e.g. ['name']) are copied from the existing
+   * translations, since the related collection may have more fields than the target
+   * translation collection.
+   */
+  static getTranslationsCreateListForNewItemReusingExistingTranslations(
+    translationsFromParsing: TranslationsFromParsingType,
+    existingTranslationsOfRelatedItem: ExistingTranslation[] | null | undefined,
+    fieldsToReuse: string[]
+  ): NewTranslationForCreation[] {
+    const parsedCreateList = TranslationHelper.getTranslationsCreateListForNewItem(translationsFromParsing);
+    const existingTranslations = existingTranslationsOfRelatedItem || [];
+    if (existingTranslations.length === 0) {
+      return parsedCreateList;
+    }
+
+    // The source entry of the new item (be_source_for_translations, e.g. German)
+    const parsedSourceEntry = parsedCreateList.find(entry => entry.be_source_for_translations);
+    const parsedSourceName = parsedSourceEntry?.name;
+    if (!parsedSourceName) {
+      return parsedCreateList;
+    }
+
+    // The source translation of the related item
+    const existingSourceLanguageCode = TranslationHelper._resolveSourceLanguageCodeForTranslations(existingTranslations, TranslationHelper.DefaultLanguage);
+    const existingSourceTranslation = existingTranslations.find(translation => translation.languages_code === existingSourceLanguageCode);
+    if (!existingSourceTranslation || existingSourceTranslation.name !== parsedSourceName) {
+      // Different source text -> the existing translations do not fit, no reuse
+      return parsedCreateList;
+    }
+
+    const coveredLanguageCodes = new Set<string>();
+    for (const parsedEntry of parsedCreateList) {
+      const languagesCodeObject = parsedEntry[FIELD_TRANSLATION_LANGUAGE_CODE] as Record<string, string> | undefined;
+      const languageCode = languagesCodeObject?.[FIELD_LANGUAGE_ID];
+      if (languageCode) {
+        coveredLanguageCodes.add(languageCode);
+      }
+    }
+
+    // Copy all languages of the related item which the parser did not provide
+    const createList: NewTranslationForCreation[] = [...parsedCreateList];
+    for (const existingTranslation of existingTranslations) {
+      const languageCode = existingTranslation.languages_code;
+      if (!languageCode || typeof languageCode !== 'string' || coveredLanguageCodes.has(languageCode)) {
+        continue;
+      }
+      const reusedFields: Record<string, any> = {};
+      for (const fieldToReuse of fieldsToReuse) {
+        reusedFields[fieldToReuse] = existingTranslation[fieldToReuse] ?? null;
+      }
+      createList.push({
+        ...reusedFields,
+        be_source_for_translations: false,
+        let_be_translated: false, // reused translation, do not machine-translate again
+        [FIELD_TRANSLATION_LANGUAGE_CODE]: {
+          [FIELD_LANGUAGE_ID]: languageCode,
+        },
+      });
+      coveredLanguageCodes.add(languageCode);
+    }
+    return createList;
+  }
+
+  /**
    * Iterates over the language keys still remaining in `remaining_translationsFromParsing`
    * (i.e. languages from parsing that were not matched to an existing translation) and
    * pushes a create-object for each one into `createTranslations`. Returns whether any

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/__tests__/TestTranslationHelper.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/helpers/__tests__/TestTranslationHelper.ts
@@ -148,4 +148,95 @@ describe('TranslationHelper Test', () => {
     expect(result.updateObject.translations.update).toHaveLength(0);
     expect(result.updateObject.translations.create).toHaveLength(0);
   });
+
+  describe('getTranslationsCreateListForNewItemReusingExistingTranslations', () => {
+    const parsedTranslationsGermanOnly: TranslationsFromParsingType = {
+      [LanguageCodes.DE]: {
+        name: 'Spaghetti Bolognese',
+      },
+    };
+
+    const existingFoodTranslations = [
+      {
+        id: 1 as PrimaryKey,
+        languages_code: LanguageCodes.DE,
+        be_source_for_translations: true,
+        let_be_translated: false,
+        name: 'Spaghetti Bolognese',
+        description: 'Mit Rinderhack',
+      },
+      {
+        id: 2 as PrimaryKey,
+        languages_code: LanguageCodes.EN,
+        be_source_for_translations: false,
+        let_be_translated: false,
+        name: 'Spaghetti bolognese',
+        description: 'With minced beef',
+      },
+      {
+        id: 3 as PrimaryKey,
+        languages_code: 'ar-SA',
+        be_source_for_translations: false,
+        let_be_translated: false,
+        name: 'سباغيتي بولونيز',
+      },
+    ];
+
+    it('reuses existing translations when the source name matches', () => {
+      const createList = TranslationHelper.getTranslationsCreateListForNewItemReusingExistingTranslations(parsedTranslationsGermanOnly, existingFoodTranslations, ['name']);
+
+      expect(createList).toHaveLength(3);
+
+      const englishEntry = createList.find(entry => (entry.languages_code as any)?.code === LanguageCodes.EN);
+      expect(englishEntry?.name).toBe('Spaghetti bolognese');
+      expect(englishEntry?.let_be_translated).toBe(false); // reused, must not be machine-translated again
+      expect(englishEntry?.be_source_for_translations).toBe(false);
+      // only the requested fields are copied, the target collection has no description
+      expect(englishEntry).not.toHaveProperty('description');
+      // no database record fields leak into the create payload
+      expect(englishEntry).not.toHaveProperty('id');
+
+      const arabicEntry = createList.find(entry => (entry.languages_code as any)?.code === 'ar-SA');
+      expect(arabicEntry?.name).toBe('سباغيتي بولونيز');
+      expect(arabicEntry?.let_be_translated).toBe(false);
+    });
+
+    it('does not reuse existing translations when the source name differs', () => {
+      const parsedTranslationsDifferentName: TranslationsFromParsingType = {
+        [LanguageCodes.DE]: {
+          name: 'Currywurst',
+        },
+      };
+
+      const createList = TranslationHelper.getTranslationsCreateListForNewItemReusingExistingTranslations(parsedTranslationsDifferentName, existingFoodTranslations, ['name']);
+
+      // only the parsed translation, remaining languages are left to the auto-translation hook
+      expect(createList).toHaveLength(1);
+      expect(createList[0]?.name).toBe('Currywurst');
+      expect((createList[0]?.languages_code as any)?.code).toBe(LanguageCodes.DE);
+    });
+
+    it('parser translations win over existing translations for the same language', () => {
+      const parsedTranslationsGermanAndEnglish: TranslationsFromParsingType = {
+        [LanguageCodes.DE]: {
+          name: 'Spaghetti Bolognese',
+        },
+        [LanguageCodes.EN]: {
+          name: 'Spaghetti bolognese (fresh from report)',
+        },
+      };
+
+      const createList = TranslationHelper.getTranslationsCreateListForNewItemReusingExistingTranslations(parsedTranslationsGermanAndEnglish, existingFoodTranslations, ['name']);
+
+      expect(createList).toHaveLength(3);
+      const englishEntry = createList.find(entry => (entry.languages_code as any)?.code === LanguageCodes.EN);
+      expect(englishEntry?.name).toBe('Spaghetti bolognese (fresh from report)');
+    });
+
+    it('returns only parsed translations when the related item has no translations', () => {
+      const createList = TranslationHelper.getTranslationsCreateListForNewItemReusingExistingTranslations(parsedTranslationsGermanOnly, [], ['name']);
+      expect(createList).toHaveLength(1);
+      expect(createList[0]?.name).toBe('Spaghetti Bolognese');
+    });
+  });
 });


### PR DESCRIPTION
…ve translation costs

Before a foodoffer is created with translations, the food's already existing translations are checked: when the source name matches, all of the food's translations are copied onto the foodoffer with let_be_translated=false, so the auto-translation hook does not machine-translate the same text again for every newly created foodoffer. When the names differ, only the parsed translations are set and the remaining languages are left to auto-translation as before.


Claude-Session: https://claude.ai/code/session_01X7bKQ7RWZZ5ViHyjZbWKZx