### PR TITLE
Automate iOS App Review submission and add daily review status check

### DIFF
--- a/.github/workflows/ios-review-status.yml
+++ b/.github/workflows/ios-review-status.yml
@@ -1,0 +1,108 @@
+name: "🍎 iOS App Review Status"
+
+on:
+  # Daily status check: fails loudly when Apple rejected a version, succeeds with a
+  # hint when an approved version waits for its manual release, and is a quiet
+  # no-op otherwise.
+  schedule:
+    - cron: '30 5 * * *'
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  check-review-status:
+    name: "🔍 Check App Review Status: ${{ matrix.app }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Rocket Meals: bundle id depends on the repository (tenant forks build
+          # their own app), resolved from the customer config below.
+          - app: "Rocket Meals"
+            upstream_only: false
+          - app: "Geonexia"
+            bundle_id: de.baumgartner-software.geonexia
+            upstream_only: true
+          - app: "Score Tracker"
+            bundle_id: de.baumgartner-software.score-tracker
+            upstream_only: true
+    steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      # Geonexia and Score Tracker only exist in the upstream repository, and forks
+      # (tenant repositories) may not have the App Store Connect key configured -
+      # in both cases skip quietly instead of failing every day.
+      - name: "🔐 Check preconditions"
+        id: guard
+        env:
+          ASC_KEY: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+          UPSTREAM_ONLY: ${{ matrix.upstream_only }}
+        run: |
+          if [ "$UPSTREAM_ONLY" = "true" ] && [ "${{ github.repository }}" != "rocket-meals/rocket-meals" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ ${{ matrix.app }} wird nur im Upstream-Repository geprüft - übersprungen."
+          elif [ -z "$ASC_KEY" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Secret EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT ist nicht gesetzt - übersprungen."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "⚙️ Setup Node.js"
+        if: steps.guard.outputs.available == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+
+      - name: "⚙️ Enable Corepack for Yarn v2"
+        if: steps.guard.outputs.available == 'true'
+        run: corepack enable
+
+      - name: "📦 Install dependencies"
+        if: steps.guard.outputs.available == 'true'
+        # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
+        # the status script only needs ts-node/typescript, which require no build step.
+        run: yarn install --immutable --mode=skip-build
+
+      - name: "🔐 Prepare Apple App Store Connect API key"
+        if: steps.guard.outputs.available == 'true'
+        uses: ./.github/actions/prepare-asc-api-key
+        with:
+          EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+
+      - name: "🏷️ Resolve customer from repository name"
+        if: steps.guard.outputs.available == 'true' && matrix.bundle_id == ''
+        run: bash scripts/customer-config.sh >> "$GITHUB_ENV"
+
+      - name: "📱 Resolve iOS bundle identifier"
+        if: steps.guard.outputs.available == 'true'
+        working-directory: ./apps/frontend/app
+        env:
+          MATRIX_BUNDLE_ID: ${{ matrix.bundle_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$MATRIX_BUNDLE_ID" ]; then
+            BUNDLE_ID="$MATRIX_BUNDLE_ID"
+          else
+            BUNDLE_ID=$(node - <<'EOF'
+          require('ts-node').register({
+            transpileOnly: true,
+            compilerOptions: { module: 'Node16', moduleResolution: 'node16' },
+          });
+          const { getCustomerConfig } = require('./config.ts');
+          console.log(getCustomerConfig().bundleIdIos);
+          EOF
+          )
+          fi
+          echo "IOS_BUNDLE_ID=${BUNDLE_ID}" >> "$GITHUB_ENV"
+
+      - name: "🔍 Check App Review status"
+        if: steps.guard.outputs.available == 'true'
+        run: yarn workspace rocket-meals-scripts check:ios:review-status

--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: "Fehlerbehebungen und Aktualisierung von Bibliotheken."
 
-  # Daily check: as soon as the previous version cleared App Review (or was released)
-  # and a newer processed build exists, it is submitted automatically.
-  schedule:
-    - cron: '20 5 * * *'
-
   # After a successful CI run a new iOS build may have been uploaded. Apple needs a
   # while to process it, so the submit script waits for processing builds
   # (IOS_SUBMIT_MAX_WAIT_MINUTES) and submits once the build turns VALID.
@@ -21,7 +16,7 @@ on:
     types: [completed]
     branches: [master]
 
-# Serialize runs so a scheduled run and a post-CI run never submit concurrently.
+# Serialize runs so a manual run and a post-CI run never submit concurrently.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -31,8 +26,8 @@ jobs:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    # Geonexia is only built in the upstream repository, so automated runs (schedule /
-    # post-CI) are upstream-only; manual dispatch stays possible everywhere. The post-CI
+    # Geonexia is only built in the upstream repository, so automated (post-CI)
+    # runs are upstream-only; manual dispatch stays possible everywhere. The post-CI
     # trigger additionally reacts only to successful CI runs.
     if: >-
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') &&
@@ -66,7 +61,7 @@ jobs:
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.geonexia
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
-          # Scheduled and post-CI runs skip gracefully when there is nothing to submit
+          # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
           # Only the post-CI trigger waits for Apple to finish processing a fresh build.

--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -8,10 +8,35 @@ on:
         required: false
         default: "Fehlerbehebungen und Aktualisierung von Bibliotheken."
 
+  # Daily check: as soon as the previous version cleared App Review (or was released)
+  # and a newer processed build exists, it is submitted automatically.
+  schedule:
+    - cron: '20 5 * * *'
+
+  # After a successful CI run a new iOS build may have been uploaded. Apple needs a
+  # while to process it, so the submit script waits for processing builds
+  # (IOS_SUBMIT_MAX_WAIT_MINUTES) and submits once the build turns VALID.
+  workflow_run:
+    workflows: ["🚀 CI"]
+    types: [completed]
+    branches: [master]
+
+# Serialize runs so a scheduled run and a post-CI run never submit concurrently.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   submit-for-review:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # Geonexia is only built in the upstream repository, so automated runs (schedule /
+    # post-CI) are upstream-only; manual dispatch stays possible everywhere. The post-CI
+    # trigger additionally reacts only to successful CI runs.
+    if: >-
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') &&
+      (github.event_name == 'workflow_dispatch' || github.repository == 'rocket-meals/rocket-meals')
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
@@ -40,4 +65,9 @@ jobs:
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.geonexia
-          IOS_RELEASE_NOTES: ${{ inputs.release_notes }}
+          IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
+          # Scheduled and post-CI runs skip gracefully when there is nothing to submit
+          # and never re-submit versions Apple has rejected.
+          IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
+          # Only the post-CI trigger waits for Apple to finish processing a fresh build.
+          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '90' || '0' }}

--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -16,16 +16,18 @@ on:
     types: [completed]
     branches: [master]
 
-# Serialize runs so a manual run and a post-CI run never submit concurrently.
+# Only the newest run per app survives: when several builds are created back to
+# back, a newer run cancels an older one that is still waiting for Apple to
+# process its (now outdated) build - the newest run submits the newest build.
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   submit-for-review:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 150
     # Geonexia is only built in the upstream repository, so automated (post-CI)
     # runs are upstream-only; manual dispatch stays possible everywhere. The post-CI
     # trigger additionally reacts only to successful CI runs.
@@ -64,5 +66,6 @@ jobs:
           # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
-          # Only the post-CI trigger waits for Apple to finish processing a fresh build.
-          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '90' || '0' }}
+          # Only the post-CI trigger waits for Apple to finish processing a fresh build
+          # (up to 120 minutes from build upload until it is submittable).
+          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '120' || '0' }}

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -16,16 +16,18 @@ on:
     types: [completed]
     branches: [master]
 
