### PR TITLE
fix: FoodWidget-Zeilen wurden vom Renderer verworfen + Speise-Fotos

### DIFF
--- a/apps/tag-und-jahr/frontend/__tests__/foodApi.test.ts
+++ b/apps/tag-und-jahr/frontend/__tests__/foodApi.test.ts
@@ -1,4 +1,6 @@
-import { formatEuro, formatLocalDate, getMealName, paginateMeals, toMeals } from '../helpers/foodApi';
+import { formatEuro, formatLocalDate, getMealImageUrl, getMealName, paginateMeals, toMeals } from '../helpers/foodApi';
+
+const SERVER_URL = 'https://example.rocket-meals.de/rocket-meals/api';
 
 describe('formatLocalDate', () => {
 	it('formats with zero-padded month and day', () => {
@@ -43,13 +45,32 @@ describe('getMealName', () => {
 	});
 });
 
+describe('getMealImageUrl', () => {
+	it('builds a scaled Directus assets url from the food image id', () => {
+		expect(getMealImageUrl({ id: '1', food: { image: 'file-123' } }, SERVER_URL)).toBe(
+			`${SERVER_URL}/assets/file-123?width=160&height=160&fit=cover&quality=60`
+		);
+		expect(getMealImageUrl({ id: '1', food: { image: { id: 'file-456' } } }, SERVER_URL)).toContain('/assets/file-456?');
+	});
+
+	it('falls back to the remote url, then undefined', () => {
+		expect(getMealImageUrl({ id: '1', food: { image_remote_url: 'https://example.org/pic.jpg' } }, SERVER_URL)).toBe('https://example.org/pic.jpg');
+		expect(getMealImageUrl({ id: '1' }, SERVER_URL)).toBeUndefined();
+	});
+});
+
 describe('toMeals', () => {
-	it('drops offers of archived foods and maps name/price', () => {
-		const meals = toMeals([
-			{ id: '1', price_student: 2.5, food: { alias: 'Schnitzel', status: 'published', translations: [] } },
-			{ id: '2', price_student: 1, food: { alias: 'Altes Gericht', status: 'archived', translations: [] } },
+	it('drops offers of archived foods and maps name/price/image', () => {
+		const meals = toMeals(
+			[
+				{ id: '1', price_student: 2.5, food: { alias: 'Schnitzel', status: 'published', image: 'file-123', translations: [] } },
+				{ id: '2', price_student: 1, food: { alias: 'Altes Gericht', status: 'archived', translations: [] } },
+			],
+			SERVER_URL
+		);
+		expect(meals).toEqual([
+			{ name: 'Schnitzel', price: '2,50 €', imageUrl: `${SERVER_URL}/assets/file-123?width=160&height=160&fit=cover&quality=60` },
 		]);
-		expect(meals).toEqual([{ name: 'Schnitzel', price: '2,50 €' }]);
 	});
 });
 

--- a/apps/tag-und-jahr/frontend/app/settings/index.tsx
+++ b/apps/tag-und-jahr/frontend/app/settings/index.tsx
@@ -4,7 +4,7 @@ import { Canteen, fetchCanteensAsync, fetchTodaysMealsAsync, Meal } from '../../
 import { FOOD_SERVERS, FoodServerKey, getFoodServer } from '../../helpers/foodServers';
 import { loadFoodWidgetSettingsAsync, saveFoodWidgetSettingsAsync } from '../../helpers/foodWidgetSettings';
 import { CLOCK_COLORS } from '../../helpers/clockDesign';
-import { syncFoodWidgetTimeline } from '../../helpers/widgetSync';
+import { syncFoodWidgetTimelineAsync } from '../../helpers/widgetSync';
 
 const MEAL_COUNT_OPTIONS = [2, 4, 6, 8];
 
@@ -78,7 +78,7 @@ export default function Settings() {
 			const todaysMeals = await fetchTodaysMealsAsync(server.serverUrl, canteen.id);
 			const settings = { serverKey: server.key, canteenId: canteen.id, canteenAlias: canteen.alias, mealCount };
 			await saveFoodWidgetSettingsAsync(settings);
-			syncFoodWidgetTimeline(settings, todaysMeals);
+			await syncFoodWidgetTimelineAsync(settings, todaysMeals);
 			setMeals(todaysMeals);
 			setStatus(
 				todaysMeals.length === 0

--- a/apps/tag-und-jahr/frontend/helpers/foodApi.ts
+++ b/apps/tag-und-jahr/frontend/helpers/foodApi.ts
@@ -12,6 +12,10 @@ export type Canteen = {
 export type Meal = {
 	name: string;
 	price: string;
+	/** Remote photo of the meal (Directus assets URL), if the food has one. */
+	imageUrl?: string;
+	/** Local file:// path of the downloaded photo inside widgetsDirectory. */
+	imagePath?: string;
 };
 
 type DirectusListResponse<T> = {
@@ -26,6 +30,8 @@ type RawTranslation = {
 type RawFood = {
 	alias?: string | null;
 	status?: string | null;
+	image?: string | { id?: string } | null;
+	image_remote_url?: string | null;
 	translations?: RawTranslation[] | null;
 };
 
@@ -68,13 +74,27 @@ export function getMealName(offer: RawFoodoffer): string {
 	return german?.name ?? any?.name ?? offer.food?.alias ?? offer.alias ?? 'Unbekanntes Gericht';
 }
 
+/**
+ * Photo URL of a food: the Directus asset (server-side scaled down for the
+ * widget) first, a remote URL as fallback.
+ */
+export function getMealImageUrl(offer: RawFoodoffer, serverUrl: string): string | undefined {
+	const image = offer.food?.image;
+	const fileId = typeof image === 'string' ? image : image?.id;
+	if (fileId) {
+		return `${serverUrl}/assets/${fileId}?width=160&height=160&fit=cover&quality=60`;
+	}
+	return offer.food?.image_remote_url ?? undefined;
+}
+
 /** Maps raw food offers to the widget's meal shape, dropping archived foods. */
-export function toMeals(offers: RawFoodoffer[]): Meal[] {
+export function toMeals(offers: RawFoodoffer[], serverUrl: string): Meal[] {
 	return offers
 		.filter((offer) => offer.food?.status !== 'archived')
 		.map((offer) => ({
 			name: getMealName(offer),
 			price: formatEuro(offer.price_student),
+			imageUrl: getMealImageUrl(offer, serverUrl),
 		}));
 }
 
@@ -112,12 +132,12 @@ export async function fetchCanteensAsync(serverUrl: string): Promise<Canteen[]> 
 
 export async function fetchTodaysMealsAsync(serverUrl: string, canteenId: string, today: Date = new Date()): Promise<Meal[]> {
 	const params = new URLSearchParams({
-		fields: 'id,alias,price_student,food.alias,food.status,food.translations.name,food.translations.languages_code',
+		fields: 'id,alias,price_student,food.alias,food.status,food.image,food.image_remote_url,food.translations.name,food.translations.languages_code',
 		limit: '-1',
 		filter: JSON.stringify({
 			_and: [{ canteen: { _eq: canteenId } }, { date: { _eq: formatLocalDate(today) } }],
 		}),
 	});
 	const response = await fetchJsonAsync<DirectusListResponse<RawFoodoffer>>(`${serverUrl}/items/foodoffers?${params}`);
-	return toMeals(response.data ?? []);
+	return toMeals(response.data ?? [], serverUrl);
 }

--- a/apps/tag-und-jahr/frontend/helpers/widgetSync.ts
+++ b/apps/tag-und-jahr/frontend/helpers/widgetSync.ts
@@ -47,17 +47,54 @@ export function syncWidgetTimeline(now: Date = new Date()): void {
 }
 
 /**
+ * Downloads the meal photos into the shared app group container
+ * (widgetsDirectory) so the widget extension can read them - widgets cannot
+ * load network images themselves. Returns the meals with local file paths.
+ * Failures are per-image and non-fatal: the widget then simply shows the row
+ * without a photo.
+ */
+async function downloadMealImagesAsync(meals: Meal[]): Promise<Meal[]> {
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const { widgetsDirectory } = require('expo-widgets');
+	if (!widgetsDirectory) {
+		return meals;
+	}
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const FileSystem = require('expo-file-system/legacy');
+	const baseDirectory = widgetsDirectory.endsWith('/') ? widgetsDirectory : `${widgetsDirectory}/`;
+	return await Promise.all(
+		meals.map(async (meal, index) => {
+			if (!meal.imageUrl) {
+				return meal;
+			}
+			try {
+				const target = `${baseDirectory}food-widget-meal-${index}.jpg`;
+				const result = await FileSystem.downloadAsync(meal.imageUrl, target);
+				if (result.status !== 200) {
+					return meal;
+				}
+				return { ...meal, imagePath: result.uri };
+			} catch (error) {
+				console.warn(`[widgetSync] photo download failed for ${meal.name}:`, error);
+				return meal;
+			}
+		})
+	);
+}
+
+/**
  * Schedules the food widget timeline from already fetched meals. WidgetKit
  * cannot swipe, so when there are more meals than fit on one page the
  * half-hour timeline entries rotate through the pages instead. The timeline
  * only covers today - tomorrow's menu is unknown until the app runs again.
  */
-export function syncFoodWidgetTimeline(settings: FoodWidgetSettings, meals: Meal[], now: Date = new Date()): void {
+export async function syncFoodWidgetTimelineAsync(settings: FoodWidgetSettings, rawMeals: Meal[], now: Date = new Date()): Promise<void> {
 	if (Platform.OS !== 'ios') {
 		return;
 	}
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const widget = require('../widgets/FoodWidget').default;
+	const meals = await downloadMealImagesAsync(rawMeals);
 
 	const updatedAt = `${now.getHours()}:${`${now.getMinutes()}`.padStart(2, '0')}`;
 	const pages = paginateMeals(meals, settings.mealCount);
@@ -105,7 +142,7 @@ export async function refreshFoodWidgetFromStoredSettingsAsync(): Promise<void> 
 			return;
 		}
 		const meals = await fetchTodaysMealsAsync(server.serverUrl, settings.canteenId);
-		syncFoodWidgetTimeline(settings, meals);
+		await syncFoodWidgetTimelineAsync(settings, meals);
 	} catch (error) {
 		console.warn('[widgetSync] food widget refresh failed:', error);
 	}

--- a/apps/tag-und-jahr/frontend/package.json
+++ b/apps/tag-und-jahr/frontend/package.json
@@ -27,6 +27,7 @@
     "@expo/vector-icons": "^15.0.2",
     "expo": "57.0.11",
     "expo-constants": "~57.0.9",
+    "expo-file-system": "~57.0.2",
     "expo-font": "~57.0.1",
     "expo-linking": "~57.0.5",
     "expo-router": "~57.0.11",

--- a/apps/tag-und-jahr/frontend/widgets/FoodWidget.tsx
+++ b/apps/tag-und-jahr/frontend/widgets/FoodWidget.tsx
@@ -1,18 +1,19 @@
-import { HStack, Spacer, Text, VStack } from '@expo/ui/swift-ui';
-import { containerBackground, font, foregroundStyle, frame, lineLimit, padding } from '@expo/ui/swift-ui/modifiers';
+import { HStack, Image, Spacer, Text, VStack } from '@expo/ui/swift-ui';
+import { containerBackground, cornerRadius, font, foregroundStyle, frame, lineLimit, padding } from '@expo/ui/swift-ui/modifiers';
 import { createWidget, type WidgetEnvironment } from 'expo-widgets';
 
 // Experimental widget: shows today's meals of the configured canteen. The app
-// fetches the data (settings screen / app start) and schedules it as timeline
+// fetches the data (settings screen / app start), downloads the meal photos
+// into the shared app group container and schedules everything as timeline
 // props - WidgetKit cannot swipe, so when there are more meals than fit on one
 // "page", the timeline rotates through the pages every 30 minutes instead
 // (see helpers/widgetSync.ts).
 export type FoodWidgetProps = {
 	/** Canteen name shown as the header. */
 	title?: string;
-	/** Meals of the current page. */
-	meals?: { name: string; price: string }[];
-	/** Small footer line, e.g. "Seite 1/2 · 12:30". */
+	/** Meals of the current page; imagePath is a file:// photo in the app group. */
+	meals?: { name: string; price: string; imagePath?: string }[];
+	/** Small footer line, e.g. "Seite 1/2 · Stand 12:30". */
 	footer?: string;
 };
 
@@ -20,6 +21,8 @@ const FoodWidgetLayout = (props: FoodWidgetProps, environment: WidgetEnvironment
 	'widget';
 	// The 'widget' directive isolates this function: no imports and no module
 	// scope values are available in here, so colors and sizes live inline.
+	// IMPORTANT: the widget renderer drops nested arrays inside mixed children,
+	// so the mapped meal rows must live in their own VStack (sole child = array).
 	const isDark = environment.colorScheme === 'dark';
 	const backgroundColor = isDark ? '#1e232e' : '#f6f2e9';
 	const titleColor = isDark ? '#e6a83c' : '#8a5a19';
@@ -31,25 +34,33 @@ const FoodWidgetLayout = (props: FoodWidgetProps, environment: WidgetEnvironment
 	const titleSize = isSmall ? 11 : 13;
 	const rowSize = isSmall ? 10 : 12;
 	const footerSize = isSmall ? 8 : 10;
+	const photoSize = isSmall ? 18 : 28;
 
 	const meals = props.meals ?? [];
 	const title = props.title ?? 'Speisen heute';
 
 	return (
-		<VStack alignment="leading" spacing={isSmall ? 2 : 4} modifiers={[frame({ maxWidth: 9999, maxHeight: 9999, alignment: 'topLeading' }), padding({ all: isSmall ? 4 : 8 }), containerBackground(backgroundColor, 'widget')]}>
+		<VStack alignment="leading" spacing={isSmall ? 3 : 5} modifiers={[frame({ maxWidth: 9999, maxHeight: 9999, alignment: 'topLeading' }), padding({ all: isSmall ? 4 : 8 }), containerBackground(backgroundColor, 'widget')]}>
 			<Text modifiers={[font({ size: titleSize, weight: 'bold' }), foregroundStyle(titleColor), lineLimit(1)]}>{title}</Text>
 			{meals.length === 0 ? (
 				<Text modifiers={[font({ size: rowSize }), foregroundStyle(mutedColor)]}>
 					Keine Daten - in der App unter Einstellungen eine Mensa wählen.
 				</Text>
 			) : (
-				meals.map((meal, index) => (
-					<HStack key={`meal-${index}`} spacing={4}>
-						<Text modifiers={[font({ size: rowSize }), foregroundStyle(textColor), lineLimit(isSmall ? 1 : 2)]}>{meal.name}</Text>
-						<Spacer />
-						{meal.price ? <Text modifiers={[font({ size: rowSize }), foregroundStyle(mutedColor)]}>{meal.price}</Text> : null}
-					</HStack>
-				))
+				<VStack alignment="leading" spacing={isSmall ? 2 : 4}>
+					{meals.map((meal, index) => (
+						<HStack key={`meal-${index}`} spacing={isSmall ? 4 : 6}>
+							{meal.imagePath ? (
+								<Image uiImage={meal.imagePath} modifiers={[frame({ width: photoSize, height: photoSize }), cornerRadius(isSmall ? 4 : 6)]} />
+							) : (
+								<Image systemName="fork.knife" size={photoSize - 6} color={mutedColor} modifiers={[frame({ width: photoSize, height: photoSize })]} />
+							)}
+							<Text modifiers={[font({ size: rowSize }), foregroundStyle(textColor), lineLimit(isSmall ? 1 : 2)]}>{meal.name}</Text>
+							<Spacer />
+							{meal.price ? <Text modifiers={[font({ size: rowSize }), foregroundStyle(mutedColor)]}>{meal.price}</Text> : null}
+						</HStack>
+					))}
+				</VStack>
 			)}
 			<Spacer />
 			{props.footer ? <Text modifiers={[font({ size: footerSize }), foregroundStyle(mutedColor), lineLimit(1)]}>{props.footer}</Text> : null}

--- a/yarn.lock
+++ b/yarn.lock
@@ -31477,6 +31477,7 @@ __metadata:
     "@types/react": "npm:~19.2.0"
     expo: "npm:57.0.11"
     expo-constants: "npm:~57.0.9"
+    expo-file-system: "npm:~57.0.2"
     expo-font: "npm:~57.0.1"
     expo-linking: "npm:~57.0.5"
     expo-router: "npm:~57.0.11"


### PR DESCRIPTION
## Problem

Das FoodWidget zeigte nur Titel und Footer („Seite 1/2 · Stand 11:01"), aber keine Speisen — obwohl die Daten korrekt geladen wurden (die Paginierung im Footer beweist es).

Ursache (in der expo-widgets-Swift-Quelle gefunden): Der Widget-Renderer (`DynamicView.swift`) verarbeitet children mit `compactMap { $0 as? [String: Any] }` — **verschachtelte Arrays in gemischten children werden stillschweigend verworfen**. Genau so ein Array erzeugt `.map()`, wenn es als Geschwister von Titel/Footer steht: `[Text, [HStack, …], Spacer, Text]` → das innere Array fliegt raus.

## Fix

1. **Rendering**: Die gemappten Speisen-Zeilen liegen jetzt in einem eigenen inneren `VStack` — dort ist das Array das *einzige* children und läuft über den unterstützten `[Any]`-Pfad des Renderers.
2. **Speise-Fotos**: 
   - `foodApi` liefert pro Speise eine Bild-URL (Directus-Asset, serverseitig auf 160 px skaliert; `image_remote_url` als Fallback).
   - Der Widget-Sync lädt die Fotos in den **geteilten App-Group-Container** (`widgetsDirectory`) — Widgets können selbst keine Netzwerkbilder laden — und übergibt `file://`-Pfade in den Props. Fehler pro Bild sind unkritisch (Zeile erscheint ohne Foto, SF-Symbol 🍴 als Platzhalter).
   - Das Widget rendert die Fotos abgerundet (18 pt small / 28 pt medium+) via `Image.uiImage`.

## Bewusst kein Versions-Bump — kommt per OTA

`expo-file-system` steckt als Abhängigkeit von `expo` **bereits im Binary von Build 2**; die Änderung ist reines JavaScript. Der Merge published das OTA-Update auf den `production`-Channel und erreicht die installierte Version 0.2.0 direkt. Wichtig: Ein Patch-Bump hätte die an `appVersion` gekoppelte `runtimeVersion` geändert und das Update am installierten Build **vorbeilaufen** lassen.

## Verifikation

- Jest: 23 Tests grün (inkl. neuer Bild-URL-Mapper-Tests).
- `tsc --noEmit` ✅, voller `expo export --platform ios` ✅ (validiert die `'widget'`-Direktiven-Transformation des geänderten Widgets).
- Renderer-Verhalten (Array-Drop) direkt in der expo-widgets-Swift-Quelle verifiziert; `Image.uiImage` liest `file://` per `Data(contentsOf:)` — App-Group-Dateien sind für die Extension lesbar.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_