### PR TITLE
Open finished matches view-only, fix match wipe on end, add enum options in place

### DIFF
--- a/apps/score-tracker/frontend/__tests__/gameSlice.loadMatch.test.ts
+++ b/apps/score-tracker/frontend/__tests__/gameSlice.loadMatch.test.ts
@@ -1,0 +1,101 @@
+// The slice only needs the storage functions from common-ui; mocking the
+// package keeps jest away from its expo-sqlite/native-module dependency chain.
+jest.mock('repo-depkit-common-ui', () => ({
+	getStorageItem: jest.fn(async () => null),
+	setStorageItem: jest.fn(async () => undefined),
+}));
+
+import gameReducer, { loadMatch, reopenMatch, setScore, startGame, goToNextRound } from '../store/gameSlice';
+import type { GameSliceState } from '../store/gameSlice';
+import type { GameHistoryEntry } from '../helpers/GameHistoryStorage';
+
+function archivedEntry(): GameHistoryEntry {
+	return {
+		id: 'match-1',
+		endedAt: 1700000000000,
+		roundsCount: 1,
+		players: [
+			{ playerId: 'p1', name: 'Anna', color: '#2563eb' },
+			{ playerId: 'p2', name: 'Ben', color: '#dc2626' },
+		],
+		finalScores: { p1: 12, p2: 7 },
+		gameTypeId: 'game-1',
+		categoryValues: { cat1: 'opt-won' },
+		playerCategoryValues: { p1: { cat2: true } },
+		rounds: [
+			{ id: 'r1', scores: { p1: 12, p2: 7 }, cardSelections: { p1: ['card-a'] }, startingPlayerId: 'p1' },
+		],
+	};
+}
+
+describe('loadMatch', () => {
+	it('opens an archived match read-only, keeping players, rounds and category values', () => {
+		const state = gameReducer(undefined, loadMatch(archivedEntry()));
+		expect(state.status).toBe('finished');
+		expect(state.matchId).toBe('match-1');
+		expect(state.endedAt).toBe(1700000000000);
+		expect(state.players.map((p) => p.name)).toEqual(['Anna', 'Ben']);
+		expect(state.rounds).toHaveLength(1);
+		expect(state.rounds[0].scores).toEqual({ p1: 12, p2: 7 });
+		expect(state.rounds[0].cardSelections).toEqual({ p1: ['card-a'] });
+		expect(state.categoryValues).toEqual({ cat1: 'opt-won' });
+		expect(state.playerCategoryValues).toEqual({ p1: { cat2: true } });
+	});
+
+	it('does not share round objects with the history entry (editing must never rewrite the archive)', () => {
+		const entry = archivedEntry();
+		let state = gameReducer(undefined, loadMatch(entry));
+		state = gameReducer(state, reopenMatch());
+		state = gameReducer(state, setScore({ roundId: 'r1', playerId: 'p1', score: 99 }));
+		expect(state.rounds[0].scores.p1).toBe(99);
+		expect(entry.rounds?.[0].scores.p1).toBe(12);
+	});
+
+	it('falls back to a single round built from the final scores for old entries without rounds', () => {
+		const entry = { ...archivedEntry(), rounds: undefined };
+		const state = gameReducer(undefined, loadMatch(entry));
+		expect(state.rounds).toHaveLength(1);
+		expect(state.rounds[0].scores).toEqual({ p1: 12, p2: 7 });
+	});
+});
+
+describe('finished (view-only) state', () => {
+	function finishedState(): GameSliceState {
+		return gameReducer(undefined, loadMatch(archivedEntry()));
+	}
+
+	it('ignores startGame, so a viewed match cannot be replaced by a fresh round', () => {
+		const state = gameReducer(finishedState(), startGame(undefined));
+		expect(state.status).toBe('finished');
+		expect(state.rounds[0].scores).toEqual({ p1: 12, p2: 7 });
+		expect(state.matchId).toBe('match-1');
+	});
+
+	it('reopenMatch puts the match back into play and clears the ended date', () => {
+		const state = gameReducer(finishedState(), reopenMatch());
+		expect(state.status).toBe('active');
+		expect(state.endedAt).toBeUndefined();
+		expect(state.matchId).toBe('match-1');
+		expect(state.rounds).toHaveLength(1);
+	});
+
+	it('reopenMatch does nothing while a match is being set up or played', () => {
+		let state = gameReducer(undefined, { type: '@@INIT' });
+		expect(gameReducer(state, reopenMatch()).status).toBe('setup');
+		state = gameReducer(state, startGame(undefined));
+		expect(gameReducer(state, reopenMatch()).status).toBe('active');
+	});
+
+	it('never grows a finished match by a new round', () => {
+		const state = gameReducer(finishedState(), goToNextRound(undefined));
+		expect(state.rounds).toHaveLength(1);
+		expect(state.currentRoundIndex).toBe(0);
+	});
+
+	it('a reopened match can grow new rounds again', () => {
+		let state = gameReducer(finishedState(), reopenMatch());
+		state = gameReducer(state, goToNextRound(undefined));
+		expect(state.rounds).toHaveLength(2);
+		expect(state.currentRoundIndex).toBe(1);
+	});
+});

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -798,9 +798,10 @@ export default function GameTypeDetailScreen() {
 		router.push('/');
 	}, [gameType, archiveRunningMatch, dispatch]);
 
