### PR TITLE
Semver with dev major version 0 for Geonexia and Score Tracker

### DIFF
--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -40,25 +40,55 @@ jobs:
         with:
           ref: master
 
+      # While getMajorVersion() in the app's config.ts is below 1 the app is still in
+      # development - automated runs must not submit it to App Review. A manual
+      # workflow_dispatch bypasses this gate deliberately.
+      - name: "🔢 Check release readiness (major version)"
+        id: release-check
+        env:
+          CONFIG_PATH: apps/geonexia/frontend/config.ts
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          MAJOR=$(node -e '
+            const fs = require("fs");
+            const content = fs.readFileSync(process.env.CONFIG_PATH, "utf-8");
+            const match = content.match(/function\s+getMajorVersion\s*\(\)[^{]*\{[\s\S]*?return\s+(\d+)/);
+            if (!match) { console.error("getMajorVersion() not found in " + process.env.CONFIG_PATH); process.exit(1); }
+            console.log(match[1]);
+          ')
+          echo "Major version: $MAJOR"
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$MAJOR" -lt 1 ]; then
+            echo "submit=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Major version $MAJOR is below 1 - app is still in development, automated submit is skipped."
+          else
+            echo "submit=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "⚙️ Setup Node.js"
+        if: steps.release-check.outputs.submit == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
 
       - name: "⚙️ Enable Corepack for Yarn v2"
+        if: steps.release-check.outputs.submit == 'true'
         run: corepack enable
 
       - name: "📦 Install dependencies"
+        if: steps.release-check.outputs.submit == 'true'
         # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
         # the submit script only needs ts-node/typescript, which require no build step.
         run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
+        if: steps.release-check.outputs.submit == 'true'
         uses: ./.github/actions/prepare-asc-api-key
         with:
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
 
       - name: "🚀 Submit latest build for App Review"
+        if: steps.release-check.outputs.submit == 'true'
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.geonexia

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -36,6 +36,31 @@ jobs:
         with:
           ref: master
 
+      # While getMajorVersion() in the app's config.ts is below 1 the app is still in
+      # development - automated runs must not submit it to App Review. A manual
+      # workflow_dispatch bypasses this gate deliberately.
+      - name: "🔢 Check release readiness (major version)"
+        id: release-check
+        env:
+          CONFIG_PATH: apps/frontend/app/config.ts
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          MAJOR=$(node -e '
+            const fs = require("fs");
+            const content = fs.readFileSync(process.env.CONFIG_PATH, "utf-8");
+            const match = content.match(/function\s+getMajorVersion\s*\(\)[^{]*\{[\s\S]*?return\s+(\d+)/);
+            if (!match) { console.error("getMajorVersion() not found in " + process.env.CONFIG_PATH); process.exit(1); }
+            console.log(match[1]);
+          ')
+          echo "Major version: $MAJOR"
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$MAJOR" -lt 1 ]; then
+            echo "submit=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Major version $MAJOR is below 1 - app is still in development, automated submit is skipped."
+          else
+            echo "submit=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Forks (tenant repositories) may not have the App Store Connect key configured -
       # in that case automated runs should skip quietly instead of failing every day.
       - name: "🔐 Check App Store Connect credentials"
@@ -51,33 +76,33 @@ jobs:
           fi
 
       - name: "⚙️ Setup Node.js"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
 
       - name: "⚙️ Enable Corepack for Yarn v2"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         run: corepack enable
 
       - name: "📦 Install dependencies"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
         # the submit script only needs ts-node/typescript, which require no build step.
         run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         uses: ./.github/actions/prepare-asc-api-key
         with:
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
 
       - name: "🏷️ Resolve customer from repository name"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         run: bash scripts/customer-config.sh >> "$GITHUB_ENV"
 
       - name: "📱 Resolve iOS bundle identifier"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         working-directory: ./apps/frontend/app
         run: |
           set -euo pipefail
@@ -94,7 +119,7 @@ jobs:
           echo "IOS_BUNDLE_ID=${BUNDLE_ID}" >> "$GITHUB_ENV"
 
       - name: "🚀 Submit latest build for App Review"
-        if: steps.guard.outputs.available == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -40,25 +40,55 @@ jobs:
         with:
           ref: master
 
+      # While getMajorVersion() in the app's config.ts is below 1 the app is still in
+      # development - automated runs must not submit it to App Review. A manual
+      # workflow_dispatch bypasses this gate deliberately.
+      - name: "🔢 Check release readiness (major version)"
+        id: release-check
+        env:
+          CONFIG_PATH: apps/score-tracker/frontend/config.ts
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          MAJOR=$(node -e '
+            const fs = require("fs");
+            const content = fs.readFileSync(process.env.CONFIG_PATH, "utf-8");
+            const match = content.match(/function\s+getMajorVersion\s*\(\)[^{]*\{[\s\S]*?return\s+(\d+)/);
+            if (!match) { console.error("getMajorVersion() not found in " + process.env.CONFIG_PATH); process.exit(1); }
+            console.log(match[1]);
+          ')
+          echo "Major version: $MAJOR"
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$MAJOR" -lt 1 ]; then
+            echo "submit=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Major version $MAJOR is below 1 - app is still in development, automated submit is skipped."
+          else
+            echo "submit=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "⚙️ Setup Node.js"
+        if: steps.release-check.outputs.submit == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
 
       - name: "⚙️ Enable Corepack for Yarn v2"
+        if: steps.release-check.outputs.submit == 'true'
         run: corepack enable
 
       - name: "📦 Install dependencies"
+        if: steps.release-check.outputs.submit == 'true'
         # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
         # the submit script only needs ts-node/typescript, which require no build step.
         run: yarn install --immutable --mode=skip-build
 
       - name: "🔐 Prepare Apple App Store Connect API key"
+        if: steps.release-check.outputs.submit == 'true'
         uses: ./.github/actions/prepare-asc-api-key
         with:
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
 
       - name: "🚀 Submit latest build for App Review"
+        if: steps.release-check.outputs.submit == 'true'
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.score-tracker

--- a/apps/geonexia/frontend/app.config.ts
+++ b/apps/geonexia/frontend/app.config.ts
@@ -10,7 +10,7 @@ require('ts-node').register({
 	},
 });
 
-const { getBuildNumber } = require('./config.ts');
+const { getBuildNumber, getVersion } = require('./config.ts');
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
@@ -19,7 +19,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 		owner: 'baumgartner-software',
 		name: 'Geonexia',
 		slug: 'geonexia',
-		version: `1.0.${buildNumber}`,
+		version: getVersion(),
 		orientation: 'default',
 		icon: './assets/generated/icon.png',
 		scheme: 'geonexia',

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -15,6 +15,19 @@ export function getBuildNumber() {
 	return 18;
 }
 
+// DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion
+// The ios-submit-review workflow reads this function: while the major version is
+// below 1 the app counts as still in development and is never submitted to
+// App Review automatically after a build. Raise to 1 for the first public release.
+export function getMajorVersion() {
+	return 0;
+}
+
+// Same semver scheme as apps/frontend/app: major.buildNumber.patch
+export function getVersion() {
+	return getMajorVersion() + '.' + getBuildNumber() + '.' + 0;
+}
+
 export const geonexiaConfig: CustomerConfig = {
 	projectName: 'Geonexia',
 	images: {

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -12,7 +12,7 @@ export type CustomerConfig = {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	return 18;
+	return 19;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion
@@ -23,9 +23,13 @@ export function getMajorVersion() {
 	return 0;
 }
 
+export function getVersionPatch() {
+	return 0;
+}
+
 // Same semver scheme as apps/frontend/app: major.buildNumber.patch
 export function getVersion() {
-	return getMajorVersion() + '.' + getBuildNumber() + '.' + 0;
+	return getMajorVersion() + '.' + getBuildNumber() + '.' + getVersionPatch();
 }
 
 export const geonexiaConfig: CustomerConfig = {

--- a/apps/score-tracker/frontend/app.config.ts
+++ b/apps/score-tracker/frontend/app.config.ts
@@ -10,7 +10,7 @@ require('ts-node').register({
 	},
 });
 
-const { getBuildNumber } = require('./config.ts');
+const { getBuildNumber, getVersion } = require('./config.ts');
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
@@ -19,7 +19,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 		owner: 'baumgartner-software',
 		name: 'Punktlandung',
 		slug: 'score-tracker',
-		version: `1.0.${buildNumber}`,
+		version: getVersion(),
 		orientation: 'default',
 		icon: './assets/icons/app_icon_source.png',
 		scheme: 'score-tracker',

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -13,7 +13,7 @@ export type CustomerConfig = {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	return 19;
+	return 20;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion
@@ -24,9 +24,13 @@ export function getMajorVersion() {
 	return 0;
 }
 
+export function getVersionPatch() {
+	return 0;
+}
+
 // Same semver scheme as apps/frontend/app: major.buildNumber.patch
 export function getVersion() {
-	return getMajorVersion() + '.' + getBuildNumber() + '.' + 0;
+	return getMajorVersion() + '.' + getBuildNumber() + '.' + getVersionPatch();
 }
 
 export const scoreTrackerConfig: CustomerConfig = {

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -16,6 +16,19 @@ export function getBuildNumber() {
 	return 19;
 }
 
+// DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion
+// The ios-submit-review workflow reads this function: while the major version is
+// below 1 the app counts as still in development and is never submitted to
+// App Review automatically after a build. Raise to 1 for the first public release.
+export function getMajorVersion() {
+	return 0;
+}
+
+// Same semver scheme as apps/frontend/app: major.buildNumber.patch
+export function getVersion() {
+	return getMajorVersion() + '.' + getBuildNumber() + '.' + 0;
+}
+
 export const scoreTrackerConfig: CustomerConfig = {
 	projectName: 'Score Tracker',
 	// App Store Connect Apple-ID (App-Informationen -> Apple-ID), required for


### PR DESCRIPTION
## Summary

Follow-up to #4129 — these two commits were pushed after that PR was merged and were still missing on `master`.

### Semver scheme for Geonexia and Score Tracker

Both apps used a flat `1.0.<buildNumber>` version string. They now follow the same three-part scheme as `apps/frontend` via `getMajorVersion()`, `getVersionPatch()` and `getVersion()` in their `config.ts`, used by `app.config.ts`:

```
version = major.buildNumber.patch
```

Since both apps are unreleased, they start at **major version 0**:

- Geonexia: build number 18 → **19**, version `0.19.0`
- Score Tracker: build number 19 → **20**, version `0.20.0`

The build number bumps make the next CI run produce fresh builds carrying the new scheme.

### Development gate for automated App Review submission

The three `ios-submit-review-*` workflows now read `getMajorVersion()` from the app's `config.ts` (same regex convention as `check-build-version.ts`, before any dependency install): while the major version is **below 1** the app counts as still in development and automated (post-CI) submission is skipped. A manual `workflow_dispatch` deliberately bypasses the gate. Rocket Meals (major 21) is unaffected.

## Notes

- Both apps use `runtimeVersion: { policy: 'appVersion' }`, so the version change also changes the OTA runtime version — irrelevant while unreleased, but existing TestFlight installs won't receive OTA updates for the old version.
- To start automated submission for Geonexia / Score Tracker later, raise `getMajorVersion()` to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9uhQoLEeMqMtr8T393uUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9uhQoLEeMqMtr8T393uUF)_