### PR TITLE
feat(score-tracker): Partien teilen & importieren über gemeinsames Export-Schema

### DIFF
--- a/apps/score-tracker/frontend/__tests__/ShareCodec.test.ts
+++ b/apps/score-tracker/frontend/__tests__/ShareCodec.test.ts
@@ -1,0 +1,137 @@
+// The helpers only need the storage functions from common-ui; mocking the
+// package keeps jest away from its expo-sqlite/native-module dependency chain.
+jest.mock('repo-depkit-common-ui', () => ({
+	getStorageItem: jest.fn(async () => null),
+	setStorageItem: jest.fn(async () => undefined),
+}));
+
+import type { Friend } from '../helpers/FriendsStorage';
+import type { GameHistoryEntry } from '../helpers/GameHistoryStorage';
+import type { GameType } from '../helpers/GameTypesStorage';
+import {
+	SHARE_STRING_PREFIX,
+	buildFriendsShareBundle,
+	buildGamesShareBundle,
+	buildMatchShareBundle,
+	decodeShareText,
+	encodeShareBundle,
+} from '../helpers/ShareCodec';
+
+function makeGameType(overrides: Partial<GameType> = {}): GameType {
+	return {
+		id: 'game-1',
+		name: 'Flip Seven',
+		icon: '🃏',
+		imageUrl: null,
+		scoringMode: 'highWins',
+		maxRounds: null,
+		maxScore: 200,
+		rules: null,
+		categories: null,
+		trackScores: true,
+		startingPlayerMode: 'fixed',
+		version: 3,
+		createdAt: 1000,
+		...overrides,
+	};
+}
+
+function makeFriend(overrides: Partial<Friend> = {}): Friend {
+	return { id: 'friend-1', name: 'Anna', color: '#2563eb', createdAt: 1000, ...overrides };
+}
+
+function makeMatch(overrides: Partial<GameHistoryEntry> = {}): GameHistoryEntry {
+	return {
+		id: 'match-1',
+		endedAt: 2000,
+		roundsCount: 2,
+		players: [
+			{ playerId: 'p1', name: 'Anna', color: '#2563eb', friendId: 'friend-1' },
+			{ playerId: 'p2', name: 'Gast', color: '#dc2626' },
+		],
+		finalScores: { p1: 42, p2: 17 },
+		gameTypeId: 'game-1',
+		rounds: [
+			{ id: 'r1', scores: { p1: 20, p2: 10 } },
+			{ id: 'r2', scores: { p1: 22, p2: 7 } },
+		],
+		...overrides,
+	};
+}
+
+describe('ShareCodec', () => {
+	it('round-trips a full match bundle through the compressed export string', () => {
+		const bundle = buildMatchShareBundle({
+			entry: makeMatch(),
+			gameType: makeGameType(),
+			friends: [makeFriend(), makeFriend({ id: 'friend-2', name: 'Ben' })],
+		});
+		const encoded = encodeShareBundle(bundle);
+		expect(encoded.startsWith(SHARE_STRING_PREFIX)).toBe(true);
+
+		const decoded = decodeShareText(encoded);
+		expect(decoded).not.toBeNull();
+		expect(decoded?.matches).toHaveLength(1);
+		expect(decoded?.matches?.[0].id).toBe('match-1');
+		expect(decoded?.games).toHaveLength(1);
+		expect(decoded?.games?.[0].name).toBe('Flip Seven');
+		expect(decoded?.games?.[0].id).toBe('game-1');
+		// Only the participating friend is bundled, not the whole roster.
+		expect(decoded?.friends?.map((friend) => friend.id)).toEqual(['friend-1']);
+	});
+
+	it('bundles a match without a specific game', () => {
+		const bundle = buildMatchShareBundle({ entry: makeMatch({ gameTypeId: undefined }), friends: [] });
+		expect(bundle.games).toEqual([]);
+		const decoded = decodeShareText(encodeShareBundle(bundle));
+		expect(decoded?.matches).toHaveLength(1);
+	});
+
+	it('round-trips games-only and friends-only bundles', () => {
+		const games = decodeShareText(encodeShareBundle(buildGamesShareBundle([makeGameType()])));
+		expect(games?.games).toHaveLength(1);
+		expect(games?.matches).toBeUndefined();
+
+		const friends = decodeShareText(encodeShareBundle(buildFriendsShareBundle([makeFriend()])));
+		expect(friends?.friends).toHaveLength(1);
+		expect(friends?.games).toBeUndefined();
+	});
+
+	it('accepts the plain (uncompressed) envelope JSON', () => {
+		const bundle = buildGamesShareBundle([makeGameType()]);
+		const decoded = decodeShareText(JSON.stringify(bundle, null, 2));
+		expect(decoded?.games).toHaveLength(1);
+	});
+
+	it('accepts the legacy friends export (bare Friend[] array)', () => {
+		const decoded = decodeShareText(JSON.stringify([makeFriend(), makeFriend({ id: 'friend-2', name: 'Ben' })]));
+		expect(decoded?.friends).toHaveLength(2);
+		expect(decoded?.games).toBeUndefined();
+	});
+
+	it('accepts the legacy game preset export (single object and array)', () => {
+		const preset = { name: 'Skat', icon: '🃏', scoringMode: 'highWins' };
+		expect(decodeShareText(JSON.stringify(preset))?.games).toHaveLength(1);
+		expect(decodeShareText(JSON.stringify([preset, { ...preset, name: 'Doppelkopf' }]))?.games).toHaveLength(2);
+	});
+
+	it('rejects garbage, empty text and tampered payloads', () => {
+		expect(decodeShareText('')).toBeNull();
+		expect(decodeShareText('   ')).toBeNull();
+		expect(decodeShareText('kein export')).toBeNull();
+		expect(decodeShareText('{"type": "something-else", "version": 1}')).toBeNull();
+		expect(decodeShareText(`${SHARE_STRING_PREFIX}!!!kaputt!!!`)).toBeNull();
+		// A match without players is not a valid shared match.
+		expect(
+			decodeShareText(
+				JSON.stringify({ type: 'score-tracker-export', version: 1, matches: [{ id: 'x', endedAt: 1, roundsCount: 0, players: [], finalScores: {} }] }),
+			),
+		).toBeNull();
+	});
+
+	it('compresses noticeably compared to the pretty-printed JSON', () => {
+		const bundle = buildMatchShareBundle({ entry: makeMatch(), gameType: makeGameType(), friends: [makeFriend()] });
+		const encoded = encodeShareBundle(bundle);
+		expect(encoded.length).toBeLessThan(JSON.stringify(bundle, null, 2).length);
+	});
+});

--- a/apps/score-tracker/frontend/__tests__/ShareImportPlan.test.ts
+++ b/apps/score-tracker/frontend/__tests__/ShareImportPlan.test.ts
@@ -1,0 +1,168 @@
+// The helpers only need the storage functions from common-ui; mocking the
+// package keeps jest away from its expo-sqlite/native-module dependency chain.
+jest.mock('repo-depkit-common-ui', () => ({
+	getStorageItem: jest.fn(async () => null),
+	setStorageItem: jest.fn(async () => undefined),
+}));
+
+import type { Friend } from '../helpers/FriendsStorage';
+import type { GameHistoryEntry } from '../helpers/GameHistoryStorage';
+import type { GameType } from '../helpers/GameTypesStorage';
+import type { ShareBundle } from '../helpers/ShareCodec';
+import { SHARE_BUNDLE_TYPE } from '../helpers/ShareCodec';
+import { buildImportPlan, dedupedFriendName, remapSharedMatch } from '../helpers/ShareImportPlan';
+
+function makeGameType(overrides: Partial<GameType> = {}): GameType {
+	return {
+		id: 'local-game-1',
+		name: 'Flip Seven',
+		icon: '🃏',
+		imageUrl: null,
+		scoringMode: 'highWins',
+		maxRounds: null,
+		maxScore: 200,
+		rules: null,
+		categories: null,
+		trackScores: true,
+		startingPlayerMode: 'fixed',
+		version: 1,
+		createdAt: 1000,
+		...overrides,
+	};
+}
+
+function makeFriend(overrides: Partial<Friend> = {}): Friend {
+	return { id: 'local-friend-1', name: 'Anna', color: '#2563eb', createdAt: 1000, ...overrides };
+}
+
+function makeBundle(overrides: Partial<ShareBundle> = {}): ShareBundle {
+	return { type: SHARE_BUNDLE_TYPE, version: 1, ...overrides };
+}
+
+const sharedGame = { name: 'Flip Seven', icon: '🃏', scoringMode: 'highWins' as const, version: 2, id: 'remote-game-1' };
+
+describe('buildImportPlan - games', () => {
+	it('creates a game that does not exist locally', () => {
+		const plan = buildImportPlan(makeBundle({ games: [sharedGame] }), { localGameTypes: [], localFriends: [], mode: 'games' });
+		expect(plan.games).toEqual([{ kind: 'create', game: sharedGame }]);
+	});
+
+	it('matches a local game by name (case-insensitive) and equal version', () => {
+		const local = makeGameType({ name: 'flip seven', version: 2 });
+		const plan = buildImportPlan(makeBundle({ games: [sharedGame] }), { localGameTypes: [local], localFriends: [], mode: 'games' });
+		expect(plan.games[0]).toEqual({ kind: 'existing', game: sharedGame, localGameType: local });
+	});
+
+	it('flags a version mismatch as conflict', () => {
+		const local = makeGameType({ version: 1 });
+		const plan = buildImportPlan(makeBundle({ games: [sharedGame] }), { localGameTypes: [local], localFriends: [], mode: 'games' });
+		expect(plan.games[0]).toEqual({
+			kind: 'versionConflict',
+			game: sharedGame,
+			localGameType: local,
+			importedVersion: 2,
+			localVersion: 1,
+		});
+	});
+
+	it('treats a missing version as version 1', () => {
+		const local = makeGameType({ version: undefined });
+		const { version: _ignored, ...gameWithoutVersion } = sharedGame;
+		const plan = buildImportPlan(makeBundle({ games: [{ ...gameWithoutVersion }] }), {
+			localGameTypes: [local],
+			localFriends: [],
+			mode: 'games',
+		});
+		expect(plan.games[0].kind).toBe('existing');
+	});
+});
+
+describe('buildImportPlan - friends', () => {
+	it('classifies friends by id, name and novelty', () => {
+		const localById = makeFriend({ id: 'friend-1', name: 'Anna umbenannt' });
+		const localByName = makeFriend({ id: 'other-id', name: 'ben' });
+		const importedById = makeFriend({ id: 'friend-1', name: 'Anna' });
+		const importedByName = makeFriend({ id: 'remote-id', name: 'Ben' });
+		const importedNew = makeFriend({ id: 'new-id', name: 'Clara' });
+
+		const plan = buildImportPlan(makeBundle({ friends: [importedById, importedByName, importedNew] }), {
+			localGameTypes: [],
+			localFriends: [localById, localByName],
+			mode: 'friends',
+		});
+
+		expect(plan.friends[0]).toEqual({ kind: 'existing', friend: importedById, localFriend: localById });
+		expect(plan.friends[1]).toEqual({ kind: 'nameConflict', friend: importedByName, localFriend: localByName });
+		expect(plan.friends[2]).toEqual({ kind: 'new', friend: importedNew });
+	});
+});
+
+describe('buildImportPlan - modes', () => {
+	const fullBundle = makeBundle({
+		games: [sharedGame],
+		friends: [makeFriend({ id: 'remote-friend' })],
+		matches: [{ id: 'm1', endedAt: 1, roundsCount: 1, players: [{ playerId: 'p1', name: 'A', color: '#fff' }], finalScores: { p1: 1 } }],
+	});
+
+	it("mode 'games' only consumes the games section", () => {
+		const plan = buildImportPlan(fullBundle, { localGameTypes: [], localFriends: [], mode: 'games' });
+		expect(plan.games).toHaveLength(1);
+		expect(plan.friends).toHaveLength(0);
+		expect(plan.matches).toHaveLength(0);
+	});
+
+	it("mode 'friends' only consumes the friends section", () => {
+		const plan = buildImportPlan(fullBundle, { localGameTypes: [], localFriends: [], mode: 'friends' });
+		expect(plan.games).toHaveLength(0);
+		expect(plan.friends).toHaveLength(1);
+		expect(plan.matches).toHaveLength(0);
+	});
+
+	it("mode 'all' consumes everything", () => {
+		const plan = buildImportPlan(fullBundle, { localGameTypes: [], localFriends: [], mode: 'all' });
+		expect(plan.games).toHaveLength(1);
+		expect(plan.friends).toHaveLength(1);
+		expect(plan.matches).toHaveLength(1);
+	});
+});
+
+describe('dedupedFriendName', () => {
+	it('appends the first free counter', () => {
+		const friends = [makeFriend({ name: 'Anna' }), makeFriend({ id: 'x', name: 'Anna (2)' })];
+		expect(dedupedFriendName('Anna', friends)).toBe('Anna (3)');
+		expect(dedupedFriendName('Ben', friends)).toBe('Ben (2)');
+	});
+});
+
+describe('remapSharedMatch', () => {
+	const entry: GameHistoryEntry = {
+		id: 'm1',
+		endedAt: 1,
+		roundsCount: 1,
+		players: [
+			{ playerId: 'p1', name: 'Anna', color: '#fff', friendId: 'remote-friend' },
+			{ playerId: 'p2', name: 'Gast', color: '#000' },
+		],
+		finalScores: { p1: 1, p2: 2 },
+		gameTypeId: 'remote-game-1',
+	};
+
+	it('rewrites game and friend references to the resolved local ids', () => {
+		const remapped = remapSharedMatch(entry, {
+			gameIdMap: { 'remote-game-1': 'local-game-1' },
+			friendIdMap: { 'remote-friend': 'local-friend-1' },
+		});
+		expect(remapped.gameTypeId).toBe('local-game-1');
+		expect(remapped.players[0].friendId).toBe('local-friend-1');
+		expect(remapped.players[1].friendId).toBeUndefined();
+		// The original entry stays untouched.
+		expect(entry.gameTypeId).toBe('remote-game-1');
+		expect(entry.players[0].friendId).toBe('remote-friend');
+	});
+
+	it('keeps unmapped ids so a later import can still link them', () => {
+		const remapped = remapSharedMatch(entry, { gameIdMap: {}, friendIdMap: {} });
+		expect(remapped.gameTypeId).toBe('remote-game-1');
+		expect(remapped.players[0].friendId).toBe('remote-friend');
+	});
+});

