### PR TITLE
Add dice roll history with die-type filters and max-roll counters

### DIFF
--- a/apps/score-tracker/frontend/__tests__/DiceHistoryStorage.test.ts
+++ b/apps/score-tracker/frontend/__tests__/DiceHistoryStorage.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Dice history: building entries from roll results, the newest-first cap,
+ * filtering by die type and the counters the history section shows - above
+ * all the max counter ("wie oft kam die 20 auf einem W20").
+ */
+
+jest.mock('repo-depkit-common-ui', () => ({
+	getStorageItem: jest.fn(),
+	setStorageItem: jest.fn(),
+}));
+
+import { getStorageItem } from 'repo-depkit-common-ui';
+import {
+	appendDiceHistoryEntry,
+	buildDiceHistoryEntry,
+	collectHistorySides,
+	computeDiceHistoryStats,
+	DICE_HISTORY_LIMIT,
+	filterHistoryEntries,
+	loadDiceHistory,
+	type DiceHistoryEntry,
+} from '../helpers/DiceHistoryStorage';
+
+const mockGetStorageItem = getStorageItem as jest.Mock;
+
+function entry(id: string, dice: { sides: number; value: number }[]): DiceHistoryEntry {
+	return {
+		id,
+		rolledAt: 1000,
+		mode: 'sum',
+		dice,
+		total: dice.reduce((sum, die) => sum + die.value, 0),
+	};
+}
+
+describe('buildDiceHistoryEntry', () => {
+	it('stores the rolled values of a sum roll', () => {
+		const result = buildDiceHistoryEntry(
+			{
+				mode: 'sum',
+				dice: [
+					{ id: 'die-1', sides: 20, value: 20 },
+					{ id: 'die-2', sides: 6, value: 3 },
+				],
+				total: 23,
+			},
+			{ id: 'entry-1', rolledAt: 42 },
+		);
+		expect(result).toEqual({
+			id: 'entry-1',
+			rolledAt: 42,
+			mode: 'sum',
+			dice: [
+				{ sides: 20, value: 20 },
+				{ sides: 6, value: 3 },
+			],
+			total: 23,
+		});
+	});
+
+	it('stores only the kept value of an advantage/disadvantage pair', () => {
+		const result = buildDiceHistoryEntry(
+			{
+				mode: 'advantage',
+				dice: [
+					{ id: 'die-1', sides: 20, valueA: 7, valueB: 18, kept: 'B' },
+					{ id: 'die-2', sides: 6, valueA: 4, valueB: 2, kept: 'A' },
+				],
+				keptTotal: 22,
+			},
+			{ id: 'entry-2', rolledAt: 42 },
+		);
+		expect(result.dice).toEqual([
+			{ sides: 20, value: 18 },
+			{ sides: 6, value: 4 },
+		]);
+		expect(result.total).toBe(22);
+	});
+});
+
+describe('appendDiceHistoryEntry', () => {
+	it('prepends the new entry (newest first)', () => {
+		const existing = [entry('old', [{ sides: 6, value: 2 }])];
+		const next = appendDiceHistoryEntry(existing, entry('new', [{ sides: 20, value: 20 }]));
+		expect(next.map((item) => item.id)).toEqual(['new', 'old']);
+	});
+
+	it('drops the oldest entries beyond the cap', () => {
+		const full = Array.from({ length: DICE_HISTORY_LIMIT }, (_, index) => entry(`entry-${index}`, [{ sides: 6, value: 1 }]));
+		const next = appendDiceHistoryEntry(full, entry('newest', [{ sides: 6, value: 6 }]));
+		expect(next).toHaveLength(DICE_HISTORY_LIMIT);
+		expect(next[0].id).toBe('newest');
+		expect(next.at(-1)?.id).toBe(`entry-${DICE_HISTORY_LIMIT - 2}`);
+	});
+});
+
+describe('collectHistorySides / filterHistoryEntries', () => {
+	const entries = [
+		entry('a', [{ sides: 20, value: 20 }, { sides: 6, value: 3 }]),
+		entry('b', [{ sides: 6, value: 6 }]),
+		entry('c', [{ sides: 4, value: 1 }]),
+	];
+
+	it('lists each occurring die type once, sorted ascending', () => {
+		expect(collectHistorySides(entries)).toEqual([4, 6, 20]);
+	});
+
+	it('keeps entries containing at least one die of the filtered type', () => {
+		expect(filterHistoryEntries(entries, 6).map((item) => item.id)).toEqual(['a', 'b']);
+		expect(filterHistoryEntries(entries, 20).map((item) => item.id)).toEqual(['a']);
+		expect(filterHistoryEntries(entries, null)).toHaveLength(3);
+	});
+});
+
+describe('computeDiceHistoryStats', () => {
+	// Three W20 rolls (20, 20, 1) plus a W6 rolling 6 and a W6 rolling 3.
+	const entries = [
+		entry('a', [{ sides: 20, value: 20 }, { sides: 6, value: 6 }]),
+		entry('b', [{ sides: 20, value: 20 }]),
+		entry('c', [{ sides: 20, value: 1 }, { sides: 6, value: 3 }]),
+	];
+
+	it('counts max rolls only for the filtered die type', () => {
+		const stats = computeDiceHistoryStats(entries, 20);
+		expect(stats.rollCount).toBe(3);
+		expect(stats.maxCount).toBe(2);
+		expect(stats.minCount).toBe(1);
+		expect(stats.average).toBeCloseTo((20 + 20 + 1) / 3);
+	});
+
+	it('counts each die against its own maximum without a filter', () => {
+		const stats = computeDiceHistoryStats(entries, null);
+		expect(stats.rollCount).toBe(5);
+		// Two natural 20s plus the W6 rolling 6.
+		expect(stats.maxCount).toBe(3);
+		expect(stats.minCount).toBe(1);
+	});
+
+	it('returns a null average for an empty selection', () => {
+		expect(computeDiceHistoryStats([], null)).toEqual({ rollCount: 0, maxCount: 0, minCount: 0, average: null });
+		expect(computeDiceHistoryStats(entries, 12).average).toBeNull();
+	});
+});
+
+describe('loadDiceHistory', () => {
+	it('drops malformed entries instead of failing the whole load', async () => {
+		const valid = entry('ok', [{ sides: 20, value: 7 }]);
+		mockGetStorageItem.mockResolvedValueOnce(
+			JSON.stringify({
+				entries: [
+					valid,
+					{ id: 'no-dice', rolledAt: 1, mode: 'sum', dice: [], total: 0 },
+					{ id: 'bad-value', rolledAt: 1, mode: 'sum', dice: [{ sides: 6, value: 9 }], total: 9 },
+					{ id: 'bad-mode', rolledAt: 1, mode: 'weird', dice: [{ sides: 6, value: 2 }], total: 2 },
+					'garbage',
+				],
+			}),
+		);
+		await expect(loadDiceHistory()).resolves.toEqual([valid]);
+	});
+
+	it('returns an empty history for missing or unreadable data', async () => {
+		mockGetStorageItem.mockResolvedValueOnce(null);
+		await expect(loadDiceHistory()).resolves.toEqual([]);
+		mockGetStorageItem.mockResolvedValueOnce('not json');
+		await expect(loadDiceHistory()).resolves.toEqual([]);
+	});
+});

