### PR TITLE
fix: iOS-Build-Credentials für neue Apps headless einrichten (Tag und Jahr)

### DIFF
--- a/.github/actions/eas-ios-build-credentials/action.yml
+++ b/.github/actions/eas-ios-build-credentials/action.yml
@@ -1,0 +1,63 @@
+name: 'EAS iOS Build Credentials'
+description: >-
+  Ensures the iOS build credentials of an Expo app exist on the EAS servers,
+  without any interactive prompt. `eas build --non-interactive` never creates
+  missing credentials (a brand-new app fails with "Credentials are not set up.
+  Run this command again in interactive mode."), so this action runs eas-cli's
+  interactive `credentials:configure-build` flow headless via
+  scripts/eas-setup-ios-build-credentials.js: the App Store Connect API key
+  (EXPO_ASC_* environment variables, exported by prepare-asc-api-key) covers
+  the Apple authentication and the few remaining confirm prompts are
+  auto-answered (reuse the team's distribution certificate, generate missing
+  provisioning profiles - including ones for app extensions such as widgets).
+  Idempotent: valid existing credentials are validated and left untouched.
+
+inputs:
+  EXPO_TOKEN:
+    required: true
+    description: Expo Access Token (für EAS CLI)
+  working-directory:
+    required: true
+    description: Verzeichnis der Expo-App relativ zum Repo-Root (z.B. ./apps/tag-und-jahr/frontend)
+  build-profile:
+    required: false
+    default: production
+    description: EAS Build-Profil aus eas.json, dessen Credentials eingerichtet werden
+
+runs:
+  using: 'composite'
+  steps:
+    - name: "🔐 Ensure iOS build credentials (headless bootstrap)"
+      shell: bash
+      env:
+        EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
+      run: |
+        set -euo pipefail
+
+        # The EXPO_ASC_* variables are exported into the job environment by the
+        # prepare-asc-api-key action (part of setup-and-install when the ASC key
+        # content is passed) - without them Apple authentication is impossible.
+        for VAR in EXPO_ASC_API_KEY_PATH EXPO_ASC_KEY_ID EXPO_ASC_ISSUER_ID EXPO_APPLE_TEAM_ID EXPO_APPLE_TEAM_TYPE; do
+          if [ -z "${!VAR:-}" ]; then
+            echo "❌ $VAR is not set. Pass EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT to setup-and-install (or run prepare-asc-api-key) before this action."
+            exit 1
+          fi
+        done
+
+        # Resolve the eas-cli package root from the eas binary on PATH
+        # (installed by expo/expo-github-action): <root>/bin/run -> <root>.
+        EAS_BIN=$(command -v eas)
+        EAS_CLI_ROOT=$(node -e "
+          const fs = require('fs');
+          const path = require('path');
+          let p = fs.realpathSync(process.argv[1]);
+          console.log(path.resolve(p, '..', '..'));
+        " "$EAS_BIN")
+        if [ ! -f "$EAS_CLI_ROOT/build/prompts.js" ]; then
+          echo "eas binary at $EAS_BIN did not lead to an eas-cli package root ($EAS_CLI_ROOT), installing a private copy..."
+          EAS_CLI_ROOT="$RUNNER_TEMP/eas-cli-bootstrap/node_modules/eas-cli"
+          npm install --prefix "$RUNNER_TEMP/eas-cli-bootstrap" eas-cli
+        fi
+        echo "Using eas-cli at $EAS_CLI_ROOT"
+
+        EAS_CLI_ROOT="$EAS_CLI_ROOT" node scripts/eas-setup-ios-build-credentials.js "${{ inputs.working-directory }}" "${{ inputs.build-profile }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,15 @@ jobs:
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT: ${{ secrets.EXPO_APPLE_APPSTORECONNECT_API_KEY_CONTENT }}
+      # eas build --non-interactive cannot bootstrap credentials for a new app
+      # ("Credentials are not set up. Run this command again in interactive
+      # mode.") - this creates/validates them headless first, using the ASC API
+      # key exported by setup-and-install (prepare-asc-api-key).
+      - name: "🔐 Ensure Tag und Jahr iOS build credentials"
+        uses: ./.github/actions/eas-ios-build-credentials
+        with:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          working-directory: ./apps/tag-und-jahr/frontend
       - name: "🛠️ Build and Submit Tag und Jahr iOS App"
         run: eas build --platform ios --non-interactive --auto-submit
         working-directory: ./apps/tag-und-jahr/frontend

--- a/scripts/eas-setup-ios-build-credentials.js
+++ b/scripts/eas-setup-ios-build-credentials.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Bootstraps the iOS build credentials of an Expo app WITHOUT any interactive
+// prompt, so a brand-new app can be built in CI right away.
+//
+// Background: `eas build --non-interactive` never creates missing credentials -
+// for a new app it aborts with "Credentials are not set up. Run this command
+// again in interactive mode." The interactive flow, on the other hand, is
+// already prompt-free when an App Store Connect API key is provided via the
+// EXPO_ASC_* environment variables (see .github/actions/prepare-asc-api-key),
+// EXCEPT for a single confirm ("Reuse this distribution certificate?") and the
+// generic prompt helpers around it.
+//
+// This script therefore runs eas-cli's own `credentials:configure-build`
+// command in-process and patches its prompt helpers to auto-answer:
+// - confirms are answered with "yes" (reuse the team's distribution
+//   certificate, generate missing provisioning profiles),
+// - selects pick the first (recommended) choice.
+// Everything else (Apple authentication, certificate validation, provisioning
+// profile creation for every target incl. app extensions) is what eas-cli does
+// in interactive mode anyway. The run is idempotent: with valid credentials in
+// place it validates them and changes nothing.
+//
+// Usage:
+//   EAS_CLI_ROOT=/path/to/node_modules/eas-cli \
+//   node scripts/eas-setup-ios-build-credentials.js <project-dir> [profile]
+//
+// Required env:
+//   EAS_CLI_ROOT           root directory of an installed eas-cli package
+//   EXPO_TOKEN             Expo access token (EAS authentication)
+//   EXPO_ASC_API_KEY_PATH  path to the App Store Connect API .p8 key
+//   EXPO_ASC_KEY_ID, EXPO_ASC_ISSUER_ID, EXPO_APPLE_TEAM_ID, EXPO_APPLE_TEAM_TYPE
+const path = require('node:path');
+const fs = require('node:fs');
+
+function fail(message) {
+	console.error(`❌ ${message}`);
+	process.exit(1);
+}
+
+const projectDir = process.argv[2];
+const profile = process.argv[3] || 'production';
+if (!projectDir) {
+	fail('Usage: node scripts/eas-setup-ios-build-credentials.js <project-dir> [profile]');
+}
+
+const easCliRoot = process.env.EAS_CLI_ROOT;
+if (!easCliRoot || !fs.existsSync(path.join(easCliRoot, 'build', 'prompts.js'))) {
+	fail(`EAS_CLI_ROOT does not point to an eas-cli installation: ${easCliRoot}`);
+}
+
+for (const name of ['EXPO_TOKEN', 'EXPO_ASC_API_KEY_PATH', 'EXPO_ASC_KEY_ID', 'EXPO_ASC_ISSUER_ID', 'EXPO_APPLE_TEAM_ID', 'EXPO_APPLE_TEAM_TYPE']) {
+	if (!process.env[name]) {
+		fail(`Missing required environment variable ${name}`);
+	}
+}
+
+// Patch the prompt helpers BEFORE any command module is loaded. All eas-cli
+// modules share this CommonJS exports object and look the functions up at call
+// time, so replacing the properties here affects the whole run.
+const prompts = require(path.join(easCliRoot, 'build', 'prompts.js'));
+
+prompts.confirmAsync = async ({ message }) => {
+	console.log(`[auto-confirm] ${message} -> yes`);
+	return true;
+};
+
+prompts.selectAsync = async (message, choices) => {
+	const first = choices[0];
+	console.log(`[auto-select] ${message} -> ${first?.title}`);
+	if (!first) {
+		throw new Error(`Cannot auto-answer select without choices: ${message}`);
+	}
+	return first.value;
+};
+
+prompts.promptAsync = async (questions) => {
+	const list = Array.isArray(questions) ? questions : [questions];
+	const answers = {};
+	for (const question of list) {
+		if (question.type === 'select' && question.choices?.length) {
+			answers[question.name] = question.choices[0].value;
+		} else if (question.type === 'confirm' || question.type === 'toggle') {
+			answers[question.name] = true;
+		} else if (question.initial !== undefined) {
+			answers[question.name] = typeof question.initial === 'function' ? await question.initial() : question.initial;
+		} else {
+			throw new Error(`Cannot auto-answer interactive prompt: ${question.message}`);
+		}
+		console.log(`[auto-answer] ${question.message} -> ${answers[question.name]}`);
+	}
+	return answers;
+};
+
+prompts.pressAnyKeyToContinueAsync = async () => {};
+
+process.chdir(projectDir);
+
+const ConfigureBuild = require(path.join(easCliRoot, 'build', 'commands', 'credentials', 'configure-build.js')).default;
+
+ConfigureBuild.run(['--platform', 'ios', '--profile', profile], easCliRoot)
+	.then(() => {
+		console.log('✅ iOS build credentials are set up');
+	})
+	.catch((error) => {
+		console.error(error);
+		fail('Setting up iOS build credentials failed');
+	});


### PR DESCRIPTION
## Problem

Der erste iOS-Build von Tag und Jahr scheiterte mit:

```
Distribution Certificate is not validated for non-interactive builds.
Failed to set up credentials.
Credentials are not set up. Run this command again in interactive mode.
```

Ursache (in der eas-cli-Quelle verifiziert): `eas build --non-interactive` **legt für eine neue App grundsätzlich keine Credentials an** — im Non-Interactive-Modus wird nur ein bereits mit der App verknüpftes Distribution Certificate wiederverwendet, sonst hart abgebrochen. Der ASC-API-Key hilft dort nicht. Der *interaktive* Flow dagegen ist mit dem ASC-Key (die `EXPO_ASC_*`-Variablen exportiert `prepare-asc-api-key` bereits) bis auf wenige Ja/Nein-Prompts promptfrei — wir haben also tatsächlich alle Infos, es fehlte nur ein Weg, den interaktiven Flow headless auszuführen.

## Fix

- **`scripts/eas-setup-ios-build-credentials.js`**: führt eas-cli's eigenes `credentials:configure-build` in-process aus und ersetzt vorher dessen Prompt-Helper durch Auto-Antworten: „Reuse this distribution certificate?" → ja (nutzt das vorhandene Team-Zertifikat von Geonexia/Score Tracker weiter), fehlende Provisioning Profiles → erzeugen (auch für App-Extensions wie das Widget-Target `…day-and-year.ExpoWidgetsTarget`). Apple-Authentifizierung läuft über den ASC-API-Key. Idempotent: vorhandene gültige Credentials werden nur validiert.
- **Neue Composite-Action `.github/actions/eas-ios-build-credentials`**: prüft die `EXPO_ASC_*`-Umgebung, löst die eas-cli-Installation vom PATH auf (Fallback: private npm-Installation) und ruft das Skript auf.
- **`ci.yml`**: `tag-und-jahr-build-ios` richtet die Credentials jetzt direkt vor `eas build` ein. Die Action ist generisch — Geonexia/Score Tracker (deren Credentials existieren schon) können sie bei Bedarf ebenfalls einbinden.

## Verifikation

- Fehlerpfad in der eas-cli-Quelle nachvollzogen (`SetUpDistributionCertificate.runNonInteractiveAsync` wirft bei fehlendem Zertifikat immer `MissingCredentialsNonInteractiveError`).
- Smoke-Test lokal gegen eine echte eas-cli-Installation: Skript lädt die CLI in-process, patcht die Prompts, startet den Flow und scheitert erwartungsgemäß erst am (absichtlich falschen) Test-Token an der EAS-API — Modul-Auflösung und Kommando-Start funktionieren.
- YAML- und JS-Syntax validiert.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_