### PR TITLE
feat(score-tracker): Clipboard-Buttons mit Toast im Kategorien-Rohdaten-Modal

### DIFF
--- a/apps/score-tracker/frontend/app/_layout.tsx
+++ b/apps/score-tracker/frontend/app/_layout.tsx
@@ -4,7 +4,7 @@ import { Drawer } from 'expo-router/drawer';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
-import { ThemeProvider, AppDrawer, DrawerItem, ModalProvider, SettingsProvider, useTheme } from 'repo-depkit-common-ui';
+import { ThemeProvider, AppDrawer, DrawerItem, ModalProvider, SettingsProvider, ToastProvider, useTheme } from 'repo-depkit-common-ui';
 import { DrawerContentComponentProps } from '@react-navigation/drawer';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
@@ -257,11 +257,15 @@ export default function Layout() {
 						<ThemeProvider>
 							<ThemeSyncBridge />
 							<SettingsProvider primaryColor={PRIMARY_COLOR}>
-								<ModalProvider>
-									<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.keyboardAvoidingView}>
-										<ThemedDrawerNavigator />
-									</KeyboardAvoidingView>
-								</ModalProvider>
+								{/* ToastProvider wraps ModalProvider so toasts (e.g. clipboard
+								    feedback) render above open bottom-sheet modals. */}
+								<ToastProvider>
+									<ModalProvider>
+										<KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.keyboardAvoidingView}>
+											<ThemedDrawerNavigator />
+										</KeyboardAvoidingView>
+									</ModalProvider>
+								</ToastProvider>
 							</SettingsProvider>
 						</ThemeProvider>
 					</SafeAreaProvider>

--- a/apps/score-tracker/frontend/components/CategoryValueRows.tsx
+++ b/apps/score-tracker/frontend/components/CategoryValueRows.tsx
@@ -11,6 +11,8 @@ import {
 	SettingsListTextInput,
 	useMyScrollViewModal,
 	useTheme,
+	useToast,
+	borderRadiusContainer,
 } from 'repo-depkit-common-ui';
 import { useDispatch, useSelector } from 'react-redux';
 import type { GameCategory, GameCategoryType, GameCategoryValue, GameCategoryValues } from '../helpers/GameCategories';
@@ -69,6 +71,10 @@ function groupPositionFor(index: number, total: number): 'top' | 'middle' | 'bot
 // `"id": "+"` (Directus-style), id-less entries or plain strings become new
 // options. The export starts with a `"//"` comment entry explaining exactly
 // that, so the pasted-along AI needs no extra briefing; the import ignores it.