--- a/apps/score-tracker/frontend/app/dice/index.tsx
+++ b/apps/score-tracker/frontend/app/dice/index.tsx
@@ -5,6 +5,17 @@ import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { SettingsListGroupTitle, useTheme, type Theme } from 'repo-depkit-common-ui';
 import { ComponentIds } from '../../constants/ComponentIds';
 import { computeRoll, type DieResult, type DieRollPair, type PoolDie, type RollMode, type RollResult } from '../../helpers/DiceRollHelper';
+import {
+	appendDiceHistoryEntry,
+	buildDiceHistoryEntry,
+	collectHistorySides,
+	computeDiceHistoryStats,
+	filterHistoryEntries,
+	loadDiceHistory,
+	saveDiceHistory,
+	type DiceHistoryEntry,
+} from '../../helpers/DiceHistoryStorage';
+import { generateId } from '../../helpers/RandomHelper';
 
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
 
@@ -38,6 +49,25 @@ const ROLL_MODES: { key: RollMode; label: string; icon: MCIName }[] = [
 	{ key: 'advantage', label: 'Vorteil', icon: 'arrow-up-bold-circle-outline' },
 	{ key: 'disadvantage', label: 'Nachteil', icon: 'arrow-down-bold-circle-outline' },
 ];
+
+/** How many history rows are rendered - the stats always cover the full history. */
+const MAX_HISTORY_ROWS = 50;
+
+function modeLabel(mode: RollMode): string {
+	return ROLL_MODES.find((entry) => entry.key === mode)?.label ?? mode;
+}
+
+function formatRolledAt(timestamp: number): string {
+	const date = new Date(timestamp);
+	const day = date.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' });
+	const time = date.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+	return `${day} ${time}`;
+}
+
+function formatAverage(average: number | null): string {
+	if (average === null) return '-';
+	return average.toFixed(1).replace('.', ',');
+}
 
 function DiceValueRow({ dice, theme }: Readonly<{ dice: DieResult[]; theme: Theme }>) {
 	return (
@@ -86,6 +116,34 @@ function DiePairBadge({ die, theme, revealed }: Readonly<{ die: DieRollPair; the
 	);
 }
 
+// One archived roll: timestamp and mode on the left, the counted value of every
+// die in the middle (maximum rolls highlighted - that's what the counter above
+// tallies), the roll's total on the right.
+function HistoryEntryRow({ entry, theme }: Readonly<{ entry: DiceHistoryEntry; theme: Theme }>) {
+	return (
+		<View nativeID={`${ComponentIds.DICE_HISTORY_ENTRY_PREFIX}${entry.id}`} style={[styles.historyRow, { backgroundColor: theme.screen.iconBg }]}>
+			<View style={styles.historyRowLeft}>
+				<Text style={[styles.historyRowTime, { color: theme.screen.placeholder }]}>{formatRolledAt(entry.rolledAt)}</Text>
+				<Text style={[styles.historyRowMode, { color: theme.screen.placeholder }]}>{modeLabel(entry.mode)}</Text>
+			</View>
+			<View style={styles.historyRowDice}>
+				{entry.dice.map((die, index) => {
+					const isMax = die.value === die.sides;
+					return (
+						<Text
+							key={`${entry.id}-${index}`}
+							style={[styles.historyRowDie, { color: isMax ? PRIMARY_COLOR : theme.screen.text, fontWeight: isMax ? '700' : '400' }]}
+						>
+							W{die.sides}: {die.value}
+						</Text>
+					);
+				})}
+			</View>
+			<Text style={[styles.historyRowTotal, { color: theme.screen.text }]}>{entry.total}</Text>
+		</View>
+	);
+}
+
 export default function DiceScreen() {
 	const { theme } = useTheme();
 	const insets = useSafeAreaInsets();
@@ -96,8 +154,27 @@ export default function DiceScreen() {
 	const [customSidesText, setCustomSidesText] = useState('');
 	const [results, setResults] = useState<RollResult | null>(null);
 	const [isRolling, setIsRolling] = useState(false);
+	const [history, setHistory] = useState<DiceHistoryEntry[]>([]);
+	/** Active die-type filter for the history section - `null` shows everything. */
+	const [historyFilter, setHistoryFilter] = useState<number | null>(null);
 	const animationRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const nextIdRef = useRef(0);
+
+	// Guards the save effect below: without it the initial empty state would be
+	// written to disk while the load is still in flight and could wipe the
+	// stored history.
+	const historyLoadedRef = useRef(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		loadDiceHistory().then((entries) => {
+			historyLoadedRef.current = true;
+			if (!cancelled) setHistory(entries);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	const addDie = useCallback((sides: number) => {
 		if (!Number.isFinite(sides) || sides < MIN_CUSTOM_SIDES || pool.length >= MAX_POOL_SIZE) return;
@@ -122,23 +199,44 @@ export default function DiceScreen() {
 		setShowCustomInput(false);
 	}, [customSidesText, addDie, pool.length]);
 
+	/** Archive a finished roll: prepend to the (capped) history and persist it. */
+	const recordRoll = useCallback((roll: RollResult) => {
+		const entry = buildDiceHistoryEntry(roll, { id: generateId(), rolledAt: Date.now() });
+		setHistory((prev) => appendDiceHistoryEntry(prev, entry));
+	}, []);
+
+	// Persisting in an effect (instead of inside recordRoll) keeps the saved
+	// state in lockstep with whatever React actually committed.
+	useEffect(() => {
+		if (!historyLoadedRef.current) return;
+		void saveDiceHistory(history);
+	}, [history]);
+
+	const clearHistory = useCallback(() => {
+		setHistory([]);
+		setHistoryFilter(null);
+	}, []);
+
 	// Shuffle the faces rapidly for a moment before settling on the final roll -
 	// cheap "animation" without needing reanimated. Each tick is already a
 	// genuine full roll via computeRoll, so the very last tick before the
-	// interval clears simply becomes the final result.
+	// interval clears simply becomes the final result - only that one is
+	// recorded in the history.
 	const handleRoll = useCallback(() => {
 		if (isRolling || pool.length === 0) return;
 		setIsRolling(true);
 		const startedAt = Date.now();
 		animationRef.current = setInterval(() => {
-			setResults(computeRoll(pool, rollMode));
+			const roll = computeRoll(pool, rollMode);
+			setResults(roll);
 			if (Date.now() - startedAt >= ROLL_ANIMATION_MS && animationRef.current) {
 				clearInterval(animationRef.current);
 				animationRef.current = null;
 				setIsRolling(false);
+				recordRoll(roll);
 			}
 		}, ROLL_ANIMATION_STEP_MS);
-	}, [pool, isRolling, rollMode]);
+	}, [pool, isRolling, rollMode, recordRoll]);
 
 	useEffect(() => {
 		return () => {
@@ -152,6 +250,21 @@ export default function DiceScreen() {
 	} else if (pool.length === 0) {
 		rollButtonLabel = 'Wähle zuerst Würfel';
 	}
+
+	const historySides = collectHistorySides(history);
+	// A stale filter (its die type vanished from the history, e.g. after
+	// clearing) falls back to "Alle" instead of showing an empty section.
+	const effectiveFilter = historyFilter !== null && historySides.includes(historyFilter) ? historyFilter : null;
+	const filteredHistory = filterHistoryEntries(history, effectiveFilter);
+	const historyStats = computeDiceHistoryStats(history, effectiveFilter);
+	const visibleHistory = filteredHistory.slice(0, MAX_HISTORY_ROWS);
+
+	const historyStatItems: { key: string; label: string; value: string }[] = [
+		{ key: 'rolls', label: 'Würfe', value: String(historyStats.rollCount) },
+		{ key: 'max', label: effectiveFilter !== null ? `Max (${effectiveFilter})` : 'Max', value: `${historyStats.maxCount}×` },
+		{ key: 'min', label: 'Einsen', value: `${historyStats.minCount}×` },
+		{ key: 'avg', label: 'Ø', value: formatAverage(historyStats.average) },
+	];
 
 	return (
 		<View style={[styles.container, { backgroundColor: theme.screen.background, paddingLeft: insets.left, paddingRight: insets.right }]}>
@@ -294,6 +407,84 @@ export default function DiceScreen() {
 							</>
 						)}
 					</View>
+				)}
+
+				{history.length > 0 && (
+					<>
+						<View style={styles.sectionHeaderRow}>
+							<SettingsListGroupTitle title="Historie" />
+							<TouchableOpacity
+								nativeID={ComponentIds.DICE_HISTORY_CLEAR_BUTTON}
+								onPress={clearHistory}
+								hitSlop={8}
+								style={styles.clearButton}
+							>
+								<Ionicons name="close-circle" size={16} color={theme.screen.placeholder} />
+								<Text style={[styles.clearButtonText, { color: theme.screen.placeholder }]}>Leeren</Text>
+							</TouchableOpacity>
+						</View>
+
+						<View style={styles.historyFilterRow}>
+							<TouchableOpacity
+								nativeID={ComponentIds.DICE_HISTORY_FILTER_ALL_BUTTON}
+								style={[
+									styles.historyFilterChip,
+									{ borderColor: PRIMARY_COLOR },
+									effectiveFilter === null && { backgroundColor: PRIMARY_COLOR },
+								]}
+								onPress={() => setHistoryFilter(null)}
+								activeOpacity={0.7}
+							>
+								<Text style={[styles.historyFilterChipText, { color: effectiveFilter === null ? '#ffffff' : PRIMARY_COLOR }]}>
+									Alle
+								</Text>
+							</TouchableOpacity>
+							{historySides.map((sides) => {
+								const selected = effectiveFilter === sides;
+								return (
+									<TouchableOpacity
+										key={sides}
+										nativeID={`${ComponentIds.DICE_HISTORY_FILTER_PREFIX}${sides}`}
+										style={[
+											styles.historyFilterChip,
+											{ borderColor: PRIMARY_COLOR },
+											selected && { backgroundColor: PRIMARY_COLOR },
+										]}
+										onPress={() => setHistoryFilter(selected ? null : sides)}
+										activeOpacity={0.7}
+									>
+										<MaterialCommunityIcons name={diceIconForSides(sides)} size={16} color={selected ? '#ffffff' : PRIMARY_COLOR} />
+										<Text style={[styles.historyFilterChipText, { color: selected ? '#ffffff' : PRIMARY_COLOR }]}>W{sides}</Text>
+									</TouchableOpacity>
+								);
+							})}
+						</View>
+
+						<View nativeID={ComponentIds.DICE_HISTORY_STATS_ROW} style={styles.historyStatsRow}>
+							{historyStatItems.map((item) => (
+								<View key={item.key} style={[styles.historyStatBox, { backgroundColor: theme.screen.iconBg }]}>
+									<Text style={[styles.historyStatValue, { color: theme.screen.text }]}>{item.value}</Text>
+									<Text style={[styles.historyStatLabel, { color: theme.screen.placeholder }]}>{item.label}</Text>
+								</View>
+							))}
+						</View>
+						<Text style={[styles.hintText, { color: theme.screen.placeholder }]}>
+							{effectiveFilter !== null
+								? `Max (${effectiveFilter}) zählt, wie oft die ${effectiveFilter} mit einem W${effectiveFilter} gewürfelt wurde.`
+								: 'Max zählt, wie oft ein Würfel seinen höchsten Wert zeigte - z.B. die 20 auf einem W20.'}
+						</Text>
+
+						<View style={styles.historyList}>
+							{visibleHistory.map((entry) => (
+								<HistoryEntryRow key={entry.id} entry={entry} theme={theme} />
+							))}
+						</View>
+						{filteredHistory.length > visibleHistory.length && (
+							<Text style={[styles.hintText, { color: theme.screen.placeholder }]}>
+								Nur die letzten {MAX_HISTORY_ROWS} Würfe werden angezeigt - die Zähler oben umfassen alle.
+							</Text>
+						)}
+					</>
 				)}
 			</ScrollView>
 
@@ -472,6 +663,82 @@ const styles = StyleSheet.create({
 		fontSize: 22,
 		fontWeight: '700',
 		marginTop: 16,
+	},
+	historyFilterRow: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		gap: 8,
+		paddingHorizontal: 16,
+	},
+	historyFilterChip: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 4,
+		paddingVertical: 6,
+		paddingHorizontal: 12,
+		borderWidth: 1.5,
+		borderRadius: 16,
+	},
+	historyFilterChipText: {
+		fontSize: 13,
+		fontWeight: '700',
+	},
+	historyStatsRow: {
+		flexDirection: 'row',
+		gap: 8,
+		paddingHorizontal: 16,
+		marginTop: 12,
+	},
+	historyStatBox: {
+		flex: 1,
+		alignItems: 'center',
+		paddingVertical: 10,
+		borderRadius: 10,
+	},
+	historyStatValue: {
+		fontSize: 17,
+		fontWeight: '700',
+	},
+	historyStatLabel: {
+		fontSize: 11,
+		fontWeight: '600',
+		marginTop: 2,
+	},
+	historyList: {
+		gap: 6,
+		paddingHorizontal: 16,
+		marginTop: 12,
+	},
+	historyRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 10,
+		paddingVertical: 8,
+		paddingHorizontal: 10,
+		borderRadius: 10,
+	},
+	historyRowLeft: {
+		width: 78,
+	},
+	historyRowTime: {
+		fontSize: 12,
+		fontWeight: '600',
+	},
+	historyRowMode: {
+		fontSize: 11,
+	},
+	historyRowDice: {
+		flex: 1,
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		columnGap: 8,
+	},
+	historyRowDie: {
+		fontSize: 13,
+	},
+	historyRowTotal: {
+		fontSize: 16,
+		fontWeight: '700',
 	},
 	footer: {
 		borderTopWidth: StyleSheet.hairlineWidth,

--- a/apps/score-tracker/frontend/constants/ComponentIds.ts
+++ b/apps/score-tracker/frontend/constants/ComponentIds.ts
@@ -243,6 +243,15 @@ export const ComponentIds = {
 	DICE_MODE_BUTTON_PREFIX: 'dice-mode-button-',
 	DICE_ROLL_BUTTON: 'dice-roll-button',
 
+	// Dice screen: roll history
+	// NOT 'dice-history-filter-all': Maestro id matchers append '.*', so the
+	// per-type filter prefix must not be a prefix of the all-filter's id.
+	DICE_HISTORY_FILTER_ALL_BUTTON: 'dice-history-all-filter-button',
+	DICE_HISTORY_FILTER_PREFIX: 'dice-history-filter-',
+	DICE_HISTORY_STATS_ROW: 'dice-history-stats-row',
+	DICE_HISTORY_ENTRY_PREFIX: 'dice-history-entry-',
+	DICE_HISTORY_CLEAR_BUTTON: 'dice-history-clear-button',
+
 	// First-launch onboarding
 	ONBOARDING_SKIP_BUTTON: 'onboarding-skip-button',
 	ONBOARDING_NEXT_BUTTON: 'onboarding-next-button',

--- a/apps/score-tracker/frontend/helpers/DiceHistoryStorage.ts
+++ b/apps/score-tracker/frontend/helpers/DiceHistoryStorage.ts
@@ -1,0 +1,165 @@
+// Persisted history of dice rolls (dice screen) plus the pure helpers the
+// screen uses to filter it by die type and to count results - e.g. how often
+// a W20 actually landed its 20.
+//
+// Only the value that COUNTED is stored per die: in sum mode that is the
+// rolled value, in advantage/disadvantage mode the kept value of the pair.
+// That keeps the stats honest ("wie oft kam die 20") without re-encoding the
+// whole pair semantics here.
+
+import { getStorageItem, setStorageItem } from 'repo-depkit-common-ui';
+import type { RollMode, RollResult } from './DiceRollHelper';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DiceHistoryDie = {
+	sides: number;
+	/** The value that counted for this die (kept value in advantage/disadvantage). */
+	value: number;
+};
+
+export type DiceHistoryEntry = {
+	id: string;
+	rolledAt: number;
+	mode: RollMode;
+	dice: DiceHistoryDie[];
+	/** Sum of the counted values - matches what the roll screen showed as "Summe". */
+	total: number;
+};
+
+/** Newest-first cap so the stored history cannot grow without bound. */
+export const DICE_HISTORY_LIMIT = 200;
+
+// ─── Building and appending entries ───────────────────────────────────────────
+
+/**
+ * Snapshot of a finished roll, ready for the history. Advantage/disadvantage
+ * pairs collapse to their kept value (see module comment).
+ */
+export function buildDiceHistoryEntry(result: RollResult, params: { id: string; rolledAt: number }): DiceHistoryEntry {
+	const dice: DiceHistoryDie[] =
+		result.mode === 'sum'
+			? result.dice.map((die) => ({ sides: die.sides, value: die.value }))
+			: result.dice.map((die) => ({ sides: die.sides, value: die.kept === 'A' ? die.valueA : die.valueB }));
+	return {
+		id: params.id,
+		rolledAt: params.rolledAt,
+		mode: result.mode,
+		dice,
+		total: result.mode === 'sum' ? result.total : result.keptTotal,
+	};
+}
+
+/** Prepend `entry` (history is newest-first) and drop everything beyond the cap. */
+export function appendDiceHistoryEntry(entries: DiceHistoryEntry[], entry: DiceHistoryEntry): DiceHistoryEntry[] {
+	return [entry, ...entries].slice(0, DICE_HISTORY_LIMIT);
+}
+
+// ─── Filtering and counting ───────────────────────────────────────────────────
+
+/** Sorted list of die types (side counts) occurring in the history - drives the filter chips. */
+export function collectHistorySides(entries: DiceHistoryEntry[]): number[] {
+	const sides = new Set<number>();
+	for (const entry of entries) {
+		for (const die of entry.dice) sides.add(die.sides);
+	}
+	return [...sides].sort((a, b) => a - b);
+}
+
+/**
+ * Entries shown under an active die-type filter: those containing at least one
+ * die with `sides` sides. `null` means no filter.
+ */
+export function filterHistoryEntries(entries: DiceHistoryEntry[], sides: number | null): DiceHistoryEntry[] {
+	if (sides === null) return entries;
+	return entries.filter((entry) => entry.dice.some((die) => die.sides === sides));
+}
+
+export type DiceHistoryStats = {
+	/** Number of individual die rolls (not entries) matching the filter. */
+	rollCount: number;
+	/** How often the maximum landed - value === sides, e.g. the 20 on a W20. */
+	maxCount: number;
+	/** How often the minimum (1) landed. */
+	minCount: number;
+	/** Mean counted value across the matching rolls, or null without any rolls. */
+	average: number | null;
+};
+
+/**
+ * Counters over the individual die rolls in the history, optionally restricted
+ * to one die type (`sides`, `null` = all dice).
+ */
+export function computeDiceHistoryStats(entries: DiceHistoryEntry[], sides: number | null): DiceHistoryStats {
+	let rollCount = 0;
+	let maxCount = 0;
+	let minCount = 0;
+	let valueSum = 0;
+	for (const entry of entries) {
+		for (const die of entry.dice) {
+			if (sides !== null && die.sides !== sides) continue;
+			rollCount += 1;
+			valueSum += die.value;
+			if (die.value === die.sides) maxCount += 1;
+			if (die.value === 1) minCount += 1;
+		}
+	}
+	return {
+		rollCount,
+		maxCount,
+		minCount,
+		average: rollCount === 0 ? null : valueSum / rollCount,
+	};
+}
+
+// ─── Storage access ───────────────────────────────────────────────────────────
+
+const DICE_HISTORY_KEY = 'score-tracker-dice-history.json';
+
+type DiceHistoryState = { entries: DiceHistoryEntry[] };
+
+function isValidDie(die: unknown): die is DiceHistoryDie {
+	if (typeof die !== 'object' || die === null) return false;
+	const { sides, value } = die as Partial<DiceHistoryDie>;
+	return typeof sides === 'number' && sides >= 2 && typeof value === 'number' && value >= 1 && value <= sides;
+}
+
+function isValidEntry(entry: unknown): entry is DiceHistoryEntry {
+	if (typeof entry !== 'object' || entry === null) return false;
+	const candidate = entry as Partial<DiceHistoryEntry>;
+	return (
+		typeof candidate.id === 'string' &&
+		typeof candidate.rolledAt === 'number' &&
+		(candidate.mode === 'sum' || candidate.mode === 'advantage' || candidate.mode === 'disadvantage') &&
+		Array.isArray(candidate.dice) &&
+		candidate.dice.length > 0 &&
+		candidate.dice.every(isValidDie) &&
+		typeof candidate.total === 'number'
+	);
+}
+
+/**
+ * Persist the dice history to disk.
+ */
+export async function saveDiceHistory(entries: DiceHistoryEntry[]): Promise<void> {
+	try {
+		await setStorageItem(DICE_HISTORY_KEY, JSON.stringify({ entries }));
+	} catch (err) {
+		console.warn('[DiceHistoryStorage] Failed to save dice history:', err);
+	}
+}
+
+/**
+ * Load the persisted dice history from disk, dropping anything malformed.
+ */
+export async function loadDiceHistory(): Promise<DiceHistoryEntry[]> {
+	try {
+		const raw = await getStorageItem(DICE_HISTORY_KEY);
+		if (raw === null) return [];
+		const parsed = JSON.parse(raw) as Partial<DiceHistoryState>;
+		if (!Array.isArray(parsed.entries)) return [];
+		return parsed.entries.filter(isValidEntry).slice(0, DICE_HISTORY_LIMIT);
+	} catch {
+		return [];
+	}
+}


### PR DESCRIPTION
The dice screen now archives every finished roll (only the settled result,
not the animation ticks) into a persisted, capped history. A new Historie
section lists the recent rolls and offers filter chips per die type plus
counters over the individual die rolls: total rolls, how often the maximum
landed (e.g. the 20 on a W20), how often the 1 came up, and the average.

Advantage/disadvantage rolls store only the kept value per die, so the
counters reflect what actually counted. Loading validates every stored
entry and drops malformed ones, and saving is deferred until the initial
load finished so it cannot wipe the stored history.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014eWw7ZyJrmnYBMMZy3TMfd