### PR TITLE
Store-Metadaten: 2025er Apple-Fragebogen übernommen, Missing-Field-Check und einheitliche Tenant-Werte

### DIFF
--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -9,20 +9,15 @@
 // questions (like the age rating questionnaire) only need to be answered here once.
 //
 // Bundle ids come from config.ts so they cannot drift apart from the builds.
-import { AppLinks, AppScreens, AppleAppMetadata, DEFAULT_APPLE_AGE_RATING_DECLARATION, GooglePlayAppMetadata, ROCKET_MEALS_WEB_HOST, StoreAppMetadata, WikiCustomIds } from 'repo-depkit-common';
+import { AppLinks, AppScreens, DEFAULT_APPLE_AGE_RATING_DECLARATION, ROCKET_MEALS_WEB_HOST, StoreAppMetadata, WikiCustomIds } from 'repo-depkit-common';
 import { CustomerConfig, devConfig, studiFutterConfig, swosyConfig } from './config';
 
-// Tenant-specific deviations from the shared metadata below (e.g. the privacy policy
-// url). Only what really differs per tenant belongs here.
-type TenantStoreOverrides = {
-	apple?: Partial<Omit<AppleAppMetadata, 'bundleId'>>;
-	google?: Partial<Omit<GooglePlayAppMetadata, 'packageName'>>;
-};
-
-// All tenants ship the same app and therefore share the same answers to Apple's age
-// rating questionnaire and the same category. The reasoning behind the answers is
-// documented in docs/Apple Altersfreigabe.txt - keep both in sync.
-function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverrides = {}): StoreAppMetadata {
+// All tenants (Demo, SWOSY, Studi|Futter) share the exact same metadata - only the app
+// name and the per-tenant derived urls (privacy policy, privacy choices) differ. The
+// values mirror the fully configured Rocket Meals demo app in App Store Connect (2025
+// questionnaire, pulled via "store-metadata pull"); the reasoning is documented in
+// docs/Apple Altersfreigabe.txt.
+function tenantStoreMetadata(config: CustomerConfig): StoreAppMetadata {
 	const metadata: StoreAppMetadata = {
 		displayName: config.projectName,
 	};
@@ -30,20 +25,18 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 		metadata.apple = {
 			bundleId: config.bundleIdIos,
 			primaryCategoryId: 'FOOD_AND_DRINK',
+			// Explicitly no secondary category - keeps all tenants identical.
+			secondaryCategoryId: null,
 			contentRightsDeclaration: 'DOES_NOT_USE_THIRD_PARTY_CONTENT',
 			// Every tenant web app serves its privacy policy as a public wiki page - the
 			// same url is used for the Google SSO consent screen (apps/backend/SSO_GOOGLE.md).
 			privacyPolicyUrl: AppLinks.getPublicWikiUrl(config.baseUrl, WikiCustomIds.PRIVACY_POLICY),
-			...overrides.apple,
-			// Answers of the updated (2025) Apple questionnaire, pulled from the fully
-			// configured Rocket Meals demo app in App Store Connect. The reasoning is
-			// documented in docs/Apple Altersfreigabe.txt - keep both in sync.
+			privacyChoicesUrl: AppLinks.getPublicWebUrl(config.baseUrl, AppScreens.DATA_ACCESS),
 			ageRatingDeclaration: {
 				...DEFAULT_APPLE_AGE_RATING_DECLARATION,
 				// Canteens may list alcoholic drinks in their menus.
 				alcoholTobaccoOrDrugUseOrReferences: 'INFREQUENT',
 				contests: 'INFREQUENT',
-				...overrides.apple?.ageRatingDeclaration,
 			},
 		};
 	}
@@ -54,32 +47,11 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 			contactWebsite: ROCKET_MEALS_WEB_HOST,
 			// Store listing texts (title, descriptions) are tenant specific and not yet
 			// managed here - "store-metadata:pull" shows the current values from Google.
-			...overrides.google,
 		};
 	}
 	return metadata;
 }
 
-// Tenant overrides win over the shared values. They mirror what is configured in App
-// Store Connect for each tenant - "store-metadata:pull" shows the current store values.
 export function getStoreMetadata(): StoreAppMetadata[] {
-	return [
-		tenantStoreMetadata(devConfig),
-		tenantStoreMetadata(swosyConfig, {
-			apple: {
-				contentRightsDeclaration: 'USES_THIRD_PARTY_CONTENT',
-				secondaryCategoryId: 'NAVIGATION',
-				privacyChoicesUrl: AppLinks.getPublicWebUrl(swosyConfig.baseUrl, AppScreens.DATA_ACCESS),
-				// The tenant apps offer chat/support and user generated content (see
-				// docs/Apple Altersfreigabe.txt), unlike the demo app.
-				ageRatingDeclaration: { messagingAndChat: true, userGeneratedContent: true },
-			},
-		}),
-		tenantStoreMetadata(studiFutterConfig, {
-			apple: {
-				secondaryCategoryId: 'EDUCATION',
-				ageRatingDeclaration: { messagingAndChat: true, userGeneratedContent: true },
-			},
-		}),
-	];
+	return [devConfig, swosyConfig, studiFutterConfig].map(tenantStoreMetadata);
 }

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -9,7 +9,7 @@
 // questions (like the age rating questionnaire) only need to be answered here once.
 //
 // Bundle ids come from config.ts so they cannot drift apart from the builds.