-# Serialize runs so a manual run and a post-CI run never submit concurrently.
+# Only the newest run per app survives: when several builds are created back to
+# back, a newer run cancels an older one that is still waiting for Apple to
+# process its (now outdated) build - the newest run submits the newest build.
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   submit-for-review:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 150
     # Post-CI trigger only reacts to successful CI runs; manual runs always go.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
@@ -99,5 +101,6 @@ jobs:
           # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
-          # Only the post-CI trigger waits for Apple to finish processing a fresh build.
-          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '90' || '0' }}
+          # Only the post-CI trigger waits for Apple to finish processing a fresh build
+          # (up to 120 minutes from build upload until it is submittable).
+          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '120' || '0' }}

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -8,38 +8,79 @@ on:
         required: false
         default: "Fehlerbehebungen und Aktualisierung von Bibliotheken."
 
+  # Daily check: as soon as the previous version cleared App Review (or was released)
+  # and a newer processed build exists, it is submitted automatically.
+  schedule:
+    - cron: '0 5 * * *'
+
+  # After a successful CI run a new iOS build may have been uploaded. Apple needs a
+  # while to process it, so the submit script waits for processing builds
+  # (IOS_SUBMIT_MAX_WAIT_MINUTES) and submits once the build turns VALID.
+  workflow_run:
+    workflows: ["🚀 CI"]
+    types: [completed]
+    branches: [master]
+
+# Serialize runs so a scheduled run and a post-CI run never submit concurrently.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   submit-for-review:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # Post-CI trigger only reacts to successful CI runs; schedule and manual runs always go.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
         with:
           ref: master
 
+      # Forks (tenant repositories) may not have the App Store Connect key configured -
+      # in that case automated runs should skip quietly instead of failing every day.
+      - name: "🔐 Check App Store Connect credentials"
+        id: guard
+        env:
+          ASC_KEY: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+        run: |
+          if [ -n "$ASC_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Secret EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT ist nicht gesetzt - Submit wird übersprungen."
+          fi
+
       - name: "⚙️ Setup Node.js"
+        if: steps.guard.outputs.available == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
 
       - name: "⚙️ Enable Corepack for Yarn v2"
+        if: steps.guard.outputs.available == 'true'
         run: corepack enable
 
       - name: "📦 Install dependencies"
+        if: steps.guard.outputs.available == 'true'
         # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
         # the submit script only needs ts-node/typescript, which require no build step.
         run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
+        if: steps.guard.outputs.available == 'true'
         uses: ./.github/actions/prepare-asc-api-key
         with:
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
 
       - name: "🏷️ Resolve customer from repository name"
+        if: steps.guard.outputs.available == 'true'
         run: bash scripts/customer-config.sh >> "$GITHUB_ENV"
 
       - name: "📱 Resolve iOS bundle identifier"
+        if: steps.guard.outputs.available == 'true'
         working-directory: ./apps/frontend/app
         run: |
           set -euo pipefail
@@ -56,6 +97,12 @@ jobs:
           echo "IOS_BUNDLE_ID=${BUNDLE_ID}" >> "$GITHUB_ENV"
 
       - name: "🚀 Submit latest build for App Review"
+        if: steps.guard.outputs.available == 'true'
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
-          IOS_RELEASE_NOTES: ${{ inputs.release_notes }}
+          IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
+          # Scheduled and post-CI runs skip gracefully when there is nothing to submit
+          # and never re-submit versions Apple has rejected.
+          IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
+          # Only the post-CI trigger waits for Apple to finish processing a fresh build.
+          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '90' || '0' }}

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: "Fehlerbehebungen und Aktualisierung von Bibliotheken."
 
