### PR TITLE
Add store metadata ground truth with pull/push sync for Apple and Google

### DIFF
--- a/.github/workflows/ios-submit-review-geonexia.yml
+++ b/.github/workflows/ios-submit-review-geonexia.yml
@@ -93,6 +93,9 @@ jobs:
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.geonexia
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
+          # Ground truth for the pre-submit metadata sync (Altersfreigabe & Co),
+          # see docs/STORE_METADATA.md.
+          STORE_METADATA_MODULE: apps/geonexia/frontend/store-metadata.ts
           # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/ios-submit-review-rocket-meals.yml
+++ b/.github/workflows/ios-submit-review-rocket-meals.yml
@@ -101,28 +101,37 @@ jobs:
         if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         run: bash scripts/customer-config.sh >> "$GITHUB_ENV"
 
-      - name: "📱 Resolve iOS bundle identifier"
+      - name: "📱 Resolve iOS bundle identifier and submit flag"
         if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
         working-directory: ./apps/frontend/app
         run: |
           set -euo pipefail
 
-          BUNDLE_ID=$(node - <<'EOF'
+          node - <<'EOF' >> "$GITHUB_ENV"
           require('ts-node').register({
             transpileOnly: true,
             compilerOptions: { module: 'Node16', moduleResolution: 'node16' },
           });
           const { getCustomerConfig } = require('./config.ts');
-          console.log(getCustomerConfig().bundleIdIos);
+          const config = getCustomerConfig();
+          console.log(`IOS_BUNDLE_ID=${config.bundleIdIos}`);
+          // Apps like the Rocket Meals demo/test app set iosAppStoreReviewSubmitEnabled
+          // to false so their builds are never submitted to App Review.
+          console.log(`IOS_REVIEW_SUBMIT_ENABLED=${config.iosAppStoreReviewSubmitEnabled !== false}`);
           EOF
-          )
-          echo "IOS_BUNDLE_ID=${BUNDLE_ID}" >> "$GITHUB_ENV"
+
+      - name: "⏭️ Review submit is disabled for this app"
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true' && env.IOS_REVIEW_SUBMIT_ENABLED != 'true'
+        run: echo "⏭️ iosAppStoreReviewSubmitEnabled ist für diesen Tenant (${IOS_BUNDLE_ID}) deaktiviert (config.ts) - es wird nichts zur Review eingereicht."
 
       - name: "🚀 Submit latest build for App Review"
-        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true'
+        if: steps.guard.outputs.available == 'true' && steps.release-check.outputs.submit == 'true' && env.IOS_REVIEW_SUBMIT_ENABLED == 'true'
         run: yarn workspace rocket-meals-scripts submit:ios:review
         env:
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
+          # Ground truth for the pre-submit metadata sync (Altersfreigabe & Co),
+          # see docs/STORE_METADATA.md.
+          STORE_METADATA_MODULE: apps/frontend/app/store-metadata.ts
           # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/ios-submit-review-score-tracker.yml
+++ b/.github/workflows/ios-submit-review-score-tracker.yml
@@ -93,6 +93,9 @@ jobs:
         env:
           IOS_BUNDLE_ID: de.baumgartner-software.score-tracker
           IOS_RELEASE_NOTES: ${{ inputs.release_notes || 'Fehlerbehebungen und Aktualisierung von Bibliotheken.' }}
+          # Ground truth for the pre-submit metadata sync (Altersfreigabe & Co),
+          # see docs/STORE_METADATA.md.
+          STORE_METADATA_MODULE: apps/score-tracker/frontend/store-metadata.ts
           # Post-CI runs skip gracefully when there is nothing to submit
           # and never re-submit versions Apple has rejected.
           IOS_SUBMIT_AUTO: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/store-metadata.yml