-import { AppLinks, AppleAppMetadata, DEFAULT_APPLE_AGE_RATING_DECLARATION, GooglePlayAppMetadata, ROCKET_MEALS_WEB_HOST, StoreAppMetadata, WikiCustomIds } from 'repo-depkit-common';
+import { AppLinks, AppScreens, AppleAppMetadata, DEFAULT_APPLE_AGE_RATING_DECLARATION, GooglePlayAppMetadata, ROCKET_MEALS_WEB_HOST, StoreAppMetadata, WikiCustomIds } from 'repo-depkit-common';
 import { CustomerConfig, devConfig, studiFutterConfig, swosyConfig } from './config';
 
 // Tenant-specific deviations from the shared metadata below (e.g. the privacy policy
@@ -30,19 +30,19 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 		metadata.apple = {
 			bundleId: config.bundleIdIos,
 			primaryCategoryId: 'FOOD_AND_DRINK',
+			contentRightsDeclaration: 'DOES_NOT_USE_THIRD_PARTY_CONTENT',
 			// Every tenant web app serves its privacy policy as a public wiki page - the
 			// same url is used for the Google SSO consent screen (apps/backend/SSO_GOOGLE.md).
 			privacyPolicyUrl: AppLinks.getPublicWikiUrl(config.baseUrl, WikiCustomIds.PRIVACY_POLICY),
 			...overrides.apple,
+			// Answers of the updated (2025) Apple questionnaire, pulled from the fully
+			// configured Rocket Meals demo app in App Store Connect. The reasoning is
+			// documented in docs/Apple Altersfreigabe.txt - keep both in sync.
 			ageRatingDeclaration: {
 				...DEFAULT_APPLE_AGE_RATING_DECLARATION,
 				// Canteens may list alcoholic drinks in their menus.
-				alcoholTobaccoOrDrugUseOrReferences: 'INFREQUENT_OR_MILD',
-				contests: 'INFREQUENT_OR_MILD',
-				// The capability questions of Apple's 2025 questionnaire (user generated
-				// content: yes, messaging/chat: yes - see docs/Apple Altersfreigabe.txt)
-				// can be added here once "store-metadata:pull" shows their API attribute
-				// names for the ageRatingDeclaration.
+				alcoholTobaccoOrDrugUseOrReferences: 'INFREQUENT',
+				contests: 'INFREQUENT',
 				...overrides.apple?.ageRatingDeclaration,
 			},
 		};
@@ -60,13 +60,26 @@ function tenantStoreMetadata(config: CustomerConfig, overrides: TenantStoreOverr
 	return metadata;
 }
 
+// Tenant overrides win over the shared values. They mirror what is configured in App
+// Store Connect for each tenant - "store-metadata:pull" shows the current store values.
 export function getStoreMetadata(): StoreAppMetadata[] {
 	return [
 		tenantStoreMetadata(devConfig),
-		// Tenant overrides win over the shared values, e.g.
-		// { apple: { privacyPolicyUrl: 'https://.../datenschutz' } } - "store-metadata:pull"
-		// shows what is currently stored in App Store Connect.
-		tenantStoreMetadata(swosyConfig, {}),
-		tenantStoreMetadata(studiFutterConfig, {}),
+		tenantStoreMetadata(swosyConfig, {
+			apple: {
+				contentRightsDeclaration: 'USES_THIRD_PARTY_CONTENT',
+				secondaryCategoryId: 'NAVIGATION',
+				privacyChoicesUrl: AppLinks.getPublicWebUrl(swosyConfig.baseUrl, AppScreens.DATA_ACCESS),
+				// The tenant apps offer chat/support and user generated content (see
+				// docs/Apple Altersfreigabe.txt), unlike the demo app.
+				ageRatingDeclaration: { messagingAndChat: true, userGeneratedContent: true },
+			},
+		}),
+		tenantStoreMetadata(studiFutterConfig, {
+			apple: {
+				secondaryCategoryId: 'EDUCATION',
+				ageRatingDeclaration: { messagingAndChat: true, userGeneratedContent: true },
+			},
+		}),
 	];
 }

--- a/apps/scripts/package.json
+++ b/apps/scripts/package.json
@@ -10,6 +10,7 @@
     "analyze:data-clumps": "ts-node --project ./tsconfig.json ./analyze-data-clumps.ts",
     "submit:ios:review": "ts-node --project ./tsconfig.json ./submit-ios-review.ts",
     "store-metadata": "ts-node --project ./tsconfig.json ./store-metadata.ts",
+    "store-metadata:extract": "ts-node --project ./tsconfig.json ./store-metadata-extract.ts",
     "apk:extract-url": "ts-node --project ./tsconfig.json ./android-preview-apk.ts extract",
     "build-number:compare-online": "ts-node --project ./tsconfig.json ./check-build-version.ts compare",
     "apk:update-readme": "ts-node --project ./tsconfig.json ./android-preview-apk.ts update-readme",