-  # Daily check: as soon as the previous version cleared App Review (or was released)
-  # and a newer processed build exists, it is submitted automatically.
-  schedule:
-    - cron: '0 5 * * *'
-
   # After a successful CI run a new iOS build may have been uploaded. Apple needs a
   # while to process it, so the submit script waits for processing builds
   # (IOS_SUBMIT_MAX_WAIT_MINUTES) and submits once the build turns VALID.
@@ -21,7 +16,7 @@ on:
     types: [completed]
     branches: [master]
 
-# Serialize runs so a scheduled run and a post-CI run never submit concurrently.
+# Serialize runs so a manual run and a post-CI run never submit concurrently.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -31,7 +26,7 @@ jobs:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    # Post-CI trigger only reacts to successful CI runs; schedule and manual runs always go.
+    # Post-CI trigger only reacts to successful CI runs; manual runs always go.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: "🔄 Checkout Repository"
@@ -101,7 +96,7 @@ jobs:
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
-          # Scheduled and post-CI runs skip gracefully when there is nothing to submit
+          # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
           # Only the post-CI trigger waits for Apple to finish processing a fresh build.

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -16,16 +16,18 @@ on:
     types: [completed]
     branches: [master]
 
-# Serialize runs so a manual run and a post-CI run never submit concurrently.
+# Only the newest run per app survives: when several builds are created back to
+# back, a newer run cancels an older one that is still waiting for Apple to
+# process its (now outdated) build - the newest run submits the newest build.
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   submit-for-review:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 150
     # Score Tracker is only built in the upstream repository, so automated (post-CI)
     # runs are upstream-only; manual dispatch stays possible everywhere. The post-CI
     # trigger additionally reacts only to successful CI runs.
@@ -64,5 +66,6 @@ jobs:
           # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
-          # Only the post-CI trigger waits for Apple to finish processing a fresh build.
-          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '90' || '0' }}
+          # Only the post-CI trigger waits for Apple to finish processing a fresh build
+          # (up to 120 minutes from build upload until it is submittable).
+          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '120' || '0' }}

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -8,10 +8,35 @@ on:
         required: false
         default: "Fehlerbehebungen und Aktualisierung von Bibliotheken."
 
+  # Daily check: as soon as the previous version cleared App Review (or was released)
+  # and a newer processed build exists, it is submitted automatically.
+  schedule:
+    - cron: '40 5 * * *'
+
+  # After a successful CI run a new iOS build may have been uploaded. Apple needs a
+  # while to process it, so the submit script waits for processing builds
+  # (IOS_SUBMIT_MAX_WAIT_MINUTES) and submits once the build turns VALID.
+  workflow_run:
+    workflows: ["🚀 CI"]
+    types: [completed]
+    branches: [master]
+
+# Serialize runs so a scheduled run and a post-CI run never submit concurrently.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   submit-for-review:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # Score Tracker is only built in the upstream repository, so automated runs (schedule /
+    # post-CI) are upstream-only; manual dispatch stays possible everywhere. The post-CI
+    # trigger additionally reacts only to successful CI runs.
+    if: >-
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') &&
+      (github.event_name == 'workflow_dispatch' || github.repository == 'rocket-meals/rocket-meals')
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4
@@ -40,4 +65,9 @@ jobs:
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.score-tracker
-          IOS_RELEASE_NOTES: ${{ inputs.release_notes }}
+          IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
+          # Scheduled and post-CI runs skip gracefully when there is nothing to submit
+          # and never re-submit versions Apple has rejected.
+          IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
+          # Only the post-CI trigger waits for Apple to finish processing a fresh build.
+          IOS_SUBMIT_MAX_WAIT_MINUTES: ${{ github.event_name == 'workflow_run' && '90' || '0' }}

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: "Fehlerbehebungen und Aktualisierung von Bibliotheken."
 
-  # Daily check: as soon as the previous version cleared App Review (or was released)
-  # and a newer processed build exists, it is submitted automatically.
-  schedule:
-    - cron: '40 5 * * *'
-
   # After a successful CI run a new iOS build may have been uploaded. Apple needs a
   # while to process it, so the submit script waits for processing builds
   # (IOS_SUBMIT_MAX_WAIT_MINUTES) and submits once the build turns VALID.
@@ -21,7 +16,7 @@ on:
     types: [completed]
     branches: [master]
 
-# Serialize runs so a scheduled run and a post-CI run never submit concurrently.
+# Serialize runs so a manual run and a post-CI run never submit concurrently.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -31,8 +26,8 @@ jobs:
     name: "🚀 Submit latest build for App Review"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    # Score Tracker is only built in the upstream repository, so automated runs (schedule /
-    # post-CI) are upstream-only; manual dispatch stays possible everywhere. The post-CI
+    # Score Tracker is only built in the upstream repository, so automated (post-CI)
+    # runs are upstream-only; manual dispatch stays possible everywhere. The post-CI
     # trigger additionally reacts only to successful CI runs.
     if: >-
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') &&
@@ -66,7 +61,7 @@ jobs:
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.score-tracker
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
-          # Scheduled and post-CI runs skip gracefully when there is nothing to submit
+          # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}
           # Only the post-CI trigger waits for Apple to finish processing a fresh build.