--- a/apps/score-tracker/frontend/app/games/[id].tsx
+++ b/apps/score-tracker/frontend/app/games/[id].tsx
@@ -28,7 +28,6 @@ import {
 	setGameTypeTrackScores,
 	setGameTypeVersion,
 	updateGameTypeFromPreset,
-	addGameTypeFromPreset,
 	removeGameType,
 } from '../../store/gameTypesSlice';
 import { loadMatch, resetScores, setGameType } from '../../store/gameSlice';
@@ -39,6 +38,7 @@ import { buildHistoryEntry, hasRecordedResults } from '../../helpers/GameHistory
 import type { ScoringMode, GameType } from '../../helpers/GameTypesStorage';
 import type { StartingPlayerMode } from '../../helpers/GameRules';
 import { gameTypeToPreset, parseGamePreset, STARTING_PLAYER_MODES, ROTATE_PLAYER_ORDER_RULE } from '../../helpers/GameRules';
+import { buildGamesShareBundle, encodeShareBundle } from '../../helpers/ShareCodec';
 import type { CategoryFilters, GameCategory, GameCategoryValues, MatchSort } from '../../helpers/GameCategories';
 import {
 	DEFAULT_MATCH_SORT,
@@ -56,6 +56,7 @@ import GameTypeIcon from '../../components/GameTypeIcon';
 import { makeGameHeaderTitle } from '../../components/GameHeaderTitle';
 import GameCategorySettings from '../../components/GameCategorySettings';
 import { GameImagePickerContent, GameImageSearchHeader, ImageQueryObservable, defaultImageQuery } from '../../components/GameImagePicker';
+import ShareImportContent from '../../components/ShareImportContent';
 import { findImageUrlForGameName } from '../../helpers/ImageSearch';
 import { describeImageSize, isInlineImage } from '../../helpers/GameImageUpload';
 import MatchFilterSort from '../../components/MatchFilterSort';
@@ -378,20 +379,22 @@ function GameTypeSettingsContent({
 		await Clipboard.setStringAsync(gameTypeId);
 	}, [gameTypeId]);
 
+	// Copies the game as a shareable template in the common export format
+	// (see helpers/ShareCodec) - the same envelope a Partie export uses.
 	const handleExportPreset = useCallback(async () => {
 		if (!gameType) return;
-		await Clipboard.setStringAsync(JSON.stringify(gameTypeToPreset(gameType), null, 2));
+		await Clipboard.setStringAsync(encodeShareBundle(buildGamesShareBundle([gameType])));
 	}, [gameType]);
 
-	const handleImportPreset = useCallback(
-		(value: string) => {
-			const preset = parseGamePreset(value);
-			if (!preset) return;
-			const action = dispatch(addGameTypeFromPreset(preset));
-			router.push({ pathname: '/games/[id]', params: { id: action.payload.id } });
-		},
-		[dispatch],
-	);
+	// Import from a shared export string. Full mode: pasting the export of a
+	// Partie here brings the Partie plus its Spiel/Freunde along - with the
+	// name/version check against the local games (see ShareImportPlan).
+	const handleOpenImportModal = useCallback(() => {
+		showModal({
+			title: 'Importieren',
+			children: <ShareImportContent mode="all" onClose={closeModal} />,
+		});
+	}, [showModal, closeModal]);
 
 	// Only clears the score-entry rules (card picker) - a custom player-order
 	// rule living in the same `rules` object, if any, is kept intact.
@@ -602,19 +605,15 @@ function GameTypeSettingsContent({
 				handleFunction={handleExportPreset}
 				groupPosition="top"
 			/>
-			<SettingsListTextInput
+			<SettingsList
 				nativeID={ComponentIds.GAMES_IMPORT_PRESET_ROW}
-				label="Spiel importieren"
+				label="Importieren"
+				value="Partie oder Spiel aus der Zwischenablage einfügen"
+				stackedValue
 				leftIcon={<Ionicons name="download-outline" size={20} color="#ffffff" />}
 				iconBgColor={PRIMARY_COLOR}
-				modalTitle="Spiel importieren"
-				placeholder='{"name": "...", "icon": "🃏", "scoringMode": "highWins", "rules": {...}}'
-				saveLabel="Importieren"
-				multiline
-				numberOfLines={10}
-				textAlignVertical="top"
-				checkTextInput={(value) => ({ isValid: parseGamePreset(value) !== null, value })}
-				onSave={handleImportPreset}
+				rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+				handleFunction={handleOpenImportModal}
 				groupPosition="bottom"
 			/>
 

--- a/apps/score-tracker/frontend/app/games/index.tsx
+++ b/apps/score-tracker/frontend/app/games/index.tsx
@@ -18,11 +18,13 @@ import { setGamesSortMode } from '../../store/appSettingsSlice';
 import { resetScores, setGameType } from '../../store/gameSlice';
 import { archiveGame } from '../../store/gameHistorySlice';
 import type { AppDispatch, RootState } from '../../store/store';
-import { FLIP_SEVEN_PRESET, MANSIONS_OF_MADNESS_PRESET, gameTypeToPreset, parseGamePreset } from '../../helpers/GameRules';
+import { FLIP_SEVEN_PRESET, MANSIONS_OF_MADNESS_PRESET } from '../../helpers/GameRules';
+import { buildGamesShareBundle, encodeShareBundle } from '../../helpers/ShareCodec';
 import { buildHistoryEntry, hasRecordedResults } from '../../helpers/GameHistoryStorage';
 import { generateId } from '../../helpers/RandomHelper';
 import { ComponentIds } from '../../constants/ComponentIds';
 import GameTypeIcon from '../../components/GameTypeIcon';
+import ShareImportContent from '../../components/ShareImportContent';
 
 const PRIMARY_COLOR = '#2563eb';
 const SUCCESS_COLOR = '#16a34a';
@@ -109,6 +111,7 @@ export default function GamesScreen() {
 	const navigation = useNavigation();
 	const [searchQuery, setSearchQuery] = useState('');
 	const { show: showModal, close: closeModal } = useMyScrollViewModal();
+	const { show: showImportModal, close: closeImportModal } = useMyScrollViewModal();
 
 	// Played matches and most recent match per game type (derived from the
 	// archived history). `lastPlayedAt` drives the default sort order.
@@ -182,21 +185,20 @@ export default function GamesScreen() {
 		router.push({ pathname: '/games/[id]', params: { id: action.payload.id } });
 	}, [dispatch, closeModal]);
 
-	const handleImportPreset = useCallback(
-		(value: string) => {
-			const preset = parseGamePreset(value);
-			if (!preset) return;
-			const action = dispatch(addGameTypeFromPreset(preset));
-			closeModal();
-			router.push({ pathname: '/games/[id]', params: { id: action.payload.id } });
-		},
-		[dispatch, closeModal],
-	);
+	// Import Spiele from a shared export string. Only the games are consumed -
+	// pasting the export of a whole Partie here imports just its Spiel (see
+	// components/ShareImportContent).
+	const handleOpenImportModal = useCallback(() => {
+		showImportModal({
+			title: 'Spiel importieren',
+			children: <ShareImportContent mode="games" onClose={closeImportModal} />,
+		});
+	}, [showImportModal, closeImportModal]);
 
-	// Copies all games as shareable templates (same JSON format the per-game
-	// export on the detail screen produces, just as an array).
+	// Copies all games as shareable templates in the common export format
+	// (see helpers/ShareCodec).
 	const handleExportAll = useCallback(async () => {
-		await Clipboard.setStringAsync(JSON.stringify(gameTypes.map(gameTypeToPreset), null, 2));
+		await Clipboard.setStringAsync(encodeShareBundle(buildGamesShareBundle(gameTypes)));
 	}, [gameTypes]);
 
 	const handleOpenSettingsModal = useCallback(() => {
@@ -244,26 +246,22 @@ export default function GamesScreen() {
 						handleFunction={handleLoadMansions}
 						groupPosition="middle"
 					/>
-					<SettingsListTextInput
+					<SettingsList
 						nativeID={ComponentIds.GAMES_IMPORT_PRESET_ROW}
 						label="Spiel importieren"
+						value="Export aus der Zwischenablage einfügen - auch aus einem Partie-Export"
+						stackedValue
 						leftIcon={<Ionicons name="clipboard-outline" size={20} color="#ffffff" />}
 						iconBgColor={PRIMARY_COLOR}
-						modalTitle="Spiel importieren"
-						placeholder='{"name": "...", "icon": "🃏", "scoringMode": "highWins", "rules": {...}}'
-						saveLabel="Importieren"
-						multiline
-						numberOfLines={10}
-						textAlignVertical="top"
-						checkTextInput={(value) => ({ isValid: parseGamePreset(value) !== null, value })}
-						onSave={handleImportPreset}
+						rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+						handleFunction={handleOpenImportModal}
 						groupPosition="bottom"
 					/>
 					<GamesSortSection />
 				</View>
 			),
 		});
-	}, [showModal, handleAddGameTypeFromModal, handleExportAll, handleLoadFlipSeven, handleLoadMansions, handleImportPreset]);
+	}, [showModal, handleAddGameTypeFromModal, handleExportAll, handleLoadFlipSeven, handleLoadMansions, handleOpenImportModal]);
 
 	React.useLayoutEffect(() => {
 		navigation.setOptions({

--- a/apps/score-tracker/frontend/app/index.tsx
+++ b/apps/score-tracker/frontend/app/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { SettingsList, SettingsListGroupTitle, useTheme } from 'repo-depkit-common-ui';
+import { SettingsList, SettingsListGroupTitle, useMyScrollViewModal, useTheme } from 'repo-depkit-common-ui';
 import { useDispatch, useSelector } from 'react-redux';
 import { router } from 'expo-router';
 import { loadMatch, resetScores, setGameType } from '../store/gameSlice';
@@ -13,6 +13,7 @@ import { buildHistoryEntry, hasRecordedResults } from '../helpers/GameHistorySto
 import { generateId } from '../helpers/RandomHelper';
 import { ComponentIds } from '../constants/ComponentIds';
 import GameTypeIcon from '../components/GameTypeIcon';
+import ShareImportContent from '../components/ShareImportContent';
 
 const PRIMARY_COLOR = '#2563eb';
 const SUCCESS_COLOR = '#16a34a';
@@ -114,6 +115,7 @@ export default function StartScreen() {
 	const gameTypes = useSelector((state: RootState) => state.gameTypes.gameTypes);
 	const historyEntries = useSelector((state: RootState) => state.gameHistory.entries);
 	const friends = useSelector((state: RootState) => state.friends.friends);
+	const { show: showImportModal, close: closeImportModal } = useMyScrollViewModal();
 
 	const greeting = getGreeting(new Date());
 
@@ -177,6 +179,15 @@ export default function StartScreen() {
 		dispatch(setGameType(undefined));
 		router.push('/match');
 	}, [archiveRunningMatch, dispatch]);
+
+	// Import a shared export (a Partie with its Spiel and Freunden, or plain
+	// Spiele/Freunde) from the clipboard - see components/ShareImportContent.
+	const handleOpenImportModal = useCallback(() => {
+		showImportModal({
+			title: 'Partie importieren',
+			children: <ShareImportContent mode="all" onClose={closeImportModal} />,
+		});
+	}, [showImportModal, closeImportModal]);
 
 	const matchRowCount = (lastPlayedGameType ? 1 : 0) + (hasRunningMatch || latestEntry ? 1 : 0);
 	const showLastMatchRow = hasRunningMatch || latestEntry != null;
@@ -254,6 +265,17 @@ export default function StartScreen() {
 					iconBgColor={PRIMARY_COLOR}
 					rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
 					handleFunction={() => router.push('/games')}
+					groupPosition="middle"
+				/>
+				<SettingsList
+					nativeID={ComponentIds.START_SCREEN_IMPORT_ROW}
+					label="Partie importieren"
+					value="Export eines anderen Spielers aus der Zwischenablage einfügen"
+					stackedValue
+					leftIcon={<Ionicons name="download-outline" size={20} color="#ffffff" />}
+					iconBgColor={PRIMARY_COLOR}
+					rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+					handleFunction={handleOpenImportModal}
 					groupPosition="bottom"
 				/>
 

--- a/apps/score-tracker/frontend/app/match/index.tsx
+++ b/apps/score-tracker/frontend/app/match/index.tsx
@@ -23,6 +23,7 @@ import {
 	AvatarStyle,
 } from 'repo-depkit-common-ui';
 import type { AvatarConfig } from 'repo-depkit-common-ui';
+import * as Clipboard from 'expo-clipboard';
 import { useDispatch, useSelector } from 'react-redux';
 import { router, useNavigation } from 'expo-router';
 import {
@@ -57,6 +58,7 @@ import { PLAYER_COLORS } from '../../helpers/GameStorage';
 import type { Player } from '../../helpers/GameStorage';
 import type { GameType } from '../../helpers/GameTypesStorage';
 import { buildHistoryEntry, hasRecordedResults } from '../../helpers/GameHistoryStorage';
+import { buildMatchShareBundle, encodeShareBundle } from '../../helpers/ShareCodec';
 import type { Friend } from '../../helpers/FriendsStorage';
 import { ComponentIds } from '../../constants/ComponentIds';
 import { logDebug } from '../../helpers/DebugLogger';
@@ -1054,8 +1056,21 @@ function MatchOptionsSection({ onClose }: Readonly<{ onClose: () => void }>) {
 	const dispatch = useDispatch<AppDispatch>();
 	const game = useSelector((state: RootState) => state.game);
 	const gameTypes = useSelector((state: RootState) => state.gameTypes.gameTypes);
+	const friends = useSelector((state: RootState) => state.friends.friends);
 	const selectedGameType = game.gameTypeId ? gameTypes.find((g) => g.id === game.gameTypeId) : undefined;
 	const trackScores = selectedGameType?.trackScores ?? true;
+
+	/**
+	 * Copy this Partie as a shareable export string to the clipboard: the match
+	 * itself plus its Spiel and the participating Freunde, so the receiver can
+	 * import everything in one go (see helpers/ShareCodec). The snapshot uses
+	 * the same builder as archiving, but doesn't archive anything.
+	 */
+	const handleExportMatch = useCallback(async () => {
+		const entry = buildHistoryEntry(game, { id: game.matchId ?? generateId(), endedAt: game.endedAt ?? Date.now() });
+		const bundle = buildMatchShareBundle({ entry, gameType: selectedGameType, friends });
+		await Clipboard.setStringAsync(encodeShareBundle(bundle));
+	}, [game, selectedGameType, friends]);
 
 	/**
 	 * Mark the match's rounds as finished: archive the match (it appears as
@@ -1096,6 +1111,16 @@ function MatchOptionsSection({ onClose }: Readonly<{ onClose: () => void }>) {
 	return (
 		<>
 			<SettingsListGroupTitle title="Partie" />
+			<SettingsList
+				nativeID={ComponentIds.GAME_SETTINGS_EXPORT_MATCH}
+				label="Partie exportieren"
+				value="Partie, Spiel & Freunde als Text in die Zwischenablage kopieren - zum Teilen mit anderen Spielern"
+				stackedValue
+				leftIcon={<Ionicons name="share-outline" size={20} color="#ffffff" />}
+				iconBgColor={PRIMARY_COLOR}
+				handleFunction={handleExportMatch}
+				groupPosition="top"
+			/>
 			{game.status === 'active' && (
 				<SettingsList
 					nativeID={ComponentIds.GAME_SETTINGS_END_MATCH}
@@ -1105,7 +1130,7 @@ function MatchOptionsSection({ onClose }: Readonly<{ onClose: () => void }>) {
 					leftIcon={<Ionicons name="flag-outline" size={20} color="#ffffff" />}
 					iconBgColor={SUCCESS_COLOR}
 					handleFunction={handleEndMatch}
-					groupPosition="top"
+					groupPosition="middle"
 				/>
 			)}
 			{game.status === 'finished' && (
@@ -1117,7 +1142,7 @@ function MatchOptionsSection({ onClose }: Readonly<{ onClose: () => void }>) {
 					leftIcon={<Ionicons name="lock-open-outline" size={20} color="#ffffff" />}
 					iconBgColor={SUCCESS_COLOR}
 					handleFunction={handleReopenMatch}
-					groupPosition="top"
+					groupPosition="middle"
 				/>
 			)}
 			{game.status === 'active' && trackScores && (

--- a/apps/score-tracker/frontend/app/players/index.tsx
+++ b/apps/score-tracker/frontend/app/players/index.tsx
@@ -21,14 +21,14 @@ import {
 	setFriendColor,
 	setFriendAvatar,
 	removeFriend,
-	importFriends,
 } from '../../store/friendsSlice';
 import type { AppDispatch, RootState } from '../../store/store';
 import { PLAYER_COLORS } from '../../helpers/GameStorage';
 import type { Friend } from '../../helpers/FriendsStorage';
-import { parseFriendsExport } from '../../helpers/FriendsStorage';
+import { buildFriendsShareBundle, encodeShareBundle } from '../../helpers/ShareCodec';
 import { ComponentIds } from '../../constants/ComponentIds';
 import { logDebug } from '../../helpers/DebugLogger';
+import ShareImportContent from '../../components/ShareImportContent';
 
 const PRIMARY_COLOR = '#2563eb';
 const DANGER_COLOR = '#dc2626';
@@ -56,8 +56,10 @@ function ExportFriendsRow({
 	nativeID?: string;
 	groupPosition?: 'top' | 'middle' | 'bottom' | 'single';
 }>) {
+	// Copies the friends in the common export format (see helpers/ShareCodec) -
+	// the same envelope a Partie export uses.
 	const handleExport = useCallback(async () => {
-		await Clipboard.setStringAsync(JSON.stringify(friends, null, 2));
+		await Clipboard.setStringAsync(encodeShareBundle(buildFriendsShareBundle(friends)));
 	}, [friends]);
 
 	return (
@@ -80,25 +82,27 @@ function ImportFriendsRow({
 	nativeID?: string;
 	groupPosition?: 'top' | 'middle' | 'bottom' | 'single';
 }>) {
-	const dispatch = useDispatch<AppDispatch>();
+	const { show: showImportModal, close: closeImportModal } = useMyScrollViewModal();
+
+	// Only the friends of an export are consumed here - pasting the export of
+	// a whole Partie imports just its Freunde (see components/ShareImportContent).
+	const handleOpenImportModal = useCallback(() => {
+		showImportModal({
+			title: 'Freunde importieren',
+			children: <ShareImportContent mode="friends" onClose={closeImportModal} />,
+		});
+	}, [showImportModal, closeImportModal]);
 
 	return (
-		<SettingsListTextInput
+		<SettingsList
 			nativeID={nativeID}
 			label="Freunde importieren"
+			value="Export aus der Zwischenablage einfügen - auch aus einem Partie-Export"
+			stackedValue
 			leftIcon={<Ionicons name="download-outline" size={20} color="#ffffff" />}
 			iconBgColor={PRIMARY_COLOR}
-			modalTitle="Freunde importieren"
-			placeholder='[{"id": "...", "name": "Anna", "color": "#2563eb", "createdAt": 0}]'
-			saveLabel="Importieren"
-			multiline
-			numberOfLines={10}
-			textAlignVertical="top"
-			checkTextInput={(value) => ({ isValid: parseFriendsExport(value) !== null, value })}
-			onSave={(value) => {
-				const parsed = parseFriendsExport(value);
-				if (parsed) dispatch(importFriends(parsed));
-			}}
+			rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+			handleFunction={handleOpenImportModal}
 			groupPosition={groupPosition}
 		/>
 	);

--- a/apps/score-tracker/frontend/components/ShareImportContent.tsx
+++ b/apps/score-tracker/frontend/components/ShareImportContent.tsx
@@ -1,0 +1,455 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { SettingsList, SettingsListGroupTitle, SettingsListSelectOptionSingle, useTheme } from 'repo-depkit-common-ui';
+import * as Clipboard from 'expo-clipboard';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from '../store/store';
+import { addGameTypeFromPreset, updateGameTypeFromPreset } from '../store/gameTypesSlice';
+import { importFriends } from '../store/friendsSlice';
+import { archiveGame } from '../store/gameHistorySlice';
+import type { Friend } from '../helpers/FriendsStorage';
+import type { ShareBundle } from '../helpers/ShareCodec';
+import { decodeShareText } from '../helpers/ShareCodec';
+import type { FriendConflictChoice, GameConflictChoice, ImportMode, ImportPlan } from '../helpers/ShareImportPlan';
+import { buildImportPlan, dedupedFriendName, remapSharedMatch } from '../helpers/ShareImportPlan';
+import { ComponentIds } from '../constants/ComponentIds';
+
+const PRIMARY_COLOR = '#2563eb';
+const SUCCESS_COLOR = '#16a34a';
+const WARNING_COLOR = '#f59e0b';
+
+function formatDate(timestamp: number): string {
+	return new Date(timestamp).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function getGroupPosition(index: number, total: number): 'top' | 'middle' | 'bottom' | 'single' {
+	if (total === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
+/** What the paste field accepts on this surface - shown as the intro hint. */
+function importHint(mode: ImportMode): string {
+	switch (mode) {
+		case 'games':
+			return 'Füge hier einen Export ein - es werden nur die enthaltenen Spiele importiert. Auch aus dem Export einer ganzen Partie wird hier nur das Spiel übernommen.';
+		case 'friends':
+			return 'Füge hier einen Export ein - es werden nur die enthaltenen Freunde importiert. Auch aus dem Export einer ganzen Partie werden hier nur die Freunde übernommen.';
+		default:
+			return 'Ein anderer Spieler kann eine Partie teilen: Partie öffnen → ⚙️ Optionen → „Partie exportieren“. Der Export landet in seiner Zwischenablage und kann hier eingefügt werden - Spiel und Freunde werden dabei mit angelegt, falls sie noch fehlen.';
+	}
+}
+
+/** Everything the plan would touch, for the "nothing matches this surface" check. */
+function planIsEmpty(plan: ImportPlan): boolean {
+	return plan.games.length === 0 && plan.friends.length === 0 && plan.matches.length === 0;
+}
+
+/**
+ * Interactive import of a shared export string (see helpers/ShareCodec):
+ * paste or load from the clipboard, review what the bundle contains, answer
+ * the conflict questions (game version mismatch, same-named friend) and
+ * import. `mode` narrows what is consumed - the games screen imports only
+ * Spiele, the friends screen only Freunde, the start screen everything.
+ */
+export default function ShareImportContent({ mode, onClose }: Readonly<{ mode: ImportMode; onClose: () => void }>) {
+	const { theme } = useTheme();
+	const dispatch = useDispatch<AppDispatch>();
+	const localGameTypes = useSelector((state: RootState) => state.gameTypes.gameTypes);
+	const localFriends = useSelector((state: RootState) => state.friends.friends);
+
+	const [text, setText] = useState('');
+	const [bundle, setBundle] = useState<ShareBundle | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [gameChoices, setGameChoices] = useState<Record<number, GameConflictChoice>>({});
+	const [friendChoices, setFriendChoices] = useState<Record<number, FriendConflictChoice>>({});
+	const [summary, setSummary] = useState<string | null>(null);
+
+	// The plan is derived, not stored: it stays consistent with the live store
+	// even if games/friends change while the modal is open.
+	const plan = useMemo(
+		() => (bundle ? buildImportPlan(bundle, { localGameTypes, localFriends, mode }) : null),
+		[bundle, localGameTypes, localFriends, mode],
+	);
+
+	const tryParse = useCallback(
+		(candidate: string) => {
+			setText(candidate);
+			setSummary(null);
+			if (candidate.trim() === '') {
+				setBundle(null);
+				setError(null);
+				return;
+			}
+			const decoded = decodeShareText(candidate);
+			if (!decoded) {
+				setBundle(null);
+				setError('Der Text ist kein gültiger Export.');
+				return;
+			}
+			const decodedPlan = buildImportPlan(decoded, { localGameTypes, localFriends, mode });
+			if (planIsEmpty(decodedPlan)) {
+				setBundle(null);
+				setError('In diesem Export ist nichts enthalten, das hier importiert werden kann.');
+				return;
+			}
+			setBundle(decoded);
+			setError(null);
+			setGameChoices({});
+			setFriendChoices({});
+		},
+		[localGameTypes, localFriends, mode],
+	);
+
+	const handleLoadClipboard = useCallback(async () => {
+		const clipboardText = await Clipboard.getStringAsync();
+		if (!clipboardText || clipboardText.trim() === '') {
+			setError('Die Zwischenablage ist leer.');
+			return;
+		}
+		tryParse(clipboardText);
+	}, [tryParse]);
+
+	const handleReset = useCallback(() => {
+		setText('');
+		setBundle(null);
+		setError(null);
+		setSummary(null);
+	}, []);
+
+	const handleImport = useCallback(() => {
+		if (!plan) return;
+
+		// Spiele first: matches need to know which local game they belong to.
+		const gameIdMap: Record<string, string> = {};
+		let gamesCreated = 0;
+		let gamesUpdated = 0;
+		plan.games.forEach((resolution, index) => {
+			if (resolution.kind === 'create') {
+				const action = dispatch(addGameTypeFromPreset(resolution.game));
+				gamesCreated++;
+				if (resolution.game.id) gameIdMap[resolution.game.id] = action.payload.id;
+				return;
+			}
+			if (resolution.kind === 'versionConflict' && (gameChoices[index] ?? 'keepLocal') === 'updateLocal') {
+				dispatch(updateGameTypeFromPreset({ gameTypeId: resolution.localGameType.id, preset: resolution.game }));
+				gamesUpdated++;
+			}
+			if (resolution.game.id) gameIdMap[resolution.game.id] = resolution.localGameType.id;
+		});
+
+		// Freunde: merge/add per resolution and remember which local id each
+		// imported id ended up as, so the match participants stay linked.
+		const friendIdMap: Record<string, string> = {};
+		const friendsToImport: Friend[] = [];
+		let friendsLinked = 0;
+		plan.friends.forEach((resolution, index) => {
+			if (resolution.kind === 'existing') {
+				friendsToImport.push(resolution.friend);
+				friendIdMap[resolution.friend.id] = resolution.friend.id;
+				return;
+			}
+			if (resolution.kind === 'new') {
+				friendsToImport.push(resolution.friend);
+				friendIdMap[resolution.friend.id] = resolution.friend.id;
+				return;
+			}
+			const choice = friendChoices[index] ?? 'samePerson';
+			if (choice === 'samePerson') {
+				friendIdMap[resolution.friend.id] = resolution.localFriend.id;
+				friendsLinked++;
+			} else if (choice === 'newPerson') {
+				friendsToImport.push(resolution.friend);
+				friendIdMap[resolution.friend.id] = resolution.friend.id;
+			} else {
+				friendsToImport.push({ ...resolution.friend, name: dedupedFriendName(resolution.friend.name, localFriends) });
+				friendIdMap[resolution.friend.id] = resolution.friend.id;
+			}
+		});
+		if (friendsToImport.length > 0) dispatch(importFriends(friendsToImport));
+
+		// Partien last, with all references remapped. `archiveGame` upserts by
+		// id, so importing the same Partie again updates it instead of
+		// duplicating it.
+		for (const match of plan.matches) {
+			dispatch(archiveGame(remapSharedMatch(match, { gameIdMap, friendIdMap })));
+		}
+
+		const parts: string[] = [];
+		if (plan.matches.length > 0) parts.push(plan.matches.length === 1 ? '1 Partie' : `${plan.matches.length} Partien`);
+		if (plan.games.length > 0) {
+			const details: string[] = [];
+			if (gamesCreated > 0) details.push(`${gamesCreated} neu`);
+			if (gamesUpdated > 0) details.push(`${gamesUpdated} aktualisiert`);
+			parts.push(`${plan.games.length === 1 ? '1 Spiel' : `${plan.games.length} Spiele`}${details.length > 0 ? ` (${details.join(', ')})` : ''}`);
+		}
+		if (plan.friends.length > 0) {
+			const details: string[] = [];
+			if (friendsToImport.length > 0) details.push(`${friendsToImport.length} übernommen`);
+			if (friendsLinked > 0) details.push(`${friendsLinked} verknüpft`);
+			parts.push(`${plan.friends.length === 1 ? '1 Freund' : `${plan.friends.length} Freunde`}${details.length > 0 ? ` (${details.join(', ')})` : ''}`);
+		}
+		setSummary(`Importiert: ${parts.join(' · ')}.`);
+	}, [plan, gameChoices, friendChoices, localFriends, dispatch]);
+
+	// ─── Done state ───────────────────────────────────────────────────────────
+
+	if (summary) {
+		return (
+			<View style={styles.container}>
+				<View style={[styles.summaryBanner, { backgroundColor: SUCCESS_COLOR }]}>
+					<Ionicons name="checkmark-circle-outline" size={20} color="#ffffff" />
+					<Text style={styles.summaryText}>{summary}</Text>
+				</View>
+				<TouchableOpacity
+					nativeID={ComponentIds.SHARE_IMPORT_DONE_BUTTON}
+					style={[styles.primaryButton, { backgroundColor: PRIMARY_COLOR }]}
+					onPress={onClose}
+					activeOpacity={0.8}
+				>
+					<Text style={styles.primaryButtonText}>Fertig</Text>
+				</TouchableOpacity>
+			</View>
+		);
+	}
+
+	// ─── Input state (nothing parsed yet) ─────────────────────────────────────
+
+	if (!plan) {
+		return (
+			<View style={styles.container}>
+				<Text style={[styles.hint, { color: theme.screen.placeholder }]}>{importHint(mode)}</Text>
+				<TouchableOpacity
+					nativeID={ComponentIds.SHARE_IMPORT_CLIPBOARD_BUTTON}
+					style={[styles.primaryButton, { backgroundColor: PRIMARY_COLOR }]}
+					onPress={handleLoadClipboard}
+					activeOpacity={0.8}
+				>
+					<Ionicons name="clipboard-outline" size={18} color="#ffffff" />
+					<Text style={styles.primaryButtonText}>Aus Zwischenablage laden</Text>
+				</TouchableOpacity>
+				<TextInput
+					nativeID={ComponentIds.SHARE_IMPORT_TEXT_INPUT}
+					style={[
+						styles.textInput,
+						{ color: theme.screen.text, borderColor: theme.screen.border, backgroundColor: theme.screen.background },
+					]}
+					placeholder="… oder Export hier einfügen"
+					placeholderTextColor={theme.screen.placeholder}
+					value={text}
+					onChangeText={tryParse}
+					multiline
+					numberOfLines={4}
+					textAlignVertical="top"
+					autoCorrect={false}
+					autoCapitalize="none"
+				/>
+				{error && <Text style={styles.errorText}>{error}</Text>}
+			</View>
+		);
+	}
+
+	// ─── Review state (parsed - show contents and conflict questions) ─────────
+
+	return (
+		<View style={styles.container}>
+			{plan.matches.length > 0 && (
+				<>
+					<SettingsListGroupTitle title={plan.matches.length === 1 ? 'Partie' : `Partien (${plan.matches.length})`} />
+					{plan.matches.map((match, index) => (
+						<SettingsList
+							key={match.id}
+							label={`Partie vom ${formatDate(match.endedAt)}`}
+							value={`${match.players.length === 1 ? '1 Spieler' : `${match.players.length} Spieler`} · ${
+								match.roundsCount === 1 ? '1 Runde' : `${match.roundsCount} Runden`
+							}`}
+							stackedValue
+							leftIcon={<Ionicons name="calendar-outline" size={20} color="#ffffff" />}
+							iconBgColor={PRIMARY_COLOR}
+							groupPosition={getGroupPosition(index, plan.matches.length)}
+						/>
+					))}
+				</>
+			)}
+
+			{plan.games.length > 0 && (
+				<>
+					<SettingsListGroupTitle title={plan.games.length === 1 ? 'Spiel' : `Spiele (${plan.games.length})`} />
+					{plan.games.map((resolution, index) => {
+						const { game } = resolution;
+						let value: string;
+						if (resolution.kind === 'create') value = 'Wird neu angelegt';
+						else if (resolution.kind === 'existing') value = `Bereits vorhanden (Version ${resolution.localGameType.version ?? 1})`;
+						else value = `Version unterschiedlich: importiert ${resolution.importedVersion}, lokal ${resolution.localVersion}`;
+						return (
+							<View key={`${game.name}-${index}`}>
+								<SettingsList
+									nativeID={`${ComponentIds.SHARE_IMPORT_GAME_ROW_PREFIX}${index}`}
+									label={`${game.icon} ${game.name}`}
+									value={value}
+									stackedValue
+									leftIcon={<Ionicons name="dice-outline" size={20} color="#ffffff" />}
+									iconBgColor={resolution.kind === 'versionConflict' ? WARNING_COLOR : PRIMARY_COLOR}
+									groupPosition={resolution.kind === 'versionConflict' ? 'top' : 'single'}
+								/>
+								{resolution.kind === 'versionConflict' && (
+									<>
+										<SettingsListSelectOptionSingle
+											nativeID={`${ComponentIds.SHARE_IMPORT_GAME_UPDATE_PREFIX}${index}`}
+											label={`Spiel auf Version ${resolution.importedVersion} aktualisieren`}
+											leftIcon={<Ionicons name="arrow-up-circle-outline" size={20} color="#ffffff" />}
+											iconBgColor={PRIMARY_COLOR}
+											isSelected={(gameChoices[index] ?? 'keepLocal') === 'updateLocal'}
+											onPress={() => setGameChoices((choices) => ({ ...choices, [index]: 'updateLocal' }))}
+											groupPosition="middle"
+										/>
+										<SettingsListSelectOptionSingle
+											nativeID={`${ComponentIds.SHARE_IMPORT_GAME_KEEP_PREFIX}${index}`}
+											label={`Lokale Version ${resolution.localVersion} behalten`}
+											leftIcon={<Ionicons name="shield-checkmark-outline" size={20} color="#ffffff" />}
+											iconBgColor={PRIMARY_COLOR}
+											isSelected={(gameChoices[index] ?? 'keepLocal') === 'keepLocal'}
+											onPress={() => setGameChoices((choices) => ({ ...choices, [index]: 'keepLocal' }))}
+											groupPosition="bottom"
+										/>
+									</>
+								)}
+							</View>
+						);
+					})}
+				</>
+			)}
+
+			{plan.friends.length > 0 && (
+				<>
+					<SettingsListGroupTitle title={plan.friends.length === 1 ? 'Freund' : `Freunde (${plan.friends.length})`} />
+					{plan.friends.map((resolution, index) => {
+						const { friend } = resolution;
+						let value: string;
+						if (resolution.kind === 'existing') value = 'Bereits vorhanden - wird aktualisiert';
+						else if (resolution.kind === 'new') value = 'Wird neu angelegt';
+						else value = `Es gibt schon einen Freund namens „${resolution.localFriend.name}“ - gleiche Person?`;
+						return (
+							<View key={friend.id}>
+								<SettingsList
+									nativeID={`${ComponentIds.SHARE_IMPORT_FRIEND_ROW_PREFIX}${index}`}
+									label={friend.name}
+									value={value}
+									stackedValue
+									leftIcon={<Ionicons name="person-outline" size={20} color="#ffffff" />}
+									iconBgColor={resolution.kind === 'nameConflict' ? WARNING_COLOR : PRIMARY_COLOR}
+									groupPosition={resolution.kind === 'nameConflict' ? 'top' : 'single'}
+								/>
+								{resolution.kind === 'nameConflict' && (
+									<>
+										<SettingsListSelectOptionSingle
+											nativeID={`${ComponentIds.SHARE_IMPORT_FRIEND_SAME_PREFIX}${index}`}
+											label={`Gleiche Person wie „${resolution.localFriend.name}“`}
+											leftIcon={<Ionicons name="git-merge-outline" size={20} color="#ffffff" />}
+											iconBgColor={PRIMARY_COLOR}
+											isSelected={(friendChoices[index] ?? 'samePerson') === 'samePerson'}
+											onPress={() => setFriendChoices((choices) => ({ ...choices, [index]: 'samePerson' }))}
+											groupPosition="middle"
+										/>
+										<SettingsListSelectOptionSingle
+											nativeID={`${ComponentIds.SHARE_IMPORT_FRIEND_NEW_PREFIX}${index}`}
+											label="Neue Person - Name behalten"
+											leftIcon={<Ionicons name="person-add-outline" size={20} color="#ffffff" />}
+											iconBgColor={PRIMARY_COLOR}
+											isSelected={(friendChoices[index] ?? 'samePerson') === 'newPerson'}
+											onPress={() => setFriendChoices((choices) => ({ ...choices, [index]: 'newPerson' }))}
+											groupPosition="middle"
+										/>
+										<SettingsListSelectOptionSingle
+											nativeID={`${ComponentIds.SHARE_IMPORT_FRIEND_RENAME_PREFIX}${index}`}
+											label={`Neue Person - umbenennen in „${dedupedFriendName(friend.name, localFriends)}“`}
+											leftIcon={<Ionicons name="pencil-outline" size={20} color="#ffffff" />}
+											iconBgColor={PRIMARY_COLOR}
+											isSelected={(friendChoices[index] ?? 'samePerson') === 'newPersonRenamed'}
+											onPress={() => setFriendChoices((choices) => ({ ...choices, [index]: 'newPersonRenamed' }))}
+											groupPosition="bottom"
+										/>
+									</>
+								)}
+							</View>
+						);
+					})}
+				</>
+			)}
+
+			<TouchableOpacity
+				nativeID={ComponentIds.SHARE_IMPORT_SUBMIT_BUTTON}
+				style={[styles.primaryButton, { backgroundColor: SUCCESS_COLOR }]}
+				onPress={handleImport}
+				activeOpacity={0.8}
+			>
+				<Ionicons name="download-outline" size={18} color="#ffffff" />
+				<Text style={styles.primaryButtonText}>Importieren</Text>
+			</TouchableOpacity>
+			<TouchableOpacity nativeID={ComponentIds.SHARE_IMPORT_RESET_BUTTON} style={styles.secondaryButton} onPress={handleReset} activeOpacity={0.7}>
+				<Text style={[styles.secondaryButtonText, { color: theme.screen.placeholder }]}>Anderen Export einfügen</Text>
+			</TouchableOpacity>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		padding: 10,
+		gap: 10,
+	},
+	hint: {
+		fontSize: 13,
+		lineHeight: 19,
+		paddingHorizontal: 4,
+	},
+	primaryButton: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 8,
+		height: 46,
+		borderRadius: 10,
+	},
+	primaryButtonText: {
+		color: '#ffffff',
+		fontSize: 15,
+		fontWeight: '600',
+	},
+	secondaryButton: {
+		alignItems: 'center',
+		paddingVertical: 8,
+	},
+	secondaryButtonText: {
+		fontSize: 13,
+		fontWeight: '600',
+	},
+	textInput: {
+		borderWidth: 1,
+		borderRadius: 10,
+		minHeight: 88,
+		padding: 10,
+		fontSize: 13,
+	},
+	errorText: {
+		color: '#dc2626',
+		fontSize: 13,
+		paddingHorizontal: 4,
+	},
+	summaryBanner: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+		borderRadius: 12,
+		paddingVertical: 12,
+		paddingHorizontal: 16,
+	},
+	summaryText: {
+		color: '#ffffff',
+		fontSize: 14,
+		fontWeight: '600',
+		flexShrink: 1,
+	},
+});

--- a/apps/score-tracker/frontend/constants/ComponentIds.ts
+++ b/apps/score-tracker/frontend/constants/ComponentIds.ts
@@ -27,6 +27,21 @@ export const ComponentIds = {
 	START_SCREEN_TIMER_ROW: 'start-screen-timer-row',
 	START_SCREEN_DICE_ROW: 'start-screen-dice-row',
 	START_SCREEN_STATS: 'start-screen-stats',
+	START_SCREEN_IMPORT_ROW: 'start-screen-import-row',
+
+	// Shared import modal (see components/ShareImportContent)
+	SHARE_IMPORT_CLIPBOARD_BUTTON: 'share-import-clipboard-button',
+	SHARE_IMPORT_TEXT_INPUT: 'share-import-text-input',
+	SHARE_IMPORT_SUBMIT_BUTTON: 'share-import-submit-button',
+	SHARE_IMPORT_RESET_BUTTON: 'share-import-reset-button',
+	SHARE_IMPORT_DONE_BUTTON: 'share-import-done-button',
+	SHARE_IMPORT_GAME_ROW_PREFIX: 'share-import-game-row-',
+	SHARE_IMPORT_GAME_UPDATE_PREFIX: 'share-import-game-update-',
+	SHARE_IMPORT_GAME_KEEP_PREFIX: 'share-import-game-keep-',
+	SHARE_IMPORT_FRIEND_ROW_PREFIX: 'share-import-friend-row-',
+	SHARE_IMPORT_FRIEND_SAME_PREFIX: 'share-import-friend-same-',
+	SHARE_IMPORT_FRIEND_NEW_PREFIX: 'share-import-friend-new-',
+	SHARE_IMPORT_FRIEND_RENAME_PREFIX: 'share-import-friend-rename-',
 
 	// Game screen header
 	GAME_HEADER_BACK_BUTTON: 'game-header-back-button',
@@ -92,6 +107,7 @@ export const ComponentIds = {
 	GAME_SETTINGS_COLUMNS_LANDSCAPE_2: 'game-settings-columns-landscape-2',
 	GAME_SETTINGS_RESET_SCORES: 'game-settings-reset-scores',
 	GAME_SETTINGS_END_MATCH: 'game-settings-end-match',
+	GAME_SETTINGS_EXPORT_MATCH: 'game-settings-export-match',
 	GAME_SETTINGS_REOPEN_MATCH: 'game-settings-reopen-match',
 	GAME_SETTINGS_DELETE_MATCH: 'game-settings-delete-match',
 	GAME_SETTINGS_PLAYER_ROW_PREFIX: 'game-settings-player-row-',

--- a/apps/score-tracker/frontend/helpers/FriendsStorage.ts
+++ b/apps/score-tracker/frontend/helpers/FriendsStorage.ts
@@ -44,7 +44,7 @@ export async function loadFriends(): Promise<Friend[]> {
 
 // ─── Import/export ──────────────────────────────────────────────────────────
 
-function isValidFriend(value: unknown): value is Friend {
+export function isValidFriend(value: unknown): value is Friend {
 	if (typeof value !== 'object' || value === null) return false;
 	const candidate = value as Record<string, unknown>;
 	return (
@@ -67,6 +67,15 @@ export function parseFriendsExport(text: string): Friend[] | null {
 	} catch {
 		return null;
 	}
+	return parseFriendsValue(parsed);
+}
+
+/**
+ * Same validation as `parseFriendsExport`, but starting from an already parsed
+ * value - for callers that carry friends nested inside a larger JSON payload
+ * (see helpers/ShareCodec).
+ */
+export function parseFriendsValue(parsed: unknown): Friend[] | null {
 	if (!Array.isArray(parsed) || parsed.length === 0) return null;
 	if (!parsed.every(isValidFriend)) return null;
 	return parsed;

--- a/apps/score-tracker/frontend/helpers/GameRules.ts
+++ b/apps/score-tracker/frontend/helpers/GameRules.ts
@@ -537,6 +537,15 @@ export function parseGamePreset(text: string): GamePreset | null {
 	} catch {
 		return null;
 	}
+	return parseGamePresetValue(parsed);
+}
+
+/**
+ * Same validation as `parseGamePreset`, but starting from an already parsed
+ * value - for callers that carry presets nested inside a larger JSON payload
+ * (see helpers/ShareCodec).
+ */
+export function parseGamePresetValue(parsed: unknown): GamePreset | null {
 	if (typeof parsed !== 'object' || parsed === null) return null;
 	const v = parsed as Record<string, unknown>;
 	if (!isValidGamePresetScalarFields(v)) return null;

--- a/apps/score-tracker/frontend/helpers/ShareCodec.ts
+++ b/apps/score-tracker/frontend/helpers/ShareCodec.ts
@@ -1,0 +1,216 @@
+import { CompressionHelper } from 'repo-depkit-common';
+import type { Friend } from './FriendsStorage';
+import { parseFriendsValue } from './FriendsStorage';
+import type { GameHistoryEntry, GameHistoryPlayerEntry } from './GameHistoryStorage';
+import type { GamePreset } from './GameRules';
+import { gameTypeToPreset, parseGamePresetValue } from './GameRules';
+import type { GameType } from './GameTypesStorage';
+
+// ─── The shared export schema ─────────────────────────────────────────────────
+//
+// Every clipboard export of the app (a whole Partie, one or more Spiele, a
+// friends list) uses the same envelope, so any import surface can pick out
+// exactly the sections it cares about: importing a Partie creates its Spiel
+// and Freunde along the way, while the games screen only reads `games` and the
+// friends screen only reads `friends` from the very same string. Sections are
+// all optional, which keeps the schema extensible.
+
+export type ShareBundle = {
+	type: typeof SHARE_BUNDLE_TYPE;
+	version: 1;
+	/** Shareable game templates. `id` is transport-only: the exporting device's
+	 *  game-type id, so `matches` in the same bundle can reference their game -
+	 *  it is never imported as-is (the importer resolves games by name). */
+	games?: SharedGame[];
+	friends?: Friend[];
+	/** Archived matches (Partien). `gameTypeId`/`friendId` reference the
+	 *  exporting device's ids and are remapped on import (see ShareImportPlan). */
+	matches?: GameHistoryEntry[];
+};
+
+export type SharedGame = GamePreset & { id?: string };
+
+export const SHARE_BUNDLE_TYPE = 'score-tracker-export';
+
+/** Prefix of a compressed export string, so pasted text is recognizable for what it is. */
+export const SHARE_STRING_PREFIX = 'SCORE-TRACKER-V1:';
+
+// ─── Building bundles ─────────────────────────────────────────────────────────
+
+/**
+ * Bundle one Partie for sharing: the match itself, its Spiel as a template
+ * (when it was played as one) and the roster entries of every participating
+ * friend - everything a receiving device needs to add the Partie to its own
+ * collection, whether or not it already knows the game or the players.
+ */
+export function buildMatchShareBundle(params: {
+	entry: GameHistoryEntry;
+	gameType?: GameType;
+	friends: Friend[];
+}): ShareBundle {
+	const { entry, gameType, friends } = params;
+	const participatingFriendIds = new Set(
+		entry.players.map((player) => player.friendId).filter((id): id is string => !!id),
+	);
+	return {
+		type: SHARE_BUNDLE_TYPE,
+		version: 1,
+		games: gameType ? [{ ...gameTypeToPreset(gameType), id: gameType.id }] : [],
+		friends: friends.filter((friend) => participatingFriendIds.has(friend.id)),
+		matches: [entry],
+	};
+}
+
+/** Bundle game templates for sharing (the "Spiel exportieren" flows). */
+export function buildGamesShareBundle(gameTypes: GameType[]): ShareBundle {
+	return {
+		type: SHARE_BUNDLE_TYPE,
+		version: 1,
+		games: gameTypes.map((gameType) => ({ ...gameTypeToPreset(gameType), id: gameType.id })),
+	};
+}
+
+/** Bundle friends for sharing (the "Freunde exportieren" flows). */
+export function buildFriendsShareBundle(friends: Friend[]): ShareBundle {
+	return { type: SHARE_BUNDLE_TYPE, version: 1, friends };
+}
+
+// ─── Encoding ─────────────────────────────────────────────────────────────────
+
+/** Serialize a bundle into the compact, prefixed clipboard string. */
+export function encodeShareBundle(bundle: ShareBundle): string {
+	return SHARE_STRING_PREFIX + CompressionHelper.compressToBase64(JSON.stringify(bundle));
+}
+
+// ─── Decoding / validation ────────────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseSharedMatchPlayer(value: unknown): GameHistoryPlayerEntry | null {
+	if (!isRecord(value)) return null;
+	if (typeof value.playerId !== 'string' || value.playerId === '') return null;
+	if (typeof value.name !== 'string') return null;
+	if (typeof value.color !== 'string') return null;
+	if (value.friendId !== undefined && typeof value.friendId !== 'string') return null;
+	return value as unknown as GameHistoryPlayerEntry;
+}
+
+/**
+ * Structural validation of one shared match. Deliberately checks only the
+ * fields the app relies on (id, players, scores) and passes optional detail
+ * fields (rounds, categories, times) through - the readers of a
+ * `GameHistoryEntry` already treat all of those as optional.
+ */
+export function parseSharedMatchValue(value: unknown): GameHistoryEntry | null {
+	if (!isRecord(value)) return null;
+	if (typeof value.id !== 'string' || value.id === '') return null;
+	if (typeof value.endedAt !== 'number') return null;
+	if (typeof value.roundsCount !== 'number') return null;
+	if (!Array.isArray(value.players) || value.players.length === 0) return null;
+	if (!value.players.every((player) => parseSharedMatchPlayer(player) !== null)) return null;
+	if (!isRecord(value.finalScores)) return null;
+	if (!Object.values(value.finalScores).every((score) => typeof score === 'number')) return null;
+	if (value.gameTypeId !== undefined && typeof value.gameTypeId !== 'string') return null;
+	if (value.rounds !== undefined && !Array.isArray(value.rounds)) return null;
+	return value as unknown as GameHistoryEntry;
+}
+
+function parseShareBundleValue(value: unknown): ShareBundle | null {
+	if (!isRecord(value)) return null;
+	if (value.type !== SHARE_BUNDLE_TYPE) return null;
+	if (typeof value.version !== 'number') return null;
+
+	const bundle: ShareBundle = { type: SHARE_BUNDLE_TYPE, version: 1 };
+
+	if (value.games !== undefined) {
+		if (!Array.isArray(value.games)) return null;
+		const games: SharedGame[] = [];
+		for (const raw of value.games) {
+			const preset = parseGamePresetValue(raw);
+			if (!preset) return null;
+			const id = isRecord(raw) && typeof raw.id === 'string' ? raw.id : undefined;
+			games.push({ ...preset, id });
+		}
+		bundle.games = games;
+	}
+
+	if (value.friends !== undefined) {
+		if (!Array.isArray(value.friends)) return null;
+		if (value.friends.length > 0) {
+			const friends = parseFriendsValue(value.friends);
+			if (!friends) return null;
+			bundle.friends = friends;
+		} else {
+			bundle.friends = [];
+		}
+	}
+
+	if (value.matches !== undefined) {
+		if (!Array.isArray(value.matches)) return null;
+		const matches: GameHistoryEntry[] = [];
+		for (const raw of value.matches) {
+			const match = parseSharedMatchValue(raw);
+			if (!match) return null;
+			matches.push(match);
+		}
+		bundle.matches = matches;
+	}
+
+	return bundle;
+}
+
+/**
+ * Parse any pasted/clipboard text into a `ShareBundle`. Accepts, in order:
+ * the compressed prefixed export string, the plain envelope JSON, and the
+ * legacy export formats from before the envelope existed (a bare `Friend[]`
+ * array, a single `GamePreset` object, an array of presets) - those are
+ * wrapped into an equivalent bundle so every import surface only has to deal
+ * with one shape. Returns `null` if the text is none of these.
+ */
+export function decodeShareText(text: string): ShareBundle | null {
+	const trimmed = text.trim();
+	if (trimmed === '') return null;
+
+	if (trimmed.startsWith(SHARE_STRING_PREFIX)) {
+		const json = CompressionHelper.decompressFromBase64(trimmed.slice(SHARE_STRING_PREFIX.length));
+		if (json === null) return null;
+		try {
+			return parseShareBundleValue(JSON.parse(json));
+		} catch {
+			return null;
+		}
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return null;
+	}
+
+	const bundle = parseShareBundleValue(parsed);
+	if (bundle) return bundle;
+
+	// Legacy: a bare friends array ("Freunde exportieren" of older versions).
+	const friends = parseFriendsValue(parsed);
+	if (friends) return { type: SHARE_BUNDLE_TYPE, version: 1, friends };
+
+	// Legacy: a single game preset ("Spiel exportieren" of older versions).
+	const preset = parseGamePresetValue(parsed);
+	if (preset) return { type: SHARE_BUNDLE_TYPE, version: 1, games: [preset] };
+
+	// Legacy: an array of game presets ("Alle Spiele exportieren" of older versions).
+	if (Array.isArray(parsed) && parsed.length > 0) {
+		const games: SharedGame[] = [];
+		for (const raw of parsed) {
+			const parsedPreset = parseGamePresetValue(raw);
+			if (!parsedPreset) return null;
+			games.push(parsedPreset);
+		}
+		return { type: SHARE_BUNDLE_TYPE, version: 1, games };
+	}
+
+	return null;
+}

--- a/apps/score-tracker/frontend/helpers/ShareImportPlan.ts
+++ b/apps/score-tracker/frontend/helpers/ShareImportPlan.ts
@@ -1,0 +1,138 @@
+import type { Friend } from './FriendsStorage';
+import type { GameHistoryEntry } from './GameHistoryStorage';
+import type { GameType } from './GameTypesStorage';
+import type { ShareBundle, SharedGame } from './ShareCodec';
+
+// ─── Import planning ──────────────────────────────────────────────────────────
+//
+// Turning a decoded `ShareBundle` into local state is not a plain merge: a
+// Spiel in the bundle may already exist locally (matched by name) with a
+// different version, and a Freund may exist under the same name but another
+// id - both cases are decisions only the user can make. `buildImportPlan`
+// therefore classifies everything up front; the import UI renders the
+// conflicts as questions and executes the plan with the collected choices
+// (see components/ShareImportContent).
+
+/** Which sections of a bundle an import surface consumes. */
+export type ImportMode = 'all' | 'games' | 'friends';
+
+export type GameImportResolution =
+	/** No local game of that name - the game will be created from the template. */
+	| { kind: 'create'; game: SharedGame }
+	/** A local game matches by name and version - it is simply used as-is. */
+	| { kind: 'existing'; game: SharedGame; localGameType: GameType }
+	/** A local game matches by name but the versions differ - the user decides
+	 *  whether the local game is updated to the imported definition. */
+	| { kind: 'versionConflict'; game: SharedGame; localGameType: GameType; importedVersion: number; localVersion: number };
+
+export type FriendImportResolution =
+	/** The same friend (same id) already exists - fields are merged onto it. */
+	| { kind: 'existing'; friend: Friend; localFriend: Friend }
+	/** Unknown id and unknown name - imported as a new friend. */
+	| { kind: 'new'; friend: Friend }
+	/** A local friend has the same name but another id - the user decides
+	 *  whether that's the same person or someone new. */
+	| { kind: 'nameConflict'; friend: Friend; localFriend: Friend };
+
+export type ImportPlan = {
+	games: GameImportResolution[];
+	friends: FriendImportResolution[];
+	matches: GameHistoryEntry[];
+};
+
+/** The user's answer to a `versionConflict`. */
+export type GameConflictChoice = 'updateLocal' | 'keepLocal';
+
+/** The user's answer to a `nameConflict`. */
+export type FriendConflictChoice = 'samePerson' | 'newPerson' | 'newPersonRenamed';
+
+function normalizeName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+/**
+ * Classify everything in the bundle against the local collections. `mode`
+ * narrows what is consumed: the games screen imports only the Spiele out of
+ * (e.g.) a full Partie export, the friends screen only the Freunde - and only
+ * a full import ('all') brings the Partien plus everything they need along.
+ */
+export function buildImportPlan(
+	bundle: ShareBundle,
+	params: { localGameTypes: GameType[]; localFriends: Friend[]; mode: ImportMode },
+): ImportPlan {
+	const { localGameTypes, localFriends, mode } = params;
+
+	const games: GameImportResolution[] = [];
+	if (mode !== 'friends') {
+		for (const game of bundle.games ?? []) {
+			const localGameType = localGameTypes.find((candidate) => normalizeName(candidate.name) === normalizeName(game.name));
+			if (!localGameType) {
+				games.push({ kind: 'create', game });
+				continue;
+			}
+			const importedVersion = game.version ?? 1;
+			const localVersion = localGameType.version ?? 1;
+			if (importedVersion === localVersion) {
+				games.push({ kind: 'existing', game, localGameType });
+			} else {
+				games.push({ kind: 'versionConflict', game, localGameType, importedVersion, localVersion });
+			}
+		}
+	}
+
+	const friends: FriendImportResolution[] = [];
+	if (mode !== 'games') {
+		for (const friend of bundle.friends ?? []) {
+			const byId = localFriends.find((candidate) => candidate.id === friend.id);
+			if (byId) {
+				friends.push({ kind: 'existing', friend, localFriend: byId });
+				continue;
+			}
+			const byName = localFriends.find((candidate) => normalizeName(candidate.name) === normalizeName(friend.name));
+			if (byName) {
+				friends.push({ kind: 'nameConflict', friend, localFriend: byName });
+			} else {
+				friends.push({ kind: 'new', friend });
+			}
+		}
+	}
+
+	const matches = mode === 'all' ? bundle.matches ?? [] : [];
+
+	return { games, friends, matches };
+}
+
+/**
+ * A name for a "same name, but a different person" friend import that doesn't
+ * collide with any local friend: `Anna` becomes `Anna (2)`, then `Anna (3)`…
+ */
+export function dedupedFriendName(name: string, localFriends: Friend[]): string {
+	const taken = new Set(localFriends.map((friend) => normalizeName(friend.name)));
+	for (let counter = 2; ; counter++) {
+		const candidate = `${name.trim()} (${counter})`;
+		if (!taken.has(normalizeName(candidate))) return candidate;
+	}
+}
+
+/**
+ * Rewrite a shared match's device-specific references to the local ones the
+ * import resolved: its `gameTypeId` to the local Spiel it was matched
+ * with/created as, and every player's `friendId` to the local friend chosen
+ * for it. An id without a mapping is kept as-is - for friends that is
+ * deliberate, so importing the friends later (e.g. from the same string on
+ * the friends screen) re-links the participants retroactively.
+ */
+export function remapSharedMatch(
+	entry: GameHistoryEntry,
+	params: { gameIdMap: Record<string, string>; friendIdMap: Record<string, string> },
+): GameHistoryEntry {
+	const { gameIdMap, friendIdMap } = params;
+	return {
+		...entry,
+		gameTypeId: entry.gameTypeId ? gameIdMap[entry.gameTypeId] ?? entry.gameTypeId : undefined,
+		players: entry.players.map((player) => ({
+			...player,
+			friendId: player.friendId ? friendIdMap[player.friendId] ?? player.friendId : undefined,
+		})),
+	};
+}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -31,3 +31,4 @@ export * from './src/GpsRouteTypes';
 export * from './src/MapOverlayTypes';
 export * from './src/UiAccentTypes';
 export * from './src/BoxplotHelper';
+export * from './src/CompressionHelper';

--- a/packages/common/src/CompressionHelper.ts
+++ b/packages/common/src/CompressionHelper.ts
@@ -1,0 +1,256 @@
+// Self-contained string compression (no dependencies, works in React Native,
+// web and Node alike): UTF-8 → LZW with variable-width codes → Base64. Meant
+// for compacting JSON payloads that travel through the clipboard or a QR code,
+// e.g. the score tracker's share/export strings - JSON is highly repetitive,
+// so LZW typically shrinks it to a fraction of its size.
+//
+// The stream format is fixed and symmetric: codes 0-255 are literal bytes,
+// new dictionary entries start at 256, the code width starts at 9 bits and
+// grows as the dictionary grows (up to 16 bits / 65536 entries, after which
+// the dictionary is frozen). The width of the i-th emitted/read code depends
+// only on i, so encoder and decoder can never drift apart.
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+const INITIAL_DICT_SIZE = 256;
+const MIN_CODE_WIDTH = 9;
+const MAX_DICT_SIZE = 1 << 16;
+
+/** Bits needed to represent every code of a dictionary with `size` entries (codes 0..size-1). */
+function codeWidthFor(size: number): number {
+  let width = MIN_CODE_WIDTH;
+  while (1 << width < size) width++;
+  return width;
+}
+
+/** Dictionary size the i-th code (0-based) was emitted with - shared between encode and decode. */
+function dictSizeAtCode(index: number): number {
+  return Math.min(INITIAL_DICT_SIZE + index, MAX_DICT_SIZE);
+}
+
+// ─── UTF-8 ────────────────────────────────────────────────────────────────────
+
+function toUtf8Bytes(input: string): number[] {
+  const bytes: number[] = [];
+  for (let i = 0; i < input.length; i++) {
+    const code = input.codePointAt(i) as number;
+    if (code > 0xffff) i++; // surrogate pair consumed two UTF-16 units
+    if (code < 0x80) {
+      bytes.push(code);
+    } else if (code < 0x800) {
+      bytes.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code < 0x10000) {
+      bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    } else {
+      bytes.push(0xf0 | (code >> 18), 0x80 | ((code >> 12) & 0x3f), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    }
+  }
+  return bytes;
+}
+
+function fromUtf8Bytes(bytes: string): string | null {
+  const parts: string[] = [];
+  for (let i = 0; i < bytes.length; ) {
+    const byte = bytes.charCodeAt(i);
+    let codePoint: number;
+    let extra: number;
+    if (byte < 0x80) {
+      codePoint = byte;
+      extra = 0;
+    } else if ((byte & 0xe0) === 0xc0) {
+      codePoint = byte & 0x1f;
+      extra = 1;
+    } else if ((byte & 0xf0) === 0xe0) {
+      codePoint = byte & 0x0f;
+      extra = 2;
+    } else if ((byte & 0xf8) === 0xf0) {
+      codePoint = byte & 0x07;
+      extra = 3;
+    } else {
+      return null;
+    }
+    if (i + extra >= bytes.length) return null;
+    for (let j = 1; j <= extra; j++) {
+      const continuation = bytes.charCodeAt(i + j);
+      if ((continuation & 0xc0) !== 0x80) return null;
+      codePoint = (codePoint << 6) | (continuation & 0x3f);
+    }
+    if (codePoint > 0x10ffff) return null;
+    parts.push(String.fromCodePoint(codePoint));
+    i += extra + 1;
+  }
+  return parts.join('');
+}
+
+// ─── Bit stream ───────────────────────────────────────────────────────────────
+
+class BitWriter {
+  private readonly bytes: number[] = [];
+  private current = 0;
+  private bitCount = 0;
+
+  write(value: number, width: number): void {
+    for (let bit = width - 1; bit >= 0; bit--) {
+      this.current = (this.current << 1) | ((value >> bit) & 1);
+      this.bitCount++;
+      if (this.bitCount === 8) {
+        this.bytes.push(this.current);
+        this.current = 0;
+        this.bitCount = 0;
+      }
+    }
+  }
+
+  /** Pad the last partial byte with zero bits and return all bytes. */
+  finish(): number[] {
+    if (this.bitCount > 0) {
+      this.bytes.push(this.current << (8 - this.bitCount));
+      this.current = 0;
+      this.bitCount = 0;
+    }
+    return this.bytes;
+  }
+}
+
+class BitReader {
+  private position = 0;
+
+  constructor(private readonly bytes: number[]) {}
+
+  remainingBits(): number {
+    return this.bytes.length * 8 - this.position;
+  }
+
+  read(width: number): number {
+    let value = 0;
+    for (let i = 0; i < width; i++) {
+      const byte = this.bytes[this.position >> 3];
+      const bit = (byte >> (7 - (this.position & 7))) & 1;
+      value = (value << 1) | bit;
+      this.position++;
+    }
+    return value;
+  }
+}
+
+// ─── Base64 ───────────────────────────────────────────────────────────────────
+
+function bytesToBase64(bytes: number[]): string {
+  let result = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i];
+    const b1 = bytes[i + 1];
+    const b2 = bytes[i + 2];
+    result += BASE64_ALPHABET[b0 >> 2];
+    result += BASE64_ALPHABET[((b0 & 3) << 4) | ((b1 ?? 0) >> 4)];
+    result += b1 === undefined ? '=' : BASE64_ALPHABET[((b1 & 15) << 2) | ((b2 ?? 0) >> 6)];
+    result += b2 === undefined ? '=' : BASE64_ALPHABET[b2 & 63];
+  }
+  return result;
+}
+
+function base64ToBytes(text: string): number[] | null {
+  const stripped = text.replace(/=+$/, '');
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+  for (const char of stripped) {
+    const value = BASE64_ALPHABET.indexOf(char);
+    if (value === -1) return null;
+    buffer = (buffer << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 0xff);
+    }
+  }
+  return bytes;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export class CompressionHelper {
+  /**
+   * Compress an arbitrary string (any unicode content) into a compact
+   * Base64-encoded LZW stream. The empty string compresses to ''.
+   */
+  static compressToBase64(input: string): string {
+    if (input === '') return '';
+    const bytes = toUtf8Bytes(input);
+
+    // Dictionary keys are byte sequences encoded as strings (each char one
+    // byte, always < 256). Codes 0-255 are implicit literals.
+    const dict = new Map<string, number>();
+    let dictSize = INITIAL_DICT_SIZE;
+    const writer = new BitWriter();
+    let emitted = 0;
+
+    const emit = (sequence: string) => {
+      const code = sequence.length === 1 ? sequence.charCodeAt(0) : (dict.get(sequence) as number);
+      writer.write(code, codeWidthFor(dictSizeAtCode(emitted)));
+      emitted++;
+    };
+
+    let current = '';
+    for (const byte of bytes) {
+      const char = String.fromCharCode(byte);
+      const extended = current + char;
+      if (extended.length === 1 || dict.has(extended)) {
+        current = extended;
+        continue;
+      }
+      emit(current);
+      if (dictSize < MAX_DICT_SIZE) {
+        dict.set(extended, dictSize);
+        dictSize++;
+      }
+      current = char;
+    }
+    emit(current);
+
+    return bytesToBase64(writer.finish());
+  }
+
+  /**
+   * Reverse of `compressToBase64`. Returns `null` for anything that is not a
+   * valid stream produced by it (bad Base64, invalid codes, malformed UTF-8).
+   */
+  static decompressFromBase64(input: string): string | null {
+    if (input === '') return '';
+    const bytes = base64ToBytes(input);
+    if (bytes === null || bytes.length === 0) return null;
+
+    const dict: string[] = [];
+    let dictSize = INITIAL_DICT_SIZE;
+    const reader = new BitReader(bytes);
+    const output: string[] = [];
+    let previous: string | null = null;
+
+    // Trailing padding is always shorter than one byte, and every code is at
+    // least 9 bits wide - so "not enough bits for another code" is the clean
+    // end of the stream.
+    for (let index = 0; reader.remainingBits() >= codeWidthFor(dictSizeAtCode(index)); index++) {
+      const code = reader.read(codeWidthFor(dictSizeAtCode(index)));
+      let entry: string;
+      if (code < INITIAL_DICT_SIZE) {
+        entry = String.fromCharCode(code);
+      } else if (code < dictSize) {
+        entry = dict[code - INITIAL_DICT_SIZE];
+      } else if (code === dictSize && previous !== null) {
+        // The classic LZW corner case: the encoder used the entry it was just
+        // about to add - it must start with the previous sequence.
+        entry = previous + previous[0];
+      } else {
+        return null;
+      }
+      output.push(entry);
+      if (previous !== null && dictSize < MAX_DICT_SIZE) {
+        dict.push(previous + entry[0]);
+        dictSize++;
+      }
+      previous = entry;
+    }
+
+    return fromUtf8Bytes(output.join(''));
+  }
+}

--- a/packages/common/src/__tests__/CompressionHelper.test.ts
+++ b/packages/common/src/__tests__/CompressionHelper.test.ts
@@ -1,0 +1,63 @@
+import { CompressionHelper } from '../CompressionHelper';
+
+function roundTrip(input: string): string | null {
+  return CompressionHelper.decompressFromBase64(CompressionHelper.compressToBase64(input));
+}
+
+describe('CompressionHelper', () => {
+  it('round-trips the empty string', () => {
+    expect(CompressionHelper.compressToBase64('')).toBe('');
+    expect(CompressionHelper.decompressFromBase64('')).toBe('');
+  });
+
+  it('round-trips short ASCII strings', () => {
+    expect(roundTrip('a')).toBe('a');
+    expect(roundTrip('ab')).toBe('ab');
+    expect(roundTrip('hello world')).toBe('hello world');
+  });
+
+  it('round-trips unicode content (umlauts, emoji, surrogate pairs)', () => {
+    const input = 'Grüße 🎲🃏 – „Spieleabend“ mit Ä/Ö/Ü/ß und 中文';
+    expect(roundTrip(input)).toBe(input);
+  });
+
+  it('round-trips the LZW KwKwK corner case', () => {
+    // Repeated pattern that forces the decoder to resolve a code that is not
+    // in its dictionary yet.
+    expect(roundTrip('aaaaaaaaaa')).toBe('aaaaaaaaaa');
+    expect(roundTrip('ababababababab')).toBe('ababababababab');
+  });
+
+  it('round-trips and shrinks large repetitive JSON', () => {
+    const entries = Array.from({ length: 200 }, (_, i) => ({
+      id: `entry-${i}`,
+      name: `Spieler ${i}`,
+      color: '#2563eb',
+      scores: { round1: i, round2: i * 2, round3: null },
+    }));
+    const json = JSON.stringify({ type: 'score-tracker-export', version: 1, entries });
+    const compressed = CompressionHelper.compressToBase64(json);
+    expect(CompressionHelper.decompressFromBase64(compressed)).toBe(json);
+    expect(compressed.length).toBeLessThan(json.length / 2);
+  });
+
+  it('round-trips content long enough to grow the code width past 9 bits', () => {
+    let input = '';
+    for (let i = 0; i < 5000; i++) {
+      input += String.fromCharCode(32 + ((i * 37) % 90)) + String.fromCharCode(32 + ((i * 13) % 90));
+    }
+    expect(roundTrip(input)).toBe(input);
+  });
+
+  it('produces Base64-only output', () => {
+    const compressed = CompressionHelper.compressToBase64('{"a": 1, "b": [1, 2, 3]}');
+    expect(compressed).toMatch(/^[A-Za-z0-9+/]+=*$/);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(CompressionHelper.decompressFromBase64('not base64 !!!')).toBeNull();
+    expect(CompressionHelper.decompressFromBase64('{"json": true}')).toBeNull();
+    // Valid Base64 but not a valid LZW stream (an out-of-range first code).
+    expect(CompressionHelper.decompressFromBase64('//8=')).toBeNull();
+  });
+});


### PR DESCRIPTION
Partien können jetzt aus dem Optionen-Modal einer Partie als komprimierter
Text in die Zwischenablage exportiert und auf einem anderen Gerät importiert
werden. Alle Exporte (Partie, Spiel, Freunde) nutzen dasselbe erweiterbare
Envelope-Schema, sodass jede Import-Stelle nur die Abschnitte übernimmt, die
sie betrifft:

- Start-Screen: "Partie importieren" (Partie + Spiel + Freunde aus der
  Zwischenablage; Hinweis, wie ein anderer Spieler exportiert)
- Spiel-Detail: Import von Partie oder Spiel; Spiele werden per Name
  gematcht, bei Versions-Unterschied entscheidet der Nutzer, ob die lokale
  Version aktualisiert wird
- Spiele-Screen: "Spiel importieren" übernimmt nur die Spiele eines Exports
- Freunde-Screen: Import übernimmt nur die Freunde; bei gleichem Namen mit
  anderer Id fragt der Import, ob es dieselbe Person ist oder eine neue
  (optional mit angepasstem Namen)

Freunde werden per Id gemergt (Re-Import idempotent), Partien per Id
ge-upsertet; Spiel-/Freund-Referenzen einer importierten Partie werden auf
die lokal aufgelösten Ids umgeschrieben. Alte Export-Formate (Friend[],
GamePreset, GamePreset[]) werden beim Import weiterhin akzeptiert.

Neu im Common-Paket: CompressionHelper (selbst-enthaltenes LZW + Base64,
keine neuen Dependencies) zum Komprimieren der Export-Strings.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MXuf3134Zy6wCw4ub1WNi2