--- a/apps/scripts/store-metadata-apple.ts
+++ b/apps/scripts/store-metadata-apple.ts
@@ -108,6 +108,9 @@ export type ApplePushPlan = {
   categoryChanges: AttributeChange[];
   contentRightsChanges: AttributeChange[];
   localizationChanges: AppleLocalizationChanges[];
+  // Age rating questions Apple reports as unanswered (null in the store) that the
+  // ground truth does not answer either - e.g. after Apple extends the questionnaire.
+  missingFields: string[];
 };
 
 export function planApplePush(current: ApplePullResult, metadata: AppleAppMetadata): ApplePushPlan {
@@ -137,11 +140,30 @@ export function planApplePush(current: ApplePullResult, metadata: AppleAppMetada
     }
   }
 
-  return { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges, localizationChanges };
+  const missingFields = Object.entries(targetAppInfo?.ageRatingDeclaration ?? {})
+    .filter(([key, value]) => value === null && metadata.ageRatingDeclaration?.[key] === undefined)
+    .map(([key]) => key);
+
+  return { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges, localizationChanges, missingFields };
 }
 
 export async function applyApplePush(token: string, plan: ApplePushPlan, dryRun: boolean): Promise<boolean> {
-  const { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges, localizationChanges } = plan;
+  const { current, targetAppInfo, ageRatingChanges, categoryChanges, contentRightsChanges, localizationChanges, missingFields } = plan;
+
+  // Unanswered questions the ground truth cannot fill mean the metadata is incomplete -
+  // a real push (and therefore the pre-submit sync) must fail so this gets fixed instead
+  // of a version silently reaching App Review with open questions.
+  if (missingFields.length > 0) {
+    const message =
+      `Apple: ${missingFields.length} Altersfreigabe-Frage(n) sind weder in App Store Connect beantwortet noch in der Ground Truth gesetzt: ` +
+      `${missingFields.join(', ')}. Bitte die Felder in der store-metadata.ts ergänzen (oder in App Store Connect beantworten und per "store-metadata pull" übernehmen).`;
+    if (dryRun) {
+      console.log(`   ⚠️ ${message}`);
+    } else {
+      throw new Error(message);
+    }
+  }
+
   const hasChanges = ageRatingChanges.length > 0 || categoryChanges.length > 0 || contentRightsChanges.length > 0 || localizationChanges.length > 0;
   if (!hasChanges) {
     console.log('   ✅ Apple: Keine Abweichungen - nichts zu tun.');

--- a/apps/scripts/store-metadata-extract.test.ts
+++ b/apps/scripts/store-metadata-extract.test.ts
@@ -1,0 +1,47 @@
+import { extractGroundTruthSnippet } from './store-metadata-extract';
+
+describe('extractGroundTruthSnippet', () => {
+  it('turns a pulled snapshot into a paste-ready ground truth block', () => {
+    const snippet = extractGroundTruthSnippet({
+      bundleId: 'de.example.app',
+      contentRightsDeclaration: 'DOES_NOT_USE_THIRD_PARTY_CONTENT',
+      appInfos: [
+        {
+          state: 'READY_FOR_DISTRIBUTION',
+          editable: false,
+          ageRatingDeclaration: { gambling: true },
+        },
+        {
+          state: 'PREPARE_FOR_SUBMISSION',
+          editable: true,
+          ageRatingDeclaration: {
+            violenceCartoonOrFantasy: 'NONE',
+            alcoholTobaccoOrDrugUseOrReferences: 'INFREQUENT_OR_MILD',
+            gambling: false,
+            inAppControls: null,
+          },
+          primaryCategoryId: 'FOOD_AND_DRINK',
+          localizations: [
+            { locale: 'de-DE', privacyPolicyUrl: 'https://rocket-meals.de/rocket-meals/wikis?custom_id=privacy-policy' },
+            { locale: 'en-US', privacyPolicyUrl: 'https://rocket-meals.de/rocket-meals/wikis?custom_id=privacy-policy' },
+          ],
+        },
+      ],
+    });
+
+    expect(snippet).toContain("alcoholTobaccoOrDrugUseOrReferences: 'INFREQUENT_OR_MILD',");
+    expect(snippet).toContain('gambling: false,');
+    // Answered fields sorted alphabetically, unanswered ones marked as comment
+    expect(snippet).toContain('// inAppControls: null, // ❗ in App Store Connect unbeantwortet');
+    expect(snippet).toContain("primaryCategoryId: 'FOOD_AND_DRINK',");
+    expect(snippet).toContain("contentRightsDeclaration: 'DOES_NOT_USE_THIRD_PARTY_CONTENT',");
+    // Identical urls across locales collapse into a single line
+    expect(snippet.match(/privacyPolicyUrl/g)).toHaveLength(1);
+    // Values from the read-only app info must not leak in
+    expect(snippet).not.toContain('gambling: true');
+  });
+
+  it('throws for snapshots without app infos', () => {
+    expect(() => extractGroundTruthSnippet({})).toThrow('keine appInfos');
+  });
+});

--- a/apps/scripts/store-metadata-extract.ts
+++ b/apps/scripts/store-metadata-extract.ts
@@ -1,0 +1,93 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { REPO_ROOT } from './store-metadata-load';
+
+// Converts a pulled Apple snapshot (reports/store-metadata/<app>.apple.json, created by
+// "store-metadata pull") into a ready-to-paste TypeScript ground-truth block for a
+// store-metadata.ts file. Usage:
+//
+//   yarn workspace rocket-meals-scripts store-metadata:extract reports/store-metadata/rocket-meals.apple.json
+
+type SnapshotAppInfo = {
+  state?: string;
+  editable?: boolean;
+  ageRatingDeclaration?: Record<string, unknown>;
+  primaryCategoryId?: string;
+  secondaryCategoryId?: string;
+  localizations?: { locale?: string; privacyPolicyUrl?: string; privacyChoicesUrl?: string }[];
+};
+
+type Snapshot = {
+  bundleId?: string;
+  contentRightsDeclaration?: string;
+  appInfos?: SnapshotAppInfo[];
+  missingFields?: string[];
+};
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return `'${value}'`;
+  }
+  return JSON.stringify(value);
+}
+
+// The editable AppInfo carries the answers of the current questionnaire; a read-only
+// one is the fallback when no version draft exists at pull time.
+export function extractGroundTruthSnippet(snapshot: Snapshot): string {
+  const appInfo = snapshot.appInfos?.find(info => info.editable) ?? snapshot.appInfos?.[0];
+  if (!appInfo) {
+    throw new Error('Snapshot enthält keine appInfos - wurde der pull erfolgreich ausgeführt?');
+  }
+
+  const lines: string[] = [];
+  lines.push(`// Extrahiert aus App Store Connect für ${snapshot.bundleId ?? 'unbekannte App'} (AppInfo-Status: ${appInfo.state ?? 'unbekannt'})`);
+
+  const declaration = appInfo.ageRatingDeclaration ?? {};
+  const answered = Object.entries(declaration).filter(([, value]) => value !== null && value !== undefined);
+  const unanswered = Object.keys(declaration).filter(key => declaration[key] === null);
+
+  lines.push('ageRatingDeclaration: {');
+  for (const [key, value] of answered.sort(([a], [b]) => a.localeCompare(b))) {
+    lines.push(`\t${key}: ${formatValue(value)},`);
+  }
+  for (const key of unanswered.sort()) {
+    lines.push(`\t// ${key}: null, // ❗ in App Store Connect unbeantwortet`);
+  }
+  lines.push('},');
+
+  if (appInfo.primaryCategoryId) {
+    lines.push(`primaryCategoryId: '${appInfo.primaryCategoryId}',`);
+  }
+  if (appInfo.secondaryCategoryId) {
+    lines.push(`secondaryCategoryId: '${appInfo.secondaryCategoryId}',`);
+  }
+  if (snapshot.contentRightsDeclaration) {
+    lines.push(`contentRightsDeclaration: '${snapshot.contentRightsDeclaration}',`);
+  }
+
+  const privacyPolicyUrls = new Set((appInfo.localizations ?? []).map(localization => localization.privacyPolicyUrl).filter(Boolean));
+  for (const url of privacyPolicyUrls) {
+    lines.push(`privacyPolicyUrl: '${url}',${privacyPolicyUrls.size > 1 ? ' // ⚠️ unterschiedliche Werte je Sprache!' : ''}`);
+  }
+
+  return lines.join('\n');
+}
+
+function main(): void {
+  const snapshotArg = process.argv[2];
+  if (!snapshotArg) {
+    throw new Error('Aufruf: store-metadata:extract <pfad/zum/snapshot.apple.json>');
+  }
+  const snapshotPath = path.isAbsolute(snapshotArg) ? snapshotArg : path.resolve(REPO_ROOT, snapshotArg);
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8')) as Snapshot;
+  console.log(extractGroundTruthSnippet(snapshot));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/apps/scripts/store-metadata-load.test.ts
+++ b/apps/scripts/store-metadata-load.test.ts
@@ -20,25 +20,26 @@ describe('loadStoreMetadataModule', () => {
     }
   });
 