-	// Tapping a match returns to it: the running one is already loaded, an
-	// archived one is loaded back into the game state (and keeps its id, so
-	// playing on updates its own history entry).
+	// Tapping a match opens it: the running one is already loaded; an archived
+	// one is loaded view-only (status `finished`) - editing it again requires
+	// "Partie wieder öffnen" in its options, so just looking at an old match
+	// can never change or lose what was recorded.
 	const handleOpenMatch = useCallback(
 		(entry: GameHistoryEntry, isRunning: boolean) => {
 			if (!isRunning) {

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -42,6 +42,7 @@ import {
 	startGame,
 	goToPreviousRound,
 	goToNextRound,
+	reopenMatch,
 	resetScores,
 	resetAll,
 } from '../store/gameSlice';
@@ -82,6 +83,11 @@ function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bot
 	if (total === 1 || index === 0) return 'top';
 	if (index === total - 1) return 'bottom';
 	return 'middle';
+}
+
+/** Day a finished match ended, for the view-only banner (same format as the Partien list). */
+function formatEndedAtDate(timestamp: number): string {
+	return new Date(timestamp).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
 // ─── Score Input Modal Content ────────────────────────────────────────────────
@@ -230,7 +236,11 @@ function ScoreInputContent({
 // the player one is rendered inside a modal, where a closure-captured value
 // would otherwise keep showing whatever was recorded at open-time.
 
-function MatchCategorySection({ categories }: Readonly<{ categories: GameCategory[] }>) {
+function MatchCategorySection({
+	categories,
+	gameTypeId,
+	readOnly,
+}: Readonly<{ categories: GameCategory[]; gameTypeId?: string; readOnly?: boolean }>) {
 	const dispatch = useDispatch<AppDispatch>();
 	const values = useSelector((state: RootState) => state.game.categoryValues);
 	const matchCategories = useMemo(() => categoriesForScope(categories, 'match'), [categories]);
@@ -245,13 +255,19 @@ function MatchCategorySection({ categories }: Readonly<{ categories: GameCategor
 				categories={matchCategories}
 				values={resolved}
 				allCategories={categories}
+				gameTypeId={gameTypeId}
+				readOnly={readOnly}
 				onChange={(categoryId, value) => dispatch(setCategoryValue({ categoryId, value }))}
 			/>
 		</View>
 	);
 }
 
-function PlayerCategorySection({ playerId, categories }: Readonly<{ playerId: string; categories: GameCategory[] }>) {
+function PlayerCategorySection({
+	playerId,
+	categories,
+	gameTypeId,
+}: Readonly<{ playerId: string; categories: GameCategory[]; gameTypeId?: string }>) {
 	const dispatch = useDispatch<AppDispatch>();
 	const values = useSelector((state: RootState) => state.game.playerCategoryValues?.[playerId]);
 	const playerCategories = useMemo(() => categoriesForScope(categories, 'player'), [categories]);
@@ -265,6 +281,7 @@ function PlayerCategorySection({ playerId, categories }: Readonly<{ playerId: st
 				categories={playerCategories}
 				values={resolved}
 				allCategories={categories}
+				gameTypeId={gameTypeId}
 				onChange={(categoryId, value) => dispatch(setPlayerCategoryValue({ playerId, categoryId, value }))}
 			/>
 		</View>
@@ -812,11 +829,16 @@ function MatchPlayersSection({ onEditPlayers }: Readonly<{ onEditPlayers: () => 
 	const dispatch = useDispatch<AppDispatch>();
 	const { theme } = useTheme();
 	const players = useSelector((state: RootState) => state.game.players);
+	const status = useSelector((state: RootState) => state.game.status);
 	const { show, close } = useMyScrollViewModal();
 
 	const handleAddPlayer = useCallback(() => {
 		show({ title: 'Spieler hinzufügen', children: <AddPlayerContent onDone={close} /> });
 	}, [show, close]);
+
+	// A finished match is view-only: its roster is part of the archived result
+	// and must not be editable until the match is explicitly re-opened.
+	if (status === 'finished') return null;
 
 	return (
 		<>
@@ -861,6 +883,113 @@ function MatchPlayersSection({ onEditPlayers }: Readonly<{ onEditPlayers: () => 
 				iconBgColor={PRIMARY_COLOR}
 				rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
 				handleFunction={onEditPlayers}
+				groupPosition="bottom"
+			/>
+		</>
+	);
+}
+
+// ─── Match options (settings modal: end/reopen/reset/delete the match) ───────
+//
+// Subscribes to the store itself so ending a match always archives the *live*
+// state. These rows used to be built inline in the settings-modal callback,
+// which captured a stale `game` snapshot - "Partie beenden" then archived (or,
+// via the hasRecordedResults guard, silently discarded) an outdated copy of
+// the match, wiping the entered rounds and players from the saved entry.
+
+function MatchOptionsSection({ onClose }: Readonly<{ onClose: () => void }>) {
+	const dispatch = useDispatch<AppDispatch>();
+	const game = useSelector((state: RootState) => state.game);
+	const gameTypes = useSelector((state: RootState) => state.gameTypes.gameTypes);
+	const selectedGameType = game.gameTypeId ? gameTypes.find((g) => g.id === game.gameTypeId) : undefined;
+	const trackScores = selectedGameType?.trackScores ?? true;
+
+	/**
+	 * Mark the match's rounds as finished: archive the match (it appears as
+	 * beendet in its game's Partien list, viewable from there) and open the
+	 * follow-up match right away - same game, same players, back in the setup
+	 * phase. A match nothing was recorded in is discarded instead of archived.
+	 */
+	const handleEndMatch = useCallback(() => {
+		if (hasRecordedResults(game)) {
+			dispatch(archiveGame(buildHistoryEntry(game, { id: game.matchId ?? generateId(), endedAt: Date.now() })));
+		}
+		dispatch(resetScores());
+		onClose();
+	}, [game, dispatch, onClose]);
+
+	/** Put a finished (view-only) match back into play - the counterpart of "Partie beenden". */
+	const handleReopenMatch = useCallback(() => {
+		dispatch(reopenMatch());
+		onClose();
+	}, [dispatch, onClose]);
+
+	/**
+	 * Throw away the match currently open - including its archived entry, if it
+	 * was opened from the history - and start over from the setup phase with
+	 * the same game preselected. The seats are emptied too: the next match
+	 * picks its players fresh instead of inheriting this one's roster.
+	 */
+	const handleDeleteMatch = useCallback(() => {
+		if (game.matchId) dispatch(removeGameFromHistory(game.matchId));
+		dispatch(resetScores({ clearPlayers: true }));
+		onClose();
+	}, [game.matchId, dispatch, onClose]);
+
+	if (game.status === 'setup') return null;
+
+	return (
+		<>
+			<SettingsListGroupTitle title="Partie" />
+			{game.status === 'active' && (
+				<SettingsList
+					nativeID={ComponentIds.GAME_SETTINGS_END_MATCH}
+					label="Partie beenden"
+					value="Runden werden als beendet markiert und die Partie gespeichert"
+					stackedValue
+					leftIcon={<Ionicons name="flag-outline" size={20} color="#ffffff" />}
+					iconBgColor={SUCCESS_COLOR}
+					handleFunction={handleEndMatch}
+					groupPosition="top"
+				/>
+			)}
+			{game.status === 'finished' && (
+				<SettingsList
+					nativeID={ComponentIds.GAME_SETTINGS_REOPEN_MATCH}
+					label="Partie wieder öffnen"
+					value="Die beendete Partie kann danach wieder bearbeitet werden"
+					stackedValue
+					leftIcon={<Ionicons name="lock-open-outline" size={20} color="#ffffff" />}
+					iconBgColor={SUCCESS_COLOR}
+					handleFunction={handleReopenMatch}
+					groupPosition="top"
+				/>
+			)}
+			{game.status === 'active' && trackScores && (
+				<SettingsList
+					nativeID={ComponentIds.GAME_SETTINGS_RESET_SCORES}
+					label="Alle Punkte zurücksetzen"
+					value="Spieler bleiben, alle Runden werden geleert"
+					stackedValue
+					leftIcon={<Ionicons name="refresh-outline" size={20} color="#ffffff" />}
+					iconBgColor={WARNING_COLOR}
+					handleFunction={() => {
+						dispatch(resetScores());
+						onClose();
+					}}
+					groupPosition="middle"
+				/>
+			)}
+			{/* Replaces the old "Neues Spiel": that left open whether it
+			    reset or deleted the match. This one only ever deletes. */}
+			<SettingsList
+				nativeID={ComponentIds.GAME_SETTINGS_DELETE_MATCH}
+				label="Partie löschen"
+				value="Diese Partie wird verworfen und aus der Liste des Spiels entfernt"
+				stackedValue
+				leftIcon={<Ionicons name="trash-outline" size={20} color="#ffffff" />}
+				iconBgColor={DANGER_COLOR}
+				handleFunction={handleDeleteMatch}
 				groupPosition="bottom"
 			/>
 		</>
@@ -975,10 +1104,22 @@ function makeGameHeaderLeft(color: string, gameTypeId: string) {
 }
 
 /** Label for the "next round" navigation button. */
-function resolveNextRoundLabel(matchFinished: boolean, maxRounds: number | null, currentRoundNumber: number): string {
+function resolveNextRoundLabel(params: {
+	matchFinished: boolean;
+	maxRounds: number | null;
+	currentRoundNumber: number;
+	/** Viewing an archived match read-only (see `GameStatus`'s `finished`). */
+	isFinishedView: boolean;
+	roundsCount: number;
+}): string {
+	const { matchFinished, maxRounds, currentRoundNumber, isFinishedView, roundsCount } = params;
+	if (isFinishedView) {
+		return currentRoundNumber >= roundsCount ? 'Partie beendet' : `Runde ${currentRoundNumber + 1}`;
+	}
 	if (matchFinished) {
 		return 'Spiel beendet';
-	} else if (maxRounds != null && currentRoundNumber >= maxRounds) {
+	}
+	if (maxRounds != null && currentRoundNumber >= maxRounds) {
 		return 'Letzte Runde';
 	}
 	return `Runde ${currentRoundNumber + 1}`;
@@ -1033,10 +1174,9 @@ export default function GameScreen() {
 	const { theme } = useTheme();
 	const insets = useSafeAreaInsets();
 	const dispatch = useDispatch<AppDispatch>();
-	const game = useSelector((state: RootState) => state.game);
 	const players = useSelector((state: RootState) => state.game.players);
-	const matchId = useSelector((state: RootState) => state.game.matchId);
 	const rounds = useSelector((state: RootState) => state.game.rounds);
+	const endedAt = useSelector((state: RootState) => state.game.endedAt);
 	const status = useSelector((state: RootState) => state.game.status);
 	const currentRoundIndex = useSelector((state: RootState) => state.game.currentRoundIndex);
 	const friends = useSelector((state: RootState) => state.friends.friends);
@@ -1060,16 +1200,19 @@ export default function GameScreen() {
 	const [isEditingPlayers, setIsEditingPlayers] = useState(false);
 	const toggleEditingPlayers = useCallback(() => setIsEditingPlayers(v => !v), []);
 
-	// Leaving the setup phase always drops back into the scoreboard view.
+	// Leaving the setup phase always drops back into the scoreboard view, and a
+	// finished (view-only) match never opens in player-edit mode.
 	const prevStatusRef = useRef(status);
 	useEffect(() => {
-		if (prevStatusRef.current === 'setup' && status === 'active') {
+		if ((prevStatusRef.current === 'setup' && status === 'active') || status === 'finished') {
 			setIsEditingPlayers(false);
 		}
 		prevStatusRef.current = status;
 	}, [status]);
 
-	const showEditRows = status === 'setup' || isEditingPlayers;
+	// A finished match is a view onto its archived entry - no editing surfaces.
+	const isFinishedView = status === 'finished';
+	const showEditRows = status === 'setup' || (isEditingPlayers && !isFinishedView);
 
 	const selectedGameType = useMemo(
 		() => (gameTypeId ? gameTypes.find((g) => g.id === gameTypeId) : undefined),
@@ -1137,11 +1280,19 @@ export default function GameScreen() {
 	const currentRoundNumber = currentRoundIndex + 1;
 	// A finished match only blocks *advancing past the end* - paging forward
 	// through already-played rounds (after having gone back) must keep working.
+	// In the view-only finished state the last recorded round is always the end.
 	const isLastPossibleRound =
-		(matchFinished && currentRoundIndex >= rounds.length - 1) || (maxRounds != null && currentRoundNumber >= maxRounds);
+		((matchFinished || isFinishedView) && currentRoundIndex >= rounds.length - 1) ||
+		(maxRounds != null && currentRoundNumber >= maxRounds);
 
 	// Label for the "next round" navigation button
-	const nextRoundLabel = resolveNextRoundLabel(matchFinished, maxRounds, currentRoundNumber);
+	const nextRoundLabel = resolveNextRoundLabel({
+		matchFinished,
+		maxRounds,
+		currentRoundNumber,
+		isFinishedView,
+		roundsCount: rounds.length,
+	});
 
 	// Tile width, only needed once a multi-column layout is active
 	const tileWidth = useMemo(() => {
@@ -1177,34 +1328,6 @@ export default function GameScreen() {
 		[showPlayerEditModal, closePlayerEditModal],
 	);
 
-	// ─── Settings modal (header gear) ────────────────────────────────────────
-
-	/**
-	 * Throw away the match currently open - including its archived entry, if it
-	 * was re-opened from the history - and start over from the setup phase with
-	 * the same game preselected. The seats are emptied too: the next match
-	 * picks its players fresh instead of inheriting this one's roster.
-	 */
-	const handleDeleteMatch = useCallback(() => {
-		if (matchId) dispatch(removeGameFromHistory(matchId));
-		dispatch(resetScores({ clearPlayers: true }));
-		closeSettingsModal();
-	}, [matchId, dispatch, closeSettingsModal]);
-
-	/**
-	 * Mark the match's rounds as finished: archive the match (it appears as
-	 * beendet in its game's Partien list, re-openable from there) and open the
-	 * follow-up match right away - same game, same players, back in the setup
-	 * phase. A match nothing was recorded in is discarded instead of archived.
-	 */
-	const handleEndMatch = useCallback(() => {
-		if (hasRecordedResults(game)) {
-			dispatch(archiveGame(buildHistoryEntry(game, { id: matchId ?? generateId(), endedAt: Date.now() })));
-		}
-		dispatch(resetScores());
-		closeSettingsModal();
-	}, [game, matchId, dispatch, closeSettingsModal]);
-
 	// ─── Game type selection (setup phase) ───────────────────────────────────
 
 	const handleOpenGameTypeModal = useCallback(() => {
@@ -1214,6 +1337,8 @@ export default function GameScreen() {
 		});
 	}, [showGameTypeModal, closeGameTypeModal]);
 
+	// All sections subscribe to the store themselves (see MatchOptionsSection),
+	// so the modal content never acts on a stale snapshot of the match.
 	const handleOpenSettingsModal = useCallback(() => {
 		showSettingsModal({
 			title: '⚙️ Optionen',
@@ -1228,52 +1353,11 @@ export default function GameScreen() {
 
 					<ColumnsSettingsSection />
 
-					{status === 'active' && (
-						<>
-							<SettingsListGroupTitle title="Partie" />
-							<SettingsList
-								nativeID={ComponentIds.GAME_SETTINGS_END_MATCH}
-								label="Partie beenden"
-								value="Runden werden als beendet markiert und die Partie gespeichert"
-								stackedValue
-								leftIcon={<Ionicons name="flag-outline" size={20} color="#ffffff" />}
-								iconBgColor={SUCCESS_COLOR}
-								handleFunction={handleEndMatch}
-								groupPosition="top"
-							/>
-							{trackScores && (
-								<SettingsList
-									nativeID={ComponentIds.GAME_SETTINGS_RESET_SCORES}
-									label="Alle Punkte zurücksetzen"
-									value="Spieler bleiben, alle Runden werden geleert"
-									stackedValue
-									leftIcon={<Ionicons name="refresh-outline" size={20} color="#ffffff" />}
-									iconBgColor={WARNING_COLOR}
-									handleFunction={() => {
-										dispatch(resetScores());
-										closeSettingsModal();
-									}}
-									groupPosition="middle"
-								/>
-							)}
-							{/* Replaces the old "Neues Spiel": that left open whether it
-							    reset or deleted the match. This one only ever deletes. */}
-							<SettingsList
-								nativeID={ComponentIds.GAME_SETTINGS_DELETE_MATCH}
-								label="Partie löschen"
-								value="Diese Partie wird verworfen und aus der Liste des Spiels entfernt"
-								stackedValue
-								leftIcon={<Ionicons name="trash-outline" size={20} color="#ffffff" />}
-								iconBgColor={DANGER_COLOR}
-								handleFunction={handleDeleteMatch}
-								groupPosition="bottom"
-							/>
-						</>
-					)}
+					<MatchOptionsSection onClose={closeSettingsModal} />
 				</View>
 			),
 		});
-	}, [status, trackScores, dispatch, closeSettingsModal, handleDeleteMatch]);
+	}, [showSettingsModal, closeSettingsModal]);
 
 	// ─── Header buttons ───────────────────────────────────────────────────────
 
@@ -1298,10 +1382,14 @@ export default function GameScreen() {
 	// its categories alone.
 	const handleTilePress = useCallback(
 		(playerId: string) => {
+			// A finished match is view-only - nothing to enter until it is
+			// re-opened via the match options.
+			if (isFinishedView) return;
 			// Only score entry needs a round; a game without points has none.
 			if (trackScores && !currentRound) return;
 			const player = players.find((p) => p.id === playerId);
-			const categorySection = playerCategories.length > 0 ? <PlayerCategorySection playerId={playerId} categories={categories} /> : null;
+			const categorySection =
+				playerCategories.length > 0 ? <PlayerCategorySection playerId={playerId} categories={categories} gameTypeId={gameTypeId} /> : null;
 			const title = player ? player.name : 'Eintrag';
 
 			if (!trackScores) {
@@ -1357,7 +1445,7 @@ export default function GameScreen() {
 				),
 			});
 		},
-		[currentRound, players, categories, playerCategories, trackScores, selectedGameType, showScoreModal, closeScoreModal, dispatch, theme],
+		[currentRound, players, categories, playerCategories, trackScores, isFinishedView, selectedGameType, gameTypeId, showScoreModal, closeScoreModal, dispatch, theme],
 	);
 
 	const handlePrevRound = useCallback(() => dispatch(goToPreviousRound()), [dispatch]);
@@ -1366,6 +1454,9 @@ export default function GameScreen() {
 	// through already-played rounds must keep their originally recorded one.
 	const handleNextRound = useCallback(() => {
 		const isCreatingNewRound = currentRoundIndex >= rounds.length - 1;
+		// Viewing a finished match pages through its recorded rounds but must
+		// never grow it by a new one.
+		if (isFinishedView && isCreatingNewRound) return;
 		if (!isCreatingNewRound || !currentRound) {
 			dispatch(goToNextRound());
 			return;
@@ -1381,7 +1472,7 @@ export default function GameScreen() {
 			state: playerOrderState ?? selectedGameType?.rules?.playerOrder?.initialState ?? 0,
 		});
 		dispatch(goToNextRound({ startingPlayerId: players[startIndex]?.id, nextOrderState: nextState }));
-	}, [currentRoundIndex, rounds.length, currentRound, selectedGameType, players, totals, scoringMode, playerOrderState, dispatch]);
+	}, [currentRoundIndex, rounds.length, currentRound, isFinishedView, selectedGameType, players, totals, scoringMode, playerOrderState, dispatch]);
 
 	// ─── Render ───────────────────────────────────────────────────────────────
 
@@ -1431,7 +1522,7 @@ export default function GameScreen() {
 								/>
 							</View>
 						)}
-						<MatchCategorySection categories={categories} />
+						<MatchCategorySection categories={categories} gameTypeId={gameTypeId} />
 						<TouchableOpacity
 							nativeID={ComponentIds.GAME_ADD_PLAYER_BUTTON_TOP}
 							style={[styles.addPlayerButton, styles.addPlayerButtonTop, { borderColor: PRIMARY_COLOR }]}
@@ -1473,7 +1564,16 @@ export default function GameScreen() {
 					</>
 				) : (
 					<>
-						{matchFinished && (
+						{isFinishedView && (
+							<View nativeID={ComponentIds.GAME_FINISHED_VIEW_BANNER} style={[styles.finishedBanner, styles.finishedViewBanner]}>
+								<Ionicons name="lock-closed-outline" size={18} color="#ffffff" />
+								<Text style={styles.finishedBannerText}>
+									Beendete Partie{endedAt ? ` vom ${formatEndedAtDate(endedAt)}` : ''} - nur Ansicht. Zum Bearbeiten in den
+									Optionen (⚙️) „Partie wieder öffnen“ wählen.
+								</Text>
+							</View>
+						)}
+						{matchFinished && !isFinishedView && (
 							<View nativeID={ComponentIds.GAME_FINISHED_BANNER} style={[styles.finishedBanner, { backgroundColor: SUCCESS_COLOR }]}>
 								<Ionicons name="trophy-outline" size={18} color="#ffffff" />
 								<Text style={styles.finishedBannerText}>
@@ -1482,7 +1582,7 @@ export default function GameScreen() {
 								</Text>
 							</View>
 						)}
-						<MatchCategorySection categories={categories} />
+						<MatchCategorySection categories={categories} gameTypeId={gameTypeId} readOnly={isFinishedView} />
 						{players.map((player) => {
 							const summary = summarizeCategoryValues(playerCategories, playerCategoryValues?.[player.id]);
 							return (
@@ -1695,6 +1795,9 @@ const styles = StyleSheet.create({
 		paddingVertical: 12,
 		paddingHorizontal: 16,
 		marginBottom: 12,
+	},
+	finishedViewBanner: {
+		backgroundColor: '#6b7280',
 	},
 	finishedBannerText: {
 		color: '#ffffff',

--- a/apps/score-tracker/frontend/components/CategoryValueRows.tsx
+++ b/apps/score-tracker/frontend/components/CategoryValueRows.tsx
@@ -11,6 +11,7 @@ import {
 	useMyScrollViewModal,
 	useTheme,
 } from 'repo-depkit-common-ui';
+import { useDispatch, useSelector } from 'react-redux';
 import type { GameCategory, GameCategoryType, GameCategoryValue, GameCategoryValues } from '../helpers/GameCategories';
 import {
 	displayDateToIso,
@@ -21,6 +22,8 @@ import {
 	parseTimeToMinutes,
 	timeFromTimestamp,
 } from '../helpers/GameCategories';
+import { addGameCategoryOption } from '../store/gameTypesSlice';
+import type { AppDispatch, RootState } from '../store/store';
 import { ComponentIds } from '../constants/ComponentIds';
 
 const PRIMARY_COLOR = '#2563eb';
@@ -53,16 +56,32 @@ function groupPositionFor(index: number, total: number): 'top' | 'middle' | 'bot
 }
 
 // ─── Enum picker (modal content) ──────────────────────────────────────────────
+//
+// When the category belongs to a known game type (`gameTypeId` set), the picker
+// subscribes to the store so it always shows the live option list - and offers
+// creating a new option right here, so a missing value (e.g. a new "Typ
+// gewonnen" outcome) can be added during entry without a detour through the
+// game's settings. The new option is selected immediately.
 
 function EnumOptionsContent({
-	category,
+	category: categoryProp,
+	gameTypeId,
 	selectedOptionId,
 	onSelect,
 }: Readonly<{
 	category: GameCategory;
+	/** Game type owning the category - enables adding new options in place. */
+	gameTypeId?: string;
 	selectedOptionId: string | null;
 	onSelect: (optionId: string | null) => void;
 }>) {
+	const dispatch = useDispatch<AppDispatch>();
+	const liveCategory = useSelector((state: RootState) =>
+		gameTypeId
+			? state.gameTypes.gameTypes.find((g) => g.id === gameTypeId)?.categories?.find((c) => c.id === categoryProp.id)
+			: undefined,
+	);
+	const category = liveCategory ?? categoryProp;
 	const options = category.options ?? [];
 	return (
 		<View style={styles.modalContent}>
@@ -78,6 +97,23 @@ function EnumOptionsContent({
 					groupPosition={groupPositionFor(index, options.length)}
 				/>
 			))}
+			{gameTypeId && (
+				<SettingsListTextInput
+					nativeID={`${ComponentIds.CATEGORY_VALUE_ENUM_ADD_OPTION_PREFIX}${category.id}`}
+					label="Neue Option hinzufügen"
+					leftIcon={<Ionicons name="add-outline" size={20} color="#ffffff" />}
+					iconBgColor={PRIMARY_COLOR}
+					modalTitle="Neue Option"
+					placeholder="z.B. Unentschieden"
+					saveLabel="Hinzufügen"
+					checkTextInput={(value) => ({ isValid: value.trim() !== '', value })}
+					onSave={(label) => {
+						const action = dispatch(addGameCategoryOption({ gameTypeId, categoryId: category.id, label: label.trim() }));
+						onSelect(action.payload.option.id);
+					}}
+					groupPosition="single"
+				/>
+			)}
 			<SettingsList
 				label="Keine Angabe"
 				leftIcon={<Ionicons name="close-circle-outline" size={20} color="#ffffff" />}
@@ -97,12 +133,18 @@ export function CategoryValueRow({
 	allCategories,
 	onChange,
 	groupPosition,
+	gameTypeId,
+	readOnly,
 }: Readonly<{
 	category: GameCategory;
 	value: GameCategoryValue | undefined;
 	allCategories: GameCategory[];
 	onChange: (value: GameCategoryValue) => void;
 	groupPosition: 'top' | 'middle' | 'bottom' | 'single';
+	/** Game type owning the categories - lets the enum picker add new options in place. */
+	gameTypeId?: string;
+	/** Render the recorded value without any way to change it (viewing a finished match). */
+	readOnly?: boolean;
 }>) {
 	const { show, close } = useMyScrollViewModal();
 	const nativeID = `${ComponentIds.CATEGORY_VALUE_ROW_PREFIX}${category.id}`;
@@ -114,6 +156,7 @@ export function CategoryValueRow({
 			children: (
 				<EnumOptionsContent
 					category={category}
+					gameTypeId={gameTypeId}
 					selectedOptionId={typeof value === 'string' ? value : null}
 					onSelect={(optionId) => {
 						onChange(optionId);
@@ -122,7 +165,21 @@ export function CategoryValueRow({
 				/>
 			),
 		});
-	}, [show, close, category, value, onChange]);
+	}, [show, close, category, gameTypeId, value, onChange]);
+
+	// Viewing a finished match: every category renders as a plain value row.
+	if (readOnly && !isComputedCategory(category)) {
+		return (
+			<SettingsList
+				nativeID={nativeID}
+				label={category.name}
+				value={formatCategoryValue(category, value)}
+				leftIcon={leftIcon}
+				iconBgColor="#6b7280"
+				groupPosition={groupPosition}
+			/>
+		);
+	}
 
 	// A computed duration is derived from two other categories and can only be
 	// changed by changing those, so it renders as a plain read-only row.
@@ -282,6 +339,8 @@ export default function CategoryValueRows({
 	allCategories,
 	onChange,
 	emptyHint,
+	gameTypeId,
+	readOnly,
 }: Readonly<{
 	categories: GameCategory[];
 	values: GameCategoryValues;
@@ -290,6 +349,10 @@ export default function CategoryValueRows({
 	onChange: (categoryId: string, value: GameCategoryValue) => void;
 	/** Shown instead of the rows when the game type has no matching categories. */
 	emptyHint?: string;
+	/** Game type owning the categories - lets the enum picker add new options in place. */
+	gameTypeId?: string;
+	/** Render the recorded values without any way to change them (viewing a finished match). */
+	readOnly?: boolean;
 }>) {
 	const { theme } = useTheme();
 
@@ -308,6 +371,8 @@ export default function CategoryValueRows({
 					allCategories={allCategories}
 					onChange={(value) => onChange(category.id, value)}
 					groupPosition={groupPositionFor(index, categories.length)}
+					gameTypeId={gameTypeId}
+					readOnly={readOnly}
 				/>
 			))}
 		</>

--- a/apps/score-tracker/frontend/constants/ComponentIds.ts
+++ b/apps/score-tracker/frontend/constants/ComponentIds.ts
@@ -27,6 +27,7 @@ export const ComponentIds = {
 	GAME_ROUND_NEXT_BUTTON: 'game-round-next-button',
 	GAME_ROUND_LABEL: 'game-round-label',
 	GAME_FINISHED_BANNER: 'game-finished-banner',
+	GAME_FINISHED_VIEW_BANNER: 'game-finished-view-banner',
 
 	// Setup phase (round 0)
 	GAME_START_BUTTON: 'game-start-button',
@@ -71,6 +72,7 @@ export const ComponentIds = {
 	GAME_SETTINGS_COLUMNS_LANDSCAPE_2: 'game-settings-columns-landscape-2',
 	GAME_SETTINGS_RESET_SCORES: 'game-settings-reset-scores',
 	GAME_SETTINGS_END_MATCH: 'game-settings-end-match',
+	GAME_SETTINGS_REOPEN_MATCH: 'game-settings-reopen-match',
 	GAME_SETTINGS_DELETE_MATCH: 'game-settings-delete-match',
 	GAME_SETTINGS_PLAYER_ROW_PREFIX: 'game-settings-player-row-',
 	GAME_SETTINGS_PLAYER_REMOVE_PREFIX: 'game-settings-player-remove-',
@@ -128,6 +130,7 @@ export const ComponentIds = {
 	// Custom categories: value entry (game screen) and definition (game detail)
 	CATEGORY_VALUE_ROW_PREFIX: 'category-value-row-',
 	CATEGORY_VALUE_ENUM_OPTION_PREFIX: 'category-value-enum-option-',
+	CATEGORY_VALUE_ENUM_ADD_OPTION_PREFIX: 'category-value-enum-add-option-',
 	GAME_CATEGORY_ROW_PREFIX: 'game-category-row-',
 	GAME_CATEGORY_MOVE_UP_PREFIX: 'game-category-move-up-',
 	GAME_CATEGORY_MOVE_DOWN_PREFIX: 'game-category-move-down-',

--- a/apps/score-tracker/frontend/helpers/GameStorage.ts
+++ b/apps/score-tracker/frontend/helpers/GameStorage.ts
@@ -37,7 +37,13 @@ export type Round = {
 	startingPlayerId?: string;
 };
 
-export type GameStatus = 'setup' | 'active';
+/**
+ * Lifecycle of the currently loaded match. `finished` is an archived match
+ * re-opened from its game's Partien list purely to look at it: everything is
+ * read-only until it is explicitly re-opened for play via the match options
+ * ("Partie wieder öffnen") - the same modal a running match is ended in.
+ */
+export type GameStatus = 'setup' | 'active' | 'finished';
 
 export type GameState = {
 	players: Player[];
@@ -54,6 +60,8 @@ export type GameState = {
 	gameTypeId?: string;
 	/** Numeric state carried between rounds for a `startingPlayerMode: 'custom'` rule (see GameRules). */
 	playerOrderState?: number;
+	/** When the match ended - only set while `status` is `finished` (viewing an archived match). */
+	endedAt?: number;
 	/** Values of the game type's match-scope categories (see GameCategories), keyed by category id. */
 	categoryValues?: GameCategoryValues;
 	/** Values of the game type's player-scope categories, keyed by player id and then category id. */
@@ -103,6 +111,7 @@ export async function loadGameState(): Promise<GameState> {
 				matchId: parsed.matchId,
 				gameTypeId: parsed.gameTypeId,
 				playerOrderState: parsed.playerOrderState,
+				endedAt: parsed.endedAt,
 				categoryValues: parsed.categoryValues ?? {},
 				playerCategoryValues: parsed.playerCategoryValues ?? {},
 			};

--- a/apps/score-tracker/frontend/store/gameSlice.ts
+++ b/apps/score-tracker/frontend/store/gameSlice.ts
@@ -23,6 +23,7 @@ const initialState: GameSliceState = {
 	matchId: undefined,
 	gameTypeId: undefined,
 	playerOrderState: undefined,
+	endedAt: undefined,
 	categoryValues: {},
 	playerCategoryValues: {},
 };
@@ -57,6 +58,7 @@ const gameSlice = createSlice({
 				matchId: action.payload.matchId,
 				gameTypeId: action.payload.gameTypeId,
 				playerOrderState: action.payload.playerOrderState,
+				endedAt: action.payload.endedAt,
 				categoryValues: action.payload.categoryValues ?? {},
 				playerCategoryValues: action.payload.playerCategoryValues ?? {},
 			};
@@ -218,7 +220,7 @@ const gameSlice = createSlice({
 		 * created.
 		 */
 		startGame(state, action: PayloadAction<{ withRounds?: boolean } | undefined>) {
-			if (state.status === 'active') return;
+			if (state.status !== 'setup') return;
 			const withRounds = action.payload?.withRounds ?? true;
 			state.status = 'active';
 			state.rounds = withRounds
@@ -227,17 +229,24 @@ const gameSlice = createSlice({
 			state.currentRoundIndex = 0;
 			state.matchId = generateId();
 			state.playerOrderState = undefined;
+			state.endedAt = undefined;
 		},
 
 		/**
-		 * Re-open an archived match (see the game detail screen's match list):
-		 * its players, rounds and recorded category values become the currently
-		 * played match again, keeping its id so archiving updates that same
-		 * history entry.
+		 * Open an archived match (see the game detail screen's match list) for
+		 * viewing: its players, rounds and recorded category values become the
+		 * currently loaded match, but in the read-only `finished` state - nothing
+		 * about the archived entry can be changed until it is explicitly
+		 * re-opened for play via `reopenMatch`. It keeps its id, so archiving
+		 * after re-opening updates that same history entry.
+		 *
+		 * The rounds and category values are deep-copied: the history entry and
+		 * the live match state must never share objects, or editing the loaded
+		 * match could silently rewrite the archive.
 		 *
 		 * Entries archived before rounds were kept fall back to a single round
 		 * holding the final scores - the per-round breakdown is gone for those,
-		 * but their totals stay visible and editable.
+		 * but their totals stay visible.
 		 */
 		loadMatch(state, action: PayloadAction<GameHistoryEntry>) {
 			const entry = action.payload;
@@ -248,22 +257,46 @@ const gameSlice = createSlice({
 				avatarConfig: player.avatarConfig,
 				friendId: player.friendId,
 			}));
-			const rounds =
-				entry.rounds ??
-				(Object.keys(entry.finalScores).length > 0
-					? [{ id: generateId(), scores: { ...entry.finalScores } }]
-					: []);
+			let rounds: Round[] = [];
+			if (entry.rounds) {
+				rounds = entry.rounds.map((round) => ({
+					id: round.id,
+					scores: { ...round.scores },
+					cardSelections: round.cardSelections
+						? Object.fromEntries(Object.entries(round.cardSelections).map(([playerId, cards]) => [playerId, [...cards]]))
+						: undefined,
+					startingPlayerId: round.startingPlayerId,
+				}));
+			} else if (Object.keys(entry.finalScores).length > 0) {
+				rounds = [{ id: generateId(), scores: { ...entry.finalScores } }];
+			}
+			const playerCategoryValues = Object.fromEntries(
+				Object.entries(entry.playerCategoryValues ?? {}).map(([playerId, values]) => [playerId, { ...values }]),
+			);
 			return {
 				players,
 				rounds,
-				status: 'active' as const,
+				status: 'finished' as const,
 				currentRoundIndex: Math.max(0, rounds.length - 1),
 				matchId: entry.id,
 				gameTypeId: entry.gameTypeId,
 				playerOrderState: undefined,
-				categoryValues: entry.categoryValues ?? {},
-				playerCategoryValues: entry.playerCategoryValues ?? {},
+				endedAt: entry.endedAt,
+				categoryValues: { ...(entry.categoryValues ?? {}) },
+				playerCategoryValues,
 			};
+		},
+
+		/**
+		 * Put a `finished` (view-only) match back into play. Only reachable from
+		 * the match options modal ("Partie wieder öffnen") - the counterpart of
+		 * "Partie beenden" there. From then on the match behaves like any running
+		 * one; ending it again updates its existing history entry.
+		 */
+		reopenMatch(state) {
+			if (state.status !== 'finished') return;
+			state.status = 'active';
+			state.endedAt = undefined;
 		},
 
 		/** Move to the previous round (view/edit its scores). No-op at round 1. */
@@ -278,6 +311,12 @@ const gameSlice = createSlice({
 		 * custom-rule state - see `computeNextStartingPlayerIndex` in GameRules.
 		 */
 		goToNextRound(state, action: PayloadAction<{ startingPlayerId?: string; nextOrderState?: number } | undefined>) {
+			// A finished (view-only) match pages through its recorded rounds but
+			// never grows by a new one - it has to be re-opened first.
+			if (state.status === 'finished') {
+				state.currentRoundIndex = Math.min(state.rounds.length - 1, state.currentRoundIndex + 1);
+				return;
+			}
 			if (state.currentRoundIndex >= state.rounds.length - 1) {
 				state.rounds.push({
 					id: generateId(),
@@ -303,6 +342,7 @@ const gameSlice = createSlice({
 			state.currentRoundIndex = 0;
 			state.matchId = undefined;
 			state.playerOrderState = undefined;
+			state.endedAt = undefined;
 			state.categoryValues = {};
 			state.playerCategoryValues = {};
 		},
@@ -316,6 +356,7 @@ const gameSlice = createSlice({
 				currentRoundIndex: 0,
 				matchId: undefined,
 				gameTypeId: undefined,
+				endedAt: undefined,
 				categoryValues: {},
 				playerCategoryValues: {},
 			};
@@ -369,6 +410,7 @@ export const {
 	linkPlayerToFriend,
 	setGameType,
 	loadMatch,
+	reopenMatch,
 	setCategoryValue,
 	setPlayerCategoryValue,
 	movePlayer,

--- a/apps/score-tracker/frontend/store/store.ts
+++ b/apps/score-tracker/frontend/store/store.ts
@@ -82,6 +82,7 @@ store.subscribe(() => {
 				matchId: game.matchId,
 				gameTypeId: game.gameTypeId,
 				playerOrderState: game.playerOrderState,
+				endedAt: game.endedAt,
 				categoryValues: game.categoryValues,
 				playerCategoryValues: game.playerCategoryValues,
 			});


### PR DESCRIPTION
- 'Partie beenden' wiped or truncated the saved match: the settings modal
  was built from a callback whose dependency list was missing
  handleEndMatch, so ending archived a stale snapshot of the match - with
  hasRecordedResults often seeing an empty state and silently discarding
  everything (always reproducible with maxRounds: 1, where ending the
  match is the only way out). The Partie rows now live in a
  MatchOptionsSection that subscribes to the store itself, so ending
  always archives the live rounds, players and category values.
- Opening an archived match from the Partien list no longer puts it back
  into play: it loads in a new read-only 'finished' status (banner, no
  score entry, no new rounds, roster and categories locked, paging
  through recorded rounds still works). Re-opening for editing is an
  explicit 'Partie wieder öffnen' in the match options - the same modal
  the match is ended in. loadMatch also deep-copies the entry so the
  live state never shares objects with the archive.
- Enum categories (e.g. 'Typ gewonnen') can now grow new options right
  in the value picker during entry ('Neue Option hinzufügen', selected
  immediately) instead of only in the game's category settings.
- Unit tests for loadMatch/reopenMatch and the finished-state guards.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D5dnSP9oyGBUgwHwTmSGsX