### PR TITLE
fix(score-tracker): decide dice advantage/disadvantage per die instead of by roll total

### DIFF
--- a/apps/score-tracker/frontend/__tests__/DiceRollHelper.test.ts
+++ b/apps/score-tracker/frontend/__tests__/DiceRollHelper.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for advantage/disadvantage picking the wrong dice.
+ *
+ * computeRoll used to compare the TOTALS of the two rolls and keep the whole
+ * winning roll. With more than one die that is wrong: a die's worse value
+ * could count just because its roll happened to win overall (reported with
+ * W10+W4+W6 rolling 7/4/1 vs 8/3/4 - the old code kept the whole second roll
+ * and its W4 showed 3 even though the first roll's W4 showed 4). Advantage and
+ * disadvantage are decided per die: each die keeps its own higher (advantage)
+ * or lower (disadvantage) value, and the result is the sum of the kept values.
+ */
+
+jest.mock('../helpers/RandomHelper', () => ({
+	randomDieValue: jest.fn(),
+}));
+
+import { computeRoll } from '../helpers/DiceRollHelper';
+import { randomDieValue } from '../helpers/RandomHelper';
+
+const mockRandomDieValue = randomDieValue as jest.Mock;
+
+const POOL = [
+	{ id: 'die-1', sides: 10 },
+	{ id: 'die-2', sides: 4 },
+	{ id: 'die-3', sides: 6 },
+];
+
+function queueRolls(values: number[]) {
+	mockRandomDieValue.mockReset();
+	for (const value of values) {
+		mockRandomDieValue.mockReturnValueOnce(value);
+	}
+}
+
+describe('computeRoll', () => {
+	it('sum mode rolls the pool once and adds everything up', () => {
+		queueRolls([7, 4, 1]);
+		const result = computeRoll(POOL, 'sum');
+		if (result.mode !== 'sum') throw new Error('expected sum result');
+		expect(result.dice.map((die) => die.value)).toEqual([7, 4, 1]);
+		expect(result.total).toBe(12);
+		expect(mockRandomDieValue).toHaveBeenCalledTimes(POOL.length);
+	});
+
+	it('advantage keeps each die\'s higher value, not the roll with the higher total', () => {
+		// Roll A: 7/4/1 (total 12), roll B: 8/3/4 (total 15). Whole-roll advantage
+		// would keep roll B for 15; per-die advantage keeps 8, 4 and 4 for 16.
+		queueRolls([7, 4, 1, 8, 3, 4]);
+		const result = computeRoll(POOL, 'advantage');
+		if (result.mode !== 'advantage') throw new Error('expected advantage result');
+		expect(result.rollA.total).toBe(12);
+		expect(result.rollB.total).toBe(15);
+		expect(result.keptRollById).toEqual({ 'die-1': 'B', 'die-2': 'A', 'die-3': 'B' });
+		expect(result.keptTotal).toBe(16);
+	});
+
+	it('disadvantage keeps each die\'s lower value', () => {
+		queueRolls([7, 4, 1, 8, 3, 4]);
+		const result = computeRoll(POOL, 'disadvantage');
+		if (result.mode !== 'disadvantage') throw new Error('expected disadvantage result');
+		expect(result.keptRollById).toEqual({ 'die-1': 'A', 'die-2': 'B', 'die-3': 'A' });
+		expect(result.keptTotal).toBe(7 + 3 + 1);
+	});
+
+	it('keeps the first roll\'s value on a per-die tie', () => {
+		queueRolls([5, 2, 3, 5, 2, 3]);
+		const advantage = computeRoll(POOL, 'advantage');
+		if (advantage.mode !== 'advantage') throw new Error('expected advantage result');
+		expect(advantage.keptRollById).toEqual({ 'die-1': 'A', 'die-2': 'A', 'die-3': 'A' });
+		expect(advantage.keptTotal).toBe(10);
+
+		queueRolls([5, 2, 3, 5, 2, 3]);
+		const disadvantage = computeRoll(POOL, 'disadvantage');
+		if (disadvantage.mode !== 'disadvantage') throw new Error('expected disadvantage result');
+		expect(disadvantage.keptRollById).toEqual({ 'die-1': 'A', 'die-2': 'A', 'die-3': 'A' });
+		expect(disadvantage.keptTotal).toBe(10);
+	});
+
+	it('works with a single die like the classic roll-twice-keep-one rule', () => {
+		const singleDie = [{ id: 'die-1', sides: 20 }];
+		queueRolls([11, 18]);
+		const advantage = computeRoll(singleDie, 'advantage');
+		if (advantage.mode !== 'advantage') throw new Error('expected advantage result');
+		expect(advantage.keptTotal).toBe(18);
+
+		queueRolls([11, 18]);
+		const disadvantage = computeRoll(singleDie, 'disadvantage');
+		if (disadvantage.mode !== 'disadvantage') throw new Error('expected disadvantage result');
+		expect(disadvantage.keptTotal).toBe(11);
+	});
+});

--- a/apps/score-tracker/frontend/app/dice/index.tsx
+++ b/apps/score-tracker/frontend/app/dice/index.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { SettingsListGroupTitle, useTheme, type Theme } from 'repo-depkit-common-ui';
 import { ComponentIds } from '../../constants/ComponentIds';
-import { randomDieValue } from '../../helpers/RandomHelper';
+import { computeRoll, type DieResult, type PoolDie, type RollMode, type RollResult } from '../../helpers/DiceRollHelper';
 
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
 
@@ -33,55 +33,31 @@ function diceIconForSides(sides: number): MCIName {
 	return DICE_TYPE_ICON[sides] ?? FALLBACK_ICON;
 }
 
-type RollMode = 'sum' | 'advantage' | 'disadvantage';
-
 const ROLL_MODES: { key: RollMode; label: string; icon: MCIName }[] = [
 	{ key: 'sum', label: 'Summe', icon: 'sigma' },
 	{ key: 'advantage', label: 'Vorteil', icon: 'arrow-up-bold-circle-outline' },
 	{ key: 'disadvantage', label: 'Nachteil', icon: 'arrow-down-bold-circle-outline' },
 ];
 
-type PoolDie = { id: string; sides: number };
-type DieResult = PoolDie & { value: number };
-type DiceRoll = { dice: DieResult[]; total: number };
-type RollResult =
-	| { mode: 'sum'; dice: DieResult[]; total: number }
-	| { mode: 'advantage' | 'disadvantage'; rollA: DiceRoll; rollB: DiceRoll; keptRoll: 'A' | 'B'; keptTotal: number };
-
-function rollValue(sides: number): number {
-	return randomDieValue(sides);
-}
-
-function rollPoolOnce(pool: PoolDie[]): DiceRoll {
-	const dice = pool.map((die) => ({ ...die, value: rollValue(die.sides) }));
-	return { dice, total: dice.reduce((sum, die) => sum + die.value, 0) };
-}
-
-// Nothing is hidden or "loaded": for advantage/disadvantage the whole pool is
-// genuinely rolled twice and BOTH rolls are shown - only the roll with the
-// higher (advantage) or lower (disadvantage) total is highlighted as the one
-// that counts. A natural generalisation of the classic single-d20 "roll
-// twice, keep one" rule to an arbitrary dice pool.
-function computeRoll(pool: PoolDie[], mode: RollMode): RollResult {
-	const rollA = rollPoolOnce(pool);
-	if (mode === 'sum') {
-		return { mode, dice: rollA.dice, total: rollA.total };
-	}
-	const rollB = rollPoolOnce(pool);
-	const rollAWins = mode === 'advantage' ? rollA.total >= rollB.total : rollA.total <= rollB.total;
-	const keptRoll = rollAWins ? 'A' : 'B';
-	return { mode, rollA, rollB, keptRoll, keptTotal: keptRoll === 'A' ? rollA.total : rollB.total };
-}
-
-function DiceValueRow({ dice, theme }: Readonly<{ dice: DieResult[]; theme: Theme }>) {
+function DiceValueRow({ dice, theme, keptIds }: Readonly<{ dice: DieResult[]; theme: Theme; keptIds?: ReadonlySet<string> }>) {
 	return (
 		<View style={styles.resultsRow}>
-			{dice.map((die) => (
-				<View key={die.id} style={[styles.resultBadge, { backgroundColor: theme.screen.iconBg }]}>
-					<Text style={[styles.resultBadgeSides, { color: theme.screen.placeholder }]}>W{die.sides}</Text>
-					<Text style={[styles.resultBadgeValue, { color: theme.screen.text }]}>{die.value}</Text>
-				</View>
-			))}
+			{dice.map((die) => {
+				const isKept = keptIds?.has(die.id) ?? false;
+				const isDimmed = keptIds != null && !isKept;
+				return (
+					<View
+						key={die.id}
+						style={[
+							styles.resultBadge,
+							{ backgroundColor: theme.screen.iconBg, borderColor: isKept ? PRIMARY_COLOR : 'transparent', opacity: isDimmed ? 0.45 : 1 },
+						]}
+					>
+						<Text style={[styles.resultBadgeSides, { color: theme.screen.placeholder }]}>W{die.sides}</Text>
+						<Text style={[styles.resultBadgeValue, { color: theme.screen.text }]}>{die.value}</Text>
+					</View>
+				);
+			})}
 		</View>
 	);
 }
@@ -268,6 +244,13 @@ export default function DiceScreen() {
 						</TouchableOpacity>
 					))}
 				</View>