--- a/apps/scripts/asc-api.ts
+++ b/apps/scripts/asc-api.ts
@@ -1,0 +1,93 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import { base64url } from './base64url';
+
+// Shared App Store Connect API helpers used by submit-ios-review.ts and
+// check-ios-review-status.ts.
+
+export const API_BASE = 'https://api.appstoreconnect.apple.com/v1';
+
+export type JsonApiResource = {
+  type: string;
+  id: string;
+  attributes?: Record<string, unknown>;
+  relationships?: Record<string, { data?: { type: string; id: string } | null }>;
+};
+
+export type JsonApiDocument = {
+  data?: JsonApiResource | JsonApiResource[];
+  included?: JsonApiResource[];
+};
+
+export function createAppStoreConnectToken(keyId: string, issuerId: string, privateKeyPath: string): string {
+  const privateKey = fs.readFileSync(privateKeyPath, 'utf8');
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'ES256', kid: keyId, typ: 'JWT' };
+  const payload = { iss: issuerId, iat: now, exp: now + 15 * 60, aud: 'appstoreconnect-v1' };
+  const unsigned = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  // App Store Connect expects the raw R||S signature (JOSE), not the DER encoding Node uses by default.
+  const signature = crypto.sign('sha256', Buffer.from(unsigned), { key: privateKey, dsaEncoding: 'ieee-p1363' });
+  return `${unsigned}.${base64url(signature)}`;
+}
+
+export type AscApiErrorDetail = { code?: string; detail?: string };
+
+export class AscApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly errors: AscApiErrorDetail[],
+    rawText: string,
+    method: string,
+    path: string
+  ) {
+    super(`App Store Connect API Fehler (${status} ${method} ${path}):\n${rawText}`);
+  }
+}
+
+export async function ascRequest(token: string, method: string, path: string, body?: unknown): Promise<JsonApiDocument> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    let errors: AscApiErrorDetail[] = [];
+    try {
+      errors = (JSON.parse(text) as { errors?: AscApiErrorDetail[] }).errors ?? [];
+    } catch {
+      // response body wasn't JSON - leave errors empty, raw text is still in the thrown error message
+    }
+    throw new AscApiError(response.status, errors, text, method, path);
+  }
+
+  return text ? JSON.parse(text) : {};
+}
+
+export function asArray(data: JsonApiResource | JsonApiResource[] | undefined): JsonApiResource[] {
+  if (!data) return [];
+  return Array.isArray(data) ? data : [data];
+}
+
+export async function findAppId(token: string, bundleId: string): Promise<string> {
+  const query = new URLSearchParams({ 'filter[bundleId]': bundleId });
+  const result = await ascRequest(token, 'GET', `/apps?${query}`);
+  const app = asArray(result.data)[0];
+  if (!app) {
+    throw new Error(`Keine App mit bundleId "${bundleId}" in App Store Connect gefunden.`);
+  }
+  return app.id;
+}
+
+export function readRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is not set.`);
+  }
+  return value;
+}

--- a/apps/scripts/check-ios-review-status.ts
+++ b/apps/scripts/check-ios-review-status.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs';
+import { JsonApiResource, asArray, ascRequest, createAppStoreConnectToken, findAppId, readRequiredEnv } from './asc-api';
+
+// Daily App Review status check. Exit code semantics for CI:
+// - Apple (or the developer) rejected a version           -> exit 1 (red run = action needed)
+// - a version is approved and waits for the manual release -> exit 0 with a loud hint
+// - anything else (in review, released, draft, ...)        -> exit 0, nothing to do
+
+// https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionstate
+const REJECTED_APP_VERSION_STATES = new Set(['REJECTED', 'METADATA_REJECTED', 'DEVELOPER_REJECTED', 'INVALID_BINARY']);
+const RELEASABLE_APP_VERSION_STATES = new Set(['PENDING_DEVELOPER_RELEASE']);
+
+function versionState(version: JsonApiResource): string {
+  return (version.attributes?.appStoreState as string) ?? 'UNKNOWN';
+}
+
+function versionString(version: JsonApiResource): string {
+  return (version.attributes?.versionString as string) ?? '?';
+}
+
+function appendStepSummary(lines: string[]): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  fs.appendFileSync(summaryPath, lines.join('\n') + '\n');
+}
+
+async function main(): Promise<void> {
+  const bundleId = readRequiredEnv('IOS_BUNDLE_ID');
+  const keyId = readRequiredEnv('EXPO_ASC_KEY_ID');
+  const issuerId = readRequiredEnv('EXPO_ASC_ISSUER_ID');
+  const privateKeyPath = readRequiredEnv('EXPO_ASC_API_KEY_PATH');
+
+  const token = createAppStoreConnectToken(keyId, issuerId, privateKeyPath);
+
+  console.log(`🔍 Suche App mit bundleId "${bundleId}" ...`);
+  const appId = await findAppId(token, bundleId);
+  console.log(`✅ App gefunden (id: ${appId})\n`);
+
+  const versionsQuery = new URLSearchParams({ 'filter[platform]': 'IOS' });
+  const versionsDoc = await ascRequest(token, 'GET', `/apps/${appId}/appStoreVersions?${versionsQuery}`);
+  const versions = asArray(versionsDoc.data);
+
+  const submissionsQuery = new URLSearchParams({ 'filter[app]': appId, 'filter[platform]': 'IOS' });
+  const submissionsDoc = await ascRequest(token, 'GET', `/reviewSubmissions?${submissionsQuery}`);
+  const submissions = asArray(submissionsDoc.data);
+
+  console.log('📋 App Store Versionen:');
+  for (const version of versions) {
+    console.log(`   - ${versionString(version)}: ${versionState(version)}`);
+  }
+  if (versions.length === 0) {
+    console.log('   (keine)');
+  }
+
+  console.log('📋 Review-Einreichungen:');
+  for (const submission of submissions) {
+    console.log(`   - ${submission.id}: ${submission.attributes?.state}`);
+  }
+  if (submissions.length === 0) {
+    console.log('   (keine)');
+  }
+  console.log('');
+
+  appendStepSummary([
+    `### 🍎 App Review Status: \`${bundleId}\``,
+    '',
+    '| App Store Version | Status |',
+    '| --- | --- |',
+    ...versions.map(v => `| ${versionString(v)} | \`${versionState(v)}\` |`),
+    ...(versions.length === 0 ? ['| _keine_ | - |'] : []),
+    '',
+  ]);
+
+  const rejected = versions.filter(v => REJECTED_APP_VERSION_STATES.has(versionState(v)));
+  if (rejected.length > 0) {
+    const details = rejected.map(v => `${versionString(v)} (${versionState(v)})`).join(', ');
+    appendStepSummary([`❌ **Abgelehnt / Aktion erforderlich:** ${details}`, '']);
+    console.error(
+      `❌ Version(en) wurden abgelehnt oder benötigen manuelle Aktion: ${details}\n` +
+        '   Bitte in App Store Connect prüfen und nach der Korrektur manuell per workflow_dispatch neu einreichen.'
+    );
+    process.exit(1);
+  }
+
+  const releasable = versions.filter(v => RELEASABLE_APP_VERSION_STATES.has(versionState(v)));
+  if (releasable.length > 0) {
+    const details = releasable.map(v => versionString(v)).join(', ');
+    appendStepSummary([`🎉 **Freigegeben - kann veröffentlicht werden:** ${details}`, '']);
+    console.log(
+      `🎉 Version(en) ${details} wurden von Apple freigegeben und können in App Store Connect veröffentlicht werden.`
+    );
+    return;
+  }
+
+  appendStepSummary(['⏭️ Keine Aktion erforderlich.', '']);
+  console.log('⏭️ Keine Aktion erforderlich - keine Ablehnung und nichts zur Veröffentlichung bereit.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -9,6 +9,7 @@
     "generate:eas": "ts-node --project ./tsconfig.json ./generate-eas-config.ts",
     "analyze:data-clumps": "ts-node --project ./tsconfig.json ./analyze-data-clumps.ts",
     "submit:ios:review": "ts-node --project ./tsconfig.json ./submit-ios-review.ts",
+    "check:ios:review-status": "ts-node --project ./tsconfig.json ./check-ios-review-status.ts",
     "apk:extract-url": "ts-node --project ./tsconfig.json ./android-preview-apk.ts extract",
     "build-number:compare-online": "ts-node --project ./tsconfig.json ./check-build-version.ts compare",
     "apk:update-readme": "ts-node --project ./tsconfig.json ./android-preview-apk.ts update-readme",

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -1,8 +1,4 @@
-import * as crypto from 'node:crypto';
-import * as fs from 'node:fs';
-import { base64url } from './base64url';
-
-const API_BASE = 'https://api.appstoreconnect.apple.com/v1';
+import { AscApiError, JsonApiResource, asArray, ascRequest, createAppStoreConnectToken, findAppId, readRequiredEnv } from './asc-api';
 
 // https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionstate
 const SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'REJECTED', 'METADATA_REJECTED', 'INVALID_BINARY']);
