### PR TITLE
fix(backend): skip foodoffer component subdivision when only one comp…

### DIFF
--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodTL1Parser.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/FoodTL1Parser.ts
@@ -846,6 +846,11 @@ export class FoodTL1Parser implements FoodParserInterface {
       textIndex++;
     }
 
+    // A subdivision into components is only meaningful when the foodoffer consists of
+    // at least two components; a single component is just the foodoffer itself.
+    if (components.length < 2) {
+      return [];
+    }
 
     return components;
   }

--- a/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/hannover/__tests__/TestFoodTL1ParserHannover.ts
+++ b/apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/src/food-sync-hook/hannover/__tests__/TestFoodTL1ParserHannover.ts
@@ -344,7 +344,7 @@ describe('FoodTL1ParserHannover Test', () => {
     expect(firstFoodoffer.basicFoodofferData.price_student).toEqual(FoodTL1ParserHannover.NIEDERSACHSEN_MENUE_PRICE);
     });
 
-  it('Foodoffer with single TEXT field has one component', async () => {
+  it('Foodoffer with single TEXT field has no components (subdivision only needed for 2 or more)', async () => {
     let foodoffersJson = await getFoodoffersJson(FoodTL1Parser_RawReportTestReaderHannover.getSavedRawReportWithVegatarian());
     expect(foodoffersJson.length).toBeGreaterThan(0);
     const firstFoodoffer = foodoffersJson[0];
@@ -352,8 +352,7 @@ describe('FoodTL1ParserHannover Test', () => {
     if (!firstFoodoffer) {
       return;
     }
-    expect(firstFoodoffer.components.length).toBe(1);
-    expect(firstFoodoffer.components[0]?.alias).toBe('Karamellpudding');
+    expect(firstFoodoffer.components.length).toBe(0);
   });
 
   it('Foodoffer with multiple TEXT fields has correct number of components', async () => {


### PR DESCRIPTION
…onent exists

A subdivision into components is only meaningful when a foodoffer consists of at least two components; a single component is just the foodoffer itself, so the TL1 parser now returns no components in that case.


Claude-Session: https://claude.ai/code/session_01XhP5WYMTtbg5pjjW8uEDgv