+				{rollMode !== 'sum' && (
+					<Text style={[styles.hintText, { color: theme.screen.placeholder }]}>
+						{rollMode === 'advantage'
+							? 'Jeder Würfel wird zweimal geworfen - pro Würfel zählt der höhere Wert.'
+							: 'Jeder Würfel wird zweimal geworfen - pro Würfel zählt der niedrigere Wert.'}
+					</Text>
+				)}
 
 				{results && (
 					<View style={styles.resultsArea}>
@@ -280,28 +263,18 @@ export default function DiceScreen() {
 							<>
 								{(['A', 'B'] as const).map((rollKey, index) => {
 									const roll = rollKey === 'A' ? results.rollA : results.rollB;
-									// Only reveal which roll counts once the shuffle has settled - while
-									// still animating, both rolls are shown neutrally so nothing gives
-									// away the outcome mid-shuffle.
-									const isKept = !isRolling && results.keptRoll === rollKey;
+									// Only reveal per die which value counts once the shuffle has
+									// settled - while still animating, both rolls are shown neutrally
+									// so nothing gives away the outcome mid-shuffle.
+									const keptIds = isRolling
+										? undefined
+										: new Set(roll.dice.filter((die) => results.keptRollById[die.id] === rollKey).map((die) => die.id));
 									return (
-										<View
-											key={rollKey}
-											style={[
-												styles.rollSet,
-												{ borderColor: isKept ? PRIMARY_COLOR : 'transparent', opacity: !isRolling && !isKept ? 0.55 : 1 },
-											]}
-										>
+										<View key={rollKey} style={[styles.rollSet, { borderColor: theme.screen.border }]}>
 											<View style={styles.rollSetHeader}>
 												<Text style={[styles.rollSetLabel, { color: theme.screen.text }]}>Wurf {index + 1}</Text>
-												{isKept && (
-													<View style={styles.keptBadge}>
-														<Text style={styles.keptBadgeText}>zählt</Text>
-													</View>
-												)}
 											</View>
-											<DiceValueRow dice={roll.dice} theme={theme} />
-											<Text style={[styles.rollSetTotal, { color: theme.screen.text }]}>Summe: {roll.total}</Text>
+											<DiceValueRow dice={roll.dice} theme={theme} keptIds={keptIds} />
 										</View>
 									);
 								})}
@@ -449,7 +422,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 14,
 		paddingHorizontal: 12,
 		borderRadius: 14,
-		borderWidth: 2,
+		borderWidth: StyleSheet.hairlineWidth,
 		marginBottom: 12,
 	},
 	rollSetHeader: {
@@ -464,23 +437,6 @@ const styles = StyleSheet.create({
 		textTransform: 'uppercase',
 		letterSpacing: 0.4,
 	},
-	keptBadge: {
-		paddingHorizontal: 8,
-		paddingVertical: 2,
-		borderRadius: 10,
-		backgroundColor: PRIMARY_COLOR,
-	},
-	keptBadgeText: {
-		color: '#ffffff',
-		fontSize: 11,
-		fontWeight: '700',
-		textTransform: 'uppercase',
-	},
-	rollSetTotal: {
-		fontSize: 16,
-		fontWeight: '700',
-		marginTop: 10,
-	},
 	resultsRow: {
 		flexDirection: 'row',
 		flexWrap: 'wrap',
@@ -493,6 +449,7 @@ const styles = StyleSheet.create({
 		width: 64,
 		height: 64,
 		borderRadius: 14,
+		borderWidth: 2,
 	},
 	resultBadgeSides: {
 		fontSize: 11,

--- a/apps/score-tracker/frontend/helpers/DiceRollHelper.ts
+++ b/apps/score-tracker/frontend/helpers/DiceRollHelper.ts
@@ -1,0 +1,52 @@
+// Dice rolling semantics for the dice screen.
+//
+// "sum" rolls the pool once and adds everything up. "advantage"/"disadvantage"
+// roll the whole pool twice and decide PER DIE which of its two values counts:
+// each die keeps its higher (advantage) or lower (disadvantage) value, and the
+// result is the sum of the kept values. Nothing is hidden or "loaded" - both
+// rolls are shown in the UI and only each die's kept value is highlighted.
+// This is the classic single-die "roll twice, keep one" rule applied to every
+// die individually - NOT to the totals of the two rolls, which would let a
+// die's worse value count just because its roll happened to win overall.
+
+import { randomDieValue } from './RandomHelper';
+
+export type RollMode = 'sum' | 'advantage' | 'disadvantage';
+
+export type PoolDie = { id: string; sides: number };
+export type DieResult = PoolDie & { value: number };
+export type DiceRoll = { dice: DieResult[]; total: number };
+
+export type RollResult =
+	| { mode: 'sum'; dice: DieResult[]; total: number }
+	| {
+			mode: 'advantage' | 'disadvantage';
+			rollA: DiceRoll;
+			rollB: DiceRoll;
+			/** For each die id, which of the two rolls holds its kept value ('A' on ties). */
+			keptRollById: Record<string, 'A' | 'B'>;
+			/** Sum of every die's kept value. */
+			keptTotal: number;
+	  };
+
+export function rollPoolOnce(pool: PoolDie[]): DiceRoll {
+	const dice = pool.map((die) => ({ ...die, value: randomDieValue(die.sides) }));
+	return { dice, total: dice.reduce((sum, die) => sum + die.value, 0) };
+}
+
+export function computeRoll(pool: PoolDie[], mode: RollMode): RollResult {
+	const rollA = rollPoolOnce(pool);
+	if (mode === 'sum') {
+		return { mode, dice: rollA.dice, total: rollA.total };
+	}
+	const rollB = rollPoolOnce(pool);
+	const keptRollById: Record<string, 'A' | 'B'> = {};
+	let keptTotal = 0;
+	rollA.dice.forEach((dieA, index) => {
+		const dieB = rollB.dice[index];
+		const keepA = mode === 'advantage' ? dieA.value >= dieB.value : dieA.value <= dieB.value;
+		keptRollById[dieA.id] = keepA ? 'A' : 'B';
+		keptTotal += keepA ? dieA.value : dieB.value;
+	});
+	return { mode, rollA, rollB, keptRollById, keptTotal };
+}


### PR DESCRIPTION
With multiple dice, Vorteil/Nachteil kept the whole roll with the higher/
lower total, so a die's worse value could count just because its roll won
overall (e.g. W4 showing 4 in roll 1 but counting 3 from roll 2). Now each
die keeps its own higher (advantage) or lower (disadvantage) value across
the two rolls and the result is the sum of the kept values.

The roll logic moves from the dice screen into helpers/DiceRollHelper.ts
with unit tests. The result view highlights each die's kept value across
both rolls (instead of marking one whole roll with a "zählt" badge), drops
the now-misleading per-roll sums, and a hint under the mode toggle explains
the per-die rule.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0162fd3p9nH3jB6ospjYabKX