### PR TITLE
Fix playbook detail screens crashing on navigation from the overview

### DIFF
--- a/apps/frontend/app/app/(app)/_layout.tsx
+++ b/apps/frontend/app/app/(app)/_layout.tsx
@@ -57,20 +57,31 @@ import { UserHelper } from '@/helper/UserHelper';
 
 const renderDrawerContent = (props: React.ComponentProps<typeof CustomDrawerContent>) => <CustomDrawerContent {...props} />;
 
-function FeedbackAndSupportHeader() {
+// The `header` screen option is invoked by react-navigation as a plain render
+// function, not mounted as a component. Hooks therefore MUST NOT be called in
+// the function passed to `header` directly — they would register on the
+// surrounding DrawerViewBase and crash with "Rendered more hooks than during
+// the previous render" as soon as the set of rendered scenes changes. Any
+// header that needs hooks lives in a *Content component rendered as an element
+// by a stable render function (same pattern as makeTranslated*Header below).
+function FeedbackAndSupportHeaderContent() {
 	const { translate } = useLanguage();
 	return <CustomStackHeader label={`${translate(TranslationKeys.feedback)} & ${translate(TranslationKeys.support)}`} key={'Feedback & Support'} />;
 }
+
+const FeedbackAndSupportHeader = () => <FeedbackAndSupportHeaderContent />;
 
 function PlaybookHeader() {
 	return <CustomStackHeader label={'Playbook'} key={'Playbook'} />;
 }
 
-function PlaybookComponentHeader() {
+function PlaybookComponentHeaderContent() {
 	const { component } = useGlobalSearchParams<{ component?: string | string[] }>();
 	const componentName = Array.isArray(component) ? component[0] : component;
 	return <CustomStackHeader label={componentName ? `Playbook: ${componentName}` : 'Playbook'} key={'Playbook-Component'} />;
 }
+
+const PlaybookComponentHeader = () => <PlaybookComponentHeaderContent />;
 
 // Screen `options.header` render-props below are almost all "translate one key,
 // render Translated{Menu,Stack}Header" — these factories return a stable function

--- a/apps/frontend/app/app/(app)/chats/_layout.tsx
+++ b/apps/frontend/app/app/(app)/chats/_layout.tsx
@@ -16,7 +16,11 @@ function makeTranslatedMenuHeader(labelKey: TranslationKeys, headerKey?: string)
 	return () => <TranslatedMenuHeader labelKey={labelKey} headerKey={headerKey} />;
 }
 
-function ChatDetailsHeader() {
+// Hooks must not run in the function passed to `header` itself (react-navigation
+// calls it as a plain function, so hooks would register on the surrounding
+// navigator component) — they live in this content component instead, rendered
+// as an element by the stable ChatDetailsHeader render function below.
+function ChatDetailsHeaderContent() {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
 	const router = useRouter();
@@ -40,6 +44,8 @@ function ChatDetailsHeader() {
 		/>
 	);
 }
+
+const ChatDetailsHeader = () => <ChatDetailsHeaderContent />;
 
 export default function ChatsLayout() {
         const { theme } = useTheme();


### PR DESCRIPTION
react-navigation invokes the header screen option as a plain render
function, not as a mounted component. PlaybookComponentHeader,
FeedbackAndSupportHeader and ChatDetailsHeader called hooks
(useGlobalSearchParams / useLanguage / useTheme) directly in that
function, so the hooks registered on the surrounding navigator
component (DrawerViewBase). Navigating from the playbook overview to a
detail screen changed the set of rendered scene headers and with it the
navigator's hook count, crashing with "Rendered more hooks than during
the previous render". Opening a detail screen directly via URL worked,
which is why only in-app navigation crashed.

Move the hook-using code into dedicated content components that the
header render functions return as elements, matching the existing
makeTranslated*Header factory pattern.

Verified via Playwright against the Expo web build: all 21 playbook
entries now open crash-free from the overview, and knob toggles and
variant switches keep working.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G9LHUHTgp1LJKuDtvUzbfx