+//
+// Inside the modal, "Kopieren"/"Einfügen" buttons copy the current (possibly
+// edited) text to the clipboard resp. fill the field from it; every clipboard
+// action and a successful "Übernehmen" confirm themselves with a toast.
 
 export function EnumOptionsRawDataRow({
 	gameTypeId,
@@ -80,19 +86,57 @@ export function EnumOptionsRawDataRow({
 	groupPosition: 'top' | 'middle' | 'bottom' | 'single';
 }>) {
 	const dispatch = useDispatch<AppDispatch>();
+	const { theme } = useTheme();
+	const { show: showToast } = useToast();
 	const options = category.options ?? [];
 
-	const handleCopy = useCallback(async () => {
-		await Clipboard.setStringAsync(enumOptionsToRawData(options));
-	}, [options]);
+	const copyToClipboard = useCallback(
+		async (rawData: string) => {
+			await Clipboard.setStringAsync(rawData);
+			showToast('JSON in die Zwischenablage kopiert');
+		},
+		[showToast],
+	);
+
+	const handleCopyFromRow = useCallback(async () => {
+		await copyToClipboard(enumOptionsToRawData(options));
+	}, [copyToClipboard, options]);
+
+	// Reads the clipboard and puts its content into the modal's text field (via
+	// setValue) - deliberately without saving, so the JSON can still be reviewed
+	// and has to be confirmed with "Übernehmen" like a manual edit.
+	const handlePaste = useCallback(
+		async (setValue: (value: string) => void) => {
+			let text = '';
+			try {
+				text = await Clipboard.getStringAsync();
+			} catch {
+				// E.g. the browser denied clipboard read permission on web.
+				showToast('Zugriff auf die Zwischenablage nicht möglich', { type: 'error' });
+				return;
+			}
+			if (text.trim() === '') {
+				showToast('Die Zwischenablage ist leer', { type: 'error' });
+				return;
+			}
+			setValue(text);
+			if (parseEnumOptionsRawData(text) === null) {
+				showToast('Eingefügt - aber kein gültiges JSON', { type: 'error' });
+			} else {
+				showToast('Aus der Zwischenablage eingefügt');
+			}
+		},
+		[showToast],
+	);
 
 	const handleApply = useCallback(
 		(value: string) => {
 			const parsed = parseEnumOptionsRawData(value);
 			if (!parsed) return;
 			dispatch(setGameCategoryOptions({ gameTypeId, categoryId: category.id, options: parsed }));
+			showToast(parsed.length === 1 ? '1 Option übernommen' : `${parsed.length} Optionen übernommen`);
 		},
-		[dispatch, gameTypeId, category.id],
+		[dispatch, gameTypeId, category.id, showToast],
 	);
 
 	return (
@@ -112,10 +156,32 @@ export function EnumOptionsRawDataRow({
 			checkTextInput={(value) => ({ isValid: parseEnumOptionsRawData(value) !== null, value })}
 			onSave={handleApply}
 			rightElement={
-				<TouchableOpacity onPress={handleCopy} hitSlop={8}>
+				<TouchableOpacity onPress={handleCopyFromRow} hitSlop={8}>
 					<MaterialCommunityIcons name="content-copy" size={20} color="#9ca3af" />
 				</TouchableOpacity>
 			}
+			renderModalChildren={(setValue, currentValue) => (
+				<View style={styles.clipboardRow}>
+					<TouchableOpacity
+						nativeID={`${ComponentIds.CATEGORY_OPTIONS_RAW_DATA_COPY_PREFIX}${category.id}`}
+						style={[styles.clipboardButton, { borderColor: theme.sheet.inputBorder }]}
+						onPress={() => copyToClipboard(currentValue)}
+						activeOpacity={0.7}
+					>
+						<MaterialCommunityIcons name="content-copy" size={18} color={theme.sheet.text} />
+						<Text style={[styles.clipboardButtonText, { color: theme.sheet.text }]}>Kopieren</Text>
+					</TouchableOpacity>
+					<TouchableOpacity
+						nativeID={`${ComponentIds.CATEGORY_OPTIONS_RAW_DATA_PASTE_PREFIX}${category.id}`}
+						style={[styles.clipboardButton, { borderColor: theme.sheet.inputBorder }]}
+						onPress={() => handlePaste(setValue)}
+						activeOpacity={0.7}
+					>
+						<MaterialCommunityIcons name="content-paste" size={18} color={theme.sheet.text} />
+						<Text style={[styles.clipboardButtonText, { color: theme.sheet.text }]}>Einfügen</Text>
+					</TouchableOpacity>
+				</View>
+			)}
 			groupPosition={groupPosition}
 		/>
 	);
@@ -449,6 +515,25 @@ export default function CategoryValueRows({
 const styles = StyleSheet.create({
 	modalContent: {
 		padding: 10,
+	},
+	clipboardRow: {
+		flexDirection: 'row',
+		gap: 12,
+		marginTop: 12,
+	},
+	clipboardButton: {
+		flex: 1,
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 8,
+		height: 44,
+		borderWidth: 1,
+		borderRadius: borderRadiusContainer,
+	},
+	clipboardButtonText: {
+		fontSize: 15,
+		fontWeight: '600',
 	},
 	emptyHint: {
 		fontSize: 13,

--- a/apps/score-tracker/frontend/constants/ComponentIds.ts
+++ b/apps/score-tracker/frontend/constants/ComponentIds.ts
@@ -132,6 +132,8 @@ export const ComponentIds = {
 	CATEGORY_VALUE_ENUM_OPTION_PREFIX: 'category-value-enum-option-',
 	CATEGORY_VALUE_ENUM_ADD_OPTION_PREFIX: 'category-value-enum-add-option-',
 	CATEGORY_OPTIONS_RAW_DATA_PREFIX: 'category-options-raw-data-',
+	CATEGORY_OPTIONS_RAW_DATA_COPY_PREFIX: 'category-options-raw-data-copy-',
+	CATEGORY_OPTIONS_RAW_DATA_PASTE_PREFIX: 'category-options-raw-data-paste-',
 	GAME_CATEGORY_ROW_PREFIX: 'game-category-row-',
 	GAME_CATEGORY_MOVE_UP_PREFIX: 'game-category-move-up-',
 	GAME_CATEGORY_MOVE_DOWN_PREFIX: 'game-category-move-down-',

--- a/packages/common-ui/index.ts
+++ b/packages/common-ui/index.ts
@@ -103,6 +103,9 @@ export { useModal } from './src/components/GlobalModal/useModal';
 export { useMyScrollViewModal } from './src/components/GlobalModal/useMyScrollViewModal';
 export type { MyScrollViewModalConfig } from './src/components/GlobalModal/useMyScrollViewModal';
 
+export { ToastProvider, useToast } from './src/components/Toast';
+export type { ToastType, ShowToastOptions, ToastContextType } from './src/components/Toast';
+
 export { default as FeatureWishesScreen } from './src/components/FeatureWishesScreen';
 export type { FeatureWishesScreenProps, FeatureWishesScreenTexts, FeatureWishItem } from './src/components/FeatureWishesScreen';
 

--- a/packages/common-ui/src/components/SettingsListTextInput/SettingsListTextInput.tsx
+++ b/packages/common-ui/src/components/SettingsListTextInput/SettingsListTextInput.tsx
@@ -55,8 +55,9 @@ export interface SettingsListTextInputProps extends Omit<SettingsListProps, 'onP
 	 *  Clicking a suggestion is equivalent to typing its value and pressing Save. */
 	suggestions?: SettingsListTextInputSuggestion[];
 	/** Optional render function for extra content rendered below the Save button.
-	 *  Receives a callback to programmatically set the text input value. */
-	renderModalChildren?: (onSuggest: (value: string) => void) => React.ReactNode;
+	 *  Receives a callback to programmatically set the text input value and the
+	 *  input's current (unsaved) value, e.g. for clipboard copy/paste buttons. */
+	renderModalChildren?: (onSuggest: (value: string) => void, currentValue: string) => React.ReactNode;
 }
 
 type ModalSheetProps = ModalSheetBaseProps<string> &
@@ -68,7 +69,7 @@ type ModalSheetProps = ModalSheetBaseProps<string> &
 		checkTextInput?: CheckTextInput;
 		allowSubmitWhenDisabled?: boolean;
 		suggestions?: SettingsListTextInputSuggestion[];
-		renderModalChildren?: (onSuggest: (value: string) => void) => React.ReactNode;
+		renderModalChildren?: (onSuggest: (value: string) => void, currentValue: string) => React.ReactNode;
 	};
 
 const ModalSheet: React.FC<ModalSheetProps> = ({
@@ -180,7 +181,7 @@ const ModalSheet: React.FC<ModalSheetProps> = ({
 					/>
 				</View>
 			)}
-			{renderModalChildren?.(setValue)}
+			{renderModalChildren?.(setValue, value)}
 		</View>
 	);
 

--- a/packages/common-ui/src/components/Toast/index.tsx
+++ b/packages/common-ui/src/components/Toast/index.tsx
@@ -1,0 +1,138 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState, ReactNode } from 'react';
+import { Animated, Platform, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { CommonUiComponentIds } from '../../constants/ComponentIds';
+import { borderRadiusContainer } from '../../constants/ui';
+
+// ─── Toast (global, short-lived feedback message) ─────────────────────────────
+//
+// Mount ToastProvider AROUND ModalProvider: its host view is rendered as a
+// sibling AFTER the children with a zIndex above the modal container (999, see
+// ModalProvider), so a toast triggered from inside a bottom-sheet modal (e.g.
+// "copied to clipboard") is visible on top of the open sheet.
+//
+// Deliberately minimal: one toast at a time (a new show() replaces the current
+// one and restarts the timer), fixed position at the top so the keyboard that
+// is usually open inside input modals never covers it, and no touch handling -
+// the host is pointerEvents="none" and can never block the UI underneath.
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export type ShowToastOptions = {
+	type?: ToastType;
+	/** How long the toast stays fully visible before fading out. Default 2000ms. */
+	durationMs?: number;
+};
+
+export type ToastContextType = {
+	show: (message: string, options?: ShowToastOptions) => void;
+};
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+const DEFAULT_DURATION_MS = 2000;
+const FADE_MS = 200;
+
+const TOAST_COLORS: Record<ToastType, string> = {
+	success: '#16a34a',
+	error: '#dc2626',
+	info: '#374151',
+};
+
+const TOAST_ICONS: Record<ToastType, keyof typeof Ionicons.glyphMap> = {
+	success: 'checkmark-circle',
+	error: 'alert-circle',
+	info: 'information-circle',
+};
+
+type ToastState = {
+	message: string;
+	type: ToastType;
+};
+
+export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+	const [toast, setToast] = useState<ToastState | null>(null);
+	const opacity = useRef(new Animated.Value(0)).current;
+	const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const insets = useSafeAreaInsets();
+
+	const show = useCallback(
+		(message: string, options?: ShowToastOptions) => {
+			if (hideTimeoutRef.current) {
+				clearTimeout(hideTimeoutRef.current);
+				hideTimeoutRef.current = null;
+			}
+			setToast({ message, type: options?.type ?? 'success' });
+			Animated.timing(opacity, { toValue: 1, duration: FADE_MS, useNativeDriver: Platform.OS !== 'web' }).start();
+			hideTimeoutRef.current = setTimeout(() => {
+				Animated.timing(opacity, { toValue: 0, duration: FADE_MS, useNativeDriver: Platform.OS !== 'web' }).start(
+					({ finished }) => {
+						// Only unmount if no newer show() has restarted the fade-in meanwhile.
+						if (finished) setToast(null);
+					},
+				);
+			}, options?.durationMs ?? DEFAULT_DURATION_MS);
+		},
+		[opacity],
+	);
+
+	const contextValue = useMemo<ToastContextType>(() => ({ show }), [show]);
+
+	return (
+		<ToastContext.Provider value={contextValue}>
+			{children}
+			{toast && (
+				<View style={[styles.host, { top: insets.top + 12 }]} pointerEvents="none">
+					<Animated.View
+						nativeID={CommonUiComponentIds.TOAST}
+						style={[styles.toast, { backgroundColor: TOAST_COLORS[toast.type], opacity }]}
+					>
+						<Ionicons name={TOAST_ICONS[toast.type]} size={18} color="#ffffff" />
+						<Text style={styles.toastText} numberOfLines={3}>
+							{toast.message}
+						</Text>
+					</Animated.View>
+				</View>
+			)}
+		</ToastContext.Provider>
+	);
+};
+
+export const useToast = (): ToastContextType => {
+	const ctx = useContext(ToastContext);
+	if (!ctx) throw new Error('useToast must be used within a ToastProvider');
+	return ctx;
+};
+
+const styles = StyleSheet.create({
+	host: {
+		position: 'absolute',
+		left: 0,
+		right: 0,
+		alignItems: 'center',
+		// Above the modal container (zIndex 999 in ModalProvider), so toasts
+		// triggered from inside a bottom-sheet modal stay visible.
+		zIndex: 2000,
+		elevation: 2000,
+	},
+	toast: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+		maxWidth: '90%',
+		paddingHorizontal: 16,
+		paddingVertical: 10,
+		borderRadius: borderRadiusContainer,
+		shadowColor: '#000000',
+		shadowOffset: { width: 0, height: 2 },
+		shadowOpacity: 0.25,
+		shadowRadius: 6,
+	},
+	toastText: {
+		color: '#ffffff',
+		fontSize: 14,
+		fontWeight: '600',
+		flexShrink: 1,
+	},
+});

--- a/packages/common-ui/src/constants/ComponentIds.ts
+++ b/packages/common-ui/src/constants/ComponentIds.ts
@@ -10,6 +10,9 @@ export enum CommonUiComponentIds {
 	// Modal
 	MODAL_CLOSE_BUTTON = 'modal-close-button',
 
+	// Toast (see components/Toast) - the currently visible toast message.
+	TOAST = 'common-ui-toast',
+
 	// Avatar editor (see MyAvatarEditor). The quick-start grid is only shown
 	// while no avatar exists yet, so its presence/absence is what tells an E2E
 	// test whether an avatar was actually stored.


### PR DESCRIPTION
Im JSON-Rohdaten-Modal der Enum-Kategorien (neben 'Übernehmen') gibt es
jetzt 'Kopieren'- und 'Einfügen'-Buttons: Kopieren legt den aktuellen
(auch ungespeicherten) Textfeld-Inhalt in die Zwischenablage, Einfügen
füllt das Feld aus der Zwischenablage - übernommen wird weiterhin erst
per 'Übernehmen'. Alle Clipboard-Aktionen und das Übernehmen bestätigen
sich per Toast.

- common-ui: neues ToastProvider/useToast (rendert über dem Modal-Layer,
  zIndex über den 999 des ModalProviders)
- common-ui: SettingsListTextInput.renderModalChildren erhält zusätzlich
  den aktuellen Eingabewert (abwärtskompatibel)
- score-tracker: ToastProvider im Root-Layout um den ModalProvider
  gelegt; Copy/Paste-Buttons inkl. Component-IDs für E2E-Tests

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011QCvio6ceHpda2H9Snpjob