### PR TITLE
feat: Foto-Raster mit Auto-Pagination im Food-Widget + Uhr-Themes (Jahresbeginn, Sonne & Mond)

### DIFF
--- a/apps/tag-und-jahr/README.md
+++ b/apps/tag-und-jahr/README.md
@@ -49,13 +49,20 @@ Der Credentials-Bootstrap in der CI **prüft** anschließend, dass die Provision
 - Das Widget benötigt einen Development Build bzw. TestFlight-Build (nicht Expo Go) und iOS 17 oder neuer.
 - Auf Android und im Web läuft nur die In-App-Ansicht; das Home-Widget ist iOS-only (der Android-Support von `expo-widgets` ist noch experimentell und hier bewusst nicht aktiviert).
 
+## Uhr-Themes
+
+Im Drawer-Menü → **Einstellungen** lassen sich zwei Anzeige-Optionen der Uhr umschalten (gelten für App und Widget – das Widget bekommt sie als Timeline-Props):
+
+- **Jahresbeginn (oben)**: Frühling (21.03., Standard) oder Neujahr (01.01.) – bestimmt, welches Datum der rote Strich bei zwölf Uhr markiert.
+- **Tagesanzeige**: „Tagesfortschritt" (der klassische blaue Punkt) oder **„Sonne & Mond"**: Die innere Scheibe zeigt oben Himmel, unten Erde, getrennt durch eine Horizontlinie. Die Sonne wandert von 06:00 (links) über den Zenit (12:00) nach 18:00 (rechts), der Mond übernimmt spiegelbildlich die Nacht – beide laufen einmal in 24 h um, unter dem Horizont verschwinden sie hinter der Erde.
+
 ## Food-Widget (experimentell)
 
-Neben der Jahresuhr enthält die App testweise ein zweites Widget **„Speisen heute"**: Es zeigt die Speisen des heutigen Tages einer Mensa. Konfiguriert wird es in der App (Drawer-Menü → **Einstellungen**):
+Neben der Jahresuhr enthält die App testweise ein zweites Widget **„Speisen heute"**: ein reines **Foto-Raster** der heutigen Speisen einer Mensa (quadratische Bilder, minimales Spacing, keine Texte). Konfiguriert wird es in der App (Drawer-Menü → **Einstellungen**):
 
 - **Server**: Studi-Futter, SWOSY oder Rocket Meals (Test) – die Mensen des gewählten Servers werden live per Directus-API geladen (bewusst ohne Cache, reines Experiment).
-- **Mensa** und **Anzahl gleichzeitig angezeigter Speisen** (2/4/6/8) wählen, dann „Speisen laden & Widget aktualisieren".
-- iOS-Widgets können **nicht wischen** (WidgetKit erlaubt keine Gesten außer Tippen). Gibt es mehr Speisen als angezeigt, rotiert das Widget stattdessen etwa alle 30 Minuten durch die Seiten (über Timeline-Einträge).
+- **Mensa** und **Bilder pro Seite** (2/4/6/8) wählen, dann „Speisen laden & Widget aktualisieren". Die Fotos werden in den geteilten App-Group-Container geladen (Widgets können keine Netzwerkbilder laden).
+- iOS-Widgets können **nicht wischen** (WidgetKit erlaubt keine Gesten außer Tippen). Stattdessen **blättert die Timeline automatisch**: Einträge im 10-Sekunden-Takt für die erste Stunde nach einem Sync, danach minütlich bis Tagesende. Wichtig: WidgetKit behandelt Eintragszeiten als *frühesten* Renderzeitpunkt und darf Wechsel je nach System-Budget zusammenfassen – die 10 Sekunden sind ein Angebot an iOS, keine Garantie.
 - Die App aktualisiert das Widget zusätzlich bei jedem Start/Foreground mit dem Tagesmenü der gespeicherten Mensa.
 
 **Expo OTA (EAS Update)** ist für die App aktiv: `updates.url` + `runtimeVersion: appVersion` in der `app.config.ts`, veröffentlicht vom CI-Job `tag-und-jahr-expo-update` (Channel `production` auf master). Da die Runtime-Version an die App-Version gekoppelt ist, erreichen OTA-Updates nur Builds derselben Version – nach nativen Änderungen (wie dem neuen Widget) muss daher die Build-Nummer in [`frontend/config.ts`](frontend/config.ts) erhöht werden; reine JS-Änderungen kommen danach OTA.