+++ b/.github/workflows/store-metadata.yml
@@ -1,0 +1,144 @@
+name: "🏪 Store Metadata: Pull / Push"
+
+# Manual sync of the app store metadata ("App-Informationen") with the ground truth in
+# the repo - see docs/STORE_METADATA.md. "pull" reads the current values from Apple /
+# Google and prints them as JSON to the console (plus job summary and artifact),
+# "push" writes the ground truth to the stores (only fields that drifted).
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "pull = Ist-Stand lesen (JSON-Ausgabe), push = Ground Truth in die Stores schreiben"
+        type: choice
+        required: true
+        default: "pull"
+        options:
+          - pull
+          - push
+      app:
+        description: "Welche App (Ground-Truth-Modul)"
+        type: choice
+        required: true
+        default: "rocket-meals"
+        options:
+          - rocket-meals
+          - geonexia
+          - score-tracker
+      store:
+        description: "Welche Stores abgleichen"
+        type: choice
+        required: true
+        default: "all"
+        options:
+          - all
+          - apple
+          - google
+      dry_run:
+        description: "push: nur anzeigen, was sich ändern würde (nichts schreiben)"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  store-metadata:
+    name: "🏪 ${{ inputs.command }} (${{ inputs.app }}, ${{ inputs.store }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+
+      - name: "⚙️ Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+
+      - name: "⚙️ Enable Corepack for Yarn v2"
+        run: corepack enable
+
+      - name: "📦 Install dependencies"
+        # --mode=skip-build disables dependency lifecycle scripts (supply-chain hardening);
+        # the sync script only needs ts-node/typescript, which require no build step.
+        run: yarn install --immutable --mode=skip-build
+
+      # Missing credentials only skip a store when store=all - an explicit
+      # --store apple/google fails loudly in the CLI instead.
+      - name: "🔐 Check App Store Connect credentials"
+        id: asc-guard
+        env:
+          ASC_KEY: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+        run: |
+          if [ -n "$ASC_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Secret EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT ist nicht gesetzt - Apple wird übersprungen."
+          fi
+
+      - name: "🔐 Prepare Apple App Store Connect API key"
+        if: steps.asc-guard.outputs.available == 'true'
+        uses: ./.github/actions/prepare-asc-api-key
+        with:
+          EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+
+      - name: "🏪 Run store-metadata ${{ inputs.command }}"
+        env:
+          COMMAND: ${{ inputs.command }}
+          APP: ${{ inputs.app }}
+          STORE: ${{ inputs.store }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          # Play-Console-Service-Account (Einrichtung -> API-Zugriff), als JSON-Inhalt.
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+
+          case "$APP" in
+            rocket-meals) MODULE="apps/frontend/app/store-metadata.ts" ;;
+            geonexia) MODULE="apps/geonexia/frontend/store-metadata.ts" ;;
+            score-tracker) MODULE="apps/score-tracker/frontend/store-metadata.ts" ;;
+            *) echo "Unbekannte App: $APP"; exit 1 ;;
+          esac
+
+          ARGS=("$COMMAND" --module "$MODULE")
+          if [ "$STORE" != "all" ]; then
+            ARGS+=(--store "$STORE")
+          fi
+          if [ "$COMMAND" = "push" ] && [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          yarn workspace rocket-meals-scripts store-metadata "${ARGS[@]}"
+
+      - name: "📄 Print pulled metadata as JSON"
+        if: inputs.command == 'pull'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          FILES=(reports/store-metadata/*.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "Keine Snapshots unter reports/store-metadata/ gefunden."
+            exit 0
+          fi
+
+          for FILE in "${FILES[@]}"; do
+            echo "===== ${FILE} ====="
+            cat "$FILE"
+            echo ""
+            {
+              echo "### \`${FILE}\`"
+              echo '```json'
+              cat "$FILE"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: "💾 Upload pulled metadata as artifact"
+        if: inputs.command == 'pull'
+        uses: actions/upload-artifact@v4
+        with:
+          name: store-metadata-${{ inputs.app }}
+          path: reports/store-metadata/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/apps/backend/SSO_GOOGLE.md
+++ b/apps/backend/SSO_GOOGLE.md
@@ -10,7 +10,7 @@
   - Anwendungslogo: Auswählen
   - Startseite der Anwendung: `<URL>` (https://rocket-meals.github.io/<rocket-meals>/)
   - Link zur Datenschutzerklärung: `<URL>`
-    (https://rocket-meals.github.io/<rocket-meals>/wikis?wikis_custom_id=privacy-policy)
+    (https://rocket-meals.de/<rocket-meals>/wikis?custom_id=privacy-policy)
   - Authorisierte Domains
     - `rocket-meals.github.io`
     - `rocket-meals.de`

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -15,6 +15,10 @@ export type CustomerConfig = {
 	baseUrl: string;
 	server_url: string;
 	appleAppId?: string;
+	// Controls whether the iOS submit workflow submits new builds to App Review.
+	// Defaults to true when not set; set to false for apps that must never be submitted
+	// automatically (e.g. the Rocket Meals demo/test app).
+	iosAppStoreReviewSubmitEnabled?: boolean;
         images: {
                 company_logo_source_path: string;
                 company_logo_source_get_for_react_native: () => ImageSourcePropType;
@@ -79,6 +83,8 @@ export const devConfig: CustomerConfig = {
 	baseUrl: '/rocket-meals',
 	server_url: ServerHelper.TEST_SERVER_CONFIG.server_url,
 	appleAppId: '6483930801',
+	// The demo app is only for testing - builds are uploaded but never submitted to App Review.
+	iosAppStoreReviewSubmitEnabled: false,
 	images: {
 		company_logo_source_path: 'assets/images/customers/rocket-meals/company.png',
 		company_logo_source_get_for_react_native: () => {return require('@/assets/images/customers/rocket-meals/company.png')},
@@ -98,6 +104,7 @@ export const swosyConfig: CustomerConfig = {
 	baseUrl: '/swosy',
 	server_url: ServerHelper.SWOSY_SERVER_CONFIG.server_url,
 	appleAppId: '6667117575',
+	iosAppStoreReviewSubmitEnabled: true,
 	images: {
 		company_logo_source_path: 'assets/images/customers/swosy/company.png',
 		company_logo_source_get_for_react_native: () => {return require('@/assets/images/customers/swosy/company.png')},
@@ -117,6 +124,7 @@ export const studiFutterConfig: CustomerConfig = {
 	baseUrl: '/studi-futter',
 	server_url: ServerHelper.STUDI_FUTTER_SERVER_CONFIG.server_url,
 	appleAppId: '1548108390',
+	iosAppStoreReviewSubmitEnabled: true,
 	images: {
 		company_logo_source_path: 'assets/images/customers/studi-futter/company.png',
 		company_logo_source_get_for_react_native: () => {return require('@/assets/images/customers/studi-futter/company.png')},

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -1,0 +1,48 @@
+// Ground truth for the app store metadata ("App-Informationen") of all rocket-meals
+// tenant apps. See packages/common/src/StoreAppMetadata.ts for the concept.
+//
+//   yarn store-metadata:pull:rocket-meals
+//   yarn store-metadata:push:rocket-meals
+//
+// Bundle ids come from config.ts so they cannot drift apart from the builds.
+import { DEFAULT_APPLE_AGE_RATING_DECLARATION, StoreAppMetadata } from 'repo-depkit-common';
+import { CustomerConfig, devConfig, studiFutterConfig, swosyConfig } from './config';
+
+// All tenants ship the same app and therefore share the same answers to Apple's age
+// rating questionnaire and the same category. The reasoning behind the answers is
+// documented in docs/Apple Altersfreigabe.txt - keep both in sync.
+function tenantStoreMetadata(config: CustomerConfig): StoreAppMetadata {
+	const metadata: StoreAppMetadata = {
+		displayName: config.projectName,
+	};
+	if (config.bundleIdIos) {
+		metadata.apple = {
+			bundleId: config.bundleIdIos,
+			ageRatingDeclaration: {
+				...DEFAULT_APPLE_AGE_RATING_DECLARATION,
+				// Canteens may list alcoholic drinks in their menus.
+				alcoholTobaccoOrDrugUseOrReferences: 'INFREQUENT_OR_MILD',
+				contests: 'INFREQUENT_OR_MILD',
+				// The capability questions of Apple's 2025 questionnaire (user generated
+				// content: yes, messaging/chat: yes - see docs/Apple Altersfreigabe.txt)
+				// can be added here once "store-metadata:pull" shows their API attribute
+				// names for the ageRatingDeclaration.
+			},
+			primaryCategoryId: 'FOOD_AND_DRINK',
+		};
+	}
+	if (config.bundleIdAndroid) {
+		metadata.google = {
+			packageName: config.bundleIdAndroid,
+			contactEmail: 'nils@baumgartner-software.de',
+			contactWebsite: 'https://rocket-meals.de',
+			// Store listing texts (title, descriptions) are tenant specific and not yet
+			// managed here - "store-metadata:pull" shows the current values from Google.
+		};
+	}
+	return metadata;
+}
+
+export function getStoreMetadata(): StoreAppMetadata[] {
+	return [devConfig, swosyConfig, studiFutterConfig].map(tenantStoreMetadata);
+}

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -9,7 +9,7 @@
 // questions (like the age rating questionnaire) only need to be answered here once.
 //
 // Bundle ids come from config.ts so they cannot drift apart from the builds.
-import { AppleAppMetadata, DEFAULT_APPLE_AGE_RATING_DECLARATION, GooglePlayAppMetadata, StoreAppMetadata } from 'repo-depkit-common';
+import { AppLinks, AppleAppMetadata, DEFAULT_APPLE_AGE_RATING_DECLARATION, GooglePlayAppMetadata, ROCKET_MEALS_WEB_HOST, StoreAppMetadata, WikiCustomIds } from 'repo-depkit-common';
 import { CustomerConfig, devConfig, studiFutterConfig, swosyConfig } from './config';
 
 // Tenant-specific deviations from the shared metadata below (e.g. the privacy policy
@@ -18,12 +18,6 @@ type TenantStoreOverrides = {
 	apple?: Partial<Omit<AppleAppMetadata, 'bundleId'>>;
 	google?: Partial<Omit<GooglePlayAppMetadata, 'packageName'>>;
 };
-
-// Every tenant web app serves its privacy policy as a public wiki page - the same url
-// is used for the Google SSO consent screen (documented in apps/backend/SSO_GOOGLE.md).
-function tenantPrivacyPolicyUrl(config: CustomerConfig): string {
-	return `https://rocket-meals.de${config.baseUrl}/wikis?custom_id=privacy-policy`;
-}
 
 // All tenants ship the same app and therefore share the same answers to Apple's age
 // rating questionnaire and the same category. The reasoning behind the answers is
@@ -36,7 +30,9 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 		metadata.apple = {
 			bundleId: config.bundleIdIos,
 			primaryCategoryId: 'FOOD_AND_DRINK',
-			privacyPolicyUrl: tenantPrivacyPolicyUrl(config),
+			// Every tenant web app serves its privacy policy as a public wiki page - the
+			// same url is used for the Google SSO consent screen (apps/backend/SSO_GOOGLE.md).
+			privacyPolicyUrl: AppLinks.getPublicWikiUrl(config.baseUrl, WikiCustomIds.PRIVACY_POLICY),
 			...overrides.apple,
 			ageRatingDeclaration: {
 				...DEFAULT_APPLE_AGE_RATING_DECLARATION,
@@ -55,7 +51,7 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 		metadata.google = {
 			packageName: config.bundleIdAndroid,
 			contactEmail: 'nils@baumgartner-software.de',
-			contactWebsite: 'https://rocket-meals.de',
+			contactWebsite: ROCKET_MEALS_WEB_HOST,
 			// Store listing texts (title, descriptions) are tenant specific and not yet
 			// managed here - "store-metadata:pull" shows the current values from Google.
 			...overrides.google,

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -22,7 +22,7 @@ type TenantStoreOverrides = {
 // Every tenant web app serves its privacy policy as a public wiki page - the same url
 // is used for the Google SSO consent screen (documented in apps/backend/SSO_GOOGLE.md).
 function tenantPrivacyPolicyUrl(config: CustomerConfig): string {
-	return `https://rocket-meals.github.io${config.baseUrl}/wikis?wikis_custom_id=privacy-policy`;
+	return `https://rocket-meals.de${config.baseUrl}/wikis?custom_id=privacy-policy`;
 }
 
 // All tenants ship the same app and therefore share the same answers to Apple's age

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -19,6 +19,12 @@ type TenantStoreOverrides = {
 	google?: Partial<Omit<GooglePlayAppMetadata, 'packageName'>>;
 };
 
+// Every tenant web app serves its privacy policy as a public wiki page - the same url
+// is used for the Google SSO consent screen (documented in apps/backend/SSO_GOOGLE.md).
+function tenantPrivacyPolicyUrl(config: CustomerConfig): string {
+	return `https://rocket-meals.github.io${config.baseUrl}/wikis?wikis_custom_id=privacy-policy`;
+}
+
 // All tenants ship the same app and therefore share the same answers to Apple's age
 // rating questionnaire and the same category. The reasoning behind the answers is
 // documented in docs/Apple Altersfreigabe.txt - keep both in sync.
@@ -30,6 +36,7 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 		metadata.apple = {
 			bundleId: config.bundleIdIos,
 			primaryCategoryId: 'FOOD_AND_DRINK',
+			privacyPolicyUrl: tenantPrivacyPolicyUrl(config),
 			...overrides.apple,
 			ageRatingDeclaration: {
 				...DEFAULT_APPLE_AGE_RATING_DECLARATION,
@@ -60,10 +67,10 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 export function getStoreMetadata(): StoreAppMetadata[] {
 	return [
 		tenantStoreMetadata(devConfig),
-		tenantStoreMetadata(swosyConfig, {
-			// Example: apple: { privacyPolicyUrl: 'https://.../datenschutz' }
-			// "store-metadata:pull" shows the value currently stored in App Store Connect.
-		}),
+		// Tenant overrides win over the shared values, e.g.
+		// { apple: { privacyPolicyUrl: 'https://.../datenschutz' } } - "store-metadata:pull"
+		// shows what is currently stored in App Store Connect.
+		tenantStoreMetadata(swosyConfig, {}),
 		tenantStoreMetadata(studiFutterConfig, {}),
 	];
 }

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -4,20 +4,33 @@
 //   yarn store-metadata:pull:rocket-meals
 //   yarn store-metadata:push:rocket-meals
 //
+// The iOS submit workflow also pushes this ground truth right before every review
+// submission (see apps/scripts/submit-ios-review.ts), so Apple's recurring metadata
+// questions (like the age rating questionnaire) only need to be answered here once.
+//
 // Bundle ids come from config.ts so they cannot drift apart from the builds.
-import { DEFAULT_APPLE_AGE_RATING_DECLARATION, StoreAppMetadata } from 'repo-depkit-common';
+import { AppleAppMetadata, DEFAULT_APPLE_AGE_RATING_DECLARATION, GooglePlayAppMetadata, StoreAppMetadata } from 'repo-depkit-common';
 import { CustomerConfig, devConfig, studiFutterConfig, swosyConfig } from './config';
+
+// Tenant-specific deviations from the shared metadata below (e.g. the privacy policy
+// url). Only what really differs per tenant belongs here.
+type TenantStoreOverrides = {
+	apple?: Partial<Omit<AppleAppMetadata, 'bundleId'>>;
+	google?: Partial<Omit<GooglePlayAppMetadata, 'packageName'>>;
+};
 
 // All tenants ship the same app and therefore share the same answers to Apple's age
 // rating questionnaire and the same category. The reasoning behind the answers is
 // documented in docs/Apple Altersfreigabe.txt - keep both in sync.
-function tenantStoreMetadata(config: CustomerConfig): StoreAppMetadata {
+function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverrides = {}): StoreAppMetadata {
 	const metadata: StoreAppMetadata = {
 		displayName: config.projectName,
 	};
 	if (config.bundleIdIos) {
 		metadata.apple = {
 			bundleId: config.bundleIdIos,
+			primaryCategoryId: 'FOOD_AND_DRINK',
+			...overrides.apple,
 			ageRatingDeclaration: {
 				...DEFAULT_APPLE_AGE_RATING_DECLARATION,
 				// Canteens may list alcoholic drinks in their menus.
@@ -27,8 +40,8 @@ function tenantStoreMetadata(config: CustomerConfig): StoreAppMetadata {
 				// content: yes, messaging/chat: yes - see docs/Apple Altersfreigabe.txt)
 				// can be added here once "store-metadata:pull" shows their API attribute
 				// names for the ageRatingDeclaration.
+				...overrides.apple?.ageRatingDeclaration,
 			},
-			primaryCategoryId: 'FOOD_AND_DRINK',
 		};
 	}
 	if (config.bundleIdAndroid) {
@@ -38,11 +51,19 @@ function tenantStoreMetadata(config: CustomerConfig): StoreAppMetadata {
 			contactWebsite: 'https://rocket-meals.de',
 			// Store listing texts (title, descriptions) are tenant specific and not yet
 			// managed here - "store-metadata:pull" shows the current values from Google.
+			...overrides.google,
 		};
 	}
 	return metadata;
 }
 
 export function getStoreMetadata(): StoreAppMetadata[] {
-	return [devConfig, swosyConfig, studiFutterConfig].map(tenantStoreMetadata);
+	return [
+		tenantStoreMetadata(devConfig),
+		tenantStoreMetadata(swosyConfig, {
+			// Example: apple: { privacyPolicyUrl: 'https://.../datenschutz' }
+			// "store-metadata:pull" shows the value currently stored in App Store Connect.
+		}),
+		tenantStoreMetadata(studiFutterConfig, {}),
+	];
 }

--- a/apps/geonexia/frontend/store-metadata.ts
+++ b/apps/geonexia/frontend/store-metadata.ts
@@ -1,0 +1,26 @@
+// Ground truth for the app store metadata ("App-Informationen") of Geonexia.
+// See packages/common/src/StoreAppMetadata.ts for the concept.
+//
+//   yarn store-metadata:pull:geonexia
+//   yarn store-metadata:push:geonexia
+import { DEFAULT_APPLE_AGE_RATING_DECLARATION, StoreAppMetadata } from 'repo-depkit-common';
+import { geonexiaConfig } from './config';
+
+export function getStoreMetadata(): StoreAppMetadata[] {
+	return [
+		{
+			displayName: geonexiaConfig.projectName,
+			apple: {
+				// Keep in sync with ios.bundleIdentifier in app.config.ts
+				bundleId: 'de.baumgartner-software.geonexia',
+				ageRatingDeclaration: {
+					...DEFAULT_APPLE_AGE_RATING_DECLARATION,
+				},
+			},
+			google: {
+				// Keep in sync with android.package in app.config.ts
+				packageName: 'com.geonexia.app',
+			},
+		},
+	];
+}

--- a/apps/score-tracker/frontend/store-metadata.ts
+++ b/apps/score-tracker/frontend/store-metadata.ts
@@ -1,0 +1,26 @@
+// Ground truth for the app store metadata ("App-Informationen") of Score Tracker.
+// See packages/common/src/StoreAppMetadata.ts for the concept.
+//
+//   yarn store-metadata:pull:score-tracker
+//   yarn store-metadata:push:score-tracker
+import { DEFAULT_APPLE_AGE_RATING_DECLARATION, StoreAppMetadata } from 'repo-depkit-common';
+import { scoreTrackerConfig } from './config';
+
+export function getStoreMetadata(): StoreAppMetadata[] {
+	return [
+		{
+			displayName: scoreTrackerConfig.projectName,
+			apple: {
+				// Keep in sync with ios.bundleIdentifier in app.config.ts
+				bundleId: 'de.baumgartner-software.score-tracker',
+				ageRatingDeclaration: {
+					...DEFAULT_APPLE_AGE_RATING_DECLARATION,
+				},
+			},
+			google: {
+				// Keep in sync with android.package in app.config.ts
+				packageName: 'com.scoretracker.app',
+			},
+		},
+	];
+}

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -9,6 +9,7 @@
     "generate:eas": "ts-node --project ./tsconfig.json ./generate-eas-config.ts",
     "analyze:data-clumps": "ts-node --project ./tsconfig.json ./analyze-data-clumps.ts",
     "submit:ios:review": "ts-node --project ./tsconfig.json ./submit-ios-review.ts",
+    "store-metadata": "ts-node --project ./tsconfig.json ./store-metadata.ts",
     "apk:extract-url": "ts-node --project ./tsconfig.json ./android-preview-apk.ts extract",
     "build-number:compare-online": "ts-node --project ./tsconfig.json ./check-build-version.ts compare",
     "apk:update-readme": "ts-node --project ./tsconfig.json ./android-preview-apk.ts update-readme",

--- a/apps/scripts/store-metadata-apple.ts
+++ b/apps/scripts/store-metadata-apple.ts
@@ -11,6 +11,13 @@ import { AttributeChange, changesToAttributeObject, computeAttributeChanges, for
 // soon as a new app store version draft exists.
 const EDITABLE_APP_INFO_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'REJECTED', 'METADATA_REJECTED', 'WAITING_FOR_REVIEW']);
 
+export type AppleAppInfoLocalizationSnapshot = {
+  localizationId: string;
+  locale: string | undefined;
+  privacyPolicyUrl: string | undefined;
+  privacyChoicesUrl: string | undefined;
+};
+
 export type AppleAppInfoSnapshot = {
   appInfoId: string;
   state: string | undefined;
@@ -19,6 +26,7 @@ export type AppleAppInfoSnapshot = {
   ageRatingDeclaration: Record<string, unknown>;
   primaryCategoryId: string | undefined;
   secondaryCategoryId: string | undefined;
+  localizations: AppleAppInfoLocalizationSnapshot[];
 };
 
 export type ApplePullResult = {
@@ -34,18 +42,29 @@ function relationshipId(resource: JsonApiResource, relationship: string): string
   return resource.relationships?.[relationship]?.data?.id;
 }
 
+async function fetchAppInfoLocalizations(token: string, appInfoId: string): Promise<AppleAppInfoLocalizationSnapshot[]> {
+  const result = await ascRequest(token, 'GET', `/appInfos/${appInfoId}/appInfoLocalizations`);
+  return asArray(result.data).map(localization => ({
+    localizationId: localization.id,
+    locale: localization.attributes?.locale as string | undefined,
+    privacyPolicyUrl: localization.attributes?.privacyPolicyUrl as string | undefined,
+    privacyChoicesUrl: localization.attributes?.privacyChoicesUrl as string | undefined,
+  }));
+}
+
 async function fetchAppInfos(token: string, appId: string): Promise<{ appInfos: AppleAppInfoSnapshot[]; appStoreAgeRating: string | undefined }> {
   const query = new URLSearchParams({ include: 'ageRatingDeclaration,primaryCategory,secondaryCategory' });
   const result = await ascRequest(token, 'GET', `/apps/${appId}/appInfos?${query}`);
   const included = result.included ?? [];
 
   let appStoreAgeRating: string | undefined;
-  const appInfos = asArray(result.data).map(appInfo => {
+  const appInfos: AppleAppInfoSnapshot[] = [];
+  for (const appInfo of asArray(result.data)) {
     const ageRatingDeclarationId = relationshipId(appInfo, 'ageRatingDeclaration');
     const declaration = included.find(item => item.type === 'ageRatingDeclarations' && item.id === ageRatingDeclarationId);
     const state = (appInfo.attributes?.state ?? appInfo.attributes?.appStoreState) as string | undefined;
     appStoreAgeRating = (appInfo.attributes?.appStoreAgeRating as string | undefined) ?? appStoreAgeRating;
-    return {
+    appInfos.push({
       appInfoId: appInfo.id,
       state,
       editable: state !== undefined && EDITABLE_APP_INFO_STATES.has(state),
@@ -53,8 +72,9 @@ async function fetchAppInfos(token: string, appId: string): Promise<{ appInfos: 
       ageRatingDeclaration: declaration?.attributes ?? {},
       primaryCategoryId: relationshipId(appInfo, 'primaryCategory'),
       secondaryCategoryId: relationshipId(appInfo, 'secondaryCategory'),
-    };
-  });
+      localizations: await fetchAppInfoLocalizations(token, appInfo.id),
+    });
+  }
 
   return { appInfos, appStoreAgeRating };
 }
@@ -75,12 +95,19 @@ export async function pullAppleMetadata(token: string, metadata: AppleAppMetadat
   };
 }
 
+export type AppleLocalizationChanges = {
+  localizationId: string;
+  locale: string | undefined;
+  changes: AttributeChange[];
+};
+
 export type ApplePushPlan = {
   current: ApplePullResult;
   targetAppInfo: AppleAppInfoSnapshot | undefined;
   ageRatingChanges: AttributeChange[];
   categoryChanges: AttributeChange[];
   contentRightsChanges: AttributeChange[];
+  localizationChanges: AppleLocalizationChanges[];
 };
 
 export function planApplePush(current: ApplePullResult, metadata: AppleAppMetadata): ApplePushPlan {
@@ -98,18 +125,30 @@ export function planApplePush(current: ApplePullResult, metadata: AppleAppMetada
 
   const contentRightsChanges = computeAttributeChanges({ contentRightsDeclaration: metadata.contentRightsDeclaration }, { contentRightsDeclaration: current.contentRightsDeclaration });
 
-  return { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges };
+  // The privacy urls apply to every locale of the app's "App-Informationen".
+  const localizationChanges: AppleLocalizationChanges[] = [];
+  for (const localization of targetAppInfo?.localizations ?? []) {
+    const changes = computeAttributeChanges(
+      { privacyPolicyUrl: metadata.privacyPolicyUrl, privacyChoicesUrl: metadata.privacyChoicesUrl },
+      { privacyPolicyUrl: localization.privacyPolicyUrl, privacyChoicesUrl: localization.privacyChoicesUrl }
+    );
+    if (changes.length > 0) {
+      localizationChanges.push({ localizationId: localization.localizationId, locale: localization.locale, changes });
+    }
+  }
+
+  return { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges, localizationChanges };
 }
 
 export async function applyApplePush(token: string, plan: ApplePushPlan, dryRun: boolean): Promise<boolean> {
-  const { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges } = plan;
-  const hasChanges = ageRatingChanges.length > 0 || categoryChanges.length > 0 || contentRightsChanges.length > 0;
+  const { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges, localizationChanges } = plan;
+  const hasChanges = ageRatingChanges.length > 0 || categoryChanges.length > 0 || contentRightsChanges.length > 0 || localizationChanges.length > 0;
   if (!hasChanges) {
     console.log('   ✅ Apple: Keine Abweichungen - nichts zu tun.');
     return false;
   }
 
-  if ((ageRatingChanges.length > 0 || categoryChanges.length > 0) && targetAppInfo && !targetAppInfo.editable) {
+  if ((ageRatingChanges.length > 0 || categoryChanges.length > 0 || localizationChanges.length > 0) && targetAppInfo && !targetAppInfo.editable) {
     throw new Error(
       `Apple: Es gibt Abweichungen, aber keine bearbeitbare AppInfo (Status: ${targetAppInfo.state}). ` +
         'Altersfreigabe und Kategorien sind nur änderbar, solange eine App-Store-Version im Entwurfsstatus existiert. ' +
@@ -143,6 +182,15 @@ export async function applyApplePush(token: string, plan: ApplePushPlan, dryRun:
       }
       await ascRequest(token, 'PATCH', `/appInfos/${targetAppInfo.appInfoId}`, {
         data: { type: 'appInfos', id: targetAppInfo.appInfoId, relationships },
+      });
+    }
+  }
+
+  for (const { localizationId, locale, changes } of localizationChanges) {
+    console.log(`   📝 Apple App-Informationen (${locale}):\n${formatChanges(changes, '      ')}`);
+    if (!dryRun) {
+      await ascRequest(token, 'PATCH', `/appInfoLocalizations/${localizationId}`, {
+        data: { type: 'appInfoLocalizations', id: localizationId, attributes: changesToAttributeObject(changes) },
       });
     }
   }

--- a/apps/scripts/store-metadata-apple.ts
+++ b/apps/scripts/store-metadata-apple.ts
@@ -1,0 +1,161 @@
+import type { AppleAppMetadata } from 'repo-depkit-common';
+import { JsonApiResource, asArray, ascRequest, findAppId } from './asc-api';
+import { AttributeChange, changesToAttributeObject, computeAttributeChanges, formatChanges } from './store-metadata-diff';
+
+// Reads and writes the "App-Informationen" (age rating declaration, categories, content
+// rights) of an app in App Store Connect. Only fields that are set in the ground truth
+// are managed - see packages/common/src/StoreAppMetadata.ts.
+
+// https://developer.apple.com/documentation/appstoreconnectapi/appinfo - the age rating
+// declaration and the categories hang off the "editable" AppInfo. Apple creates one as
+// soon as a new app store version draft exists.
+const EDITABLE_APP_INFO_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'REJECTED', 'METADATA_REJECTED', 'WAITING_FOR_REVIEW']);
+
+export type AppleAppInfoSnapshot = {
+  appInfoId: string;
+  state: string | undefined;
+  editable: boolean;
+  ageRatingDeclarationId: string | undefined;
+  ageRatingDeclaration: Record<string, unknown>;
+  primaryCategoryId: string | undefined;
+  secondaryCategoryId: string | undefined;
+};
+
+export type ApplePullResult = {
+  appId: string;
+  bundleId: string;
+  name: string | undefined;
+  contentRightsDeclaration: string | undefined;
+  appStoreAgeRating: string | undefined;
+  appInfos: AppleAppInfoSnapshot[];
+};
+
+function relationshipId(resource: JsonApiResource, relationship: string): string | undefined {
+  return resource.relationships?.[relationship]?.data?.id;
+}
+
+async function fetchAppInfos(token: string, appId: string): Promise<{ appInfos: AppleAppInfoSnapshot[]; appStoreAgeRating: string | undefined }> {
+  const query = new URLSearchParams({ include: 'ageRatingDeclaration,primaryCategory,secondaryCategory' });
+  const result = await ascRequest(token, 'GET', `/apps/${appId}/appInfos?${query}`);
+  const included = result.included ?? [];
+
+  let appStoreAgeRating: string | undefined;
+  const appInfos = asArray(result.data).map(appInfo => {
+    const ageRatingDeclarationId = relationshipId(appInfo, 'ageRatingDeclaration');
+    const declaration = included.find(item => item.type === 'ageRatingDeclarations' && item.id === ageRatingDeclarationId);
+    const state = (appInfo.attributes?.state ?? appInfo.attributes?.appStoreState) as string | undefined;
+    appStoreAgeRating = (appInfo.attributes?.appStoreAgeRating as string | undefined) ?? appStoreAgeRating;
+    return {
+      appInfoId: appInfo.id,
+      state,
+      editable: state !== undefined && EDITABLE_APP_INFO_STATES.has(state),
+      ageRatingDeclarationId,
+      ageRatingDeclaration: declaration?.attributes ?? {},
+      primaryCategoryId: relationshipId(appInfo, 'primaryCategory'),
+      secondaryCategoryId: relationshipId(appInfo, 'secondaryCategory'),
+    };
+  });
+
+  return { appInfos, appStoreAgeRating };
+}
+
+export async function pullAppleMetadata(token: string, metadata: AppleAppMetadata): Promise<ApplePullResult> {
+  const appId = await findAppId(token, metadata.bundleId);
+  const appResult = await ascRequest(token, 'GET', `/apps/${appId}`);
+  const app = asArray(appResult.data)[0];
+  const { appInfos, appStoreAgeRating } = await fetchAppInfos(token, appId);
+
+  return {
+    appId,
+    bundleId: metadata.bundleId,
+    name: app?.attributes?.name as string | undefined,
+    contentRightsDeclaration: app?.attributes?.contentRightsDeclaration as string | undefined,
+    appStoreAgeRating,
+    appInfos,
+  };
+}
+
+export type ApplePushPlan = {
+  current: ApplePullResult;
+  targetAppInfo: AppleAppInfoSnapshot | undefined;
+  ageRatingChanges: AttributeChange[];
+  categoryChanges: AttributeChange[];
+  contentRightsChanges: AttributeChange[];
+};
+
+export function planApplePush(current: ApplePullResult, metadata: AppleAppMetadata): ApplePushPlan {
+  // Prefer the editable AppInfo; a read-only one is still useful to show the diff.
+  const targetAppInfo = current.appInfos.find(info => info.editable) ?? current.appInfos[0];
+
+  const ageRatingChanges = metadata.ageRatingDeclaration && targetAppInfo ? computeAttributeChanges(metadata.ageRatingDeclaration, targetAppInfo.ageRatingDeclaration) : [];
+
+  const categoryChanges = targetAppInfo
+    ? computeAttributeChanges(
+        { primaryCategoryId: metadata.primaryCategoryId, secondaryCategoryId: metadata.secondaryCategoryId },
+        { primaryCategoryId: targetAppInfo.primaryCategoryId, secondaryCategoryId: targetAppInfo.secondaryCategoryId }
+      )
+    : [];
+
+  const contentRightsChanges = computeAttributeChanges({ contentRightsDeclaration: metadata.contentRightsDeclaration }, { contentRightsDeclaration: current.contentRightsDeclaration });
+
+  return { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges };
+}
+
+export async function applyApplePush(token: string, plan: ApplePushPlan, dryRun: boolean): Promise<boolean> {
+  const { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges } = plan;
+  const hasChanges = ageRatingChanges.length > 0 || categoryChanges.length > 0 || contentRightsChanges.length > 0;
+  if (!hasChanges) {
+    console.log('   ✅ Apple: Keine Abweichungen - nichts zu tun.');
+    return false;
+  }
+
+  if ((ageRatingChanges.length > 0 || categoryChanges.length > 0) && targetAppInfo && !targetAppInfo.editable) {
+    throw new Error(
+      `Apple: Es gibt Abweichungen, aber keine bearbeitbare AppInfo (Status: ${targetAppInfo.state}). ` +
+        'Altersfreigabe und Kategorien sind nur änderbar, solange eine App-Store-Version im Entwurfsstatus existiert. ' +
+        'Bitte zuerst eine neue Version anlegen (macht der Submit-Workflow automatisch) und dann erneut pushen.'
+    );
+  }
+
+  if (ageRatingChanges.length > 0 && targetAppInfo) {
+    console.log(`   📝 Apple Altersfreigabe (${ageRatingChanges.length} Änderungen):\n${formatChanges(ageRatingChanges, '      ')}`);
+    if (!targetAppInfo.ageRatingDeclarationId) {
+      throw new Error('Apple: AppInfo hat keine ageRatingDeclaration-Relationship - bitte in App Store Connect prüfen.');
+    }
+    if (!dryRun) {
+      await ascRequest(token, 'PATCH', `/ageRatingDeclarations/${targetAppInfo.ageRatingDeclarationId}`, {
+        data: {
+          type: 'ageRatingDeclarations',
+          id: targetAppInfo.ageRatingDeclarationId,
+          attributes: changesToAttributeObject(ageRatingChanges),
+        },
+      });
+    }
+  }
+
+  if (categoryChanges.length > 0 && targetAppInfo) {
+    console.log(`   📝 Apple Kategorien:\n${formatChanges(categoryChanges, '      ')}`);
+    if (!dryRun) {
+      const relationships: Record<string, { data: { type: string; id: string } | null }> = {};
+      for (const change of categoryChanges) {
+        const relationship = change.key === 'primaryCategoryId' ? 'primaryCategory' : 'secondaryCategory';
+        relationships[relationship] = { data: change.to ? { type: 'appCategories', id: String(change.to) } : null };
+      }
+      await ascRequest(token, 'PATCH', `/appInfos/${targetAppInfo.appInfoId}`, {
+        data: { type: 'appInfos', id: targetAppInfo.appInfoId, relationships },
+      });
+    }
+  }
+
+  if (contentRightsChanges.length > 0) {
+    console.log(`   📝 Apple Content Rights:\n${formatChanges(contentRightsChanges, '      ')}`);
+    if (!dryRun) {
+      await ascRequest(token, 'PATCH', `/apps/${current.appId}`, {
+        data: { type: 'apps', id: current.appId, attributes: changesToAttributeObject(contentRightsChanges) },
+      });
+    }
+  }
+
+  console.log(dryRun ? '   🔍 Apple: Dry-Run - nichts geschrieben.' : '   ✅ Apple: Änderungen übertragen.');
+  return true;
+}

--- a/apps/scripts/store-metadata-diff.test.ts
+++ b/apps/scripts/store-metadata-diff.test.ts
@@ -1,0 +1,46 @@
+import { changesToAttributeObject, computeAttributeChanges, formatChanges, slugifyDisplayName } from './store-metadata-diff';
+
+describe('computeAttributeChanges', () => {
+  it('reports only fields that differ', () => {
+    const desired = { a: 'NONE', b: false, c: 'FREQUENT_OR_INTENSE' };
+    const current = { a: 'NONE', b: true, c: 'NONE', ignored: 'stays' };
+    expect(computeAttributeChanges(desired, current)).toEqual([
+      { key: 'b', from: true, to: false },
+      { key: 'c', from: 'NONE', to: 'FREQUENT_OR_INTENSE' },
+    ]);
+  });
+
+  it('ignores fields that are undefined in the ground truth', () => {
+    expect(computeAttributeChanges({ a: undefined, b: 'x' }, { a: 'store-value', b: 'x' })).toEqual([]);
+  });
+
+  it('treats missing current values as change', () => {
+    expect(computeAttributeChanges({ a: 'NONE' }, {})).toEqual([{ key: 'a', from: undefined, to: 'NONE' }]);
+  });
+
+  it('treats null and undefined as equal (Apple reports unanswered questions as null)', () => {
+    expect(computeAttributeChanges({ kidsAgeBand: null }, {})).toEqual([]);
+  });
+});
+
+describe('changesToAttributeObject', () => {
+  it('builds a patch object from changes', () => {
+    const changes = computeAttributeChanges({ a: 'NONE', b: false }, { a: 'FREQUENT_OR_INTENSE', b: true });
+    expect(changesToAttributeObject(changes)).toEqual({ a: 'NONE', b: false });
+  });
+});
+
+describe('formatChanges', () => {
+  it('formats human readable lines', () => {
+    const changes = computeAttributeChanges({ gambling: false }, { gambling: true });
+    expect(formatChanges(changes, '')).toBe('gambling: true -> false');
+  });
+});
+
+describe('slugifyDisplayName', () => {
+  it('creates safe file names', () => {
+    expect(slugifyDisplayName('Studi|Futter')).toBe('studi-futter');
+    expect(slugifyDisplayName('SWOSY 2.0')).toBe('swosy-2-0');
+    expect(slugifyDisplayName('***')).toBe('app');
+  });
+});

--- a/apps/scripts/store-metadata-diff.ts
+++ b/apps/scripts/store-metadata-diff.ts
@@ -1,0 +1,50 @@
+// Pure helpers for comparing the store metadata ground truth with the values the store
+// APIs report. Kept free of I/O so they are easy to test.
+
+export type AttributeChange = {
+  key: string;
+  from: unknown;
+  to: unknown;
+};
+
+function isEqualValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+// Returns the attributes that need to be written so that `current` matches `desired`.
+// Only keys that are set (not undefined) in the ground truth are managed - everything
+// else stays untouched in the store.
+export function computeAttributeChanges(desired: Record<string, unknown>, current: Record<string, unknown>): AttributeChange[] {
+  const changes: AttributeChange[] = [];
+  for (const [key, desiredValue] of Object.entries(desired)) {
+    if (desiredValue === undefined) {
+      continue;
+    }
+    const currentValue = current[key];
+    if (!isEqualValue(desiredValue, currentValue)) {
+      changes.push({ key, from: currentValue, to: desiredValue });
+    }
+  }
+  return changes;
+}
+
+export function changesToAttributeObject(changes: AttributeChange[]): Record<string, unknown> {
+  const attributes: Record<string, unknown> = {};
+  for (const change of changes) {
+    attributes[change.key] = change.to;
+  }
+  return attributes;
+}
+
+export function formatChanges(changes: AttributeChange[], indent = '   '): string {
+  return changes.map(change => `${indent}${change.key}: ${JSON.stringify(change.from ?? null)} -> ${JSON.stringify(change.to)}`).join('\n');
+}
+
+// Turns a display name like "Studi|Futter" into a safe file name like "studi-futter".
+export function slugifyDisplayName(displayName: string): string {
+  const slug = displayName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'app';
+}

--- a/apps/scripts/store-metadata-google.ts
+++ b/apps/scripts/store-metadata-google.ts
@@ -1,0 +1,219 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import type { GooglePlayAppMetadata } from 'repo-depkit-common';
+import { base64url } from './base64url';
+import { AttributeChange, computeAttributeChanges, formatChanges } from './store-metadata-diff';
+
+// Reads and writes the store listing ("Store-Eintrag") and app details of an app in the
+// Google Play Console via the Play Developer API (androidpublisher v3).
+//
+// Authentication uses a Google Cloud service account that is linked to the Play Console
+// (Setup -> API access). Provide the key via one of:
+//   GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH - path to the service-account .json file
+//   GOOGLE_PLAY_SERVICE_ACCOUNT_JSON      - the .json content itself (for CI secrets)
+//
+// Note: The content rating questionnaire ("Altersfreigabe") and the data safety form
+// have NO public API - those stay manual in the Play Console. Listings, contact details
+// and default language are fully automatable and handled here.
+
+const API_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+
+type ServiceAccount = { client_email: string; private_key: string; token_uri?: string };
+
+function readServiceAccount(): ServiceAccount {
+  const path = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH;
+  const content = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON;
+  const json = content ?? (path ? fs.readFileSync(path, 'utf8') : undefined);
+  if (!json) {
+    throw new Error('Weder GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH noch GOOGLE_PLAY_SERVICE_ACCOUNT_JSON ist gesetzt.');
+  }
+  const account = JSON.parse(json) as ServiceAccount;
+  if (!account.client_email || !account.private_key) {
+    throw new Error('Service-Account-JSON enthält kein client_email/private_key.');
+  }
+  return account;
+}
+
+export function hasGooglePlayCredentials(): boolean {
+  return Boolean(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH || process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+}
+
+export async function createGooglePlayAccessToken(): Promise<string> {
+  const account = readServiceAccount();
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = { iss: account.client_email, scope: SCOPE, aud: account.token_uri ?? TOKEN_URL, iat: now, exp: now + 3600 };
+  const unsigned = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signature = crypto.sign('sha256', Buffer.from(unsigned), account.private_key);
+  const assertion = `${unsigned}.${base64url(signature)}`;
+
+  const response = await fetch(account.token_uri ?? TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer', assertion }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Google OAuth Token Fehler (${response.status}):\n${text}`);
+  }
+  return (JSON.parse(text) as { access_token: string }).access_token;
+}
+
+async function googleRequest(accessToken: string, method: string, path: string, body?: unknown): Promise<any> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Google Play API Fehler (${response.status} ${method} ${path}):\n${text}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+export type GooglePlayListingSnapshot = {
+  language: string;
+  title?: string;
+  shortDescription?: string;
+  fullDescription?: string;
+  video?: string;
+};
+
+export type GooglePullResult = {
+  packageName: string;
+  details: {
+    defaultLanguage?: string;
+    contactEmail?: string;
+    contactPhone?: string;
+    contactWebsite?: string;
+  };
+  listings: GooglePlayListingSnapshot[];
+};
+
+async function createEdit(accessToken: string, packageName: string): Promise<string> {
+  const edit = await googleRequest(accessToken, 'POST', `/applications/${packageName}/edits`, {});
+  return edit.id as string;
+}
+
+async function deleteEdit(accessToken: string, packageName: string, editId: string): Promise<void> {
+  try {
+    await googleRequest(accessToken, 'DELETE', `/applications/${packageName}/edits/${editId}`);
+  } catch {
+    // Abandoned edits expire on their own - deletion failures are not worth failing the run.
+  }
+}
+
+export async function pullGoogleMetadata(accessToken: string, metadata: GooglePlayAppMetadata): Promise<GooglePullResult> {
+  const packageName = metadata.packageName;
+  const editId = await createEdit(accessToken, packageName);
+  try {
+    const details = await googleRequest(accessToken, 'GET', `/applications/${packageName}/edits/${editId}/details`);
+    const listingsResult = await googleRequest(accessToken, 'GET', `/applications/${packageName}/edits/${editId}/listings`);
+    const listings: GooglePlayListingSnapshot[] = ((listingsResult.listings ?? []) as any[]).map(listing => ({
+      language: listing.language,
+      title: listing.title,
+      shortDescription: listing.shortDescription,
+      fullDescription: listing.fullDescription,
+      video: listing.video,
+    }));
+    return {
+      packageName,
+      details: {
+        defaultLanguage: details.defaultLanguage,
+        contactEmail: details.contactEmail,
+        contactPhone: details.contactPhone,
+        contactWebsite: details.contactWebsite,
+      },
+      listings,
+    };
+  } finally {
+    await deleteEdit(accessToken, packageName, editId);
+  }
+}
+
+export type GooglePushPlan = {
+  current: GooglePullResult;
+  detailsChanges: AttributeChange[];
+  listingChanges: { language: string; changes: AttributeChange[] }[];
+};
+
+export function planGooglePush(current: GooglePullResult, metadata: GooglePlayAppMetadata): GooglePushPlan {
+  const detailsChanges = computeAttributeChanges(
+    {
+      defaultLanguage: metadata.defaultLanguage,
+      contactEmail: metadata.contactEmail,
+      contactPhone: metadata.contactPhone,
+      contactWebsite: metadata.contactWebsite,
+    },
+    current.details as Record<string, unknown>
+  );
+
+  const listingChanges: GooglePushPlan['listingChanges'] = [];
+  for (const [language, desiredListing] of Object.entries(metadata.listings ?? {})) {
+    const currentListing = current.listings.find(listing => listing.language === language) ?? { language };
+    const changes = computeAttributeChanges(desiredListing as Record<string, unknown>, currentListing as unknown as Record<string, unknown>);
+    if (changes.length > 0) {
+      listingChanges.push({ language, changes });
+    }
+  }
+
+  return { current, detailsChanges, listingChanges };
+}
+
+export async function applyGooglePush(accessToken: string, metadata: GooglePlayAppMetadata, plan: GooglePushPlan, dryRun: boolean): Promise<boolean> {
+  const { current, detailsChanges, listingChanges } = plan;
+  if (detailsChanges.length === 0 && listingChanges.length === 0) {
+    console.log('   ✅ Google: Keine Abweichungen - nichts zu tun.');
+    return false;
+  }
+
+  if (detailsChanges.length > 0) {
+    console.log(`   📝 Google App-Details:\n${formatChanges(detailsChanges, '      ')}`);
+  }
+  for (const { language, changes } of listingChanges) {
+    console.log(`   📝 Google Store-Eintrag (${language}):\n${formatChanges(changes, '      ')}`);
+  }
+
+  if (dryRun) {
+    console.log('   🔍 Google: Dry-Run - nichts geschrieben.');
+    return true;
+  }
+
+  const packageName = metadata.packageName;
+  const editId = await createEdit(accessToken, packageName);
+  try {
+    if (detailsChanges.length > 0) {
+      const patch: Record<string, unknown> = {};
+      for (const change of detailsChanges) {
+        patch[change.key] = change.to;
+      }
+      await googleRequest(accessToken, 'PATCH', `/applications/${packageName}/edits/${editId}/details`, patch);
+    }
+
+    for (const { language } of listingChanges) {
+      const desiredListing = metadata.listings?.[language] ?? {};
+      const currentListing = current.listings.find(listing => listing.language === language);
+      // PUT replaces the whole listing, so keep unmanaged fields from the current state.
+      await googleRequest(accessToken, 'PUT', `/applications/${packageName}/edits/${editId}/listings/${language}`, {
+        language,
+        title: desiredListing.title ?? currentListing?.title,
+        shortDescription: desiredListing.shortDescription ?? currentListing?.shortDescription,
+        fullDescription: desiredListing.fullDescription ?? currentListing?.fullDescription,
+        video: desiredListing.video ?? currentListing?.video,
+      });
+    }
+
+    await googleRequest(accessToken, 'POST', `/applications/${packageName}/edits/${editId}:commit`);
+    console.log('   ✅ Google: Änderungen übertragen (Edit committed).');
+    return true;
+  } catch (error) {
+    await deleteEdit(accessToken, packageName, editId);
+    throw error;
+  }
+}

--- a/apps/scripts/store-metadata-load.test.ts
+++ b/apps/scripts/store-metadata-load.test.ts
@@ -1,0 +1,51 @@
+import { filterStoreMetadata, loadStoreMetadataModule } from './store-metadata-load';
+
+// Loads the real ground-truth modules of all apps to catch broken imports or missing
+// exports before a sync run in CI would.
+describe('loadStoreMetadataModule', () => {
+  it('loads the rocket-meals tenant ground truth', () => {
+    const metadata = loadStoreMetadataModule('apps/frontend/app/store-metadata.ts');
+    const bundleIds = metadata.map(entry => entry.apple?.bundleId);
+    expect(bundleIds).toContain('de.baumgartner-software.swosy');
+    expect(bundleIds).toContain('de.stwh.app');
+    for (const entry of metadata) {
+      expect(entry.apple?.ageRatingDeclaration?.gambling).toBe(false);
+      // Documented deviation from the defaults, see docs/Apple Altersfreigabe.txt
+      expect(entry.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT_OR_MILD');
+      expect(entry.apple?.primaryCategoryId).toBe('FOOD_AND_DRINK');
+    }
+  });
+
+  it('loads the geonexia ground truth', () => {
+    const metadata = loadStoreMetadataModule('apps/geonexia/frontend/store-metadata.ts');
+    expect(metadata[0].apple?.bundleId).toBe('de.baumgartner-software.geonexia');
+    expect(metadata[0].google?.packageName).toBe('com.geonexia.app');
+  });
+
+  it('loads the score-tracker ground truth', () => {
+    const metadata = loadStoreMetadataModule('apps/score-tracker/frontend/store-metadata.ts');
+    expect(metadata[0].apple?.bundleId).toBe('de.baumgartner-software.score-tracker');
+    expect(metadata[0].google?.packageName).toBe('com.scoretracker.app');
+  });
+
+  it('throws for unknown modules', () => {
+    expect(() => loadStoreMetadataModule('apps/does-not-exist/store-metadata.ts')).toThrow('nicht gefunden');
+  });
+});
+
+describe('filterStoreMetadata', () => {
+  const metadata = loadStoreMetadataModule('apps/frontend/app/store-metadata.ts');
+
+  it('filters by bundle id, package name and display name', () => {
+    expect(filterStoreMetadata(metadata, 'de.stwh.app')).toHaveLength(1);
+    expect(filterStoreMetadata(metadata, 'swosy').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns everything without a filter', () => {
+    expect(filterStoreMetadata(metadata, undefined)).toHaveLength(metadata.length);
+  });
+
+  it('throws when nothing matches', () => {
+    expect(() => filterStoreMetadata(metadata, 'no-such-app')).toThrow('Kein App-Eintrag');
+  });
+});

--- a/apps/scripts/store-metadata-load.test.ts
+++ b/apps/scripts/store-metadata-load.test.ts
@@ -14,7 +14,7 @@ describe('loadStoreMetadataModule', () => {
       expect(entry.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT_OR_MILD');
       expect(entry.apple?.primaryCategoryId).toBe('FOOD_AND_DRINK');
       // Derived from config.ts baseUrl, same pattern as the Google SSO consent screen
-      expect(entry.apple?.privacyPolicyUrl).toMatch(/^https:\/\/rocket-meals\.github\.io\/[a-z-]+\/wikis\?wikis_custom_id=privacy-policy$/);
+      expect(entry.apple?.privacyPolicyUrl).toMatch(/^https:\/\/rocket-meals\.de\/[a-z-]+\/wikis\?custom_id=privacy-policy$/);
     }
   });
 

--- a/apps/scripts/store-metadata-load.test.ts
+++ b/apps/scripts/store-metadata-load.test.ts
@@ -13,6 +13,8 @@ describe('loadStoreMetadataModule', () => {
       // Documented deviation from the defaults, see docs/Apple Altersfreigabe.txt
       expect(entry.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT_OR_MILD');
       expect(entry.apple?.primaryCategoryId).toBe('FOOD_AND_DRINK');
+      // Derived from config.ts baseUrl, same pattern as the Google SSO consent screen
+      expect(entry.apple?.privacyPolicyUrl).toMatch(/^https:\/\/rocket-meals\.github\.io\/[a-z-]+\/wikis\?wikis_custom_id=privacy-policy$/);
     }
   });
 

--- a/apps/scripts/store-metadata-load.ts
+++ b/apps/scripts/store-metadata-load.ts
@@ -1,0 +1,43 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { StoreAppMetadata } from 'repo-depkit-common';
+
+// Loads a ground truth module (e.g. apps/frontend/app/store-metadata.ts). Every app in
+// the monorepo manages its own store metadata; the module just has to export a
+// getStoreMetadata(): StoreAppMetadata[] function.
+
+export const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+export function loadStoreMetadataModule(modulePath: string): StoreAppMetadata[] {
+  const absolutePath = path.isAbsolute(modulePath) ? modulePath : path.resolve(REPO_ROOT, modulePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Ground-Truth-Modul nicht gefunden: ${absolutePath}`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const loaded = require(absolutePath) as { getStoreMetadata?: () => StoreAppMetadata[] };
+  if (typeof loaded.getStoreMetadata !== 'function') {
+    throw new Error(`${absolutePath} exportiert keine Funktion getStoreMetadata(): StoreAppMetadata[]`);
+  }
+
+  const metadata = loaded.getStoreMetadata();
+  if (!Array.isArray(metadata) || metadata.length === 0) {
+    throw new Error(`${absolutePath}: getStoreMetadata() lieferte keine Einträge.`);
+  }
+  return metadata;
+}
+
+// --app <filter> matches against display name, bundle id and package name.
+export function filterStoreMetadata(metadata: StoreAppMetadata[], appFilter: string | undefined): StoreAppMetadata[] {
+  if (!appFilter) {
+    return metadata;
+  }
+  const needle = appFilter.toLowerCase();
+  const filtered = metadata.filter(entry =>
+    [entry.displayName, entry.apple?.bundleId, entry.google?.packageName].some(value => value?.toLowerCase().includes(needle))
+  );
+  if (filtered.length === 0) {
+    throw new Error(`Kein App-Eintrag passt zum Filter "${appFilter}".`);
+  }
+  return filtered;
+}

--- a/apps/scripts/store-metadata-plan.test.ts
+++ b/apps/scripts/store-metadata-plan.test.ts
@@ -18,6 +18,7 @@ describe('planApplePush', () => {
         ageRatingDeclaration: { gambling: false, violenceCartoonOrFantasy: 'NONE' },
         primaryCategoryId: 'FOOD_AND_DRINK',
         secondaryCategoryId: undefined,
+        localizations: [],
       },
       {
         appInfoId: 'info-editable',
@@ -27,6 +28,10 @@ describe('planApplePush', () => {
         ageRatingDeclaration: { gambling: true, violenceCartoonOrFantasy: 'NONE' },
         primaryCategoryId: 'EDUCATION',
         secondaryCategoryId: undefined,
+        localizations: [
+          { localizationId: 'loc-de', locale: 'de-DE', privacyPolicyUrl: 'https://old.example.com/datenschutz', privacyChoicesUrl: undefined },
+          { localizationId: 'loc-en', locale: 'en-US', privacyPolicyUrl: undefined, privacyChoicesUrl: undefined },
+        ],
       },
     ],
   };
@@ -49,6 +54,15 @@ describe('planApplePush', () => {
     expect(plan.ageRatingChanges).toEqual([]);
     expect(plan.categoryChanges).toEqual([]);
     expect(plan.contentRightsChanges).toEqual([]);
+    expect(plan.localizationChanges).toEqual([]);
+  });
+
+  it('updates the privacy policy url for every locale that differs', () => {
+    const plan = planApplePush(current, { bundleId: 'de.example.app', privacyPolicyUrl: 'https://new.example.com/datenschutz' });
+    expect(plan.localizationChanges).toEqual([
+      { localizationId: 'loc-de', locale: 'de-DE', changes: [{ key: 'privacyPolicyUrl', from: 'https://old.example.com/datenschutz', to: 'https://new.example.com/datenschutz' }] },
+      { localizationId: 'loc-en', locale: 'en-US', changes: [{ key: 'privacyPolicyUrl', from: undefined, to: 'https://new.example.com/datenschutz' }] },
+    ]);
   });
 });
 

--- a/apps/scripts/store-metadata-plan.test.ts
+++ b/apps/scripts/store-metadata-plan.test.ts
@@ -1,0 +1,83 @@
+import type { AppleAppMetadata, GooglePlayAppMetadata } from 'repo-depkit-common';
+import { ApplePullResult, planApplePush } from './store-metadata-apple';
+import { GooglePullResult, planGooglePush } from './store-metadata-google';
+
+describe('planApplePush', () => {
+  const current: ApplePullResult = {
+    appId: 'app-1',
+    bundleId: 'de.example.app',
+    name: 'Example',
+    contentRightsDeclaration: undefined,
+    appStoreAgeRating: 'FOUR_PLUS',
+    appInfos: [
+      {
+        appInfoId: 'info-readonly',
+        state: 'READY_FOR_DISTRIBUTION',
+        editable: false,
+        ageRatingDeclarationId: 'age-1',
+        ageRatingDeclaration: { gambling: false, violenceCartoonOrFantasy: 'NONE' },
+        primaryCategoryId: 'FOOD_AND_DRINK',
+        secondaryCategoryId: undefined,
+      },
+      {
+        appInfoId: 'info-editable',
+        state: 'PREPARE_FOR_SUBMISSION',
+        editable: true,
+        ageRatingDeclarationId: 'age-2',
+        ageRatingDeclaration: { gambling: true, violenceCartoonOrFantasy: 'NONE' },
+        primaryCategoryId: 'EDUCATION',
+        secondaryCategoryId: undefined,
+      },
+    ],
+  };
+
+  it('prefers the editable app info and only reports drifted fields', () => {
+    const metadata: AppleAppMetadata = {
+      bundleId: 'de.example.app',
+      ageRatingDeclaration: { gambling: false, violenceCartoonOrFantasy: 'NONE' },
+      primaryCategoryId: 'FOOD_AND_DRINK',
+    };
+    const plan = planApplePush(current, metadata);
+    expect(plan.targetAppInfo?.appInfoId).toBe('info-editable');
+    expect(plan.ageRatingChanges).toEqual([{ key: 'gambling', from: true, to: false }]);
+    expect(plan.categoryChanges).toEqual([{ key: 'primaryCategoryId', from: 'EDUCATION', to: 'FOOD_AND_DRINK' }]);
+    expect(plan.contentRightsChanges).toEqual([]);
+  });
+
+  it('manages nothing when the ground truth defines nothing', () => {
+    const plan = planApplePush(current, { bundleId: 'de.example.app' });
+    expect(plan.ageRatingChanges).toEqual([]);
+    expect(plan.categoryChanges).toEqual([]);
+    expect(plan.contentRightsChanges).toEqual([]);
+  });
+});
+
+describe('planGooglePush', () => {
+  const current: GooglePullResult = {
+    packageName: 'de.example.app',
+    details: { defaultLanguage: 'de-DE', contactEmail: 'old@example.com' },
+    listings: [{ language: 'de-DE', title: 'Alter Titel', shortDescription: 'Kurz' }],
+  };
+
+  it('reports drifted details and listings', () => {
+    const metadata: GooglePlayAppMetadata = {
+      packageName: 'de.example.app',
+      contactEmail: 'new@example.com',
+      listings: { 'de-DE': { title: 'Neuer Titel' } },
+    };
+    const plan = planGooglePush(current, metadata);
+    expect(plan.detailsChanges).toEqual([{ key: 'contactEmail', from: 'old@example.com', to: 'new@example.com' }]);
+    expect(plan.listingChanges).toEqual([{ language: 'de-DE', changes: [{ key: 'title', from: 'Alter Titel', to: 'Neuer Titel' }] }]);
+  });
+
+  it('is empty when store and ground truth match', () => {
+    const metadata: GooglePlayAppMetadata = {
+      packageName: 'de.example.app',
+      defaultLanguage: 'de-DE',
+      listings: { 'de-DE': { title: 'Alter Titel' } },
+    };
+    const plan = planGooglePush(current, metadata);
+    expect(plan.detailsChanges).toEqual([]);
+    expect(plan.listingChanges).toEqual([]);
+  });
+});

--- a/apps/scripts/store-metadata.ts
+++ b/apps/scripts/store-metadata.ts
@@ -1,0 +1,211 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { EXPO_ASC_ISSUER_ID, EXPO_ASC_KEY_ID, StoreAppMetadata } from 'repo-depkit-common';
+import { createAppStoreConnectToken } from './asc-api';
+import { applyApplePush, planApplePush, pullAppleMetadata } from './store-metadata-apple';
+import { formatChanges, slugifyDisplayName } from './store-metadata-diff';
+import { applyGooglePush, createGooglePlayAccessToken, hasGooglePlayCredentials, planGooglePush, pullGoogleMetadata } from './store-metadata-google';
+import { REPO_ROOT, filterStoreMetadata, loadStoreMetadataModule } from './store-metadata-load';
+
+// CLI for syncing app store metadata ("App-Informationen") with the ground truth that
+// every app defines in its store-metadata.ts. See packages/common/src/StoreAppMetadata.ts.
+//
+// Usage (from the repo root, see the store-metadata:* scripts in package.json):
+//   yarn workspace rocket-meals-scripts store-metadata pull --module apps/frontend/app/store-metadata.ts
+//   yarn workspace rocket-meals-scripts store-metadata push --module apps/frontend/app/store-metadata.ts [--dry-run]
+//
+// Options:
+//   --module <path>        Ground-truth module, relative to the repo root (required)
+//   --store apple|google   Only sync one store (default: both)
+//   --app <filter>         Only sync entries matching the filter (name/bundleId/package)
+//   --dry-run              push only: show what would change, write nothing
+//
+// Credentials:
+//   Apple:  EXPO_ASC_API_KEY_PATH (path to the .p8 key). Key id and issuer id default to
+//           the values in repo-depkit-common (AppleAppStoreConfig) and can be overridden
+//           via EXPO_ASC_KEY_ID / EXPO_ASC_ISSUER_ID.
+//   Google: GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH or GOOGLE_PLAY_SERVICE_ACCOUNT_JSON.
+//
+// Pull writes snapshots to reports/store-metadata/<app>.<store>.json and prints the
+// drift between store and ground truth. Push writes only the drifted fields.
+
+type CliOptions = {
+  command: 'pull' | 'push';
+  modulePath: string;
+  store: 'apple' | 'google' | 'all';
+  appFilter: string | undefined;
+  dryRun: boolean;
+};
+
+function parseCliOptions(argv: string[]): CliOptions {
+  const [command, ...rest] = argv;
+  if (command !== 'pull' && command !== 'push') {
+    throw new Error(`Unbekanntes Kommando "${command ?? ''}" - erwartet "pull" oder "push".`);
+  }
+
+  let modulePath: string | undefined;
+  let store: CliOptions['store'] = 'all';
+  let appFilter: string | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === '--module') {
+      modulePath = rest[++i];
+    } else if (arg === '--store') {
+      const value = rest[++i];
+      if (value !== 'apple' && value !== 'google') {
+        throw new Error(`--store erwartet "apple" oder "google", nicht "${value}".`);
+      }
+      store = value;
+    } else if (arg === '--app') {
+      appFilter = rest[++i];
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else {
+      throw new Error(`Unbekannte Option "${arg}".`);
+    }
+  }
+
+  if (!modulePath) {
+    throw new Error('Option --module <pfad/zur/store-metadata.ts> fehlt.');
+  }
+
+  return { command, modulePath, store, appFilter, dryRun };
+}
+
+const REPORT_DIR = path.join(REPO_ROOT, 'reports', 'store-metadata');
+
+function writeReport(displayName: string, store: 'apple' | 'google', snapshot: unknown): string {
+  fs.mkdirSync(REPORT_DIR, { recursive: true });
+  const reportPath = path.join(REPORT_DIR, `${slugifyDisplayName(displayName)}.${store}.json`);
+  fs.writeFileSync(reportPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  return path.relative(REPO_ROOT, reportPath);
+}
+
+// Missing credentials only skip a store when the user asked for "both" (default) - an
+// explicit --store apple/google must fail loudly instead.
+function resolveAppleToken(options: CliOptions): string | undefined {
+  const keyPath = process.env.EXPO_ASC_API_KEY_PATH;
+  if (!keyPath) {
+    if (options.store === 'apple') {
+      throw new Error('EXPO_ASC_API_KEY_PATH ist nicht gesetzt (Pfad zum App Store Connect .p8 Key).');
+    }
+    console.log('⚠️ Apple wird übersprungen: EXPO_ASC_API_KEY_PATH ist nicht gesetzt.\n');
+    return undefined;
+  }
+  const keyId = process.env.EXPO_ASC_KEY_ID ?? EXPO_ASC_KEY_ID;
+  const issuerId = process.env.EXPO_ASC_ISSUER_ID ?? EXPO_ASC_ISSUER_ID;
+  return createAppStoreConnectToken(keyId, issuerId, keyPath);
+}
+
+async function resolveGoogleToken(options: CliOptions): Promise<string | undefined> {
+  if (!hasGooglePlayCredentials()) {
+    if (options.store === 'google') {
+      throw new Error('Weder GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH noch GOOGLE_PLAY_SERVICE_ACCOUNT_JSON ist gesetzt.');
+    }
+    console.log('⚠️ Google wird übersprungen: Kein Play-Service-Account konfiguriert (GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH).\n');
+    return undefined;
+  }
+  return await createGooglePlayAccessToken();
+}
+
+async function handleApple(options: CliOptions, appleToken: string, entry: StoreAppMetadata): Promise<void> {
+  if (!entry.apple) {
+    return;
+  }
+  console.log(`🍎 Apple (${entry.apple.bundleId}):`);
+  const current = await pullAppleMetadata(appleToken, entry.apple);
+  const plan = planApplePush(current, entry.apple);
+
+  if (options.command === 'pull') {
+    const reportPath = writeReport(entry.displayName, 'apple', current);
+    console.log(`   Name: ${current.name}, Altersfreigabe: ${current.appStoreAgeRating ?? 'unbekannt'}, Content Rights: ${current.contentRightsDeclaration ?? 'unbekannt'}`);
+    for (const appInfo of current.appInfos) {
+      console.log(`   AppInfo ${appInfo.appInfoId} (${appInfo.state}${appInfo.editable ? ', bearbeitbar' : ''}): Kategorie ${appInfo.primaryCategoryId ?? '-'}`);
+    }
+    const driftedChanges = [...plan.ageRatingChanges, ...plan.categoryChanges, ...plan.contentRightsChanges];
+    if (driftedChanges.length > 0) {
+      console.log(`   ⚠️ Abweichungen zur Ground Truth (Store -> Soll):\n${formatChanges(driftedChanges, '      ')}`);
+    } else {
+      console.log('   ✅ Store entspricht der Ground Truth.');
+    }
+    console.log(`   💾 Snapshot: ${reportPath}\n`);
+    return;
+  }
+
+  await applyApplePush(appleToken, plan, options.dryRun);
+  console.log('');
+}
+
+async function handleGoogle(options: CliOptions, googleToken: string, entry: StoreAppMetadata): Promise<void> {
+  if (!entry.google) {
+    return;
+  }
+  console.log(`🤖 Google Play (${entry.google.packageName}):`);
+  const current = await pullGoogleMetadata(googleToken, entry.google);
+  const plan = planGooglePush(current, entry.google);
+
+  if (options.command === 'pull') {
+    const reportPath = writeReport(entry.displayName, 'google', current);
+    console.log(`   Standardsprache: ${current.details.defaultLanguage ?? '-'}, Kontakt: ${current.details.contactEmail ?? '-'}`);
+    for (const listing of current.listings) {
+      console.log(`   Listing ${listing.language}: "${listing.title ?? ''}"`);
+    }
+    const driftedChanges = [...plan.detailsChanges, ...plan.listingChanges.flatMap(listing => listing.changes)];
+    if (driftedChanges.length > 0) {
+      console.log(`   ⚠️ Abweichungen zur Ground Truth (Store -> Soll):\n${formatChanges(driftedChanges, '      ')}`);
+    } else {
+      console.log('   ✅ Store entspricht der Ground Truth.');
+    }
+    console.log(`   💾 Snapshot: ${reportPath}\n`);
+    return;
+  }
+
+  await applyGooglePush(googleToken, entry.google, plan, options.dryRun);
+  console.log('');
+}
+
+async function main(): Promise<void> {
+  const options = parseCliOptions(process.argv.slice(2));
+  const metadata = filterStoreMetadata(loadStoreMetadataModule(options.modulePath), options.appFilter);
+
+  console.log(`📦 Ground Truth: ${options.modulePath} (${metadata.length} App(s))`);
+  console.log(`🛠️ Kommando: ${options.command}${options.dryRun ? ' (dry-run)' : ''}, Stores: ${options.store}\n`);
+
+  const wantsApple = options.store !== 'google' && metadata.some(entry => entry.apple);
+  const wantsGoogle = options.store !== 'apple' && metadata.some(entry => entry.google);
+  const appleToken = wantsApple ? resolveAppleToken(options) : undefined;
+  const googleToken = wantsGoogle ? await resolveGoogleToken(options) : undefined;
+
+  const failures: string[] = [];
+  for (const entry of metadata) {
+    console.log(`===== ${entry.displayName} =====`);
+    if (appleToken && entry.apple) {
+      try {
+        await handleApple(options, appleToken, entry);
+      } catch (error) {
+        failures.push(`${entry.displayName} (Apple): ${error instanceof Error ? error.message : String(error)}`);
+        console.error(`   ❌ ${error instanceof Error ? error.message : error}\n`);
+      }
+    }
+    if (googleToken && entry.google) {
+      try {
+        await handleGoogle(options, googleToken, entry);
+      } catch (error) {
+        failures.push(`${entry.displayName} (Google): ${error instanceof Error ? error.message : String(error)}`);
+        console.error(`   ❌ ${error instanceof Error ? error.message : error}\n`);
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Fehler bei ${failures.length} Sync-Schritt(en):\n- ${failures.join('\n- ')}`);
+  }
+  console.log('🎉 Fertig.');
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/apps/scripts/store-metadata.ts
+++ b/apps/scripts/store-metadata.ts
@@ -124,7 +124,7 @@ async function handleApple(options: CliOptions, appleToken: string, entry: Store
     for (const appInfo of current.appInfos) {
       console.log(`   AppInfo ${appInfo.appInfoId} (${appInfo.state}${appInfo.editable ? ', bearbeitbar' : ''}): Kategorie ${appInfo.primaryCategoryId ?? '-'}`);
     }
-    const driftedChanges = [...plan.ageRatingChanges, ...plan.categoryChanges, ...plan.contentRightsChanges];
+    const driftedChanges = [...plan.ageRatingChanges, ...plan.categoryChanges, ...plan.contentRightsChanges, ...plan.localizationChanges.flatMap(localization => localization.changes)];
     if (driftedChanges.length > 0) {
       console.log(`   ⚠️ Abweichungen zur Ground Truth (Store -> Soll):\n${formatChanges(driftedChanges, '      ')}`);
     } else {

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -272,26 +272,22 @@ type Credentials = { keyId: string; issuerId: string; privateKeyPath: string };
 // Before submitting, the "App-Informationen" (age rating declaration, categories,
 // privacy urls) are aligned with the ground truth from STORE_METADATA_MODULE - see
 // docs/STORE_METADATA.md. This runs after findOrCreateAppStoreVersion so an editable
-// AppInfo is guaranteed to exist. A failed sync must not block the submission itself
-// (the build would otherwise never reach the review), so errors only log loudly.
+// AppInfo is guaranteed to exist. A failed sync BLOCKS the submission: a version must
+// not reach App Review with metadata that drifted from the ground truth. Only a run
+// without STORE_METADATA_MODULE (sync not configured, e.g. local invocation) skips.
 async function syncStoreMetadata(token: string, bundleId: string): Promise<void> {
   const modulePath = process.env.STORE_METADATA_MODULE;
   if (!modulePath) {
     console.log('   ⏭️ STORE_METADATA_MODULE ist nicht gesetzt - Metadaten-Sync wird übersprungen.');
     return;
   }
-  try {
-    const entry = loadStoreMetadataModule(modulePath).find(candidate => candidate.apple?.bundleId === bundleId);
-    if (!entry?.apple) {
-      console.log(`   ⏭️ Keine Apple Ground Truth für "${bundleId}" in ${modulePath} - Metadaten-Sync wird übersprungen.`);
-      return;
-    }
-    const current = await pullAppleMetadata(token, entry.apple);
-    const plan = planApplePush(current, entry.apple);
-    await applyApplePush(token, plan, false);
-  } catch (error) {
-    console.error(`   ⚠️ Store-Metadaten-Sync fehlgeschlagen - die Einreichung läuft trotzdem weiter: ${error instanceof Error ? error.message : error}`);
+  const entry = loadStoreMetadataModule(modulePath).find(candidate => candidate.apple?.bundleId === bundleId);
+  if (!entry?.apple) {
+    throw new Error(`Keine Apple Ground Truth für "${bundleId}" in ${modulePath} - bitte einen Eintrag ergänzen (siehe docs/STORE_METADATA.md).`);
   }
+  const current = await pullAppleMetadata(token, entry.apple);
+  const plan = planApplePush(current, entry.apple);
+  await applyApplePush(token, plan, false);
 }
 
 async function attemptSubmission(bundleId: string, releaseNotes: string, credentials: Credentials): Promise<void> {

--- a/apps/scripts/submit-ios-review.ts
+++ b/apps/scripts/submit-ios-review.ts
@@ -1,4 +1,6 @@
 import { AscApiError, JsonApiResource, asArray, ascRequest, createAppStoreConnectToken, findAppId, readRequiredEnv } from './asc-api';
+import { applyApplePush, planApplePush, pullAppleMetadata } from './store-metadata-apple';
+import { loadStoreMetadataModule } from './store-metadata-load';
 
 // https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionstate
 const SUBMITTABLE_APP_VERSION_STATES = new Set(['PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'REJECTED', 'METADATA_REJECTED', 'INVALID_BINARY']);
@@ -267,6 +269,31 @@ function sleepMinutes(minutes: number): Promise<void> {
 
 type Credentials = { keyId: string; issuerId: string; privateKeyPath: string };
 
+// Before submitting, the "App-Informationen" (age rating declaration, categories,
+// privacy urls) are aligned with the ground truth from STORE_METADATA_MODULE - see
+// docs/STORE_METADATA.md. This runs after findOrCreateAppStoreVersion so an editable
+// AppInfo is guaranteed to exist. A failed sync must not block the submission itself
+// (the build would otherwise never reach the review), so errors only log loudly.
+async function syncStoreMetadata(token: string, bundleId: string): Promise<void> {
+  const modulePath = process.env.STORE_METADATA_MODULE;
+  if (!modulePath) {
+    console.log('   ⏭️ STORE_METADATA_MODULE ist nicht gesetzt - Metadaten-Sync wird übersprungen.');
+    return;
+  }
+  try {
+    const entry = loadStoreMetadataModule(modulePath).find(candidate => candidate.apple?.bundleId === bundleId);
+    if (!entry?.apple) {
+      console.log(`   ⏭️ Keine Apple Ground Truth für "${bundleId}" in ${modulePath} - Metadaten-Sync wird übersprungen.`);
+      return;
+    }
+    const current = await pullAppleMetadata(token, entry.apple);
+    const plan = planApplePush(current, entry.apple);
+    await applyApplePush(token, plan, false);
+  } catch (error) {
+    console.error(`   ⚠️ Store-Metadaten-Sync fehlgeschlagen - die Einreichung läuft trotzdem weiter: ${error instanceof Error ? error.message : error}`);
+  }
+}
+
 async function attemptSubmission(bundleId: string, releaseNotes: string, credentials: Credentials): Promise<void> {
   // The App Store Connect JWT expires after 15 minutes, so every attempt of the
   // retry loop below needs a fresh one.
@@ -289,6 +316,9 @@ async function attemptSubmission(bundleId: string, releaseNotes: string, credent
 
   console.log('📝 Aktualisiere Changelog-Text (What\'s New) ...');
   await updateReleaseNotes(token, appStoreVersionId, releaseNotes);
+
+  console.log('📋 Gleiche App-Informationen (Altersfreigabe & Co) mit der Ground Truth ab ...');
+  await syncStoreMetadata(token, bundleId);
 
   console.log('🔍 Prüfe auf bereits laufende Review-Einreichung ...');
   const reusableSubmissionId = await findReusableReviewSubmission(token, appId);

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -66,6 +66,16 @@ Optionen (an das Workspace-Kommando anhängbar, z. B.
 
 `pull` schreibt zusätzlich Snapshots nach `reports/store-metadata/<app>.<store>.json`.
 
+### Manuell per GitHub Workflow
+
+Der Workflow **"🏪 Store Metadata: Pull / Push"** (`.github/workflows/store-metadata.yml`)
+kann per `workflow_dispatch` gestartet werden: Kommando (`pull`/`push`), App
+(`rocket-meals`/`geonexia`/`score-tracker`), Store (`all`/`apple`/`google`) und für
+`push` optional Dry-Run. Beim `pull` landen die Snapshots als JSON in der
+Console-Ausgabe, in der Job-Summary und als Workflow-Artifact (30 Tage) - es wird
+nichts ins Repo committet. Credentials kommen aus den Repo-Secrets
+`EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT` und `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
+
 ## Zugangsdaten
 
 **Apple** (gleicher Key wie der iOS-Submit-Workflow, Team-weit gültig - deckt alle

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -1,0 +1,87 @@
+# Store-Metadaten (App-Informationen) als Ground Truth
+
+Apple (App Store Connect) und Google (Play Console) fragen regelmäßig Metadaten ab -
+z. B. die Altersfreigabe unter "App-Informationen". Damit das nicht pro Tenant/App von
+Hand gepflegt werden muss, liegt die **Ground Truth versioniert im Repo** und wird per
+CLI mit den Stores abgeglichen.
+
+## Aufbau
+
+- **Typen + Defaults**: `packages/common/src/StoreAppMetadata.ts` (`repo-depkit-common`)
+- **Ground Truth pro App** (jede App verwaltet ihre Metadaten selbst):
+  - `apps/frontend/app/store-metadata.ts` (alle Rocket-Meals-Tenants: Demo, SWOSY, Studi|Futter)
+  - `apps/geonexia/frontend/store-metadata.ts`
+  - `apps/score-tracker/frontend/store-metadata.ts`
+- **CLI**: `apps/scripts/store-metadata.ts` (Workspace `rocket-meals-scripts`)
+
+Es werden **nur Felder verwaltet, die in der Ground Truth gesetzt sind** - alles andere
+bleibt in den Stores unangetastet. Die fachliche Begründung der Altersfreigabe-Antworten
+steht in `docs/Apple Altersfreigabe.txt`.
+
+## Kommandos
+
+```bash
+# Ist-Stand aus den Stores lesen + Abweichungen zur Ground Truth anzeigen
+yarn store-metadata:pull:rocket-meals
+yarn store-metadata:pull:geonexia
+yarn store-metadata:pull:score-tracker
+
+# Ground Truth in die Stores schreiben (nur abweichende Felder)
+yarn store-metadata:push:rocket-meals
+yarn store-metadata:push:geonexia
+yarn store-metadata:push:score-tracker
+```
+
+Optionen (an das Workspace-Kommando anhängbar, z. B.
+`yarn workspace rocket-meals-scripts store-metadata push --module apps/frontend/app/store-metadata.ts --dry-run`):
+
+- `--store apple|google` - nur einen Store abgleichen
+- `--app <filter>` - nur Apps, deren Name/BundleId/Package den Filter enthält
+- `--dry-run` - (push) nur anzeigen, nichts schreiben
+
+`pull` schreibt zusätzlich Snapshots nach `reports/store-metadata/<app>.<store>.json`.
+
+## Zugangsdaten
+
+**Apple** (gleicher Key wie der iOS-Submit-Workflow, Team-weit gültig - deckt alle
+Tenants ab):
+
+```bash
+export EXPO_ASC_API_KEY_PATH=/pfad/zum/AuthKey.p8
+# Key-ID und Issuer-ID kommen automatisch aus repo-depkit-common (AppleAppStoreConfig)
+```
+
+**Google** (Service-Account, in der Play Console unter "Einrichtung -> API-Zugriff" mit
+dem Entwicklerkonto verknüpfen, Rechte: "App-Informationen bearbeiten"):
+
+```bash
+export GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH=/pfad/zum/service-account.json
+# oder GOOGLE_PLAY_SERVICE_ACCOUNT_JSON mit dem JSON-Inhalt (für CI-Secrets)
+```
+
+Fehlen Zugangsdaten für einen Store, wird er mit Warnung übersprungen (außer er wurde
+explizit per `--store` angefordert).
+
+## Was wird verwaltet?
+
+| Feld | Apple | Google |
+| --- | --- | --- |
+| Altersfreigabe-Fragebogen (`ageRatingDeclaration`) | ✅ per API | ❌ keine öffentliche API |
+| Kategorien (`primaryCategoryId`/`secondaryCategoryId`) | ✅ | ❌ keine öffentliche API |
+| Content-Rights-Erklärung | ✅ | - |
+| Kontaktdaten / Standardsprache | - | ✅ (`edits/details`) |
+| Store-Eintrag (Titel, Beschreibungen) | (noch nicht) | ✅ (`edits/listings`) |
+
+## Bekannte Einschränkungen
+
+- **Apple**: Altersfreigabe und Kategorien sind nur änderbar, solange eine App-Store-
+  Version im Entwurfsstatus existiert (legt der Submit-Workflow ohnehin an). Die
+  Änderungen werden erst mit der nächsten eingereichten Version live.
+- **Apple 2025er-Fragebogen**: Apple hat den Fragebogen erweitert (neue Ratings
+  4+/9+/13+/16+/18+, Fähigkeiten wie "Benutzergenerierte Inhalte"). `pull` zeigt alle
+  Attribute, die Apple aktuell liefert - neue Fragen können direkt in der Ground Truth
+  ergänzt werden (der Typ ist dafür offen).
+- **Apple Datenschutz-Labels** ("App-Datenschutz"): keine öffentliche REST-API.
+- **Google Altersfreigabe** (Inhaltseinstufungs-Fragebogen) und **Datensicherheits-
+  Formular**: keine öffentliche API - bleiben manuell in der Play Console. Der Rest
+  (Listings, Kontaktdaten) läuft per API.

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -9,7 +9,8 @@ CLI mit den Stores abgeglichen.
 
 - **Typen + Defaults**: `packages/common/src/StoreAppMetadata.ts` (`repo-depkit-common`)
 - **Ground Truth pro App** (jede App verwaltet ihre Metadaten selbst):
-  - `apps/frontend/app/store-metadata.ts` (alle Rocket-Meals-Tenants: Demo, SWOSY, Studi|Futter)
+  - `apps/frontend/app/store-metadata.ts` (alle Rocket-Meals-Tenants: Demo, SWOSY,
+    Studi|Futter - gemeinsame Werte mit wenigen Tenant-Overrides, z. B. Datenschutz-URL)
   - `apps/geonexia/frontend/store-metadata.ts`
   - `apps/score-tracker/frontend/store-metadata.ts`
 - **CLI**: `apps/scripts/store-metadata.ts` (Workspace `rocket-meals-scripts`)
@@ -17,6 +18,23 @@ CLI mit den Stores abgeglichen.
 Es werden **nur Felder verwaltet, die in der Ground Truth gesetzt sind** - alles andere
 bleibt in den Stores unangetastet. Die fachliche Begründung der Altersfreigabe-Antworten
 steht in `docs/Apple Altersfreigabe.txt`.
+
+## Automatischer Sync im Submit-Workflow
+
+Die `ios-submit-review-*`-Workflows setzen `STORE_METADATA_MODULE`, dadurch gleicht
+`apps/scripts/submit-ios-review.ts` die App-Informationen **vor jeder Review-Einreichung**
+mit der Ground Truth ab - genau dann existiert garantiert eine bearbeitbare Version.
+Neue Apple-Pflichtangaben also einfach in der Ground Truth ergänzen; der nächste Submit
+verteilt sie. Ein fehlgeschlagener Metadaten-Sync blockiert die Einreichung nicht,
+sondern loggt eine deutliche Warnung.
+
+## Review-Submit pro Tenant deaktivieren
+
+In `apps/frontend/app/config.ts` steuert `iosAppStoreReviewSubmitEnabled` pro Tenant, ob
+der Submit-Workflow Builds zur App-Review einreicht. Die Rocket-Meals-Demo-App steht auf
+`false` (reine Test-App), SWOSY und Studi|Futter auf `true`. Nicht gesetzt bedeutet
+`true`. Der Workflow überspringt den Submit-Step dann komplett (mit Log-Hinweis) - auch
+bei manuellen `workflow_dispatch`-Läufen.
 
 ## Kommandos
 
@@ -69,6 +87,7 @@ explizit per `--store` angefordert).
 | Altersfreigabe-Fragebogen (`ageRatingDeclaration`) | ✅ per API | ❌ keine öffentliche API |
 | Kategorien (`primaryCategoryId`/`secondaryCategoryId`) | ✅ | ❌ keine öffentliche API |
 | Content-Rights-Erklärung | ✅ | - |
+| Datenschutz-URL (`privacyPolicyUrl`/`privacyChoicesUrl`) | ✅ (alle Sprachen) | ❌ keine öffentliche API |
 | Kontaktdaten / Standardsprache | - | ✅ (`edits/details`) |
 | Store-Eintrag (Titel, Beschreibungen) | (noch nicht) | ✅ (`edits/listings`) |
 

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -31,7 +31,7 @@ Review gehen. Nur wenn `STORE_METADATA_MODULE` gar nicht gesetzt ist (z. B. loka
 Aufruf), wird der Sync mit Log-Hinweis übersprungen.
 
 Die Datenschutz-URL der Rocket-Meals-Tenants wird aus der `baseUrl` in `config.ts`
-abgeleitet (`https://rocket-meals.github.io/<tenant>/wikis?wikis_custom_id=privacy-policy`,
+abgeleitet (`https://rocket-meals.de/<tenant>/wikis?custom_id=privacy-policy`,
 gleiches Schema wie beim Google-SSO-Zustimmungsbildschirm, siehe
 `apps/backend/SSO_GOOGLE.md`) und kann pro Tenant per Override ersetzt werden.
 

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -25,8 +25,15 @@ Die `ios-submit-review-*`-Workflows setzen `STORE_METADATA_MODULE`, dadurch glei
 `apps/scripts/submit-ios-review.ts` die App-Informationen **vor jeder Review-Einreichung**
 mit der Ground Truth ab - genau dann existiert garantiert eine bearbeitbare Version.
 Neue Apple-Pflichtangaben also einfach in der Ground Truth ergänzen; der nächste Submit
-verteilt sie. Ein fehlgeschlagener Metadaten-Sync blockiert die Einreichung nicht,
-sondern loggt eine deutliche Warnung.
+verteilt sie. **Ein fehlgeschlagener Metadaten-Sync blockiert die Einreichung** (der
+Workflow schlägt fehl): Es darf keine Version mit veralteten App-Informationen zur
+Review gehen. Nur wenn `STORE_METADATA_MODULE` gar nicht gesetzt ist (z. B. lokaler
+Aufruf), wird der Sync mit Log-Hinweis übersprungen.
+
+Die Datenschutz-URL der Rocket-Meals-Tenants wird aus der `baseUrl` in `config.ts`
+abgeleitet (`https://rocket-meals.github.io/<tenant>/wikis?wikis_custom_id=privacy-policy`,
+gleiches Schema wie beim Google-SSO-Zustimmungsbildschirm, siehe
+`apps/backend/SSO_GOOGLE.md`) und kann pro Tenant per Override ersetzt werden.
 
 ## Review-Submit pro Tenant deaktivieren
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,13 @@
     "clean-install": "yarn clean && yarn",
     "format": "prettier . --write",
     "lint": "eslint . --ext .js,.ts,.tsx --fix",
-    "analyze-data-clumps": "yarn workspace rocket-meals-scripts analyze:data-clumps"
+    "analyze-data-clumps": "yarn workspace rocket-meals-scripts analyze:data-clumps",
+    "store-metadata:pull:rocket-meals": "yarn workspace rocket-meals-scripts store-metadata pull --module apps/frontend/app/store-metadata.ts",
+    "store-metadata:push:rocket-meals": "yarn workspace rocket-meals-scripts store-metadata push --module apps/frontend/app/store-metadata.ts",
+    "store-metadata:pull:geonexia": "yarn workspace rocket-meals-scripts store-metadata pull --module apps/geonexia/frontend/store-metadata.ts",
+    "store-metadata:push:geonexia": "yarn workspace rocket-meals-scripts store-metadata push --module apps/geonexia/frontend/store-metadata.ts",
+    "store-metadata:pull:score-tracker": "yarn workspace rocket-meals-scripts store-metadata pull --module apps/score-tracker/frontend/store-metadata.ts",
+    "store-metadata:push:score-tracker": "yarn workspace rocket-meals-scripts store-metadata push --module apps/score-tracker/frontend/store-metadata.ts"
   },
   "workspaces": [
     "apps/frontend/app",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -25,6 +25,7 @@ export * from './src/FriendshipStatus';
 export * from './src/AppFeedbackSourceIdentifier';
 export * from './src/CustomerAppStoreIds';
 export * from './src/AppleAppStoreConfig';
+export * from './src/StoreAppMetadata';
 export * from './src/DirectusItemStatus';
 export * from './src/GpsRouteTypes';
 export * from './src/MapOverlayTypes';

--- a/packages/common/src/AppLinks.ts
+++ b/packages/common/src/AppLinks.ts
@@ -45,6 +45,19 @@ export interface AppLinkParam {
   value: string | number | boolean;
 }
 
+// Public host serving the tenant web apps (e.g. https://rocket-meals.de/swosy/...).
+export const ROCKET_MEALS_WEB_HOST = 'https://rocket-meals.de';
+
+// Query parameter the wikis screen uses to look up a wiki page
+// (see apps/frontend/app/app/(wikis)/wikis/index.tsx).
+export const WIKIS_CUSTOM_ID_PARAM = 'custom_id';
+
+// Well-known wiki custom_ids referenced outside the app itself
+// (app store metadata, Google SSO consent screen, ...).
+export enum WikiCustomIds {
+  PRIVACY_POLICY = 'privacy-policy',
+}
+
 export class AppLinks {
   static build(path: AppScreens | string, params: AppLinkParam[] = []): string {
     const query = params.map(p => `${encodeURIComponent(p.key)}=${encodeURIComponent(String(p.value))}`).join('&');
@@ -57,6 +70,14 @@ export class AppLinks {
 
   static campus(params: AppLinkParam[] = []): string {
     return this.build(AppScreens.CAMPUS, params);
+  }
+
+  // Public web url of a tenant's wiki page, e.g.
+  // https://rocket-meals.de/swosy/wikis?custom_id=privacy-policy - used as the privacy
+  // policy link in the app stores and the Google SSO consent screen.
+  static getPublicWikiUrl(tenantBaseUrl: string, customId: WikiCustomIds | string): string {
+    const fullPath = this.build(AppScreens.WIKIS, [{ key: WIKIS_CUSTOM_ID_PARAM, value: customId }]);
+    return `${ROCKET_MEALS_WEB_HOST}${tenantBaseUrl}/${fullPath}`;
   }
 
   static getGithubPagesBaseUrl(repositoryOwner: string, repositoryName: string): string {

--- a/packages/common/src/StoreAppMetadata.ts
+++ b/packages/common/src/StoreAppMetadata.ts
@@ -1,0 +1,95 @@
+// Ground truth for app store metadata ("App-Informationen") that Apple App Store Connect
+// and the Google Play Console ask for. Each app (apps/frontend, apps/geonexia,
+// apps/score-tracker, ...) defines its own ground truth in a store-metadata.ts file and
+// the rocket-meals-scripts workspace syncs it via the store APIs:
+//
+//   yarn store-metadata:pull:<app>   - read the current values from Apple/Google
+//   yarn store-metadata:push:<app>   - write the ground truth to Apple/Google
+//
+// Only fields that are set in the ground truth are managed (pushed); everything that is
+// undefined stays untouched in the stores.
+
+// https://developer.apple.com/documentation/appstoreconnectapi/ageratingdeclaration
+export type AppleAgeRatingLevel = 'NONE' | 'INFREQUENT_OR_MILD' | 'FREQUENT_OR_INTENSE';
+
+export type AppleAgeRatingDeclarationAttributes = {
+	alcoholTobaccoOrDrugUseOrReferences?: AppleAgeRatingLevel;
+	contests?: AppleAgeRatingLevel;
+	gamblingSimulated?: AppleAgeRatingLevel;
+	horrorOrFearThemes?: AppleAgeRatingLevel;
+	matureOrSuggestiveThemes?: AppleAgeRatingLevel;
+	medicalOrTreatmentInformation?: AppleAgeRatingLevel;
+	profanityOrCrudeHumor?: AppleAgeRatingLevel;
+	sexualContentGraphicAndNudity?: AppleAgeRatingLevel;
+	sexualContentOrNudity?: AppleAgeRatingLevel;
+	violenceCartoonOrFantasy?: AppleAgeRatingLevel;
+	violenceRealistic?: AppleAgeRatingLevel;
+	violenceRealisticProlongedGraphicOrSadistic?: AppleAgeRatingLevel;
+	gambling?: boolean;
+	lootBox?: boolean;
+	unrestrictedWebAccess?: boolean;
+	ageRatingOverride?: 'NONE' | 'SEVENTEEN_PLUS' | 'UNRATED';
+	koreaAgeRatingOverride?: 'NONE' | 'FIFTEEN_PLUS' | 'NINETEEN_PLUS';
+	kidsAgeBand?: 'FIVE_AND_UNDER' | 'SIX_TO_EIGHT' | 'NINE_TO_ELEVEN' | null;
+	// Apple extends the questionnaire over time (e.g. the 2025 update with the new
+	// 4+/9+/13+/16+/18+ ratings). "store-metadata:pull" prints every attribute Apple
+	// currently reports, so new questions can be answered here without a type update.
+	[appleAttribute: string]: unknown;
+};
+
+export type AppleAppMetadata = {
+	bundleId: string;
+	ageRatingDeclaration?: AppleAgeRatingDeclarationAttributes;
+	// https://developer.apple.com/documentation/appstoreconnectapi/appcategory - e.g. 'FOOD_AND_DRINK'
+	primaryCategoryId?: string;
+	secondaryCategoryId?: string;
+	contentRightsDeclaration?: 'DOES_NOT_USE_THIRD_PARTY_CONTENT' | 'USES_THIRD_PARTY_CONTENT';
+};
+
+// https://developers.google.com/android-publisher/api-ref/rest/v3/edits.listings
+export type GooglePlayListing = {
+	title?: string;
+	shortDescription?: string;
+	fullDescription?: string;
+	video?: string;
+};
+
+export type GooglePlayAppMetadata = {
+	packageName: string;
+	// https://developers.google.com/android-publisher/api-ref/rest/v3/edits.details
+	defaultLanguage?: string;
+	contactEmail?: string;
+	contactPhone?: string;
+	contactWebsite?: string;
+	// BCP-47 language code (e.g. 'de-DE') -> store listing
+	listings?: Record<string, GooglePlayListing>;
+};
+
+export type StoreAppMetadata = {
+	// Only used for logs and report file names
+	displayName: string;
+	apple?: AppleAppMetadata;
+	google?: GooglePlayAppMetadata;
+};
+
+// All rocket-meals family apps share the same harmless content profile. Apps spread this
+// and override single answers where their content differs.
+export const DEFAULT_APPLE_AGE_RATING_DECLARATION: AppleAgeRatingDeclarationAttributes = {
+	alcoholTobaccoOrDrugUseOrReferences: 'NONE',
+	contests: 'NONE',
+	gamblingSimulated: 'NONE',
+	horrorOrFearThemes: 'NONE',
+	matureOrSuggestiveThemes: 'NONE',
+	medicalOrTreatmentInformation: 'NONE',
+	profanityOrCrudeHumor: 'NONE',
+	sexualContentGraphicAndNudity: 'NONE',
+	sexualContentOrNudity: 'NONE',
+	violenceCartoonOrFantasy: 'NONE',
+	violenceRealistic: 'NONE',
+	violenceRealisticProlongedGraphicOrSadistic: 'NONE',
+	gambling: false,
+	lootBox: false,
+	unrestrictedWebAccess: false,
+	ageRatingOverride: 'NONE',
+	koreaAgeRatingOverride: 'NONE',
+};

--- a/packages/common/src/StoreAppMetadata.ts
+++ b/packages/common/src/StoreAppMetadata.ts
@@ -44,6 +44,9 @@ export type AppleAppMetadata = {
 	primaryCategoryId?: string;
 	secondaryCategoryId?: string;
 	contentRightsDeclaration?: 'DOES_NOT_USE_THIRD_PARTY_CONTENT' | 'USES_THIRD_PARTY_CONTENT';
+	// Applied to every locale of the app's "App-Informationen" (appInfoLocalizations).
+	privacyPolicyUrl?: string;
+	privacyChoicesUrl?: string;
 };
 
 // https://developers.google.com/android-publisher/api-ref/rest/v3/edits.listings

--- a/packages/common/src/__tests__/AppLinks.test.ts
+++ b/packages/common/src/__tests__/AppLinks.test.ts
@@ -1,0 +1,12 @@
+import { AppLinks, ROCKET_MEALS_WEB_HOST, WikiCustomIds } from '../AppLinks';
+
+describe('AppLinks.getPublicWikiUrl', () => {
+  it('builds the public privacy policy url of a tenant', () => {
+    expect(AppLinks.getPublicWikiUrl('/swosy', WikiCustomIds.PRIVACY_POLICY)).toBe('https://rocket-meals.de/swosy/wikis?custom_id=privacy-policy');
+    expect(AppLinks.getPublicWikiUrl('/studi-futter', WikiCustomIds.PRIVACY_POLICY)).toBe('https://rocket-meals.de/studi-futter/wikis?custom_id=privacy-policy');
+  });
+
+  it('uses the shared web host', () => {
+    expect(AppLinks.getPublicWikiUrl('/rocket-meals', WikiCustomIds.PRIVACY_POLICY).startsWith(ROCKET_MEALS_WEB_HOST)).toBe(true);
+  });
+});


### PR DESCRIPTION
App store metadata (Altersfreigabe, Kategorien, Play listings/contact
details) is now versioned in the repo as TypeScript ground truth and
synced via the store APIs instead of being maintained manually per
tenant in App Store Connect / Play Console.

- packages/common: StoreAppMetadata types + shared age rating defaults
- each app manages its own ground truth (apps/frontend for all tenants,
  geonexia, score-tracker), reusing bundle ids from config.ts
- rocket-meals-scripts: store-metadata CLI with pull (snapshot + drift
  report) and push (writes only drifted fields, --dry-run supported);
  Apple via the existing ASC api helpers, Google via the Play Developer
  API (androidpublisher v3, service account)
- yarn store-metadata:{pull,push}:{rocket-meals,geonexia,score-tracker}
- docs/STORE_METADATA.md documents usage, credentials and API limits

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016tZ7WjTKwrS7k8FDs6f15T