### PR TITLE
fix: Apple-Capability-Sync über dokumentierte Einzel-Requests (Auto-Sync bleibt immer an)

### DIFF
--- a/apps/tag-und-jahr/README.md
+++ b/apps/tag-und-jahr/README.md
@@ -26,6 +26,12 @@ Anders als bei einem manuell gepflegten Xcode-Projekt entsteht das Widget hier k
 - **Tagespunkt:** `Sekunden seit örtlicher Mitternacht / 86.400 × 360°`, Start oben, im Uhrzeigersinn.
 - **Jahresmarke:** `Zeit seit letztem 21. März / Jahreszyklus × 360°`, Start oben am Frühlingsbeginn, im Uhrzeigersinn.
 
+### Apple-Capabilities (App Groups, Push)
+
+> ⚠️ **Niemals `EXPO_NO_CAPABILITY_SYNC=1` setzen.** Die Apple-Capabilities (App Groups für das Widget, Push Notifications) sollen **immer automatisch** mit den Entitlements der App synchronisiert werden – manuelles Pflegen im Developer-Portal driftet zwangsläufig auseinander.
+>
+> Hintergrund: eas-cli/`@expo/apple-utils` schickt den Capability-Sync als einen Sammel-PATCH, den die heutige App-Store-Connect-API ablehnt („Unexpected or invalid value at 'data.relationships.bundleIdCapabilities.data.[0].attributes'"). Der Credentials-Bootstrap ([`scripts/eas-setup-ios-build-credentials.js`](../../scripts/eas-setup-ios-build-credentials.js), läuft in der CI vor `eas build`) ersetzt deshalb genau diesen einen Aufruf durch die dokumentierten Einzel-Requests (POST/DELETE `/v1/bundleIdCapabilities`) – gleiche Sync-Semantik, funktionierendes Request-Format. Sobald die Capabilities stimmen, ist jeder weitere Sync (auch der in `eas build`) ein No-op und der fehlerhafte Codepfad wird gar nicht mehr erreicht. Sollte der Fehler upstream gefixt werden, kann dieser Patch entfallen; der Auto-Sync bleibt in jedem Fall an.
+
 ### Grenzen
 
 - `expo-widgets` ist als Alpha gekennzeichnet – API-Details können sich mit künftigen SDKs ändern.

--- a/scripts/eas-setup-ios-build-credentials.js
+++ b/scripts/eas-setup-ios-build-credentials.js
@@ -20,6 +20,18 @@
 // in interactive mode anyway. The run is idempotent: with valid credentials in
 // place it validates them and changes nothing.
 //
+// It also fixes eas-cli's Apple capability auto-sync (which must ALWAYS stay
+// enabled - never set EXPO_NO_CAPABILITY_SYNC=1 in this repository): current
+// eas-cli/@expo/apple-utils sends one big PATCH /v1/bundleIds/{id} with inline
+// capability attributes, which today's App Store Connect API rejects with
+// "Unexpected or invalid value at 'data.relationships.bundleIdCapabilities.
+// data.[0].attributes'". This script replaces that single call with the
+// documented per-capability requests (POST /v1/bundleIdCapabilities to enable,
+// DELETE /v1/bundleIdCapabilities/{id} to disable) - same sync semantics, same
+// desired state, working request format. Once the capabilities match, later
+// syncs (e.g. inside `eas build`) produce an empty patch request and never hit
+// the broken code path.
+//
 // Usage:
 //   EAS_CLI_ROOT=/path/to/node_modules/eas-cli \
 //   node scripts/eas-setup-ios-build-credentials.js <project-dir> [profile]
@@ -29,8 +41,10 @@
 //   EXPO_TOKEN             Expo access token (EAS authentication)
 //   EXPO_ASC_API_KEY_PATH  path to the App Store Connect API .p8 key
 //   EXPO_ASC_KEY_ID, EXPO_ASC_ISSUER_ID, EXPO_APPLE_TEAM_ID, EXPO_APPLE_TEAM_TYPE
+const crypto = require('node:crypto');
 const path = require('node:path');
 const fs = require('node:fs');
+const { createRequire } = require('node:module');
 
 function fail(message) {
 	console.error(`❌ ${message}`);
@@ -92,6 +106,103 @@ prompts.promptAsync = async (questions) => {
 };
 
 prompts.pressAnyKeyToContinueAsync = async () => {};
+
+// ─── Fix Apple capability auto-sync ──────────────────────────────────────────
+// Replace apple-utils' broken bulk PATCH (rejected by today's ASC API) with the
+// documented per-capability requests, talking directly to the App Store Connect
+// API using the same .p8 key. Auto-sync itself stays fully enabled.
+
+function base64url(input) {
+	return Buffer.from(input).toString('base64url');
+}
+
+function createAscApiToken() {
+	const now = Math.floor(Date.now() / 1000);
+	const header = { alg: 'ES256', kid: process.env.EXPO_ASC_KEY_ID, typ: 'JWT' };
+	const payload = { iss: process.env.EXPO_ASC_ISSUER_ID, iat: now - 10, exp: now + 10 * 60, aud: 'appstoreconnect-v1' };
+	const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+	const key = fs.readFileSync(process.env.EXPO_ASC_API_KEY_PATH, 'utf8');
+	// JWT ES256 requires the raw (IEEE P1363) signature encoding.
+	const signature = crypto.sign('sha256', Buffer.from(signingInput), { key, dsaEncoding: 'ieee-p1363' });
+	return `${signingInput}.${signature.toString('base64url')}`;
+}
+
+async function ascRequestAsync(method, pathname, body) {
+	const response = await fetch(`https://api.appstoreconnect.apple.com${pathname}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${createAscApiToken()}`,
+			'Content-Type': 'application/json',
+		},
+		body: body ? JSON.stringify(body) : undefined,
+	});
+	if (response.status === 204) {
+		return null;
+	}
+	const text = await response.text();
+	const json = text ? JSON.parse(text) : null;
+	if (!response.ok) {
+		const error = new Error(`ASC API ${method} ${pathname} failed with ${response.status}: ${text}`);
+		error.status = response.status;
+		error.details = json;
+		throw error;
+	}
+	return json;
+}
+
+async function enableCapabilityAsync(bundleIdId, operation) {
+	try {
+		await ascRequestAsync('POST', '/v1/bundleIdCapabilities', {
+			data: {
+				type: 'bundleIdCapabilities',
+				attributes: {
+					capabilityType: operation.capabilityType,
+					settings: operation.settings ?? [],
+				},
+				relationships: {
+					bundleId: { data: { type: 'bundleIds', id: bundleIdId } },
+				},
+			},
+		});
+		console.log(`[capability-sync] enabled ${operation.capabilityType}`);
+	} catch (error) {
+		// 409 = capability already enabled - the desired state is reached.
+		if (error.status === 409) {
+			console.log(`[capability-sync] ${operation.capabilityType} already enabled`);
+			return;
+		}
+		throw error;
+	}
+}
+
+async function disableCapabilityAsync(bundleIdId, operation) {
+	const listing = await ascRequestAsync('GET', `/v1/bundleIds/${bundleIdId}/bundleIdCapabilities?limit=200`);
+	const existing = listing?.data?.find((capability) => capability.attributes?.capabilityType === operation.capabilityType);
+	if (!existing) {
+		console.log(`[capability-sync] ${operation.capabilityType} already disabled`);
+		return;
+	}
+	await ascRequestAsync('DELETE', `/v1/bundleIdCapabilities/${existing.id}`);
+	console.log(`[capability-sync] disabled ${operation.capabilityType}`);
+}
+
+// Resolve exactly the @expo/apple-utils copy that eas-cli itself uses.
+const easCliRequire = createRequire(path.join(easCliRoot, 'build', 'prompts.js'));
+const appleUtils = easCliRequire('@expo/apple-utils');
+if (typeof appleUtils.BundleId?.prototype?.updateBundleIdCapabilityAsync !== 'function') {
+	fail('Could not patch @expo/apple-utils: BundleId.updateBundleIdCapabilityAsync not found (eas-cli internals changed?)');
+}
+appleUtils.BundleId.prototype.updateBundleIdCapabilityAsync = async function (operations) {
+	const list = Array.isArray(operations) ? operations : [operations];
+	console.log(`[capability-sync] syncing ${list.length} capability change(s) for ${this.attributes?.identifier ?? this.id} via per-capability ASC API requests`);
+	for (const operation of list) {
+		if (operation.option === 'OFF') {
+			await disableCapabilityAsync(this.id, operation);
+		} else {
+			await enableCapabilityAsync(this.id, operation);
+		}
+	}
+};
 
 process.chdir(projectDir);
 