--- a/apps/tag-und-jahr/frontend/__tests__/clock.test.ts
+++ b/apps/tag-und-jahr/frontend/__tests__/clock.test.ts
@@ -1,4 +1,14 @@
-import { getDayAngleDegrees, getDayFraction, getLastSpringStart, getYearAngleDegrees, getYearFraction } from '../helpers/clock';
+import {
+	getCalendarYearFraction,
+	getDayAngleDegrees,
+	getDayFraction,
+	getLastSpringStart,
+	getMoonAngleDegrees,
+	getSunAngleDegrees,
+	getYearAngleDegrees,
+	getYearAngleDegreesFor,
+	getYearFraction,
+} from '../helpers/clock';
 
 describe('day fraction and angle', () => {
 	it('is 0 at local midnight', () => {
@@ -56,5 +66,36 @@ describe('year fraction and angle', () => {
 	it('stays below 1 just before the next start of spring', () => {
 		expect(getYearFraction(new Date(2027, 2, 20, 23, 59, 59))).toBeLessThan(1);
 		expect(getYearFraction(new Date(2027, 2, 20, 23, 59, 59))).toBeGreaterThan(0.99);
+	});
+});
+
+describe('calendar year fraction (Neujahr start)', () => {
+	it('is 0 on 1 January and ~0.5 mid-year', () => {
+		expect(getCalendarYearFraction(new Date(2026, 0, 1, 0, 0, 0))).toBe(0);
+		const midYear = getCalendarYearFraction(new Date(2026, 6, 2, 12, 0, 0));
+		expect(midYear).toBeGreaterThan(0.49);
+		expect(midYear).toBeLessThan(0.51);
+	});
+
+	it('getYearAngleDegreesFor switches the anchor', () => {
+		const newYear = new Date(2026, 0, 1, 0, 0, 0);
+		expect(getYearAngleDegreesFor(newYear, 'newyear')).toBe(0);
+		expect(getYearAngleDegreesFor(newYear, 'spring')).toBeGreaterThan(180);
+		const spring = new Date(2026, 2, 21, 0, 0, 0);
+		expect(getYearAngleDegreesFor(spring, 'spring')).toBe(0);
+	});
+});
+
+describe('sun and moon angles (Sonne & Mond display)', () => {
+	it('anchors the sun left at 06:00, top at 12:00, right at 18:00', () => {
+		expect(getSunAngleDegrees(new Date(2026, 7, 9, 6, 0, 0))).toBe(0);
+		expect(getSunAngleDegrees(new Date(2026, 7, 9, 12, 0, 0))).toBe(90);
+		expect(getSunAngleDegrees(new Date(2026, 7, 9, 18, 0, 0))).toBe(180);
+		expect(getSunAngleDegrees(new Date(2026, 7, 9, 0, 0, 0))).toBe(270);
+	});
+
+	it('shifts the moon by 12 hours', () => {
+		expect(getMoonAngleDegrees(new Date(2026, 7, 9, 18, 0, 0))).toBe(0);
+		expect(getMoonAngleDegrees(new Date(2026, 7, 9, 0, 0, 0))).toBe(90);
 	});
 });

--- a/apps/tag-und-jahr/frontend/__tests__/foodApi.test.ts
+++ b/apps/tag-und-jahr/frontend/__tests__/foodApi.test.ts
@@ -48,7 +48,7 @@ describe('getMealName', () => {
 describe('getMealImageUrl', () => {
 	it('builds a scaled Directus assets url from the food image id', () => {
 		expect(getMealImageUrl({ id: '1', food: { image: 'file-123' } }, SERVER_URL)).toBe(
-			`${SERVER_URL}/assets/file-123?width=160&height=160&fit=cover&quality=60`
+			`${SERVER_URL}/assets/file-123?width=512&height=512&fit=cover&quality=70`
 		);
 		expect(getMealImageUrl({ id: '1', food: { image: { id: 'file-456' } } }, SERVER_URL)).toContain('/assets/file-456?');
 	});
@@ -69,7 +69,7 @@ describe('toMeals', () => {
 			SERVER_URL
 		);
 		expect(meals).toEqual([
-			{ name: 'Schnitzel', price: '2,50 €', imageUrl: `${SERVER_URL}/assets/file-123?width=160&height=160&fit=cover&quality=60` },
+			{ name: 'Schnitzel', price: '2,50 €', imageUrl: `${SERVER_URL}/assets/file-123?width=512&height=512&fit=cover&quality=70` },
 		]);
 	});
 });

--- a/apps/tag-und-jahr/frontend/__tests__/widgetSync.test.ts
+++ b/apps/tag-und-jahr/frontend/__tests__/widgetSync.test.ts
@@ -1,4 +1,12 @@
-import { getTimelineEntryDates, TIMELINE_DAYS, TIMELINE_STEP_MINUTES } from '../helpers/widgetSync';
+import {
+	FOOD_FAST_STEP_SECONDS,
+	FOOD_FAST_WINDOW_MINUTES,
+	FOOD_SLOW_STEP_SECONDS,
+	getFoodTimelineEntryDates,
+	getTimelineEntryDates,
+	TIMELINE_DAYS,
+	TIMELINE_STEP_MINUTES,
+} from '../helpers/widgetSync';
 
 describe('widget timeline entry dates', () => {
 	const stepMs = TIMELINE_STEP_MINUTES * 60 * 1000;
@@ -25,5 +33,23 @@ describe('widget timeline entry dates', () => {
 		expect(dates.length).toBeGreaterThanOrEqual(expectedEntries);
 		const last = dates[dates.length - 1];
 		expect(last.getTime() - now.getTime()).toBeLessThanOrEqual(TIMELINE_DAYS * 24 * 60 * 60 * 1000);
+	});
+});
+
+describe('food widget timeline entry dates (auto pagination)', () => {
+	it('uses 10-second steps in the fast window, then minute steps', () => {
+		const now = new Date(2026, 7, 9, 10, 0, 0);
+		const dates = getFoodTimelineEntryDates(now);
+		expect(dates[1].getTime() - dates[0].getTime()).toBe(FOOD_FAST_STEP_SECONDS * 1000);
+		const fastEntries = (FOOD_FAST_WINDOW_MINUTES * 60) / FOOD_FAST_STEP_SECONDS;
+		expect(dates[fastEntries + 1].getTime() - dates[fastEntries].getTime()).toBe(FOOD_SLOW_STEP_SECONDS * 1000);
+	});
+
+	it('never crosses into the next day', () => {
+		const now = new Date(2026, 7, 9, 23, 30, 0);
+		const dates = getFoodTimelineEntryDates(now);
+		const endOfDay = new Date(2026, 7, 10).getTime();
+		expect(dates.length).toBeGreaterThan(0);
+		expect(dates[dates.length - 1].getTime()).toBeLessThan(endOfDay);
 	});
 });

--- a/apps/tag-und-jahr/frontend/app.config.ts
+++ b/apps/tag-und-jahr/frontend/app.config.ts
@@ -121,6 +121,9 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 							description: 'Zeigt die Speisen des heutigen Tages der gewählten Mensa (experimentell).',
 							ios: {
 								supportedFamilies: ['systemSmall', 'systemMedium', 'systemLarge'],
+								// Pure photo grid - the images should fill the widget, so the
+								// system margins are disabled.
+								contentMarginsDisabled: true,
 								initialLayout: 'widgets/FoodWidget.tsx',
 							},
 						},

--- a/apps/tag-und-jahr/frontend/app/index.tsx
+++ b/apps/tag-und-jahr/frontend/app/index.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useFocusEffect } from 'expo-router';
 import { AppState, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import YearClock from '../components/YearClock';
 import { CLOCK_COLORS } from '../helpers/clockDesign';
+import { ClockSettings, DEFAULT_CLOCK_SETTINGS, loadClockSettingsAsync } from '../helpers/clockSettings';
 import { refreshFoodWidgetFromStoredSettingsAsync, syncWidgetTimeline } from '../helpers/widgetSync';
 
 export default function Index() {
 	const { width, height } = useWindowDimensions();
 	const [now, setNow] = useState(() => new Date());
+	const [clockSettings, setClockSettings] = useState<ClockSettings>(DEFAULT_CLOCK_SETTINGS);
 
 	// The in-app clock ticks once a minute - like the widget it is an object
 	// for contemplation, not a precision instrument.
@@ -16,15 +19,24 @@ export default function Index() {
 		return () => clearInterval(interval);
 	}, []);
 
+	// Reload the display options whenever this screen gains focus, so changes
+	// made in the settings screen show up immediately.
+	useFocusEffect(
+		useCallback(() => {
+			loadClockSettingsAsync().then(setClockSettings);
+		}, [])
+	);
+
 	// Refresh the widget timelines on every start and whenever the app returns
-	// to the foreground: the year clock gets ~7 days of half-hour states, the
-	// experimental food widget gets today's menu (if configured in settings).
+	// to the foreground: the year clock gets ~7 days of half-hour states (with
+	// the current display options as props), the experimental food widget gets
+	// today's menu (if configured in settings).
 	useEffect(() => {
-		syncWidgetTimeline();
+		loadClockSettingsAsync().then((settings) => syncWidgetTimeline(settings));
 		refreshFoodWidgetFromStoredSettingsAsync();
 		const subscription = AppState.addEventListener('change', (state) => {
 			if (state === 'active') {
-				syncWidgetTimeline();
+				loadClockSettingsAsync().then((settings) => syncWidgetTimeline(settings));
 				refreshFoodWidgetFromStoredSettingsAsync();
 			}
 		});
@@ -36,11 +48,15 @@ export default function Index() {
 	return (
 		<SafeAreaView style={styles.container}>
 			<View style={styles.clockContainer}>
-				<YearClock size={clockSize} date={now} />
+				<YearClock size={clockSize} date={now} settings={clockSettings} />
 			</View>
 			<Text style={styles.caption}>
-				Der rote Strich steht für den 21. März und wandert in einem Jahr einmal im Kreis. Der blaue Punkt wandert einmal am Tag. Keine
-				Uhrzeit - nur das Vergehen der Zeit.
+				{clockSettings.yearStart === 'newyear'
+					? 'Der rote Strich steht für den 1. Januar und wandert in einem Jahr einmal im Kreis. '
+					: 'Der rote Strich steht für den 21. März und wandert in einem Jahr einmal im Kreis. '}
+				{clockSettings.dayDisplay === 'sunmoon'
+					? 'Sonne und Mond wandern über den Horizont: Sonne von 06:00 bis 18:00, Mond in der Nacht.'
+					: 'Der blaue Punkt wandert einmal am Tag. Keine Uhrzeit - nur das Vergehen der Zeit.'}
 			</Text>
 		</SafeAreaView>
 	);

--- a/apps/tag-und-jahr/frontend/app/settings/index.tsx
+++ b/apps/tag-und-jahr/frontend/app/settings/index.tsx
@@ -4,7 +4,8 @@ import { Canteen, fetchCanteensAsync, fetchTodaysMealsAsync, Meal } from '../../
 import { FOOD_SERVERS, FoodServerKey, getFoodServer } from '../../helpers/foodServers';
 import { loadFoodWidgetSettingsAsync, saveFoodWidgetSettingsAsync } from '../../helpers/foodWidgetSettings';
 import { CLOCK_COLORS } from '../../helpers/clockDesign';
-import { syncFoodWidgetTimelineAsync } from '../../helpers/widgetSync';
+import { ClockSettings, DEFAULT_CLOCK_SETTINGS, loadClockSettingsAsync, saveClockSettingsAsync } from '../../helpers/clockSettings';
+import { syncFoodWidgetTimelineAsync, syncWidgetTimeline } from '../../helpers/widgetSync';
 
 const MEAL_COUNT_OPTIONS = [2, 4, 6, 8];
 
@@ -12,6 +13,7 @@ const MEAL_COUNT_OPTIONS = [2, 4, 6, 8];
 // many meals the food widget shows at once, then push today's menu into the
 // widget timeline. Deliberately no caching - data is fetched fresh on demand.
 export default function Settings() {
+	const [clockSettings, setClockSettings] = useState<ClockSettings>(DEFAULT_CLOCK_SETTINGS);
 	const [serverKey, setServerKey] = useState<FoodServerKey | null>(null);
 	const [canteens, setCanteens] = useState<Canteen[]>([]);
 	const [canteensLoading, setCanteensLoading] = useState(false);
@@ -24,12 +26,23 @@ export default function Settings() {
 
 	// Hydrate persisted settings once.
 	useEffect(() => {
+		loadClockSettingsAsync().then(setClockSettings);
 		loadFoodWidgetSettingsAsync().then((stored) => {
 			if (stored) {
 				setServerKey(stored.serverKey);
 				setCanteenId(stored.canteenId);
 				setMealCount(stored.mealCount);
 			}
+		});
+	}, []);
+
+	// Persist a clock display option and refresh the clock widget right away.
+	const updateClockSettings = useCallback((update: Partial<ClockSettings>) => {
+		setClockSettings((previous) => {
+			const next = { ...previous, ...update };
+			saveClockSettingsAsync(next).catch((err) => console.warn('[settings] saving clock settings failed:', err));
+			syncWidgetTimeline(next);
+			return next;
 		});
 	}, []);
 
@@ -94,10 +107,30 @@ export default function Settings() {
 
 	return (
 		<ScrollView style={styles.container} contentContainerStyle={styles.content}>
-			<Text style={styles.heading}>Food-Widget (experimentell)</Text>
+			<Text style={styles.heading}>Uhr</Text>
+			<Text style={styles.sectionTitle}>Jahresbeginn (oben)</Text>
+			<View style={styles.chipRow}>
+				<Chip label="Frühling (21.03.)" selected={clockSettings.yearStart === 'spring'} onPress={() => updateClockSettings({ yearStart: 'spring' })} />
+				<Chip label="Neujahr (01.01.)" selected={clockSettings.yearStart === 'newyear'} onPress={() => updateClockSettings({ yearStart: 'newyear' })} />
+			</View>
+
+			<Text style={styles.sectionTitle}>Tagesanzeige</Text>
+			<View style={styles.chipRow}>
+				<Chip label="Tagesfortschritt" selected={clockSettings.dayDisplay === 'progress'} onPress={() => updateClockSettings({ dayDisplay: 'progress' })} />
+				<Chip label="Sonne & Mond" selected={clockSettings.dayDisplay === 'sunmoon'} onPress={() => updateClockSettings({ dayDisplay: 'sunmoon' })} />
+			</View>
+			{clockSettings.dayDisplay === 'sunmoon' ? (
+				<Text style={styles.hint}>
+					Sonne und Mond wandern über den Horizont: Sonne von 06:00 (links) bis 18:00 (rechts), der Mond übernimmt die Nacht. Darüber
+					Himmel, darunter Erde.
+				</Text>
+			) : null}
+
+			<Text style={[styles.heading, styles.headingSpaced]}>Food-Widget (experimentell)</Text>
 			<Text style={styles.hint}>
-				Zeigt die Speisen des heutigen Tages als Home-Widget. iOS-Widgets können nicht wischen - bei mehr Speisen als angezeigt
-				rotiert das Widget etwa alle 30 Minuten durch die Seiten.
+				Zeigt die Speisen des heutigen Tages als Foto-Raster im Home-Widget. iOS-Widgets können nicht wischen - stattdessen blättert
+				die Timeline automatisch weiter (alle 10 Sekunden in der ersten Stunde, danach minütlich; iOS kann Wechsel je nach
+				System-Budget zusammenfassen).
 			</Text>
 
 			<Text style={styles.sectionTitle}>Server</Text>
@@ -135,7 +168,7 @@ export default function Settings() {
 				))}
 			</View>
 
-			<Text style={styles.sectionTitle}>Speisen gleichzeitig</Text>
+			<Text style={styles.sectionTitle}>Bilder pro Seite</Text>
 			<View style={styles.chipRow}>
 				{MEAL_COUNT_OPTIONS.map((count) => (
 					<Chip key={count} label={`${count}`} selected={count === mealCount} onPress={() => setMealCount(count)} />
@@ -190,6 +223,9 @@ const styles = StyleSheet.create({
 		fontSize: 20,
 		fontWeight: '600',
 		marginBottom: 8,
+	},
+	headingSpaced: {
+		marginTop: 32,
 	},
 	hint: {
 		color: '#c8cfdc',

--- a/apps/tag-und-jahr/frontend/components/YearClock.tsx
+++ b/apps/tag-und-jahr/frontend/components/YearClock.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Svg, { Circle, Rect, G } from 'react-native-svg';
-import { getDayAngleDegrees, getYearAngleDegrees } from '../helpers/clock';
+import Svg, { Circle, ClipPath, Defs, G, Line, Rect } from 'react-native-svg';
+import { getDayAngleDegrees, getMoonAngleDegrees, getSunAngleDegrees, getYearAngleDegreesFor } from '../helpers/clock';
+import { ClockSettings, DEFAULT_CLOCK_SETTINGS } from '../helpers/clockSettings';
 import { CLOCK_COLORS, CLOCK_PROPORTIONS } from '../helpers/clockDesign';
 
 export type YearClockProps = {
@@ -8,15 +9,22 @@ export type YearClockProps = {
 	size: number;
 	/** The moment to display. */
 	date: Date;
+	/** Display options (year start anchor, day display theme). */
+	settings?: ClockSettings;
 };
+
+const SKY_COLOR = '#4f7fb5';
+const HORIZON_COLOR = '#e8e4da';
+const SUN_COLOR = '#f5c84c';
+const MOON_COLOR = '#f2f0ea';
 
 /**
  * The in-app rendering of the "Tag und Jahr" clock. The home screen widget
  * (widgets/TagUndJahrWidget.tsx) draws the same design with SwiftUI views.
  */
-export default function YearClock({ size, date }: Readonly<YearClockProps>) {
+export default function YearClock({ size, date, settings = DEFAULT_CLOCK_SETTINGS }: Readonly<YearClockProps>) {
 	const center = size / 2;
-	const yearAngle = getYearAngleDegrees(date);
+	const yearAngle = getYearAngleDegreesFor(date, settings.yearStart);
 	const dayAngle = getDayAngleDegrees(date);
 
 	const markWidth = CLOCK_PROPORTIONS.yearMarkWidth * size;
@@ -24,10 +32,43 @@ export default function YearClock({ size, date }: Readonly<YearClockProps>) {
 	const markCenterY = center - CLOCK_PROPORTIONS.yearMarkCenterRadius * size;
 	const dotCenterY = center - CLOCK_PROPORTIONS.dayDotCenterRadius * size;
 
+	const innerRadius = (CLOCK_PROPORTIONS.dayDisc * size) / 2;
+	const bodyRadius = innerRadius * 0.14;
+	const orbitRadius = innerRadius * 0.72;
+	const sunAngle = getSunAngleDegrees(date);
+	const moonAngle = getMoonAngleDegrees(date);
+
 	return (
 		<Svg width={size} height={size}>
+			<Defs>
+				<ClipPath id="innerDisc">
+					<Circle cx={center} cy={center} r={innerRadius} />
+				</ClipPath>
+			</Defs>
 			<Circle cx={center} cy={center} r={size / 2} fill={CLOCK_COLORS.yearDisc} />
-			<Circle cx={center} cy={center} r={(CLOCK_PROPORTIONS.dayDisc * size) / 2} fill={CLOCK_COLORS.dayDisc} />
+			{settings.dayDisplay === 'sunmoon' ? (
+				<G clipPath="#innerDisc">
+					<Circle cx={center} cy={center} r={innerRadius} fill={SKY_COLOR} />
+					{/* Sun/moon: one revolution per 24h, anchored left at 06:00. */}
+					<G rotation={sunAngle} origin={`${center}, ${center}`}>
+						<Circle cx={center - orbitRadius} cy={center} r={bodyRadius} fill={SUN_COLOR} />
+					</G>
+					<G rotation={moonAngle} origin={`${center}, ${center}`}>
+						<Circle cx={center - orbitRadius} cy={center} r={bodyRadius} fill={MOON_COLOR} />
+					</G>
+					{/* Earth covers the lower half, hiding the body below the horizon. */}
+					<Rect x={center - innerRadius} y={center} width={innerRadius * 2} height={innerRadius} fill={CLOCK_COLORS.dayDisc} />
+					<Line x1={center - innerRadius} y1={center} x2={center + innerRadius} y2={center} stroke={HORIZON_COLOR} strokeWidth={1.5} />
+				</G>
+			) : (
+				<>
+					<Circle cx={center} cy={center} r={innerRadius} fill={CLOCK_COLORS.dayDisc} />
+					<G rotation={dayAngle} origin={`${center}, ${center}`}>
+						<Circle cx={center} cy={dotCenterY} r={(CLOCK_PROPORTIONS.dayDotRing * size) / 2} fill={CLOCK_COLORS.dayDotRing} />
+						<Circle cx={center} cy={dotCenterY} r={(CLOCK_PROPORTIONS.dayDot * size) / 2} fill={CLOCK_COLORS.dayDot} />
+					</G>
+				</>
+			)}
 			<G rotation={yearAngle} origin={`${center}, ${center}`}>
 				<Rect
 					x={center - markWidth / 2}
@@ -37,10 +78,6 @@ export default function YearClock({ size, date }: Readonly<YearClockProps>) {
 					rx={markWidth / 2}
 					fill={CLOCK_COLORS.yearMark}
 				/>
-			</G>
-			<G rotation={dayAngle} origin={`${center}, ${center}`}>
-				<Circle cx={center} cy={dotCenterY} r={(CLOCK_PROPORTIONS.dayDotRing * size) / 2} fill={CLOCK_COLORS.dayDotRing} />
-				<Circle cx={center} cy={dotCenterY} r={(CLOCK_PROPORTIONS.dayDot * size) / 2} fill={CLOCK_COLORS.dayDot} />
 			</G>
 		</Svg>
 	);

--- a/apps/tag-und-jahr/frontend/config.ts
+++ b/apps/tag-und-jahr/frontend/config.ts
@@ -13,8 +13,9 @@ export type CustomerConfig = {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	// 2: Drawer navigation, settings screen and the experimental food widget.
-	return 2;
+	// 3: Photo-grid food widget (content margins disabled - native change)
+	// and clock themes (year start, sun/moon day display).
+	return 3;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion

--- a/apps/tag-und-jahr/frontend/helpers/clock.ts
+++ b/apps/tag-und-jahr/frontend/helpers/clock.ts
@@ -61,3 +61,37 @@ export function getDayAngleDegrees(date: Date): number {
 export function getYearAngleDegrees(date: Date): number {
 	return getYearFraction(date) * 360;
 }
+
+/**
+ * Fraction [0, 1) of the calendar year (1 January to 1 January) that has
+ * passed - the alternative "Neujahr" year start.
+ */
+export function getCalendarYearFraction(date: Date): number {
+	const startOfYear = new Date(date.getFullYear(), 0, 1);
+	const startOfNextYear = new Date(date.getFullYear() + 1, 0, 1);
+	return (date.getTime() - startOfYear.getTime()) / (startOfNextYear.getTime() - startOfYear.getTime());
+}
+
+/**
+ * Year mark angle for a configurable year start: 'spring' anchors 21 March at
+ * twelve o'clock, 'newyear' anchors 1 January there.
+ */
+export function getYearAngleDegreesFor(date: Date, yearStart: 'spring' | 'newyear'): number {
+	return (yearStart === 'newyear' ? getCalendarYearFraction(date) : getYearFraction(date)) * 360;
+}
+
+/**
+ * Sun angle in degrees for the "Sonne & Mond" day display: one full clockwise
+ * revolution per 24h, anchored at the LEFT horizon point at 06:00 local time
+ * (so 12:00 = top, 18:00 = right horizon, 00:00 = bottom, i.e. below the
+ * horizon). The moon is the same motion shifted by 12 hours.
+ */
+export function getSunAngleDegrees(date: Date): number {
+	const hoursSinceSix = (getDayFraction(date) * 24 - 6 + 24) % 24;
+	return (hoursSinceSix / 24) * 360;
+}
+
+/** Moon angle: the sun's motion shifted by 12 hours (above horizon 18:00-06:00). */
+export function getMoonAngleDegrees(date: Date): number {
+	return (getSunAngleDegrees(date) + 180) % 360;
+}

--- a/apps/tag-und-jahr/frontend/helpers/clockSettings.ts
+++ b/apps/tag-und-jahr/frontend/helpers/clockSettings.ts
@@ -1,0 +1,44 @@
+import Storage from 'expo-sqlite/kv-store';
+
+// Persisted display options of the year clock (app screen AND widget - the
+// widget receives them as timeline props, since a widget cannot read the app
+// storage itself).
+
+/** Which date sits at twelve o'clock for the red year mark. */
+export type YearStart = 'spring' | 'newyear';
+
+/** How the day is displayed: the classic dot or a sun/moon horizon scene. */
+export type DayDisplay = 'progress' | 'sunmoon';
+
+export type ClockSettings = {
+	yearStart: YearStart;
+	dayDisplay: DayDisplay;
+};
+
+export const DEFAULT_CLOCK_SETTINGS: ClockSettings = {
+	yearStart: 'spring',
+	dayDisplay: 'progress',
+};
+
+const STORAGE_KEY = 'clockSettings.v1';
+
+export async function loadClockSettingsAsync(): Promise<ClockSettings> {
+	try {
+		const raw = await Storage.getItem(STORAGE_KEY);
+		if (!raw) {
+			return DEFAULT_CLOCK_SETTINGS;
+		}
+		const parsed = JSON.parse(raw) as Partial<ClockSettings>;
+		return {
+			yearStart: parsed.yearStart === 'newyear' ? 'newyear' : 'spring',
+			dayDisplay: parsed.dayDisplay === 'sunmoon' ? 'sunmoon' : 'progress',
+		};
+	} catch (error) {
+		console.warn('[clockSettings] load failed:', error);
+		return DEFAULT_CLOCK_SETTINGS;
+	}
+}
+
+export async function saveClockSettingsAsync(settings: ClockSettings): Promise<void> {
+	await Storage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}

--- a/apps/tag-und-jahr/frontend/helpers/foodApi.ts
+++ b/apps/tag-und-jahr/frontend/helpers/foodApi.ts
@@ -82,7 +82,7 @@ export function getMealImageUrl(offer: RawFoodoffer, serverUrl: string): string 
 	const image = offer.food?.image;
 	const fileId = typeof image === 'string' ? image : image?.id;
 	if (fileId) {
-		return `${serverUrl}/assets/${fileId}?width=160&height=160&fit=cover&quality=60`;
+		return `${serverUrl}/assets/${fileId}?width=512&height=512&fit=cover&quality=70`;
 	}
 	return offer.food?.image_remote_url ?? undefined;
 }

--- a/apps/tag-und-jahr/frontend/helpers/widgetSync.ts
+++ b/apps/tag-und-jahr/frontend/helpers/widgetSync.ts
@@ -1,21 +1,32 @@
 import { Platform } from 'react-native';
+import { ClockSettings, DEFAULT_CLOCK_SETTINGS } from './clockSettings';
 import { fetchTodaysMealsAsync, Meal, paginateMeals } from './foodApi';
 import { getFoodServer } from './foodServers';
 import { FoodWidgetSettings, loadFoodWidgetSettingsAsync } from './foodWidgetSettings';
 
-// WidgetKit does not guarantee minute-precise rendering. The app therefore
-// schedules timeline states every 30 minutes; iOS decides when it actually
-// renders them. For a contemplative object this fuzziness is acceptable.
+// WidgetKit does not guarantee minute-precise rendering. The clock widget
+// schedules states every 30 minutes; iOS decides when it actually renders
+// them. For a contemplative object this fuzziness is acceptable.
 export const TIMELINE_STEP_MINUTES = 30;
 
-// How far into the future the timeline reaches. After that the widget shows
-// its last state until the app is opened again (the timeline is refreshed on
-// every app start and foreground activation).
+// How far into the future the clock timeline reaches. After that the widget
+// shows its last state until the app is opened again (the timeline is
+// refreshed on every app start and foreground activation).
 export const TIMELINE_DAYS = 7;
 
+// Auto-pagination of the food widget: the timeline advances to the next page
+// every 10 seconds for the first hour after a sync, afterwards once per
+// minute until the end of the day (keeps the entry count bounded). NOTE:
+// WidgetKit treats entry dates as the EARLIEST render moment and may coalesce
+// sub-minute entries depending on system budget - the timeline offers the
+// 10s cadence, iOS decides how closely it follows it.
+export const FOOD_FAST_STEP_SECONDS = 10;
+export const FOOD_FAST_WINDOW_MINUTES = 60;
+export const FOOD_SLOW_STEP_SECONDS = 60;
+
 /**
- * The dates of all timeline entries: every half hour boundary from the most
- * recent one until TIMELINE_DAYS from now. Pure function for testability.
+ * The dates of all clock timeline entries: every half hour boundary from the
+ * most recent one until TIMELINE_DAYS from now. Pure function for testability.
  */
 export function getTimelineEntryDates(now: Date, days: number = TIMELINE_DAYS): Date[] {
 	const stepMs = TIMELINE_STEP_MINUTES * 60 * 1000;
@@ -29,12 +40,31 @@ export function getTimelineEntryDates(now: Date, days: number = TIMELINE_DAYS): 
 }
 
 /**
- * Registers the year clock widget and schedules its timeline. iOS only - on
- * Android and web this is a no-op (expo-widgets ships stubs, but the widget
- * layout uses @expo/ui/swift-ui, which only exists on iOS, so the module stays
- * unloaded).
+ * The dates of the food widget timeline entries: 10-second steps for the
+ * first hour, one-minute steps afterwards, all capped at the end of today.
+ * Pure function for testability.
  */
-export function syncWidgetTimeline(now: Date = new Date()): void {
+export function getFoodTimelineEntryDates(now: Date): Date[] {
+	const endOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).getTime();
+	const fastUntil = Math.min(now.getTime() + FOOD_FAST_WINDOW_MINUTES * 60 * 1000, endOfDay);
+	const dates: Date[] = [];
+	for (let time = now.getTime(); time < fastUntil; time += FOOD_FAST_STEP_SECONDS * 1000) {
+		dates.push(new Date(time));
+	}
+	for (let time = fastUntil; time < endOfDay; time += FOOD_SLOW_STEP_SECONDS * 1000) {
+		dates.push(new Date(time));
+	}
+	return dates;
+}
+
+/**
+ * Registers the year clock widget and schedules its timeline with the given
+ * display options as props (the widget cannot read the app storage itself).
+ * iOS only - on Android and web this is a no-op (expo-widgets ships stubs,
+ * but the widget layout uses @expo/ui/swift-ui, which only exists on iOS,
+ * so the module stays unloaded).
+ */
+export function syncWidgetTimeline(clockSettings: ClockSettings = DEFAULT_CLOCK_SETTINGS, now: Date = new Date()): void {
 	if (Platform.OS !== 'ios') {
 		return;
 	}
@@ -42,16 +72,17 @@ export function syncWidgetTimeline(now: Date = new Date()): void {
 	// registers the layout with the native ExpoWidgets module.
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const widget = require('../widgets/TagUndJahrWidget').default;
-	// The widget derives everything from the entry date, so the props are empty.
-	widget.updateTimeline(getTimelineEntryDates(now).map((date) => ({ date, props: {} })));
+	// Time derives from the entry date; the props carry the display options.
+	const props = { yearStart: clockSettings.yearStart, dayDisplay: clockSettings.dayDisplay };
+	widget.updateTimeline(getTimelineEntryDates(now).map((date) => ({ date, props })));
 }
 
 /**
  * Downloads the meal photos into the shared app group container
  * (widgetsDirectory) so the widget extension can read them - widgets cannot
  * load network images themselves. Returns the meals with local file paths.
- * Failures are per-image and non-fatal: the widget then simply shows the row
- * without a photo.
+ * Failures are per-image and non-fatal: the widget then shows a placeholder
+ * tile for that meal.
  */
 async function downloadMealImagesAsync(meals: Meal[]): Promise<Meal[]> {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -83,10 +114,10 @@ async function downloadMealImagesAsync(meals: Meal[]): Promise<Meal[]> {
 }
 
 /**
- * Schedules the food widget timeline from already fetched meals. WidgetKit
- * cannot swipe, so when there are more meals than fit on one page the
- * half-hour timeline entries rotate through the pages instead. The timeline
- * only covers today - tomorrow's menu is unknown until the app runs again.
+ * Schedules the food widget timeline from already fetched meals: a pure photo
+ * grid, auto-paginating through the pages (WidgetKit cannot swipe). The
+ * timeline only covers today - tomorrow's menu is unknown until the app runs
+ * again.
  */
 export async function syncFoodWidgetTimelineAsync(settings: FoodWidgetSettings, rawMeals: Meal[], now: Date = new Date()): Promise<void> {
 	if (Platform.OS !== 'ios') {
@@ -96,33 +127,17 @@ export async function syncFoodWidgetTimelineAsync(settings: FoodWidgetSettings, 
 	const widget = require('../widgets/FoodWidget').default;
 	const meals = await downloadMealImagesAsync(rawMeals);
 
-	const updatedAt = `${now.getHours()}:${`${now.getMinutes()}`.padStart(2, '0')}`;
 	const pages = paginateMeals(meals, settings.mealCount);
 	if (pages.length === 0) {
-		widget.updateSnapshot({
-			title: settings.canteenAlias,
-			meals: [],
-			footer: `Keine Speisen heute · ${updatedAt}`,
-		});
+		widget.updateSnapshot({ meals: [] });
 		return;
 	}
 
-	// One entry per half hour until end of day, cycling through the pages.
-	const endOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-	const entryDates = getTimelineEntryDates(now, 1).filter((date) => date < endOfDay);
 	widget.updateTimeline(
-		entryDates.map((date, index) => {
-			const pageIndex = index % pages.length;
-			const pageInfo = pages.length > 1 ? `Seite ${pageIndex + 1}/${pages.length} · ` : '';
-			return {
-				date,
-				props: {
-					title: settings.canteenAlias,
-					meals: pages[pageIndex],
-					footer: `${pageInfo}Stand ${updatedAt}`,
-				},
-			};
-		})
+		getFoodTimelineEntryDates(now).map((date, index) => ({
+			date,
+			props: { meals: pages[index % pages.length] },
+		}))
 	);
 }
 

--- a/apps/tag-und-jahr/frontend/widgets/FoodWidget.tsx
+++ b/apps/tag-und-jahr/frontend/widgets/FoodWidget.tsx
@@ -1,70 +1,90 @@
-import { HStack, Image, Spacer, Text, VStack } from '@expo/ui/swift-ui';
-import { containerBackground, cornerRadius, font, foregroundStyle, frame, lineLimit, padding } from '@expo/ui/swift-ui/modifiers';
+import { HStack, Image, Rectangle, Text, VStack, ZStack } from '@expo/ui/swift-ui';
+import { containerBackground, cornerRadius, font, foregroundStyle, frame, padding, resizable } from '@expo/ui/swift-ui/modifiers';
 import { createWidget, type WidgetEnvironment } from 'expo-widgets';
 
-// Experimental widget: shows today's meals of the configured canteen. The app
-// fetches the data (settings screen / app start), downloads the meal photos
-// into the shared app group container and schedules everything as timeline
-// props - WidgetKit cannot swipe, so when there are more meals than fit on one
-// "page", the timeline rotates through the pages every 30 minutes instead
-// (see helpers/widgetSync.ts).
+// Experimental widget: a pure photo grid of today's meals - no texts, square
+// images filling the widget with light spacing. The app fetches the data,
+// downloads the photos into the shared app group container and schedules the
+// pages as timeline entries: WidgetKit cannot swipe, so the timeline
+// auto-paginates instead (10-second steps for the first hour, then
+// per-minute; iOS may coalesce sub-minute entries depending on its budget -
+// see helpers/widgetSync.ts).
 export type FoodWidgetProps = {
-	/** Canteen name shown as the header. */
-	title?: string;
 	/** Meals of the current page; imagePath is a file:// photo in the app group. */
 	meals?: { name: string; price: string; imagePath?: string }[];
-	/** Small footer line, e.g. "Seite 1/2 · Stand 12:30". */
-	footer?: string;
 };
 
 const FoodWidgetLayout = (props: FoodWidgetProps, environment: WidgetEnvironment) => {
 	'widget';
 	// The 'widget' directive isolates this function: no imports and no module
 	// scope values are available in here, so colors and sizes live inline.
-	// IMPORTANT: the widget renderer drops nested arrays inside mixed children,
-	// so the mapped meal rows must live in their own VStack (sole child = array).
+	// NOTE: the widget renderer drops nested arrays inside mixed children, so
+	// mapped rows/cells always live in their own stack (sole child = array).
 	const isDark = environment.colorScheme === 'dark';
 	const backgroundColor = isDark ? '#1e232e' : '#f6f2e9';
-	const titleColor = isDark ? '#e6a83c' : '#8a5a19';
-	const textColor = isDark ? '#f2f0ea' : '#2b2b28';
+	const placeholderColor = isDark ? '#2c3342' : '#e4ddcd';
 	const mutedColor = isDark ? '#9aa3b2' : '#8b8677';
 
-	const family = environment.widgetFamily;
-	const isSmall = family === 'systemSmall';
-	const titleSize = isSmall ? 11 : 13;
-	const rowSize = isSmall ? 10 : 12;
-	const footerSize = isSmall ? 8 : 10;
-	const photoSize = isSmall ? 18 : 28;
-
 	const meals = props.meals ?? [];
-	const title = props.title ?? 'Speisen heute';
 
-	return (
-		<VStack alignment="leading" spacing={isSmall ? 3 : 5} modifiers={[frame({ maxWidth: 9999, maxHeight: 9999, alignment: 'topLeading' }), padding({ all: isSmall ? 4 : 8 }), containerBackground(backgroundColor, 'widget')]}>
-			<Text modifiers={[font({ size: titleSize, weight: 'bold' }), foregroundStyle(titleColor), lineLimit(1)]}>{title}</Text>
-			{meals.length === 0 ? (
-				<Text modifiers={[font({ size: rowSize }), foregroundStyle(mutedColor)]}>
+	if (meals.length === 0) {
+		return (
+			<ZStack modifiers={[frame({ maxWidth: 9999, maxHeight: 9999 }), containerBackground(backgroundColor, 'widget')]}>
+				<Text modifiers={[font({ size: 11 }), foregroundStyle(mutedColor), padding({ all: 8 })]}>
 					Keine Daten - in der App unter Einstellungen eine Mensa wählen.
 				</Text>
-			) : (
-				<VStack alignment="leading" spacing={isSmall ? 2 : 4}>
-					{meals.map((meal, index) => (
-						<HStack key={`meal-${index}`} spacing={isSmall ? 4 : 6}>
-							{meal.imagePath ? (
-								<Image uiImage={meal.imagePath} modifiers={[frame({ width: photoSize, height: photoSize }), cornerRadius(isSmall ? 4 : 6)]} />
-							) : (
-								<Image systemName="fork.knife" size={photoSize - 6} color={mutedColor} modifiers={[frame({ width: photoSize, height: photoSize })]} />
-							)}
-							<Text modifiers={[font({ size: rowSize }), foregroundStyle(textColor), lineLimit(isSmall ? 1 : 2)]}>{meal.name}</Text>
-							<Spacer />
-							{meal.price ? <Text modifiers={[font({ size: rowSize }), foregroundStyle(mutedColor)]}>{meal.price}</Text> : null}
-						</HStack>
-					))}
-				</VStack>
-			)}
-			<Spacer />
-			{props.footer ? <Text modifiers={[font({ size: footerSize }), foregroundStyle(mutedColor), lineLimit(1)]}>{props.footer}</Text> : null}
-		</VStack>
+			</ZStack>
+		);
+	}
+
+	// Grid geometry: content margins are disabled, so the canvas is roughly the
+	// full widget. Sizes are conservative estimates of the smallest device
+	// variant per family (no GeometryReader in the widget runtime).
+	const family = environment.widgetFamily;
+	const isMedium = family === 'systemMedium';
+	const isLarge = family === 'systemLarge' || family === 'systemExtraLarge';
+	const canvasWidth = isLarge ? 322 : isMedium ? 310 : 148;
+	const canvasHeight = isLarge ? 322 : 148;
+	const spacing = 2;
+
+	// Square-ish grid: on the 2:1 medium widget twice as many columns as rows.
+	const count = meals.length;
+	const columns = Math.max(1, Math.ceil(Math.sqrt(isMedium ? count * 2 : count)));
+	const rows = Math.max(1, Math.ceil(count / columns));
+	const cellSize = Math.floor(
+		Math.min((canvasWidth - spacing * (columns - 1)) / columns, (canvasHeight - spacing * (rows - 1)) / rows)
+	);
+
+	// Chunk the meals into grid rows (plain loops - keep the isolated runtime simple).
+	const gridRows: { name: string; imagePath?: string }[][] = [];
+	for (let index = 0; index < count; index += columns) {
+		gridRows.push(meals.slice(index, index + columns));
+	}
+
+	return (
+		<ZStack modifiers={[frame({ maxWidth: 9999, maxHeight: 9999 }), containerBackground(backgroundColor, 'widget')]}>
+			<VStack spacing={spacing}>
+				{gridRows.map((row, rowIndex) => (
+					<HStack key={`row-${rowIndex}`} spacing={spacing}>
+						{row.map((meal, cellIndex) => (
+							<ZStack key={`cell-${rowIndex}-${cellIndex}`} modifiers={[frame({ width: cellSize, height: cellSize })]}>
+								{meal.imagePath ? (
+									<Image
+										uiImage={meal.imagePath}
+										modifiers={[resizable(), frame({ width: cellSize, height: cellSize }), cornerRadius(4)]}
+									/>
+								) : (
+									<ZStack modifiers={[frame({ width: cellSize, height: cellSize })]}>
+										<Rectangle modifiers={[frame({ width: cellSize, height: cellSize }), foregroundStyle(placeholderColor), cornerRadius(4)]} />
+										<Image systemName="fork.knife" size={Math.max(12, cellSize * 0.3)} color={mutedColor} />
+									</ZStack>
+								)}
+							</ZStack>
+						))}
+					</HStack>
+				))}
+			</VStack>
+		</ZStack>
 	);
 };
 

--- a/apps/tag-und-jahr/frontend/widgets/TagUndJahrWidget.tsx
+++ b/apps/tag-und-jahr/frontend/widgets/TagUndJahrWidget.tsx
@@ -1,13 +1,16 @@
-import { Circle, Capsule, ZStack } from '@expo/ui/swift-ui';
-import { background, containerBackground, foregroundStyle, frame, offset, rotationEffect } from '@expo/ui/swift-ui/modifiers';
+import { Circle, Capsule, Rectangle, ZStack } from '@expo/ui/swift-ui';
+import { background, clipShape, containerBackground, foregroundStyle, frame, offset, rotationEffect } from '@expo/ui/swift-ui/modifiers';
 import { createWidget, type WidgetEnvironment } from 'expo-widgets';
 
-// The widget needs no props: everything derives from the timeline entry date
-// (environment.date). The app only schedules half-hour timeline entries so
-// WidgetKit re-renders regularly (see helpers/widgetSync.ts).
-export type TagUndJahrWidgetProps = object;
+// Display options arrive as timeline props (a widget cannot read the app
+// storage): year start anchor and the day display theme. Defaults match the
+// original design (spring start, progress dot).
+export type TagUndJahrWidgetProps = {
+	yearStart?: 'spring' | 'newyear';
+	dayDisplay?: 'progress' | 'sunmoon';
+};
 
-const TagUndJahrWidgetLayout = (_props: TagUndJahrWidgetProps, environment: WidgetEnvironment) => {
+const TagUndJahrWidgetLayout = (props: TagUndJahrWidgetProps, environment: WidgetEnvironment) => {
 	'widget';
 	// The 'widget' directive isolates this function: no imports and no module
 	// scope values are available in here. The palette, the proportions (see
@@ -19,25 +22,49 @@ const TagUndJahrWidgetLayout = (_props: TagUndJahrWidgetProps, environment: Widg
 	const yearMarkColor = '#c1271c';
 	const dayDotColor = '#2fa6a0';
 	const dayDotRingColor = '#d8dde4';
+	const skyColor = '#4f7fb5';
+	const earthColor = '#6b4a2c';
+	const horizonColor = '#e8e4da';
+	const sunColor = '#f5c84c';
+	const moonColor = '#f2f0ea';
 
 	const date = environment.date instanceof Date ? environment.date : new Date();
+	const yearStart = props.yearStart === 'newyear' ? 'newyear' : 'spring';
+	const dayDisplay = props.dayDisplay === 'sunmoon' ? 'sunmoon' : 'progress';
 
-	// Blue dot: once around per day, clockwise, twelve o'clock at local midnight.
+	// Day fraction since local midnight (mirrors helpers/clock.ts).
 	const secondsSinceMidnight = date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
-	const dayAngle = (secondsSinceMidnight / 86400) * 360;
+	const dayFraction = secondsSinceMidnight / 86400;
+	const dayAngle = dayFraction * 360;
 
-	// Red mark: represents 21 March (start of spring) and travels once around
-	// the circle per year - at the start of spring it stands at twelve o'clock.
-	const springOfSameYear = new Date(date.getFullYear(), 2, 21);
-	const lastSpring = date.getTime() >= springOfSameYear.getTime() ? springOfSameYear : new Date(date.getFullYear() - 1, 2, 21);
-	const nextSpring = new Date(lastSpring.getFullYear() + 1, 2, 21);
-	const yearAngle = ((date.getTime() - lastSpring.getTime()) / (nextSpring.getTime() - lastSpring.getTime())) * 360;
+	// Red year mark: 'spring' anchors 21 March at twelve o'clock, 'newyear'
+	// anchors 1 January there. One revolution per year either way.
+	let yearAngle: number;
+	if (yearStart === 'newyear') {
+		const startOfYear = new Date(date.getFullYear(), 0, 1);
+		const startOfNextYear = new Date(date.getFullYear() + 1, 0, 1);
+		yearAngle = ((date.getTime() - startOfYear.getTime()) / (startOfNextYear.getTime() - startOfYear.getTime())) * 360;
+	} else {
+		const springOfSameYear = new Date(date.getFullYear(), 2, 21);
+		const lastSpring = date.getTime() >= springOfSameYear.getTime() ? springOfSameYear : new Date(date.getFullYear() - 1, 2, 21);
+		const nextSpring = new Date(lastSpring.getFullYear() + 1, 2, 21);
+		yearAngle = ((date.getTime() - lastSpring.getTime()) / (nextSpring.getTime() - lastSpring.getTime())) * 360;
+	}
+
+	// Sun/moon: one clockwise revolution per 24h, anchored at the LEFT horizon
+	// point at 06:00 (12:00 = top, 18:00 = right, night = below the horizon).
+	// The moon is the same motion shifted by 12 hours.
+	const sunAngle = ((((dayFraction * 24 - 6 + 24) % 24) / 24) * 360);
+	const moonAngle = (sunAngle + 180) % 360;
 
 	// Fixed sizes per family: the widget runtime has no GeometryReader, so the
 	// clock diameter is chosen to fit the smallest device variant of each family
 	// (content margins are disabled in the app config).
 	const family = environment.widgetFamily;
 	const diameter = family === 'systemLarge' || family === 'systemExtraLarge' ? 300 : 132;
+	const innerDiameter = diameter * 0.64;
+	const bodySize = innerDiameter * 0.14;
+	const orbitRadius = innerDiameter * 0.36;
 
 	return (
 		<ZStack
@@ -48,29 +75,57 @@ const TagUndJahrWidgetLayout = (_props: TagUndJahrWidgetProps, environment: Widg
 			]}
 		>
 			<Circle modifiers={[frame({ width: diameter, height: diameter }), foregroundStyle(yearDiscColor)]} />
-			<Circle modifiers={[frame({ width: diameter * 0.64, height: diameter * 0.64 }), foregroundStyle(dayDiscColor)]} />
+			{dayDisplay === 'sunmoon' ? (
+				<ZStack modifiers={[frame({ width: innerDiameter, height: innerDiameter }), clipShape('circle')]}>
+					<Circle modifiers={[frame({ width: innerDiameter, height: innerDiameter }), foregroundStyle(skyColor)]} />
+					<Circle
+						modifiers={[
+							frame({ width: bodySize, height: bodySize }),
+							foregroundStyle(sunColor),
+							offset({ x: -orbitRadius }),
+							rotationEffect(sunAngle),
+						]}
+					/>
+					<Circle
+						modifiers={[
+							frame({ width: bodySize, height: bodySize }),
+							foregroundStyle(moonColor),
+							offset({ x: -orbitRadius }),
+							rotationEffect(moonAngle),
+						]}
+					/>
+					<Rectangle
+						modifiers={[frame({ width: innerDiameter, height: innerDiameter / 2 }), foregroundStyle(earthColor), offset({ y: innerDiameter / 4 })]}
+					/>
+					<Rectangle modifiers={[frame({ width: innerDiameter, height: 1.5 }), foregroundStyle(horizonColor)]} />
+				</ZStack>
+			) : (
+				<ZStack modifiers={[frame({ width: innerDiameter, height: innerDiameter })]}>
+					<Circle modifiers={[frame({ width: innerDiameter, height: innerDiameter }), foregroundStyle(dayDiscColor)]} />
+					<Circle
+						modifiers={[
+							frame({ width: diameter * 0.072, height: diameter * 0.072 }),
+							foregroundStyle(dayDotRingColor),
+							offset({ y: -diameter * 0.2 }),
+							rotationEffect(dayAngle),
+						]}
+					/>
+					<Circle
+						modifiers={[
+							frame({ width: diameter * 0.056, height: diameter * 0.056 }),
+							foregroundStyle(dayDotColor),
+							offset({ y: -diameter * 0.2 }),
+							rotationEffect(dayAngle),
+						]}
+					/>
+				</ZStack>
+			)}
 			<Capsule
 				modifiers={[
 					frame({ width: diameter * 0.035, height: diameter * 0.1 }),
 					foregroundStyle(yearMarkColor),
 					offset({ y: -diameter * 0.41 }),
 					rotationEffect(yearAngle),
-				]}
-			/>
-			<Circle
-				modifiers={[
-					frame({ width: diameter * 0.072, height: diameter * 0.072 }),
-					foregroundStyle(dayDotRingColor),
-					offset({ y: -diameter * 0.2 }),
-					rotationEffect(dayAngle),
-				]}
-			/>
-			<Circle
-				modifiers={[
-					frame({ width: diameter * 0.056, height: diameter * 0.056 }),
-					foregroundStyle(dayDotColor),
-					offset({ y: -diameter * 0.2 }),
-					rotationEffect(dayAngle),
 				]}
 			/>
 		</ZStack>


### PR DESCRIPTION
## Food-Widget: reines Foto-Raster mit Auto-Pagination

- **Nur noch Bilder**: quadratische, skalierte Fotos (`resizable`) mit 2 pt Spacing, kein Mensa-Name, kein Footer. Das Raster passt sich der Widget-Familie an (medium: doppelt so viele Spalten wie Zeilen), Content-Margins sind deaktiviert, damit die Bilder den Platz maximal füllen. Fotos werden jetzt in 512 px geladen.
- **Auto-Pagination**: Timeline-Einträge im **10-Sekunden-Takt** für die erste Stunde nach einem Sync, danach minütlich bis Tagesende. Wichtige Ehrlichkeit dazu: WidgetKit behandelt Eintragszeiten als *frühesten* Renderzeitpunkt und darf Wechsel je nach System-Budget zusammenfassen — die 10 Sekunden sind ein Angebot an iOS, keine Garantie (dokumentiert in README und Settings-Screen).

## Uhr-Themes (gelten für App und Widget)

Neue Sektion „Uhr" in den Einstellungen; das Widget bekommt die Optionen als Timeline-Props (Widgets können den App-Speicher nicht lesen):

- **Jahresbeginn (oben)**: Frühling (21.03., Standard) oder **Neujahr (01.01.)** als Zwölf-Uhr-Anker des roten Strichs.
- **Tagesanzeige**: „Tagesfortschritt" (blauer Punkt) oder **„Sonne & Mond"**: innere Scheibe mit Himmel oben, Erde unten, Horizontlinie dazwischen. Die Sonne wandert von 06:00 (links) über den Zenit (12:00) nach 18:00 (rechts), der Mond um 12 h versetzt durch die Nacht; unter dem Horizont verschwinden beide hinter der Erde (Erd-Hälfte wird über den Körpern gezeichnet, die Scheibe per `clipShape('circle')` beschnitten). Identisch in der In-App-SVG-Ansicht umgesetzt.

## Version: Build 2 → 3 (0.3.0)

Das Deaktivieren der Content-Margins ist eine **native** Änderung (generierter Widget-Swift-Code) und braucht einen neuen Build. Bewusst Build-Nummer statt Patch erhöht: Ein reiner Patch-Bump hätte die an `appVersion` gekoppelte `runtimeVersion` geändert und das OTA-Update am installierten Build vorbeilaufen lassen, ohne dass die CI einen neuen Build erzeugt hätte. Der Merge löst den TestFlight-Build 0.3.0 aus.

## Verifikation

- Jest: 29 Tests grün (neu: Sonne/Mond-Winkel-Anker, Neujahr-Jahresanker, 10-s/60-s-Timeline-Kadenz mit Tagesende-Grenze).
- `tsc --noEmit` ✅, `expo config` (Version 0.3.0, Margins beider Widgets) ✅, voller `expo export --platform ios` ✅.
- Renderer-Beschränkungen beachtet: gemappte Zellen/Zeilen liegen jeweils als einziges Kind in eigenen Stacks (der Widget-Renderer verwirft verschachtelte Arrays in gemischten Kindern); `resizable`/`clipShape` in der Swift-Modifier-Registry verifiziert.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_