### PR TITLE
Fix ts-node ES2020 compile error in submit:ios:review by using StringHelper

### DIFF
--- a/apps/scripts/base64url.ts
+++ b/apps/scripts/base64url.ts
@@ -1,3 +1,7 @@
+// Deep import so ts-node (target ES2020) only compiles StringHelper.ts instead of the
+// whole common package index.
+import { StringHelper } from 'repo-depkit-common/src/StringHelper';
+
 // Base64url-encodes a value, per RFC 4648 §5 (used for JWT header/payload segments).
 // SonarCloud reliability rule (regex ReDoS): the previous implementation stripped
 // padding with /=+$/ (an unbounded quantifier). Base64 padding is always 0-2 characters,
@@ -5,5 +9,8 @@
 // input size.
 export function base64url(input: Buffer | string): string {
   const buffer = typeof input === 'string' ? Buffer.from(input) : input;
-  return buffer.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/={1,2}$/, '');
+  const base64 = buffer.toString('base64');
+  const withDashes = StringHelper.replaceAllLiteralWithOptions({ str: base64, find: '+', replace: '-' });
+  const urlSafe = StringHelper.replaceAllLiteralWithOptions({ str: withDashes, find: '/', replace: '_' });
+  return urlSafe.replace(/={1,2}$/, '');
 }

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -2,6 +2,9 @@
   "name": "rocket-meals-scripts",
   "version": "1.0.0",
   "private": true,
+  "dependencies": {
+    "repo-depkit-common": "workspace:*"
+  },
   "scripts": {
     "generate:eas": "ts-node --project ./tsconfig.json ./generate-eas-config.ts",
     "analyze:data-clumps": "ts-node --project ./tsconfig.json ./analyze-data-clumps.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27229,6 +27229,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^22.9.4"
     jest: "npm:^29.7.0"
+    repo-depkit-common: "workspace:*"
     ts-jest: "npm:^29.1.3"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.8.3"


### PR DESCRIPTION
String.prototype.replaceAll requires ES2021, but apps/scripts compiles with
target ES2020, so ts-node failed with TS2550 when running submit:ios:review.
Replace the native replaceAll calls in base64url.ts with the ES2020-compatible
StringHelper.replaceAllLiteralWithOptions from the repo-depkit-common package
and add that workspace dependency to rocket-meals-scripts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01285xcFa7YUg7giHnQnrKXC