### PR DESCRIPTION
## Problem

Der Credentials-Bootstrap scheiterte beim Capability-Sync für `de.baumgartner-software.day-and-year` (`APP_GROUPS` + `PUSH_NOTIFICATIONS`):

```
Apple API error: The request entity is not a valid request document object -
Unexpected or invalid value at 'data.relationships.bundleIdCapabilities.data.[0].attributes'.
```

Ursache: eas-cli/`@expo/apple-utils` schickt den Sync als **einen Sammel-PATCH** auf `/v1/bundleIds/{id}` mit inline Capability-Attributen — dieses Format lehnt die heutige App-Store-Connect-API ab. Ein Upstream-Fix existiert nicht: eas-cli 21.7.0 und `@expo/apple-utils` 2.1.22 sind die aktuellsten Versionen und beide betroffen.

## Fix

**`EXPO_NO_CAPABILITY_SYNC=1` wird ausdrücklich NICHT gesetzt — der Auto-Sync bleibt immer aktiv** (jetzt auch als ⚠️-Hinweis in `apps/tag-und-jahr/README.md` dokumentiert).

Stattdessen ersetzt `scripts/eas-setup-ios-build-credentials.js` (das ohnehin eas-cli in-process ausführt) genau den einen kaputten Aufruf `BundleId.updateBundleIdCapabilityAsync` durch die **dokumentierten Einzel-Requests** der ASC-API:

- Aktivieren: `POST /v1/bundleIdCapabilities` pro Capability (HTTP 409 = bereits aktiv → ok)
- Deaktivieren: `DELETE /v1/bundleIdCapabilities/{id}` (Capability-ID per GET ermittelt)

Gleiche Sync-Semantik und derselbe Soll-Zustand wie bei eas-cli, nur mit funktionierendem Request-Format. Signiert wird mit dem vorhandenen ASC-`.p8`-Key (ES256-JWT über `node:crypto`, keine neuen Abhängigkeiten). Sobald die Capabilities einmal stimmen, erzeugt jeder weitere Sync — auch der innerhalb von `eas build` — eine leere Änderungsliste und erreicht den fehlerhaften Codepfad gar nicht mehr. Fällt der Upstream-Fix irgendwann, kann der Patch ersatzlos entfallen.

## Verifikation

- Patch-Punkte gegen eine echte eas-cli-Installation verifiziert (`BundleId.updateBundleIdCapabilityAsync` existiert und ist ersetzbar; `@expo/apple-utils` wird exakt in der Kopie aufgelöst, die eas-cli nutzt).
- ES256-JWT-Signierung mit lokal generiertem P-256-Key getestet (64-Byte-P1363-Signatur, verifiziert korrekt).
- End-to-End-Smoke-Test: Skript lädt eas-cli, patcht Prompts + Capability-Sync und scheitert erst erwartungsgemäß am absichtlich falschen Test-Token an der EAS-API.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_