### PR TITLE
chore(frontend): increase build number to 201 for new app build

### DIFF
--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -35,7 +35,7 @@ export enum ConfigCustomerEnum {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	return 200;
+	return 201;
 }
 
 export function getMajorVersion() {


### PR DESCRIPTION
## Zusammenfassung

Erhöht die Build-Nummer der Frontend-App in `apps/frontend/app/config.ts` von **200 auf 201**, damit der nächtliche Sync/Build eine neue native App-Version (21.201.x) erzeugt.

## Hintergrund

Der grüne GPS-Lauf-/Jogging-Button auf dem Lageplan wurde bereits in PR #3998 (21.07.2026) aus dem Code entfernt. Installierte Builds der Version 21.195.x können diese Änderung wegen der `runtimeVersion: { policy: 'appVersion' }`-Einstellung jedoch nicht per OTA-Update erhalten — es braucht einen neuen Store-Build.

## Änderung

- `getBuildNumber()`: `200` → `201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Etzvmxnn89N9jmUrmvWe7t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etzvmxnn89N9jmUrmvWe7t)_