### PR TITLE
Add stack header with back button to playbook screens

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -62,6 +62,16 @@ function FeedbackAndSupportHeader() {
 	return <CustomStackHeader label={`${translate(TranslationKeys.feedback)} & ${translate(TranslationKeys.support)}`} key={'Feedback & Support'} />;
 }
 
+function PlaybookHeader() {
+	return <CustomStackHeader label={'Playbook'} key={'Playbook'} />;
+}
+
+function PlaybookComponentHeader() {
+	const { component } = useGlobalSearchParams<{ component?: string | string[] }>();
+	const componentName = Array.isArray(component) ? component[0] : component;
+	return <CustomStackHeader label={componentName ? `Playbook: ${componentName}` : 'Playbook'} key={'Playbook-Component'} />;
+}
+
 // Screen `options.header` render-props below are almost all "translate one key,
 // render Translated{Menu,Stack}Header" — these factories return a stable function
 // per call site instead of defining a new arrow (nested in this component's render
@@ -762,6 +772,20 @@ export default function Layout() {
 					options={{
 						headerShown: false,
 						title: translate(TranslationKeys.onboarding),
+					}}
+				/>
+				<Drawer.Screen
+					name="experimentell/playbook/index"
+					options={{
+						header: PlaybookHeader,
+						title: 'Playbook',
+					}}
+				/>
+				<Drawer.Screen
+					name="experimentell/playbook/[component]"
+					options={{
+						header: PlaybookComponentHeader,
+						title: 'Playbook',
 					}}
 				/>
 				<Drawer.Screen

--- a/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
+++ b/apps/frontend/app/components/CustomStackHeader/CustomStackHeader.tsx
@@ -28,6 +28,9 @@ const makeBackTrigger = (onPress: () => void, color: string) => (triggerProps: o
 // for the plain cases where the target doesn't depend on anything but the pathname.
 const GO_BACK_TARGET_RULES: { pathIncludes: string; target: string }[] = [
 	{ pathIncludes: `/${AppScreens.FOOD_OFFERS}/details`, target: `/${AppScreens.FOOD_OFFERS}` },
+	// Playbook detail -> playbook overview (trailing slash so the overview itself doesn't match)
+	{ pathIncludes: `/${AppScreens.EXPERIMENTELL}/playbook/`, target: `/${AppScreens.EXPERIMENTELL}/playbook` },
+	{ pathIncludes: `/${AppScreens.EXPERIMENTELL}/playbook`, target: `/${AppScreens.EXPERIMENTELL}` },
 	{ pathIncludes: `/${AppScreens.HOUSING}/details`, target: `/${AppScreens.HOUSING}` },
 	{ pathIncludes: `/${AppScreens.STATISTICS}`, target: `/${AppScreens.MANAGEMENT}` },
 	{ pathIncludes: `/${AppScreens.SUPPORT_TICKET}`, target: `/${AppScreens.SUPPORT_FAQ}` },


### PR DESCRIPTION
The playbook overview and component detail screens previously used the
default drawer header (hamburger menu), so there was no way to navigate
back from a component page to try other components. Both screens now
render CustomStackHeader with a back arrow; the detail header shows the
current component name. Back navigation targets are registered so the
detail screen returns to the playbook overview (also when deep-linked)
and the overview returns to the experimentell screen.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012oBkLojj4h4yqGsVvQf7sL