@@ -41,83 +37,6 @@ class SkipSubmission extends Error {
 // submission), in auto mode they are expected and just end the run gracefully.
 function submissionBlocked(message: string, retryWhileProcessing = false): Error {
   return AUTO_MODE ? new SkipSubmission(message, retryWhileProcessing) : new Error(message);
-}
-
-type JsonApiResource = {
-  type: string;
-  id: string;
-  attributes?: Record<string, unknown>;
-  relationships?: Record<string, { data?: { type: string; id: string } | null }>;
-};
-
-type JsonApiDocument = {
-  data?: JsonApiResource | JsonApiResource[];
-  included?: JsonApiResource[];
-};
-
-function createAppStoreConnectToken(keyId: string, issuerId: string, privateKeyPath: string): string {
-  const privateKey = fs.readFileSync(privateKeyPath, 'utf8');
-  const now = Math.floor(Date.now() / 1000);
-  const header = { alg: 'ES256', kid: keyId, typ: 'JWT' };
-  const payload = { iss: issuerId, iat: now, exp: now + 15 * 60, aud: 'appstoreconnect-v1' };
-  const unsigned = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
-  // App Store Connect expects the raw R||S signature (JOSE), not the DER encoding Node uses by default.
-  const signature = crypto.sign('sha256', Buffer.from(unsigned), { key: privateKey, dsaEncoding: 'ieee-p1363' });
-  return `${unsigned}.${base64url(signature)}`;
-}
-
-type AscApiErrorDetail = { code?: string; detail?: string };
-
-class AscApiError extends Error {
-  constructor(
-    public readonly status: number,
-    public readonly errors: AscApiErrorDetail[],
-    rawText: string,
-    method: string,
-    path: string
-  ) {
-    super(`App Store Connect API Fehler (${status} ${method} ${path}):\n${rawText}`);
-  }
-}
-
-async function ascRequest(token: string, method: string, path: string, body?: unknown): Promise<JsonApiDocument> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-
-  const text = await response.text();
-
-  if (!response.ok) {
-    let errors: AscApiErrorDetail[] = [];
-    try {
-      errors = (JSON.parse(text) as { errors?: AscApiErrorDetail[] }).errors ?? [];
-    } catch {
-      // response body wasn't JSON - leave errors empty, raw text is still in the thrown error message
-    }
-    throw new AscApiError(response.status, errors, text, method, path);
-  }
-
-  return text ? JSON.parse(text) : {};
-}
-
-function asArray(data: JsonApiResource | JsonApiResource[] | undefined): JsonApiResource[] {
-  if (!data) return [];
-  return Array.isArray(data) ? data : [data];
-}
-
-async function findAppId(token: string, bundleId: string): Promise<string> {
-  const query = new URLSearchParams({ 'filter[bundleId]': bundleId });
-  const result = await ascRequest(token, 'GET', `/apps?${query}`);
-  const app = asArray(result.data)[0];
-  if (!app) {
-    throw new Error(`Keine App mit bundleId "${bundleId}" in App Store Connect gefunden.`);
-  }
-  return app.id;
 }
 
 async function findLatestValidBuild(token: string, appId: string): Promise<{ buildId: string; version: string }> {
@@ -327,14 +246,6 @@ async function hasProcessingBuild(token: string, appId: string): Promise<boolean
 
 function sleepMinutes(minutes: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, minutes * 60 * 1000));
