### PR TITLE
Fix backend build: narrow markdown-it Token past noUncheckedIndexedAccess

### DIFF
--- a/packages/common/src/MarkdownSectionHelper.ts
+++ b/packages/common/src/MarkdownSectionHelper.ts
@@ -87,7 +87,9 @@ function buildBlocks(tokens: Token[], md: MarkdownItInstance, env: unknown, coll
 	};
 
 	while (idx < tokens.length) {
-		const token = tokens[idx];
+		// Guaranteed by the loop condition (idx < tokens.length); narrows past
+		// noUncheckedIndexedAccess's `Token | undefined` for consumers of this package.
+		const token = tokens[idx]!;
 
 		if (token.type === 'heading_open') {
 			const level = headingLevel(token);


### PR DESCRIPTION
## Summary
- The "🔨 Directus Backend Build" CI job failed with TypeScript errors in `MarkdownSectionHelper.ts` (shared between the backend extension and the frontend): `Argument of type 'Token | undefined' is not assignable to parameter of type 'Token'` (x2) and `'token' is possibly 'undefined'`.
- The backend extension's `tsconfig.json` sets `noUncheckedIndexedAccess: true`, so `tokens[idx]` in `buildBlocks` is typed `Token | undefined`. Since the backend build typechecks this shared source file as part of its own compilation, the array element type must be narrowed for consumers with that flag enabled.
- Narrowed `tokens[idx]` to `Token` with a non-null assertion, since the surrounding `while (idx < tokens.length)` loop condition already guarantees the index is in bounds.

## Test plan
- [x] `yarn workspace directus-extension-rocket-meals-bundle typecheck` — passes (exit 0)
- [x] `yarn app-backend-build-without-test` — builds successfully
- [x] `yarn jest packages/common/src/__tests__/MarkdownSectionHelper.test.ts` — 13/13 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01T8PhbaP88f5jKAiZ22gczP)_