-  it('applies the tenant overrides on top of the shared metadata', () => {
+  it('keeps all tenants identical except name and per-tenant urls', () => {
     const metadata = loadStoreMetadataModule('apps/frontend/app/store-metadata.ts');
-    const demo = metadata.find(entry => entry.apple?.bundleId === 'de.baumgartner-software.rocket-meals-demo');
-    const swosy = metadata.find(entry => entry.apple?.bundleId === 'de.baumgartner-software.swosy');
-    const studiFutter = metadata.find(entry => entry.apple?.bundleId === 'de.stwh.app');
+    expect(metadata).toHaveLength(3);
 
-    expect(demo?.apple?.ageRatingDeclaration?.messagingAndChat).toBe(false);
-    expect(demo?.apple?.contentRightsDeclaration).toBe('DOES_NOT_USE_THIRD_PARTY_CONTENT');
+    for (const entry of metadata) {
+      // Identical for every tenant
+      expect(entry.apple?.ageRatingDeclaration?.messagingAndChat).toBe(false);
+      expect(entry.apple?.ageRatingDeclaration?.userGeneratedContent).toBe(false);
+      expect(entry.apple?.contentRightsDeclaration).toBe('DOES_NOT_USE_THIRD_PARTY_CONTENT');
+      expect(entry.apple?.secondaryCategoryId).toBeNull();
+    }
 
-    expect(swosy?.apple?.ageRatingDeclaration?.messagingAndChat).toBe(true);
-    expect(swosy?.apple?.ageRatingDeclaration?.userGeneratedContent).toBe(true);
-    // Shared answers must survive the override merge
-    expect(swosy?.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT');
-    expect(swosy?.apple?.contentRightsDeclaration).toBe('USES_THIRD_PARTY_CONTENT');
-    expect(swosy?.apple?.secondaryCategoryId).toBe('NAVIGATION');
-    expect(swosy?.apple?.privacyChoicesUrl).toBe('https://rocket-meals.de/swosy/data-access');
+    // The age rating declarations must be exactly equal across all tenants
+    const [demo, swosy, studiFutter] = metadata;
+    expect(swosy.apple?.ageRatingDeclaration).toEqual(demo.apple?.ageRatingDeclaration);
+    expect(studiFutter.apple?.ageRatingDeclaration).toEqual(demo.apple?.ageRatingDeclaration);
 
-    expect(studiFutter?.apple?.secondaryCategoryId).toBe('EDUCATION');
-    expect(studiFutter?.apple?.ageRatingDeclaration?.userGeneratedContent).toBe(true);
+    // Only the per-tenant derived urls differ
+    expect(swosy.apple?.privacyChoicesUrl).toBe('https://rocket-meals.de/swosy/data-access');
+    expect(studiFutter.apple?.privacyChoicesUrl).toBe('https://rocket-meals.de/studi-futter/data-access');
   });
 
   it('loads the geonexia ground truth', () => {

--- a/apps/scripts/store-metadata-load.test.ts
+++ b/apps/scripts/store-metadata-load.test.ts
@@ -11,11 +11,34 @@ describe('loadStoreMetadataModule', () => {
     for (const entry of metadata) {
       expect(entry.apple?.ageRatingDeclaration?.gambling).toBe(false);
       // Documented deviation from the defaults, see docs/Apple Altersfreigabe.txt
-      expect(entry.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT_OR_MILD');
+      expect(entry.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT');
+      // Explicit null answers so the missing-field check does not flag them
+      expect(entry.apple?.ageRatingDeclaration?.developerAgeRatingInfoUrl).toBeNull();
       expect(entry.apple?.primaryCategoryId).toBe('FOOD_AND_DRINK');
       // Derived from config.ts baseUrl, same pattern as the Google SSO consent screen
       expect(entry.apple?.privacyPolicyUrl).toMatch(/^https:\/\/rocket-meals\.de\/[a-z-]+\/wikis\?custom_id=privacy-policy$/);
     }
+  });
+
+  it('applies the tenant overrides on top of the shared metadata', () => {
+    const metadata = loadStoreMetadataModule('apps/frontend/app/store-metadata.ts');
+    const demo = metadata.find(entry => entry.apple?.bundleId === 'de.baumgartner-software.rocket-meals-demo');
+    const swosy = metadata.find(entry => entry.apple?.bundleId === 'de.baumgartner-software.swosy');
+    const studiFutter = metadata.find(entry => entry.apple?.bundleId === 'de.stwh.app');
+
+    expect(demo?.apple?.ageRatingDeclaration?.messagingAndChat).toBe(false);
+    expect(demo?.apple?.contentRightsDeclaration).toBe('DOES_NOT_USE_THIRD_PARTY_CONTENT');
+
+    expect(swosy?.apple?.ageRatingDeclaration?.messagingAndChat).toBe(true);
+    expect(swosy?.apple?.ageRatingDeclaration?.userGeneratedContent).toBe(true);
+    // Shared answers must survive the override merge
+    expect(swosy?.apple?.ageRatingDeclaration?.alcoholTobaccoOrDrugUseOrReferences).toBe('INFREQUENT');
+    expect(swosy?.apple?.contentRightsDeclaration).toBe('USES_THIRD_PARTY_CONTENT');
+    expect(swosy?.apple?.secondaryCategoryId).toBe('NAVIGATION');
+    expect(swosy?.apple?.privacyChoicesUrl).toBe('https://rocket-meals.de/swosy/data-access');
+
+    expect(studiFutter?.apple?.secondaryCategoryId).toBe('EDUCATION');
+    expect(studiFutter?.apple?.ageRatingDeclaration?.userGeneratedContent).toBe(true);
   });
 
   it('loads the geonexia ground truth', () => {

--- a/apps/scripts/store-metadata-plan.test.ts
+++ b/apps/scripts/store-metadata-plan.test.ts
@@ -57,6 +57,20 @@ describe('planApplePush', () => {
     expect(plan.localizationChanges).toEqual([]);
   });
 
+  it('flags unanswered store questions the ground truth does not answer', () => {
+    const withUnanswered: ApplePullResult = {
+      ...current,
+      appInfos: [
+        {
+          ...current.appInfos[1],
+          ageRatingDeclaration: { gambling: false, inAppControls: null, ageAssurance: null },
+        },
+      ],
+    };
+    const plan = planApplePush(withUnanswered, { bundleId: 'de.example.app', ageRatingDeclaration: { gambling: false, inAppControls: 'NONE' } });
+    expect(plan.missingFields).toEqual(['ageAssurance']);
+  });
+
   it('updates the privacy policy url for every locale that differs', () => {
     const plan = planApplePush(current, { bundleId: 'de.example.app', privacyPolicyUrl: 'https://new.example.com/datenschutz' });
     expect(plan.localizationChanges).toEqual([

--- a/apps/scripts/store-metadata.ts
+++ b/apps/scripts/store-metadata.ts
@@ -119,7 +119,8 @@ async function handleApple(options: CliOptions, appleToken: string, entry: Store
   const plan = planApplePush(current, entry.apple);
 
   if (options.command === 'pull') {
-    const reportPath = writeReport(entry.displayName, 'apple', current);
+    // The snapshot marks unanswered questions so they are easy to spot in the JSON.
+    const reportPath = writeReport(entry.displayName, 'apple', { ...current, missingFields: plan.missingFields });
     console.log(`   Name: ${current.name}, Altersfreigabe: ${current.appStoreAgeRating ?? 'unbekannt'}, Content Rights: ${current.contentRightsDeclaration ?? 'unbekannt'}`);
     for (const appInfo of current.appInfos) {
       console.log(`   AppInfo ${appInfo.appInfoId} (${appInfo.state}${appInfo.editable ? ', bearbeitbar' : ''}): Kategorie ${appInfo.primaryCategoryId ?? '-'}`);
@@ -129,6 +130,10 @@ async function handleApple(options: CliOptions, appleToken: string, entry: Store
       console.log(`   ⚠️ Abweichungen zur Ground Truth (Store -> Soll):\n${formatChanges(driftedChanges, '      ')}`);
     } else {
       console.log('   ✅ Store entspricht der Ground Truth.');
+    }
+    if (plan.missingFields.length > 0) {
+      console.log(`   ❗ Unbeantwortete Altersfreigabe-Fragen (weder im Store noch in der Ground Truth): ${plan.missingFields.join(', ')}`);
+      console.log('      Ein push (und damit der nächste Review-Submit) schlägt fehl, bis diese Felder ergänzt sind.');
     }
     console.log(`   💾 Snapshot: ${reportPath}\n`);
     return;

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -66,6 +66,25 @@ Optionen (an das Workspace-Kommando anhängbar, z. B.
 
 `pull` schreibt zusätzlich Snapshots nach `reports/store-metadata/<app>.<store>.json`.
 
+### Unbeantwortete Fragen (fehlende Daten)
+
+Altersfreigabe-Fragen, die Apple als unbeantwortet meldet (`null` im Store) und die auch
+die Ground Truth nicht beantwortet, werden beim `pull` markiert (Console: `❗`, im
+Snapshot-JSON als `missingFields`). Ein echter `push` - und damit auch der Sync vor dem
+Review-Submit - **schlägt dann fehl** und listet die fehlenden Felder auf, damit
+auffällt, dass etwas ergänzt werden muss (z. B. wenn Apple den Fragebogen erweitert).
+`--dry-run` zeigt die Warnung nur an.
+
+### Snapshot in Ground Truth umwandeln
+
+```bash
+yarn workspace rocket-meals-scripts store-metadata:extract reports/store-metadata/rocket-meals.apple.json
+```
+
+Extrahiert aus einem Pull-Snapshot einen fertigen TypeScript-Block (Altersfreigabe,
+Kategorien, Content Rights, Datenschutz-URL) zum Einfügen in die `store-metadata.ts`.
+Unbeantwortete Fragen erscheinen als auskommentierte Zeilen mit `❗`-Markierung.
+
 ### Manuell per GitHub Workflow
 
 Der Workflow **"🏪 Store Metadata: Pull / Push"** (`.github/workflows/store-metadata.yml`)

--- a/packages/common/src/AppLinks.ts
+++ b/packages/common/src/AppLinks.ts
@@ -72,12 +72,16 @@ export class AppLinks {
     return this.build(AppScreens.CAMPUS, params);
   }
 
+  // Public web url of a tenant app screen, e.g. https://rocket-meals.de/swosy/data-access
+  static getPublicWebUrl(tenantBaseUrl: string, path: AppScreens | string, params: AppLinkParam[] = []): string {
+    return `${ROCKET_MEALS_WEB_HOST}${tenantBaseUrl}/${this.build(path, params)}`;
+  }
+
   // Public web url of a tenant's wiki page, e.g.
   // https://rocket-meals.de/swosy/wikis?custom_id=privacy-policy - used as the privacy
   // policy link in the app stores and the Google SSO consent screen.
   static getPublicWikiUrl(tenantBaseUrl: string, customId: WikiCustomIds | string): string {
-    const fullPath = this.build(AppScreens.WIKIS, [{ key: WIKIS_CUSTOM_ID_PARAM, value: customId }]);
-    return `${ROCKET_MEALS_WEB_HOST}${tenantBaseUrl}/${fullPath}`;
+    return this.getPublicWebUrl(tenantBaseUrl, AppScreens.WIKIS, [{ key: WIKIS_CUSTOM_ID_PARAM, value: customId }]);
   }
 
   static getGithubPagesBaseUrl(repositoryOwner: string, repositoryName: string): string {

--- a/packages/common/src/StoreAppMetadata.ts
+++ b/packages/common/src/StoreAppMetadata.ts
@@ -10,12 +10,15 @@
 // undefined stays untouched in the stores.
 
 // https://developer.apple.com/documentation/appstoreconnectapi/ageratingdeclaration
-export type AppleAgeRatingLevel = 'NONE' | 'INFREQUENT_OR_MILD' | 'FREQUENT_OR_INTENSE';
+// The updated (2025) questionnaire uses INFREQUENT/FREQUENT, older declarations still
+// report INFREQUENT_OR_MILD/FREQUENT_OR_INTENSE.
+export type AppleAgeRatingLevel = 'NONE' | 'INFREQUENT' | 'FREQUENT' | 'INFREQUENT_OR_MILD' | 'FREQUENT_OR_INTENSE';
 
 export type AppleAgeRatingDeclarationAttributes = {
 	alcoholTobaccoOrDrugUseOrReferences?: AppleAgeRatingLevel;
 	contests?: AppleAgeRatingLevel;
 	gamblingSimulated?: AppleAgeRatingLevel;
+	gunsOrOtherWeapons?: AppleAgeRatingLevel;
 	horrorOrFearThemes?: AppleAgeRatingLevel;
 	matureOrSuggestiveThemes?: AppleAgeRatingLevel;
 	medicalOrTreatmentInformation?: AppleAgeRatingLevel;
@@ -25,15 +28,25 @@ export type AppleAgeRatingDeclarationAttributes = {
 	violenceCartoonOrFantasy?: AppleAgeRatingLevel;
 	violenceRealistic?: AppleAgeRatingLevel;
 	violenceRealisticProlongedGraphicOrSadistic?: AppleAgeRatingLevel;
+	advertising?: boolean;
+	ageAssurance?: boolean;
 	gambling?: boolean;
+	healthOrWellnessTopics?: boolean;
 	lootBox?: boolean;
+	messagingAndChat?: boolean;
+	parentalControls?: boolean;
+	socialMedia?: boolean | null;
+	socialMediaAgeRestricted?: boolean | null;
 	unrestrictedWebAccess?: boolean;
+	userGeneratedContent?: boolean;
+	developerAgeRatingInfoUrl?: string | null;
 	ageRatingOverride?: 'NONE' | 'SEVENTEEN_PLUS' | 'UNRATED';
+	ageRatingOverrideV2?: string;
 	koreaAgeRatingOverride?: 'NONE' | 'FIFTEEN_PLUS' | 'NINETEEN_PLUS';
 	kidsAgeBand?: 'FIVE_AND_UNDER' | 'SIX_TO_EIGHT' | 'NINE_TO_ELEVEN' | null;
-	// Apple extends the questionnaire over time (e.g. the 2025 update with the new
-	// 4+/9+/13+/16+/18+ ratings). "store-metadata:pull" prints every attribute Apple
-	// currently reports, so new questions can be answered here without a type update.
+	// Apple extends the questionnaire over time. "store-metadata:pull" prints every
+	// attribute Apple currently reports, so new questions can be answered here without
+	// a type update.
 	[appleAttribute: string]: unknown;
 };
 
@@ -76,11 +89,14 @@ export type StoreAppMetadata = {
 };
 
 // All rocket-meals family apps share the same harmless content profile. Apps spread this
-// and override single answers where their content differs.
+// and override single answers where their content differs. The attribute set matches
+// what App Store Connect reports for the updated (2025) questionnaire - verified via
+// "store-metadata pull" against the fully configured Rocket Meals demo app.
 export const DEFAULT_APPLE_AGE_RATING_DECLARATION: AppleAgeRatingDeclarationAttributes = {
 	alcoholTobaccoOrDrugUseOrReferences: 'NONE',
 	contests: 'NONE',
 	gamblingSimulated: 'NONE',
+	gunsOrOtherWeapons: 'NONE',
 	horrorOrFearThemes: 'NONE',
 	matureOrSuggestiveThemes: 'NONE',
 	medicalOrTreatmentInformation: 'NONE',
@@ -90,12 +106,22 @@ export const DEFAULT_APPLE_AGE_RATING_DECLARATION: AppleAgeRatingDeclarationAttr
 	violenceCartoonOrFantasy: 'NONE',
 	violenceRealistic: 'NONE',
 	violenceRealisticProlongedGraphicOrSadistic: 'NONE',
+	advertising: false,
+	ageAssurance: false,
 	gambling: false,
+	healthOrWellnessTopics: false,
 	lootBox: false,
+	messagingAndChat: false,
+	parentalControls: false,
+	socialMedia: false,
+	socialMediaAgeRestricted: false,
 	unrestrictedWebAccess: false,
+	userGeneratedContent: false,
 	ageRatingOverride: 'NONE',
+	ageRatingOverrideV2: 'NONE',
 	koreaAgeRatingOverride: 'NONE',
-	// null is a valid answer ("not a kids app") - set explicitly so it does not count
-	// as an unanswered question.
+	// null is a valid answer here ("not a kids app" / "no info url") - set explicitly so
+	// these do not count as unanswered questions.
 	kidsAgeBand: null,
+	developerAgeRatingInfoUrl: null,
 };

--- a/packages/common/src/StoreAppMetadata.ts
+++ b/packages/common/src/StoreAppMetadata.ts
@@ -55,7 +55,8 @@ export type AppleAppMetadata = {
 	ageRatingDeclaration?: AppleAgeRatingDeclarationAttributes;
 	// https://developer.apple.com/documentation/appstoreconnectapi/appcategory - e.g. 'FOOD_AND_DRINK'
 	primaryCategoryId?: string;
-	secondaryCategoryId?: string;
+	// null explicitly clears the secondary category in the store
+	secondaryCategoryId?: string | null;
 	contentRightsDeclaration?: 'DOES_NOT_USE_THIRD_PARTY_CONTENT' | 'USES_THIRD_PARTY_CONTENT';
 	// Applied to every locale of the app's "App-Informationen" (appInfoLocalizations).
 	privacyPolicyUrl?: string;

--- a/packages/common/src/StoreAppMetadata.ts
+++ b/packages/common/src/StoreAppMetadata.ts
@@ -95,4 +95,7 @@ export const DEFAULT_APPLE_AGE_RATING_DECLARATION: AppleAgeRatingDeclarationAttr
 	unrestrictedWebAccess: false,
 	ageRatingOverride: 'NONE',
 	koreaAgeRatingOverride: 'NONE',
+	// null is a valid answer ("not a kids app") - set explicitly so it does not count
+	// as an unanswered question.
+	kidsAgeBand: null,
 };


### PR DESCRIPTION
## Zusammenfassung

Baut auf dem bereits gemergten Store-Metadata-System auf und bringt drei Erweiterungen:

### 1. Erkennung unbeantworteter Altersfreigabe-Fragen
- `planApplePush` meldet `missingFields`: Fragen, die Apple als unbeantwortet (`null`) liefert und die auch die Ground Truth nicht beantwortet (z. B. wenn Apple den Fragebogen erweitert).
- `pull` markiert sie auf der Console (`❗`) und im Snapshot-JSON; ein echter `push` — und damit der Sync vor jedem Review-Submit — **schlägt mit Feldliste fehl**, damit Lücken auffallen statt still liegenzubleiben. `--dry-run` warnt nur.
- Gültige `null`-Antworten (`kidsAgeBand`, `developerAgeRatingInfoUrl`) sind explizit in den Defaults gesetzt und zählen nicht als fehlend.

### 2. Extract-Script
- `yarn workspace rocket-meals-scripts store-metadata:extract <snapshot.apple.json>` wandelt einen Pull-Snapshot in einen fertigen TypeScript-Ground-Truth-Block um (beantwortete Felder sortiert, unbeantwortete als auskommentierte `❗`-Zeilen).

### 3. Echte App-Store-Connect-Werte, vereinheitlicht für alle Tenants
- Per Workflow-Pull aus der fertig konfigurierten Rocket-Meals-Demo-App übernommen: Der neue (2025) Fragebogen nutzt `INFREQUENT`/`FREQUENT` und neue Fragen (`messagingAndChat`, `userGeneratedContent`, `socialMedia`, `socialMediaAgeRestricted`, `advertising`, `ageAssurance`, `parentalControls`, `healthOrWellnessTopics`, `gunsOrOtherWeapons`, `ageRatingOverrideV2`, `developerAgeRatingInfoUrl`). Typen und gemeinsame Defaults in `repo-depkit-common` decken jetzt das volle Attribut-Set ab.
- **Demo, SWOSY und Studi|Futter teilen exakt dieselbe Ground Truth** — nur App-Name und die pro Tenant abgeleiteten URLs (Datenschutz: `https://rocket-meals.de/<tenant>/wikis?custom_id=privacy-policy`, Privacy Choices: `https://rocket-meals.de/<tenant>/data-access`) unterscheiden sich.
- `secondaryCategoryId: null` löscht die Zweitkategorie explizit im Store (SWOSY `NAVIGATION` / Studi|Futter `EDUCATION` werden entfernt); neuer Helper `AppLinks.getPublicWebUrl`.

## Auswirkungen beim nächsten Push/Submit (gegen echte Store-Daten simuliert)

Für SWOSY z. B.: `messagingAndChat`/`userGeneratedContent` `true → false`, `contests` `NONE → INFREQUENT`, Zweitkategorie entfernt, Content Rights `USES_THIRD_PARTY_CONTENT → DOES_NOT_USE_THIRD_PARTY_CONTENT`, URLs migrieren von `rocket-meals.github.io` auf `rocket-meals.de`, `socialMedia`-Fragen werden erstmals beantwortet. Für die Demo-App gibt es außer der URL-Migration keine Drift.

## Tests

- 44 Tests in `rocket-meals-scripts` (inkl. Missing-Field-, Extract- und Gleichheits-Tests über alle Tenants), 51 in `repo-depkit-common` — alle grün.
- Typecheck und ESLint sauber; Push-Plan gegen die echten Pull-Snapshots von Demo und SWOSY simuliert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tZ7WjTKwrS7k8FDs6f15T

---
_Generated by [Claude Code](https://claude.ai/code/session_016tZ7WjTKwrS7k8FDs6f15T)_