-}
-
-function readRequiredEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Environment variable ${name} is not set.`);
-  }
-  return value;
 }
 
 type Credentials = { keyId: string; issuerId: string; privateKeyPath: string };

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -10,6 +10,39 @@ const SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVEL
 // https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmission
 const NON_TERMINAL_REVIEW_SUBMISSION_STATES = new Set(['READY_FOR_REVIEW', 'WAITING_FOR_REVIEW', 'IN_REVIEW', 'UNRESOLVED_ISSUES', 'CANCELING', 'COMPLETING']);
 
+// Automated (scheduled / post-CI) runs must never blindly re-submit a version Apple has
+// rejected - that needs a human to look at the rejection first. Only untouched drafts
+// are submitted without a human in the loop.
+const AUTO_SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION']);
+
+// IOS_SUBMIT_AUTO=true turns "nothing to submit" situations into a graceful exit 0
+// instead of a hard error, so scheduled runs don't show up as failures.
+const AUTO_MODE = process.env.IOS_SUBMIT_AUTO === 'true';
+
+// While a freshly uploaded build is still being processed by Apple, wait up to this many
+// minutes for it to become VALID before giving up (used by the post-CI trigger).
+const MAX_WAIT_MINUTES = Number(process.env.IOS_SUBMIT_MAX_WAIT_MINUTES ?? '0');
+const POLL_INTERVAL_MINUTES = 5;
+// Grace period in which we also retry when no processing build is visible yet - the
+// upload from CI may not have arrived at Apple at the moment this script starts.
+const INITIAL_GRACE_MINUTES = 15;
+
+// Thrown in auto mode when there is nothing that can (or should) be submitted right now.
+class SkipSubmission extends Error {
+  constructor(
+    message: string,
+    public readonly retryWhileProcessing: boolean = false
+  ) {
+    super(message);
+  }
+}
+
+// In manual mode blocked submissions are real errors (the user explicitly asked for a
+// submission), in auto mode they are expected and just end the run gracefully.
+function submissionBlocked(message: string, retryWhileProcessing = false): Error {
+  return AUTO_MODE ? new SkipSubmission(message, retryWhileProcessing) : new Error(message);
+}
+
 type JsonApiResource = {
   type: string;
   id: string;
@@ -99,7 +132,7 @@ async function findLatestValidBuild(token: string, appId: string): Promise<{ bui
   const result = await ascRequest(token, 'GET', `/builds?${query}`);
   const build = asArray(result.data)[0];
   if (!build) {
-    throw new Error(`Kein verarbeiteter (VALID) Build für App ${appId} gefunden. Wurde bereits ein Build hochgeladen und von Apple verarbeitet?`);
+    throw submissionBlocked(`Kein verarbeiteter (VALID) Build für App ${appId} gefunden. Wurde bereits ein Build hochgeladen und von Apple verarbeitet?`, true);
   }
 
   const preReleaseVersionId = build.relationships?.preReleaseVersion?.data?.id;
@@ -128,8 +161,17 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
   if (exactMatch) {
     const state = exactMatch.attributes?.appStoreState as string;
     if (!SUBMITTABLE_APP_VERSION_STATES.has(state)) {
-      throw new Error(
-        `App Store Version ${versionString} existiert bereits mit Status "${state}" und kann nicht automatisch eingereicht werden. Bitte manuell in App Store Connect prüfen.`
+      // e.g. WAITING_FOR_REVIEW, IN_REVIEW, PENDING_DEVELOPER_RELEASE, READY_FOR_SALE.
+      // Retry-worthy in auto mode: a build that is still processing may carry a new
+      // version number and change the situation.
+      throw submissionBlocked(
+        `App Store Version ${versionString} existiert bereits mit Status "${state}" und kann nicht automatisch eingereicht werden. Bitte manuell in App Store Connect prüfen.`,
+        true
+      );
+    }
+    if (AUTO_MODE && !AUTO_SUBMITTABLE_APP_VERSION_STATES.has(state)) {
+      throw new SkipSubmission(
+        `App Store Version ${versionString} hat den Status "${state}" (Ablehnung durch Apple?). Automatische Wieder-Einreichung ist deaktiviert - bitte prüfen und bei Bedarf manuell per workflow_dispatch einreichen.`
       );
     }
     return exactMatch.id;
@@ -137,6 +179,12 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
 
   const editableVersion = versions.find(v => SUBMITTABLE_APP_VERSION_STATES.has(v.attributes?.appStoreState as string));
   if (editableVersion) {
+    const editableState = editableVersion.attributes?.appStoreState as string;
+    if (AUTO_MODE && !AUTO_SUBMITTABLE_APP_VERSION_STATES.has(editableState)) {
+      throw new SkipSubmission(
+        `Vorhandene Entwurfsversion "${editableVersion.attributes?.versionString}" hat den Status "${editableState}" (Ablehnung durch Apple?). Automatische Wieder-Einreichung ist deaktiviert - bitte prüfen und bei Bedarf manuell per workflow_dispatch einreichen.`
+      );
+    }
     console.log(`   Benenne vorhandene Entwurfsversion "${editableVersion.attributes?.versionString}" (${editableVersion.id}) zu "${versionString}" um ...`);
     await ascRequest(token, 'PATCH', `/appStoreVersions/${editableVersion.id}`, {
       data: {
@@ -148,15 +196,26 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
     return editableVersion.id;
   }
 
-  const created = await ascRequest(token, 'POST', '/appStoreVersions', {
-    data: {
-      type: 'appStoreVersions',
-      attributes: { platform: 'IOS', versionString, releaseType: 'MANUAL' },
-      relationships: { app: { data: { type: 'apps', id: appId } } },
-    },
-  });
-
-  return (created.data as JsonApiResource).id;
+  try {
+    const created = await ascRequest(token, 'POST', '/appStoreVersions', {
+      data: {
+        type: 'appStoreVersions',
+        attributes: { platform: 'IOS', versionString, releaseType: 'MANUAL' },
+        relationships: { app: { data: { type: 'apps', id: appId } } },
+      },
+    });
+    return (created.data as JsonApiResource).id;
+  } catch (error) {
+    // Apple allows only one editable version at a time; e.g. while an approved version
+    // still waits for its manual release, creating the next one fails with 409. In auto
+    // mode that just means "not now" - the next scheduled run will try again.
+    if (AUTO_MODE && error instanceof AscApiError && error.status === 409) {
+      throw new SkipSubmission(
+        `Neue App Store Version ${versionString} kann aktuell nicht angelegt werden (409 von App Store Connect) - z. B. wartet eine freigegebene Version noch auf den manuellen Release. Details: ${error.message}`
+      );
+    }
+    throw error;
+  }
 }
 
 async function attachBuild(token: string, appStoreVersionId: string, buildId: string): Promise<void> {
@@ -214,7 +273,7 @@ async function findReusableReviewSubmission(token: string, appId: string): Promi
 
   const state = active.attributes?.state as string;
   if (state !== 'READY_FOR_REVIEW') {
-    throw new Error(
+    throw submissionBlocked(
       `Für diese App läuft bereits eine Review-Einreichung (Status "${state}"). Bitte in App Store Connect prüfen, bevor eine neue Einreichung gestartet wird.`
     );
   }
@@ -255,6 +314,21 @@ async function submitReviewSubmission(token: string, reviewSubmissionId: string)
   });
 }
 
+async function hasProcessingBuild(token: string, appId: string): Promise<boolean> {
+  const query = new URLSearchParams({
+    'filter[app]': appId,
+    'filter[processingState]': 'PROCESSING',
+    sort: '-uploadedDate',
+    limit: '1',
+  });
+  const result = await ascRequest(token, 'GET', `/builds?${query}`);
+  return asArray(result.data).length > 0;
+}
+
+function sleepMinutes(minutes: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, minutes * 60 * 1000));
+}
+
 function readRequiredEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
@@ -263,14 +337,12 @@ function readRequiredEnv(name: string): string {
   return value;
 }
 
-async function main(): Promise<void> {
-  const bundleId = readRequiredEnv('IOS_BUNDLE_ID');
-  const releaseNotes = readRequiredEnv('IOS_RELEASE_NOTES');
-  const keyId = readRequiredEnv('EXPO_ASC_KEY_ID');
-  const issuerId = readRequiredEnv('EXPO_ASC_ISSUER_ID');
-  const privateKeyPath = readRequiredEnv('EXPO_ASC_API_KEY_PATH');
+type Credentials = { keyId: string; issuerId: string; privateKeyPath: string };
 
-  const token = createAppStoreConnectToken(keyId, issuerId, privateKeyPath);
+async function attemptSubmission(bundleId: string, releaseNotes: string, credentials: Credentials): Promise<void> {
+  // The App Store Connect JWT expires after 15 minutes, so every attempt of the
+  // retry loop below needs a fresh one.
+  const token = createAppStoreConnectToken(credentials.keyId, credentials.issuerId, credentials.privateKeyPath);
 
   console.log(`🔍 Suche App mit bundleId "${bundleId}" ...`);
   const appId = await findAppId(token, bundleId);
@@ -302,6 +374,55 @@ async function main(): Promise<void> {
   await submitReviewSubmission(token, reviewSubmissionId);
 
   console.log(`\n🎉 App Store Version ${version} (Build ${buildId}) wurde erfolgreich zur Review eingereicht.`);
+}
+
+async function main(): Promise<void> {
+  const bundleId = readRequiredEnv('IOS_BUNDLE_ID');
+  const releaseNotes = readRequiredEnv('IOS_RELEASE_NOTES');
+  const credentials: Credentials = {
+    keyId: readRequiredEnv('EXPO_ASC_KEY_ID'),
+    issuerId: readRequiredEnv('EXPO_ASC_ISSUER_ID'),
+    privateKeyPath: readRequiredEnv('EXPO_ASC_API_KEY_PATH'),
+  };
+
+  if (AUTO_MODE) {
+    console.log(`🤖 Automatischer Modus aktiv (max. Wartezeit auf Apple-Verarbeitung: ${MAX_WAIT_MINUTES} Minuten).\n`);
+  }
+
+  const deadline = Date.now() + MAX_WAIT_MINUTES * 60 * 1000;
+  const graceDeadline = Date.now() + Math.min(MAX_WAIT_MINUTES, INITIAL_GRACE_MINUTES) * 60 * 1000;
+
+  // In auto mode a blocked submission is retried as long as Apple is still processing a
+  // freshly uploaded build (its version may become submittable once it turns VALID).
+  for (;;) {
+    try {
+      await attemptSubmission(bundleId, releaseNotes, credentials);
+      return;
+    } catch (error) {
+      if (!(error instanceof SkipSubmission)) {
+        throw error;
+      }
+
+      let retry = false;
+      if (error.retryWhileProcessing && Date.now() < deadline) {
+        const token = createAppStoreConnectToken(credentials.keyId, credentials.issuerId, credentials.privateKeyPath);
+        const appId = await findAppId(token, bundleId);
+        const processing = await hasProcessingBuild(token, appId);
+        if (processing) {
+          console.log('⏳ Apple verarbeitet gerade einen hochgeladenen Build ...');
+        }
+        retry = processing || Date.now() < graceDeadline;
+      }
+
+      if (!retry) {
+        console.log(`\n⏭️ Keine Einreichung durchgeführt: ${error.message}`);
+        return;
+      }
+
+      console.log(`   Nächster Versuch in ${POLL_INTERVAL_MINUTES} Minuten ...\n`);
+      await sleepMinutes(POLL_INTERVAL_MINUTES);
+    }
+  }
 }
 
 main().catch(error => {

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -10,7 +10,7 @@ const SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVEL
 // https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmission
 const NON_TERMINAL_REVIEW_SUBMISSION_STATES = new Set(['READY_FOR_REVIEW', 'WAITING_FOR_REVIEW', 'IN_REVIEW', 'UNRESOLVED_ISSUES', 'CANCELING', 'COMPLETING']);
 
-// Automated (scheduled / post-CI) runs must never blindly re-submit a version Apple has
+// Automated (post-CI) runs must never blindly re-submit a version Apple has
 // rejected - that needs a human to look at the rejection first. Only untouched drafts
 // are submitted without a human in the loop.
 const AUTO_SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION']);
@@ -208,7 +208,7 @@ async function findOrCreateAppStoreVersion(token: string, appId: string, version
   } catch (error) {
     // Apple allows only one editable version at a time; e.g. while an approved version
     // still waits for its manual release, creating the next one fails with 409. In auto
-    // mode that just means "not now" - the next scheduled run will try again.
+    // mode that just means "not now" - the next automated or manual run will try again.
     if (AUTO_MODE && error instanceof AscApiError && error.status === 409) {
       throw new SkipSubmission(
         `Neue App Store Version ${versionString} kann aktuell nicht angelegt werden (409 von App Store Connect) - z. B. wartet eine freigegebene Version noch auf den manuellen Release. Details: ${error.message}`


### PR DESCRIPTION
## Summary

Automates the iOS App Review pipeline for Rocket Meals, Geonexia and Score Tracker:

### 1. Submit for review runs automatically after new builds

The three `ios-submit-review-*` workflows now trigger via `workflow_run` after every **successful CI run** (which is when new iOS builds are uploaded via EAS), in addition to manual `workflow_dispatch`:

- The submit script waits **up to 120 minutes** for Apple to finish processing a freshly uploaded build (polling every 5 minutes while a build is in `PROCESSING`), then submits it once it turns `VALID`. Without a processing build the run exits after a 15-minute grace period.
- **Per-app concurrency with `cancel-in-progress`**: when several builds of one app are created back to back, only the newest submit run survives — superseded runs waiting on outdated builds are cancelled, and the surviving run submits the newest build.
- New `IOS_SUBMIT_AUTO` mode: automated runs skip gracefully (exit 0) when there is nothing to submit — version still in review, awaiting manual release, no new build, active review submission — instead of failing. **Versions rejected by Apple are never re-submitted automatically**; those still require a manual `workflow_dispatch` after human review. Manual dispatch behavior is unchanged.
- Geonexia / Score Tracker automation is upstream-only (their apps are not built in forks); the Rocket Meals workflow skips quietly on tenant forks without the App Store Connect key.

### 2. New daily review status check (`ios-review-status.yml`)

A matrix workflow (05:30 UTC daily + manual dispatch) checking the App Store version states per app:

- ❌ **Rejected** (`REJECTED`, `METADATA_REJECTED`, `DEVELOPER_REJECTED`, `INVALID_BINARY`) → run fails so it shows up red
- 🎉 **Approved, awaiting manual release** (`PENDING_DEVELOPER_RELEASE`) → run succeeds with a prominent hint in the step summary
- ⏭️ Anything else (in review, released, draft) → quiet no-op with a status table

### Refactoring

Shared App Store Connect API plumbing (JWT creation, request wrapper, app lookup) extracted from `submit-ios-review.ts` into `apps/scripts/asc-api.ts`, used by both the submit and the new status script.

## Notes

- The `workflow_run` and `schedule` triggers only become active once this is merged to `master`.
- Versions are still created with `releaseType: MANUAL` — publishing after approval remains a manual step in App Store Connect (the daily status check tells you when that is possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9uhQoLEeMqMtr8T393uUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9uhQoLEeMqMtr8T393uUF)_