### PR TITLE
fix: ASC-API-Key lokal fürs Auto-Submit bereitstellen (Tag und Jahr)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,6 +672,14 @@ jobs:
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           working-directory: ./apps/tag-und-jahr/frontend
+      # --auto-submit cannot link an App Store Connect API key to a new app in
+      # non-interactive mode ("App Store Connect API Keys cannot be set up in
+      # --non-interactive mode"). The submit profile therefore references the
+      # key locally (ascApiKeyPath/-Id/-IssuerId in eas.json); this step places
+      # the .p8 written by prepare-asc-api-key at that path. The file is
+      # gitignored (*.p8).
+      - name: "🔑 Provide ASC API key for auto-submit"
+        run: cp "$EXPO_ASC_API_KEY_PATH" ./apps/tag-und-jahr/frontend/asc-api-key.p8
       - name: "🛠️ Build and Submit Tag und Jahr iOS App"
         run: eas build --platform ios --non-interactive --auto-submit
         working-directory: ./apps/tag-und-jahr/frontend

--- a/apps/tag-und-jahr/frontend/eas.json
+++ b/apps/tag-und-jahr/frontend/eas.json
@@ -24,7 +24,10 @@
       "ios": {
         "appleId": "nils@baumgartner-software.de",
         "ascAppId": "6799734478",
-        "appleTeamId": "6U99CRVHVR"
+        "appleTeamId": "6U99CRVHVR",
+        "ascApiKeyPath": "./asc-api-key.p8",
+        "ascApiKeyId": "39JT9543R7",
+        "ascApiKeyIssuerId": "a8db47e8-cb43-4861-b383-58ec4f9a9fc6"
       }
     }
   }


### PR DESCRIPTION
## Problem

Der Build kam diesmal deutlich weiter — Credentials-Bootstrap ✅ (beide Provisioning Profiles erzeugt), Capability-Sync ✅ („Synced capabilities: No updates"), Upload zu EAS Build ✅. Dann scheiterte der `--auto-submit`-Teil:

```
Looking up credentials configuration for de.baumgartner-software.day-and-year...
App Store Connect API Keys cannot be set up in --non-interactive mode.
```

Ursache: Für die **Submission** sucht eas einen auf den EAS-Servern hinterlegten und **mit der App verknüpften** ASC-API-Key (so laufen Geonexia/Score Tracker, deren Verknüpfung existiert schon). Für eine neue App kann diese Verknüpfung non-interaktiv nicht angelegt werden.

## Fix

Das Submit-Profil referenziert den Key jetzt **lokal** — der von eas.json offiziell unterstützte Weg, der ohne EAS-Credentials-Service auskommt und non-interaktiv funktioniert:

- `apps/tag-und-jahr/frontend/eas.json`: `ascApiKeyPath: "./asc-api-key.p8"`, dazu `ascApiKeyId`/`ascApiKeyIssuerId` (dieselben Werte, die als Repo-Konstanten in `packages/common/src/AppleAppStoreConfig.ts` liegen).
- `ci.yml`: Der Build-Job kopiert die von `prepare-asc-api-key` geschriebene `.p8` vor `eas build` an den referenzierten Pfad. Die Datei ist durch das bestehende `.gitignore`-Muster (`*.p8`) vom Commit ausgeschlossen.

Damit ist die Kette komplett non-interaktiv: Capabilities → Zertifikat/Profiles → Build → TestFlight-Submit.

## Verifikation

- Feldnamen gegen das eas-json-Schema der aktuellen eas-cli verifiziert (`ascApiKeyPath`/`ascApiKeyId`/`ascApiKeyIssuerId`; sind alle drei gesetzt, nutzt die Submission den lokalen Key statt des Credentials-Service — der fehlschlagende Codepfad wird nicht betreten).
- YAML validiert; `*.p8` in `apps/tag-und-jahr/frontend/.gitignore` bestätigt.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_