### PR TITLE
feat(ci): build Android preview APKs for Score Tracker and Geonexia with README links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ref_name: ${{ github.ref_name }}
 
+  # Only master@rocket-meals/rocket-meals builds the Geonexia preview APK and
+  # gets the README link - forks and other branches must not push commits
+  # upstream nor advertise a preview APK from an unverified fork build.
+  geonexia-build-android-preview:
+    name: "🧪 Geonexia Build Android Preview APK"
+    runs-on: ubuntu-latest
+    needs: [geonexia-check-build, check-repository]
+    if: needs.geonexia-check-build.outputs.should-build == 'true' && github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        uses: ./.github/actions/setup-and-install
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: "🧪 Build Geonexia Android Preview APK & update README"
+        uses: ./.github/actions/build-android-preview-apk
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          working-directory: ./apps/geonexia/frontend
+          eas-profile: preview
+          app-key: geonexia
+          app-label: "Geonexia"
+          update-readme: 'true'
+
+      - name: "💾 Commit README update"
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update Geonexia Android preview APK link in README [skip ci]"
+            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   score-tracker-check-build:
     name: "🔍 Score Tracker Check iOS Build Number (online)"
     runs-on: ubuntu-latest
@@ -531,6 +577,52 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ref_name: ${{ github.ref_name }}
+
+  # Only master@rocket-meals/rocket-meals builds the Score Tracker preview APK
+  # and gets the README link - forks and other branches must not push commits
+  # upstream nor advertise a preview APK from an unverified fork build.
+  score-tracker-build-android-preview:
+    name: "🧪 Score Tracker Build Android Preview APK"
+    runs-on: ubuntu-latest
+    needs: [score-tracker-check-build, check-repository]
+    if: needs.score-tracker-check-build.outputs.should-build == 'true' && github.ref_name == 'master' && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🧰 Setup Node.js, Yarn & Dependencies"
+        uses: ./.github/actions/setup-and-install
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      - name: "🧪 Build Score Tracker Android Preview APK & update README"
+        uses: ./.github/actions/build-android-preview-apk
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          working-directory: ./apps/score-tracker/frontend
+          eas-profile: preview
+          app-key: score-tracker
+          app-label: "Score Tracker"
+          update-readme: 'true'
+
+      - name: "💾 Commit README update"
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update Score Tracker Android preview APK link in README [skip ci]"
+            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-gh-pages:
     name: "🌍 Deploy to GitHub Pages"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ https://github.com/rocket-meals/studi-futter
 **Rocket Meals (Frontend):** 📱 [Neueste Android Preview APK herunterladen](https://expo.dev/artifacts/eas/AIHxB8Ozu-UoAyY1563cEHDcnRm9MWiaCVikyZ4wBBI.apk)
 <!-- android-preview-apk:frontend:end -->
 
+<!-- android-preview-apk:score-tracker:start -->
+**Score Tracker:** 📱 Noch keine Android Preview APK gebaut - der Link erscheint hier nach dem nächsten Build.
+<!-- android-preview-apk:score-tracker:end -->
+
+<!-- android-preview-apk:geonexia:start -->
+**Geonexia:** 📱 Noch keine Android Preview APK gebaut - der Link erscheint hier nach dem nächsten Build.
+<!-- android-preview-apk:geonexia:end -->
+
 # 🚀 Rocket Meals
 
 **Rocket Meals** ist eine innovative Lösung zur digitalen Verwaltung und Präsentation von

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -12,7 +12,8 @@ export type CustomerConfig = {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	return 19;
+	// 20: Trigger new builds incl. Android preview APK link in the README.
+	return 20;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -13,8 +13,8 @@ export type CustomerConfig = {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	// 21: iOS privacy manifest + Android blockedPermissions (native changes).
-	return 21;
+	// 22: Trigger new builds incl. Android preview APK link in the README.
+	return 22;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion


### PR DESCRIPTION
Add upstream-master-only CI jobs that build the Android preview APK for
Score Tracker and Geonexia (eas profile: preview) and publish the download
link into the README, mirroring the existing Rocket Meals frontend job.
Add the matching README marker blocks and bump both build numbers
(Score Tracker 21 -> 22, Geonexia 19 -> 20) to trigger the builds.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013gnxaS9XxnF94peG36fdHr