### PR TITLE
fix: expo-widgets-Bundle-Build im Monorepo — App-Dependencies nesten

### DIFF
--- a/apps/tag-und-jahr/frontend/package.json
+++ b/apps/tag-und-jahr/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "tag-und-jahr",
   "main": "expo-router/entry",
   "version": "1.0.0",
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Problem

Signing ist gelöst ✅ — jetzt scheiterte der Xcode-Build beim **Bündeln des Widget-JavaScripts**:

```
Unable to resolve module @babel/runtime/helpers/interopRequireWildcard
from .../apps/tag-und-jahr/frontend/node_modules/expo-widgets/bundle/index.ts
```

Ursache (lokal exakt reproduziert): expo-widgets bündelt das Widget-JS in einem eigenen Xcode-Build-Step mit seiner **eigenen Metro-Config**, die den `projectRoot` auf das expo-widgets-Paketverzeichnis umbiegt. Die von `expo/metro-config` relativ berechneten `nodeModulesPaths` lösen danach falsch auf — das im **Monorepo-Root** gehoistete `@babel/runtime` (Yarn-Workspaces-Hoisting) wird nicht mehr gefunden, obwohl es existiert.

## Fix

`installConfig.hoistingLimits: "workspaces"` in `apps/tag-und-jahr/frontend/package.json` — Yarn installiert damit alle Dependencies dieser App unter `apps/tag-und-jahr/frontend/node_modules` statt sie ins Root zu hoisten. Die Auflösung aus dem expo-widgets-Bundle heraus funktioniert dann, weil alles direkt neben dem Paket liegt. Nur diese eine App ist betroffen; die anderen Workspaces (SDK 54) bleiben unverändert.

## Verifikation (lokal, gleicher Aufruf wie der Xcode-Build-Step)

- **Vorher**: `node node_modules/expo-widgets/scripts/build-bundle.mjs` schlägt mit exakt dem CI-Fehler fehl.
- **Nachher**: Bundle-Build läuft durch — 98 Module, `ExpoWidgets.bundle` geschrieben.
- Jest der App (13 Tests), `tsc --noEmit`, `expo config` ✅; Score-Tracker-Tests (199) ✅ — das Nesting hat keine Seiteneffekte auf die anderen Apps.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_