### PR TITLE
fix: EAS-Projekt-Initialisierung für dynamische App-Configs (geteilte Action)

### DIFF
--- a/.github/actions/eas-init-project/action.yml
+++ b/.github/actions/eas-init-project/action.yml
@@ -1,0 +1,102 @@
+name: 'EAS Init Project'
+description: >-
+  Ensures the Expo app in the given directory is linked to an EAS project.
+  Checks for a configured projectId first; otherwise runs `eas init`, which
+  creates the project on EAS (or reuses the existing one with the same
+  owner/slug). With a static app.json, eas init writes the projectId itself.
+  With a dynamic config (app.config.ts) eas init cannot write the file and
+  exits non-zero after printing the projectId - this action tolerates that,
+  extracts the id and injects `extra.eas.projectId` into app.config.ts itself.
+
+inputs:
+  EXPO_TOKEN:
+    required: true
+    description: Expo Access Token (für EAS CLI)
+  working-directory:
+    required: true
+    description: Verzeichnis der Expo-App relativ zum Repo-Root (z.B. ./apps/geonexia/frontend)
+
+outputs:
+  project-id:
+    description: Die EAS-Projekt-ID der App (leer, wenn sie bereits konfiguriert war)
+    value: ${{ steps.init.outputs.project-id }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: "🔧 Ensure EAS project is initialized"
+      id: init
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
+      run: |
+        set -euo pipefail
+
+        if grep -q 'projectId' app.config.ts 2>/dev/null || grep -q '"projectId"' app.json 2>/dev/null; then
+          echo "✅ EAS project already configured"
+          echo "project-id=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "EAS project not yet configured, running eas init..."
+        set +e
+        OUTPUT=$(eas init --non-interactive --force 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$OUTPUT"
+
+        # Static config (app.json): eas init wrote the projectId itself.
+        if grep -q '"projectId"' app.json 2>/dev/null; then
+          echo "✅ eas init wrote the projectId into app.json"
+          echo "project-id=$(node -e 'console.log(require("./app.json").expo?.extra?.eas?.projectId ?? "")')" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Dynamic config (app.config.ts): eas init created/linked the project but
+        # cannot write the file ("Cannot automatically write to dynamic config")
+        # and exits non-zero. The printed output contains the projectId - extract
+        # it and write it into app.config.ts ourselves.
+        PROJECT_ID=$(echo "$OUTPUT" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+        if [ -z "$PROJECT_ID" ]; then
+          echo "❌ eas init failed (exit $EXIT_CODE) and no projectId was found in its output."
+          exit ${EXIT_CODE:-1}
+        fi
+
+        echo "Injecting projectId $PROJECT_ID into app.config.ts..."
+        PROJECT_ID="$PROJECT_ID" node <<'NODEEOF'
+        const fs = require('fs');
+        const projectId = process.env.PROJECT_ID;
+        let content = fs.readFileSync('./app.config.ts', 'utf8');
+
+        if (/\bprojectId\b/.test(content)) {
+          console.log('app.config.ts already contains a projectId, nothing to do');
+          process.exit(0);
+        }
+
+        const easBlock = `eas: {\n\t\t\t\tprojectId: '${projectId}',\n\t\t\t},\n\t\t\t`;
+        const withExtra = content.replace(/(\bextra\s*:\s*\{\s*\n)/, `$1\t\t\t${easBlock.trimEnd()}\n`);
+        if (withExtra !== content) {
+          content = withExtra;
+        } else {
+          // No extra block yet: add one before the closing brace of the returned config.
+          const block = `\t\textra: {\n\t\t\teas: {\n\t\t\t\tprojectId: '${projectId}',\n\t\t\t},\n\t\t},\n`;
+          const patched = content.replace(/(\n\t\};\n\};?\s*)$/, `\n${block}$1`);
+          if (patched === content) {
+            console.error('Could not find an insertion point for extra.eas.projectId in app.config.ts');
+            process.exit(1);
+          }
+          content = patched;
+        }
+
+        fs.writeFileSync('./app.config.ts', content);
+        console.log('app.config.ts patched successfully');
+        NODEEOF
+
+        if ! grep -q 'projectId' app.config.ts; then
+          echo "❌ Patching app.config.ts failed - projectId still missing."
+          exit 1
+        fi
+
+        echo "✅ EAS project $PROJECT_ID initialized and written to app.config.ts"
+        echo "project-id=$PROJECT_ID" >> "$GITHUB_OUTPUT"

--- a/.github/actions/geonexia-expo-update/action.yml
+++ b/.github/actions/geonexia-expo-update/action.yml
@@ -61,17 +61,10 @@ runs:
         ./scripts/generateIcons.sh "$ICON_SOURCE" "$COMPANY_LOGO" "./apps/geonexia/frontend/assets/generated/"
 
     - name: "🔧 Initialize EAS project if not configured"
-      run: |
-        if grep -q 'projectId' app.config.ts 2>/dev/null || grep -q '"projectId"' app.json 2>/dev/null; then
-          echo "EAS project already configured"
-        else
-          echo "EAS project not yet configured, running eas init..."
-          eas init --non-interactive --force
-        fi
-      working-directory: ./apps/geonexia/frontend
-      shell: bash
-      env:
+      uses: ./.github/actions/eas-init-project
+      with:
         EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
+        working-directory: ./apps/geonexia/frontend
 
     - name: "🔧 Configure EAS Update settings (loop until complete)"
       run: |

--- a/.github/actions/score-tracker-expo-update/action.yml
+++ b/.github/actions/score-tracker-expo-update/action.yml
@@ -61,17 +61,10 @@ runs:
         ./scripts/generateIcons.sh "$ICON_SOURCE" "$COMPANY_LOGO" "./apps/score-tracker/frontend/assets/generated/"
 
     - name: "🔧 Initialize EAS project if not configured"
-      run: |
-        if grep -q 'projectId' app.config.ts 2>/dev/null || grep -q '"projectId"' app.json 2>/dev/null; then
-          echo "EAS project already configured"
-        else
-          echo "EAS project not yet configured, running eas init..."
-          eas init --non-interactive --force
-        fi
-      working-directory: ./apps/score-tracker/frontend
-      shell: bash
-      env:
+      uses: ./.github/actions/eas-init-project
+      with:
         EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
+        working-directory: ./apps/score-tracker/frontend
 
     - name: "🔧 Configure EAS Update settings (loop until complete)"
       run: |

--- a/.github/actions/tag-und-jahr-expo-update/action.yml
+++ b/.github/actions/tag-und-jahr-expo-update/action.yml
@@ -52,17 +52,10 @@ runs:
     # generate:icon` after design changes).
 
     - name: "🔧 Initialize EAS project if not configured"
-      run: |
-        if grep -q 'projectId' app.config.ts 2>/dev/null || grep -q '"projectId"' app.json 2>/dev/null; then
-          echo "EAS project already configured"
-        else
-          echo "EAS project not yet configured, running eas init..."
-          eas init --non-interactive --force
-        fi
-      working-directory: ./apps/tag-und-jahr/frontend
-      shell: bash
-      env:
+      uses: ./.github/actions/eas-init-project
+      with:
         EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
+        working-directory: ./apps/tag-und-jahr/frontend
 
     - name: "🔧 Configure EAS Update settings (loop until complete)"
       run: |

--- a/apps/tag-und-jahr/frontend/app.config.ts
+++ b/apps/tag-und-jahr/frontend/app.config.ts
@@ -73,6 +73,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 		},
 		updates: {
 			enabled: true,
+			url: 'https://u.expo.dev/354220f2-0d5a-46a0-bf47-15d8433432a9',
 			fallbackToCacheTimeout: 10 * 1000,
 		},
 		runtimeVersion: {
@@ -119,6 +120,11 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			typedRoutes: true,
 		},
 		extra: {
+			eas: {
+				// Created by the first tag-und-jahr-expo-update CI run (eas init),
+				// see https://expo.dev/accounts/baumgartner-software/projects/tag-und-jahr
+				projectId: '354220f2-0d5a-46a0-bf47-15d8433432a9',
+			},
 			// Open-source dependency versions of this app and of its workspace
 			// packages, collected from node_modules at config-evaluation time
 			// (expo start / export / build / update) and read at runtime via


### PR DESCRIPTION
## Problem

Der erste `tag-und-jahr-expo-update`-Lauf auf `master` schlug fehl: `eas init --non-interactive --force` legt das EAS-Projekt zwar an, kann die `projectId` bei **dynamischer Config** (`app.config.ts`) aber nicht selbst eintragen und bricht mit `Cannot automatically write to dynamic config` ab. Der gleiche kopierte Inline-Schritt steckte auch in den Geonexia- und Score-Tracker-Actions.

## Fix

- **Neue geteilte Action `.github/actions/eas-init-project`**: prüft, ob eine `projectId` konfiguriert ist; führt sonst `eas init` aus (legt das Projekt an bzw. verlinkt ein vorhandenes mit gleichem Owner/Slug), toleriert den Dynamic-Config-Fehler, extrahiert die `projectId` aus der CLI-Ausgabe und schreibt `extra.eas.projectId` selbst in die `app.config.ts`. Der bestehende „Commit EAS config changes"-Schritt der Update-Actions committet die Änderung anschließend wie gehabt.
- `geonexia-expo-update`, `score-tracker-expo-update` und `tag-und-jahr-expo-update` nutzen jetzt diese Action statt des dreifach kopierten Inline-Schritts.
- Die vom fehlgeschlagenen Lauf **bereits erzeugte** Projekt-ID `354220f2-0d5a-46a0-bf47-15d8433432a9` ist samt `updates.url` direkt in die Tag-und-Jahr-Config eingetragen — der nächste Lauf findet sie sofort vor.

## Verifikation

- Patch-Logik der neuen Action lokal exakt gegen den Config-Stand simuliert, an dem die CI gescheitert ist (Merge-Commit `6d0e5cc`): `extra.eas.projectId` wird korrekt in den `extra`-Block eingefügt.
- `npx expo config` löst `projectId` und `updates.url` der Tag-und-Jahr-App korrekt auf.
- YAML der neuen Action validiert.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_