### PR TITLE
feat(score-tracker): Weitere-Tools-Screen mit externen Links und Playbook im Dev-Modus

### DIFF
--- a/apps/score-tracker/frontend/app/_layout.tsx
+++ b/apps/score-tracker/frontend/app/_layout.tsx
@@ -129,6 +129,29 @@ function ThemedDrawerNavigator() {
 					}}
 				/>
 				<Drawer.Screen
+					name="tools/index"
+					options={{
+						title: 'Weitere Tools',
+						drawerIcon: makeDrawerIcon(Ionicons, 'construct-outline'),
+					}}
+				/>
+				{/* Component playbook (dev tooling) - visible in the custom drawer
+				    content only while the debug mode is active (see settings). */}
+				<Drawer.Screen
+					name="playbook/index"
+					options={{
+						title: 'Playbook',
+						drawerIcon: makeDrawerIcon(Ionicons, 'extension-puzzle-outline'),
+					}}
+				/>
+				<Drawer.Screen
+					name="playbook/[component]"
+					options={{
+						title: 'Playbook',
+						drawerItemStyle: { display: 'none' },
+					}}
+				/>
+				<Drawer.Screen
 					name="settings/index"
 					options={{
 						title: 'Einstellungen',
@@ -144,6 +167,10 @@ function ThemedDrawerNavigator() {
 
 function CustomDrawerContent(props: DrawerContentComponentProps) {
 	const activeKey = props.state.routes[props.state.index].name;
+	// The playbook (component gallery, dev tooling) only appears while the debug
+	// mode is active - toggled in the settings' hidden Debug section (revealed by
+	// pressing the footer logo).
+	const debugMode = useSelector((state: RootState) => state.debug.debugMode);
 
 	const items: DrawerItem[] = [
 		{
@@ -181,6 +208,24 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
 			renderIcon: (_, color) => <MaterialCommunityIcons name="dice-multiple-outline" size={24} color={color} />,
 			onPress: () => props.navigation.navigate('dice/index'),
 		},
+		{
+			key: 'tools/index',
+			label: 'Weitere Tools',
+			nativeID: ComponentIds.DRAWER_ITEM_TOOLS,
+			renderIcon: (_, color) => <Ionicons name="construct-outline" size={24} color={color} />,
+			onPress: () => props.navigation.navigate('tools/index'),
+		},
+		...(debugMode
+			? [
+					{
+						key: 'playbook/index',
+						label: 'Playbook',
+						nativeID: ComponentIds.DRAWER_ITEM_PLAYBOOK,
+						renderIcon: (_: boolean, color: string) => <Ionicons name="extension-puzzle-outline" size={24} color={color} />,
+						onPress: () => props.navigation.navigate('playbook/index'),
+					},
+				]
+			: []),
 		{
 			key: 'settings/index',
 			label: 'Einstellungen',

--- a/apps/score-tracker/frontend/app/playbook/[component].tsx
+++ b/apps/score-tracker/frontend/app/playbook/[component].tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+	CommonUiComponentIds,
+	KnobDefinition,
+	KnobValue,
+	SettingsList,
+	SettingsListBoolean,
+	SettingsListGroupTitle,
+	SettingsListNumberInput,
+	SettingsListTextInput,
+	buildPlaybookProps,
+	getPlaybookEntry,
+	serializeKnobValue,
+	useTheme,
+} from 'repo-depkit-common-ui';
+
+type GroupPosition = 'single' | 'top' | 'bottom' | 'middle';
+
+function getGroupPosition(index: number, total: number): GroupPosition {
+	if (total === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
+/**
+ * Playbook detail – renders one common-ui component from the playbook
+ * registry (packages/common-ui/src/playbook) with live-configurable props.
+ *
+ * The URL is the single source of truth: every knob is read from the query
+ * parameters (falling back to the registry defaults) and every change writes
+ * back via router.setParams. A specific component state is therefore always
+ * shareable and directly openable, e.g.
+ * `/playbook/SettingsListBoolean?isEnabled=false&variant=with-icon`.
+ * Mirrors the rocket-meals frontend's playbook detail screen.
+ */
+export default function PlaybookComponentScreen() {
+	const { theme } = useTheme();
+	const insets = useSafeAreaInsets();
+	const params = useLocalSearchParams<Record<string, string | string[]>>();
+	const componentParam = Array.isArray(params.component) ? params.component[0] : params.component;
+	const entry = componentParam ? getPlaybookEntry(componentParam) : undefined;
+
+	if (!entry) {
+		return (
+			<View style={[styles.container, styles.centered, { backgroundColor: theme.screen.background }]}>
+				<Text style={[styles.body, { color: theme.screen.text }]}>Unknown playbook component: {String(componentParam)}</Text>
+			</View>
+		);
+	}
+
+	const setKnob = (knobName: string, value: KnobValue) => {
+		router.setParams({ [knobName]: serializeKnobValue(value) });
+	};
+
+	const { componentProps, knobValues, variantName } = buildPlaybookProps(entry, params, setKnob);
+	const TargetComponent = entry.component;
+
+	const knobEntries = Object.entries(entry.knobs);
+	const variantNames = entry.variants ? Object.keys(entry.variants) : [];
+
+	const cycleSelectKnob = (knobName: string, knob: KnobDefinition) => {
+		const options = knob.options ?? [];
+		if (options.length === 0) return;
+		const currentIndex = options.indexOf(String(knobValues[knobName]));
+		const nextOption = options[(currentIndex + 1) % options.length];
+		if (nextOption !== undefined) {
+			setKnob(knobName, nextOption);
+		}
+	};
+
+	const renderKnob = (knobName: string, knob: KnobDefinition, groupPosition: GroupPosition) => {
+		const nativeID = CommonUiComponentIds.PLAYBOOK_KNOB_PREFIX + knobName;
+		const label = knob.label ?? knobName;
+		const value = knobValues[knobName];
+
+		switch (knob.type) {
+			case 'boolean':
+				return <SettingsListBoolean key={knobName} nativeID={nativeID} label={label} isEnabled={value === true} onToggle={() => setKnob(knobName, value !== true)} groupPosition={groupPosition} />;
+			case 'number':
+				return <SettingsListNumberInput key={knobName} nativeID={nativeID} label={label} value={String(value)} initialValue={Number(value)} allowDecimal={true} onSave={(saved) => setKnob(knobName, saved)} groupPosition={groupPosition} />;
+			case 'select':
+				return <SettingsList key={knobName} nativeID={nativeID} title={label} value={String(value)} handleFunction={() => cycleSelectKnob(knobName, knob)} groupPosition={groupPosition} />;
+			case 'text':
+				return <SettingsListTextInput key={knobName} nativeID={nativeID} label={label} placeholder={label} value={String(value)} initialValue={String(value)} onSave={(saved) => setKnob(knobName, saved)} groupPosition={groupPosition} />;
+		}
+	};
+
+	return (
+		<ScrollView style={[styles.container, { backgroundColor: theme.screen.background }]} contentContainerStyle={{ backgroundColor: theme.screen.background, paddingBottom: insets.bottom + 32 }}>
+			<View style={styles.content}>
+				<Text style={[styles.heading, { color: theme.screen.text }]}>{entry.name}</Text>
+				{!!entry.description && <Text style={[styles.body, { color: theme.screen.text }]}>{entry.description}</Text>}
+
+				<SettingsListGroupTitle title="Preview" />
+				<View nativeID={CommonUiComponentIds.PLAYBOOK_TARGET} style={[styles.target, entry.targetContainerStyle]}>
+					<TargetComponent {...componentProps} />
+				</View>
+
+				{variantNames.length > 0 && (
+					<>
+						<SettingsListGroupTitle title="Variant" />
+						{['default', ...variantNames].map((name, index) => {
+							const isActive = name === 'default' ? variantName === undefined : variantName === name;
+							return (
+								<SettingsList
+									key={name}
+									nativeID={CommonUiComponentIds.PLAYBOOK_VARIANT_PREFIX + name}
+									title={name}
+									value={isActive ? '✓' : ''}
+									handleFunction={() => router.setParams({ variant: name === 'default' ? '' : name })}
+									groupPosition={getGroupPosition(index, variantNames.length + 1)}
+								/>
+							);
+						})}
+					</>
+				)}
+
+				{knobEntries.length > 0 && (
+					<>
+						<SettingsListGroupTitle title="Knobs" />
+						{knobEntries.map(([knobName, knob], index) => renderKnob(knobName, knob, getGroupPosition(index, knobEntries.length)))}
+					</>
+				)}
+			</View>
+		</ScrollView>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	centered: {
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: 20,
+	},
+	content: {
+		width: '100%',
+		padding: 16,
+	},
+	heading: {
+		fontSize: 24,
+		fontWeight: '700',
+		marginVertical: 10,
+	},
+	body: {
+		fontSize: 14,
+		lineHeight: 20,
+		marginBottom: 10,
+	},
+	target: {
+		width: '100%',
+		marginBottom: 10,
+	},
+});

--- a/apps/score-tracker/frontend/app/playbook/index.tsx
+++ b/apps/score-tracker/frontend/app/playbook/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { CommonUiComponentIds, SettingsList, playbookRegistryData, useTheme } from 'repo-depkit-common-ui';
+
+const PRIMARY_COLOR = '#2563eb';
+
+type GroupPosition = 'single' | 'top' | 'bottom' | 'middle';
+
+function getGroupPosition(index: number, total: number): GroupPosition {
+	if (total === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
+/**
+ * Playbook overview – lists every common-ui component registered in the
+ * playbook registry (packages/common-ui/src/playbook). Tapping an entry opens
+ * the generic detail screen where the component's props ("knobs") can be
+ * tweaked live and via URL query parameters. Mirrors the rocket-meals
+ * frontend's playbook (apps/frontend/app/app/(app)/experimentell/playbook);
+ * only reachable from the drawer while the debug mode is active.
+ */
+export default function PlaybookIndexScreen() {
+	const { theme } = useTheme();
+	const insets = useSafeAreaInsets();
+
+	const openEntry = (name: string) => {
+		router.push({ pathname: '/playbook/[component]', params: { component: name } });
+	};
+
+	return (
+		<View style={[styles.container, { backgroundColor: theme.screen.background }]}>
+			<ScrollView contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 32, paddingLeft: insets.left, paddingRight: insets.right }]}>
+				<Text style={[styles.heading, { color: theme.screen.text }]}>Playbook</Text>
+				<Text style={[styles.body, { color: theme.screen.placeholder }]}>
+					Interactive gallery of all registered common-ui components. Props can also be set via URL query parameters, e.g. ?isEnabled=false
+				</Text>
+				<View style={styles.list}>
+					{playbookRegistryData.map((entry, index) => (
+						<SettingsList
+							key={entry.name}
+							nativeID={CommonUiComponentIds.PLAYBOOK_ITEM_PREFIX + entry.name}
+							iconBgColor={PRIMARY_COLOR}
+							leftIcon={<MaterialCommunityIcons name="puzzle-outline" size={22} color="#ffffff" />}
+							label={entry.name}
+							rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+							handleFunction={() => openEntry(entry.name)}
+							groupPosition={getGroupPosition(index, playbookRegistryData.length)}
+						/>
+					))}
+				</View>
+			</ScrollView>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		padding: 16,
+	},
+	heading: {
+		fontSize: 24,
+		fontWeight: '700',
+		marginVertical: 10,
+	},
+	body: {
+		fontSize: 14,
+		lineHeight: 20,
+		marginBottom: 10,
+	},
+	list: {
+		width: '100%',
+		marginTop: 10,
+	},
+});

--- a/apps/score-tracker/frontend/app/tools/index.tsx
+++ b/apps/score-tracker/frontend/app/tools/index.tsx
@@ -1,0 +1,181 @@
+import React, { useCallback } from 'react';
+import { View, ScrollView, StyleSheet, Text, Linking } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { SettingsList, SettingsListGroupTitle, useMyScrollViewModal, useTheme } from 'repo-depkit-common-ui';
+import { ComponentIds } from '../../constants/ComponentIds';
+
+const PRIMARY_COLOR = '#2563eb';
+const DATABASE_COLOR = '#16a34a';
+const ONLINE_COLOR = '#f59e0b';
+
+type GroupPosition = 'single' | 'top' | 'bottom' | 'middle';
+
+function getGroupPosition(index: number, total: number): GroupPosition {
+	if (total === 1) return 'single';
+	if (index === 0) return 'top';
+	if (index === total - 1) return 'bottom';
+	return 'middle';
+}
+
+// ─── External tool catalog ────────────────────────────────────────────────────
+//
+// Each category is one row on the screen; tapping it opens a modal listing the
+// external tools of that category. The links open in the browser (or the
+// respective app) - nothing is embedded, the app only links out.
+
+type ExternalTool = {
+	id: string;
+	name: string;
+	description: string;
+	url: string;
+};
+
+type ToolCategory = {
+	id: string;
+	label: string;
+	value: string;
+	modalTitle: string;
+	hint: string;
+	iconBgColor: string;
+	iconName: React.ComponentProps<typeof Ionicons>['name'];
+	tools: ExternalTool[];
+};
+
+const TOOL_CATEGORIES: ToolCategory[] = [
+	{
+		id: 'appointment',
+		label: 'Termin-Abstimmung',
+		value: 'Spieleabend-Termin finden',
+		modalTitle: '📅 Termin-Abstimmung',
+		hint: 'Mit diesen externen Diensten findet ihr einen Termin für den nächsten Spieleabend. Die Links öffnen sich außerhalb der App.',
+		iconBgColor: PRIMARY_COLOR,
+		iconName: 'calendar-outline',
+		tools: [
+			{ id: 'doodle', name: 'Doodle', description: 'Der Klassiker für Terminumfragen', url: 'https://doodle.com/' },
+			{ id: 'dfn', name: 'DFN Terminplaner', description: 'Ohne Anmeldung, datenschutzfreundlich', url: 'https://terminplaner.dfn.de/' },
+			{ id: 'nuudel', name: 'Nuudel', description: 'Von Digitalcourage, ohne Tracking', url: 'https://nuudel.digitalcourage.de/' },
+			{ id: 'rallly', name: 'Rallly', description: 'Open-Source-Terminabstimmung', url: 'https://rallly.co/' },
+		],
+	},
+	{
+		id: 'databases',
+		label: 'Spiele-Datenbanken',
+		value: 'Regeln, Bewertungen & Infos',
+		modalTitle: '📚 Spiele-Datenbanken',
+		hint: 'Regeln nachschlagen, Bewertungen lesen oder neue Spiele entdecken.',
+		iconBgColor: DATABASE_COLOR,
+		iconName: 'library-outline',
+		tools: [
+			{ id: 'bgg', name: 'BoardGameGeek', description: 'Die größte Brettspiel-Datenbank (englisch)', url: 'https://boardgamegeek.com/' },
+			{ id: 'spielregeln', name: 'Spielregeln.de', description: 'Spielregeln auf Deutsch nachschlagen', url: 'https://www.spielregeln.de/' },
+		],
+	},
+	{
+		id: 'online-play',
+		label: 'Online spielen',
+		value: 'Brettspiele im Browser',
+		modalTitle: '🎮 Online spielen',
+		hint: 'Wenn ihr nicht am selben Tisch sitzt: Hier könnt ihr Brettspiele online miteinander spielen.',
+		iconBgColor: ONLINE_COLOR,
+		iconName: 'game-controller-outline',
+		tools: [
+			{ id: 'bga', name: 'Board Game Arena', description: 'Hunderte Brettspiele online spielen', url: 'https://boardgamearena.com/' },
+			{ id: 'tabletopia', name: 'Tabletopia', description: 'Brettspiele in 3D im Browser', url: 'https://tabletopia.com/' },
+		],
+	},
+];
+
+function openExternalUrl(url: string) {
+	Linking.openURL(url).catch((err) => {
+		console.warn('[Tools] Failed to open external link:', url, err);
+	});
+}
+
+// ─── Modal content: list of external links ────────────────────────────────────
+
+function ToolLinkList({ category }: Readonly<{ category: ToolCategory }>) {
+	const { theme } = useTheme();
+	return (
+		<View style={styles.modalContainer}>
+			<Text style={[styles.hintText, { color: theme.screen.placeholder }]}>{category.hint}</Text>
+			{category.tools.map((tool, index) => (
+				<SettingsList
+					key={tool.id}
+					nativeID={ComponentIds.TOOLS_LINK_ROW_PREFIX + tool.id}
+					iconBgColor={category.iconBgColor}
+					leftIcon={<Ionicons name="globe-outline" size={22} color="#ffffff" />}
+					label={tool.name}
+					value={tool.description}
+					rightIcon={<Ionicons name="open-outline" size={20} color="#9ca3af" />}
+					handleFunction={() => openExternalUrl(tool.url)}
+					groupPosition={getGroupPosition(index, category.tools.length)}
+				/>
+			))}
+		</View>
+	);
+}
+
+// ─── Tools screen ─────────────────────────────────────────────────────────────
+
+export default function ToolsScreen() {
+	const { theme } = useTheme();
+	const insets = useSafeAreaInsets();
+	const { show: showModal } = useMyScrollViewModal();
+
+	const handleOpenCategory = useCallback(
+		(category: ToolCategory) => {
+			showModal({
+				title: category.modalTitle,
+				children: <ToolLinkList category={category} />,
+			});
+		},
+		[showModal]
+	);
+
+	return (
+		<View style={[styles.container, { backgroundColor: theme.screen.background }]}>
+			<ScrollView contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 32, paddingLeft: insets.left, paddingRight: insets.right }]}>
+				<Text style={[styles.introText, { color: theme.screen.placeholder }]}>
+					Nützliche externe Dienste rund um den Spieleabend. Die Links öffnen sich außerhalb der App.
+				</Text>
+
+				<SettingsListGroupTitle title="Externe Tools" />
+				{TOOL_CATEGORIES.map((category, index) => (
+					<SettingsList
+						key={category.id}
+						nativeID={ComponentIds.TOOLS_CATEGORY_ROW_PREFIX + category.id}
+						iconBgColor={category.iconBgColor}
+						leftIcon={<Ionicons name={category.iconName} size={22} color="#ffffff" />}
+						label={category.label}
+						value={category.value}
+						rightIcon={<Ionicons name="chevron-forward" size={20} color="#9ca3af" />}
+						handleFunction={() => handleOpenCategory(category)}
+						groupPosition={getGroupPosition(index, TOOL_CATEGORIES.length)}
+					/>
+				))}
+			</ScrollView>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	listContent: {},
+	introText: {
+		fontSize: 14,
+		lineHeight: 20,
+		paddingHorizontal: 16,
+		paddingTop: 16,
+	},
+	modalContainer: {
+		paddingBottom: 24,
+	},
+	hintText: {
+		fontSize: 14,
+		lineHeight: 20,
+		marginBottom: 12,
+	},
+});

--- a/apps/score-tracker/frontend/constants/ComponentIds.ts
+++ b/apps/score-tracker/frontend/constants/ComponentIds.ts
@@ -15,6 +15,9 @@ export const ComponentIds = {
 	DRAWER_ITEM_PLAYERS: 'drawer-item-players',
 	DRAWER_ITEM_TIMER: 'drawer-item-timer',
 	DRAWER_ITEM_DICE: 'drawer-item-dice',
+	DRAWER_ITEM_TOOLS: 'drawer-item-tools',
+	// Only rendered while the debug mode is active (see app/_layout).
+	DRAWER_ITEM_PLAYBOOK: 'drawer-item-playbook',
 	DRAWER_ITEM_SETTINGS: 'drawer-item-settings',
 
 	// Start screen (home, shown after onboarding)
@@ -226,6 +229,10 @@ export const ComponentIds = {
 	ONBOARDING_SKIP_BUTTON: 'onboarding-skip-button',
 	ONBOARDING_NEXT_BUTTON: 'onboarding-next-button',
 	ONBOARDING_BACK_BUTTON: 'onboarding-return-button',
+
+	// Tools screen (external tools, see app/tools)
+	TOOLS_CATEGORY_ROW_PREFIX: 'tools-category-row-',
+	TOOLS_LINK_ROW_PREFIX: 'tools-link-row-',
 
 	// Settings screen: legal & support
 	SETTINGS_PRIVACY_ROW: 'settings-privacy-row',


### PR DESCRIPTION
- Neuer Screen 'Weitere Tools' in der Seitenleiste: Kategorien (Termin-
  Abstimmung, Spiele-Datenbanken, Online spielen) öffnen je ein Modal mit
  externen Tools (Doodle, DFN Terminplaner, Nuudel, Rallly, BoardGameGeek,
  Spielregeln.de, Board Game Arena, Tabletopia) als SettingsList-Zeilen mit
  External-Link-Icon rechts.
- Playbook (common-ui Komponenten-Galerie) als eigene Screens übernommen;
  der Seitenleisten-Eintrag erscheint nur bei aktivem Debug-Modus
  (Einstellungen: Klick auf das Logo unten).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012BVADEjuMPd3AvFcmAw2Ai