### PR TITLE
feat: randloses Food-Grid mit Platzhaltern + Widget-Vorschau im Settings-Screen

### DIFF
--- a/apps/tag-und-jahr/frontend/__tests__/gridLayout.test.ts
+++ b/apps/tag-und-jahr/frontend/__tests__/gridLayout.test.ts
@@ -1,0 +1,33 @@
+import { computeGridLayout } from '../helpers/gridLayout';
+
+describe('computeGridLayout', () => {
+	it('lays out 4 items as an exact 2x2 grid on a square canvas', () => {
+		const layout = computeGridLayout(4, 160, 160, 2);
+		expect(layout.columns).toBe(2);
+		expect(layout.rows).toBe(2);
+		expect(layout.cellCount).toBe(4);
+		expect(layout.cellSize).toBe(79);
+	});
+
+	it('pads 3 items on a square canvas to a 2x2 grid with one placeholder', () => {
+		const layout = computeGridLayout(3, 160, 160, 2);
+		expect(layout.columns).toBe(2);
+		expect(layout.rows).toBe(2);
+		expect(layout.cellCount).toBe(4);
+	});
+
+	it('covers the canvas in both dimensions (bleed, never letterbox)', () => {
+		const spacing = 2;
+		for (const count of [2, 3, 4, 5, 6, 8]) {
+			const layout = computeGridLayout(count, 348, 160, spacing);
+			const gridWidth = layout.columns * layout.cellSize + spacing * (layout.columns - 1);
+			const gridHeight = layout.rows * layout.cellSize + spacing * (layout.rows - 1);
+			expect(gridWidth).toBeGreaterThanOrEqual(348);
+			expect(gridHeight).toBeGreaterThanOrEqual(160);
+		}
+	});
+
+	it('returns an empty layout for zero items', () => {
+		expect(computeGridLayout(0, 160, 160, 2).cellCount).toBe(0);
+	});
+});

--- a/apps/tag-und-jahr/frontend/app/settings/index.tsx
+++ b/apps/tag-und-jahr/frontend/app/settings/index.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { Canteen, fetchCanteensAsync, fetchTodaysMealsAsync, Meal } from '../../helpers/foodApi';
 import { FOOD_SERVERS, FoodServerKey, getFoodServer } from '../../helpers/foodServers';
 import { loadFoodWidgetSettingsAsync, saveFoodWidgetSettingsAsync } from '../../helpers/foodWidgetSettings';
 import { CLOCK_COLORS } from '../../helpers/clockDesign';
 import { ClockSettings, DEFAULT_CLOCK_SETTINGS, loadClockSettingsAsync, saveClockSettingsAsync } from '../../helpers/clockSettings';
 import { syncFoodWidgetTimelineAsync, syncWidgetTimeline } from '../../helpers/widgetSync';
+import { ClockWidgetPreview, FoodWidgetPreview } from '../../components/WidgetPreview';
 
 const MEAL_COUNT_OPTIONS = [2, 4, 6, 8];
 
@@ -13,6 +14,8 @@ const MEAL_COUNT_OPTIONS = [2, 4, 6, 8];
 // many meals the food widget shows at once, then push today's menu into the
 // widget timeline. Deliberately no caching - data is fetched fresh on demand.
 export default function Settings() {
+	const { width } = useWindowDimensions();
+	const [previewKind, setPreviewKind] = useState<'clock' | 'food'>('clock');
 	const [clockSettings, setClockSettings] = useState<ClockSettings>(DEFAULT_CLOCK_SETTINGS);
 	const [serverKey, setServerKey] = useState<FoodServerKey | null>(null);
 	const [canteens, setCanteens] = useState<Canteen[]>([]);
@@ -77,6 +80,29 @@ export default function Settings() {
 		};
 	}, [serverKey]);
 
+	// Load today's meals for the preview as soon as server and canteen are
+	// known (hydrated from storage or freshly picked) - no caching, the
+	// preview simply reflects what the widget would show.
+	useEffect(() => {
+		const server = getFoodServer(serverKey ?? undefined);
+		if (!server || !canteenId) {
+			return;
+		}
+		let cancelled = false;
+		fetchTodaysMealsAsync(server.serverUrl, canteenId)
+			.then((loaded) => {
+				if (!cancelled) {
+					setMeals(loaded);
+				}
+			})
+			.catch(() => {
+				// Preview only - errors surface via the explicit button flow.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [serverKey, canteenId]);
+
 	const applyToWidget = useCallback(async () => {
 		const server = getFoodServer(serverKey ?? undefined);
 		const canteen = canteens.find((entry) => entry.id === canteenId);
@@ -105,9 +131,28 @@ export default function Settings() {
 		}
 	}, [serverKey, canteens, canteenId, mealCount]);
 
+	const previewSize = Math.min(width - 40, 329);
+
 	return (
 		<ScrollView style={styles.container} contentContainerStyle={styles.content}>
-			<Text style={styles.heading}>Uhr</Text>
+			<Text style={styles.heading}>Widget-Vorschau</Text>
+			<View style={styles.chipRow}>
+				<Chip label="Kalender" selected={previewKind === 'clock'} onPress={() => setPreviewKind('clock')} />
+				<Chip label="Food-Widget" selected={previewKind === 'food'} onPress={() => setPreviewKind('food')} />
+			</View>
+			<View style={styles.previewContainer}>
+				{previewKind === 'clock' ? (
+					<ClockWidgetPreview size={previewSize} settings={clockSettings} />
+				) : (
+					<FoodWidgetPreview size={previewSize} meals={meals ?? []} mealsPerPage={mealCount} />
+				)}
+			</View>
+			<Text style={styles.hint}>
+				So sieht das Widget mit den aktuellen Einstellungen aus. Das Food-Widget blättert hier live alle 10 Sekunden - auf dem
+				Home-Bildschirm bietet die Timeline iOS denselben Takt an, das System darf Wechsel aber zusammenfassen.
+			</Text>
+
+			<Text style={[styles.heading, styles.headingSpaced]}>Uhr</Text>
 			<Text style={styles.sectionTitle}>Jahresbeginn (oben)</Text>
 			<View style={styles.chipRow}>
 				<Chip label="Frühling (21.03.)" selected={clockSettings.yearStart === 'spring'} onPress={() => updateClockSettings({ yearStart: 'spring' })} />
@@ -226,6 +271,10 @@ const styles = StyleSheet.create({
 	},
 	headingSpaced: {
 		marginTop: 32,
+	},
+	previewContainer: {
+		marginTop: 12,
+		marginBottom: 4,
 	},
 	hint: {
 		color: '#c8cfdc',

--- a/apps/tag-und-jahr/frontend/components/WidgetPreview.tsx
+++ b/apps/tag-und-jahr/frontend/components/WidgetPreview.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import YearClock from './YearClock';
+import { ClockSettings } from '../helpers/clockSettings';
+import { Meal, paginateMeals } from '../helpers/foodApi';
+import { computeGridLayout } from '../helpers/gridLayout';
+
+// In-app preview of the home screen widgets ("Playbook"): a square canvas the
+// size of a large widget that mimics what the configured widget will look
+// like - the year clock with the chosen theme, or the food photo grid with
+// live auto-pagination (10s, like the widget timeline offers to iOS).
+
+const CLOCK_BACKGROUND = '#5d6b85';
+const FOOD_BACKGROUND_DARK = '#1e232e';
+const PLACEHOLDER_DARK = '#2c3342';
+
+export function ClockWidgetPreview({ size, settings }: Readonly<{ size: number; settings: ClockSettings }>) {
+	const [now, setNow] = useState(() => new Date());
+	useEffect(() => {
+		const interval = setInterval(() => setNow(new Date()), 60 * 1000);
+		return () => clearInterval(interval);
+	}, []);
+	return (
+		<View style={[styles.canvas, { width: size, height: size, backgroundColor: CLOCK_BACKGROUND }]}>
+			<YearClock size={size * 0.9} date={now} settings={settings} />
+		</View>
+	);
+}
+
+export function FoodWidgetPreview({ size, meals, mealsPerPage }: Readonly<{ size: number; meals: Meal[]; mealsPerPage: number }>) {
+	const pages = useMemo(() => paginateMeals(meals, mealsPerPage), [meals, mealsPerPage]);
+	const [pageIndex, setPageIndex] = useState(0);
+
+	// Live auto-pagination like the widget timeline offers to iOS: next page
+	// every 10 seconds.
+	useEffect(() => {
+		setPageIndex(0);
+		if (pages.length <= 1) {
+			return;
+		}
+		const interval = setInterval(() => setPageIndex((previous) => (previous + 1) % pages.length), 10 * 1000);
+		return () => clearInterval(interval);
+	}, [pages.length]);
+
+	if (pages.length === 0) {
+		return (
+			<View style={[styles.canvas, { width: size, height: size, backgroundColor: FOOD_BACKGROUND_DARK }]}>
+				<Text style={styles.emptyText}>Keine Daten - unten Server und Mensa wählen und Speisen laden.</Text>
+			</View>
+		);
+	}
+
+	const page = pages[Math.min(pageIndex, pages.length - 1)];
+	const spacing = 2;
+	const layout = computeGridLayout(page.length, size, size, spacing);
+	const cells: (Meal | null)[] = [];
+	for (let index = 0; index < layout.cellCount; index++) {
+		cells.push(index < page.length ? page[index] : null);
+	}
+
+	return (
+		<View style={[styles.canvas, { width: size, height: size, backgroundColor: FOOD_BACKGROUND_DARK }]}>
+			<View style={{ width: layout.columns * layout.cellSize + spacing * (layout.columns - 1), flexDirection: 'row', flexWrap: 'wrap', gap: spacing }}>
+				{cells.map((meal, index) => (
+					<View key={`cell-${index}`} style={{ width: layout.cellSize, height: layout.cellSize, backgroundColor: PLACEHOLDER_DARK }}>
+						{meal?.imageUrl ? <Image source={{ uri: meal.imageUrl }} style={styles.cellImage} resizeMode="cover" /> : null}
+						{meal && !meal.imageUrl ? <Text style={styles.cellFallback}>🍴</Text> : null}
+					</View>
+				))}
+			</View>
+			{pages.length > 1 ? (
+				<Text style={styles.pageBadge}>
+					{Math.min(pageIndex, pages.length - 1) + 1}/{pages.length}
+				</Text>
+			) : null}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	canvas: {
+		borderRadius: 24,
+		overflow: 'hidden',
+		alignItems: 'center',
+		justifyContent: 'center',
+		alignSelf: 'center',
+	},
+	emptyText: {
+		color: '#9aa3b2',
+		fontSize: 12,
+		textAlign: 'center',
+		paddingHorizontal: 16,
+	},
+	cellImage: {
+		width: '100%',
+		height: '100%',
+	},
+	cellFallback: {
+		flex: 1,
+		textAlign: 'center',
+		textAlignVertical: 'center',
+		fontSize: 24,
+		opacity: 0.5,
+	},
+	pageBadge: {
+		position: 'absolute',
+		right: 8,
+		bottom: 6,
+		color: 'rgba(255,255,255,0.8)',
+		fontSize: 11,
+		backgroundColor: 'rgba(0,0,0,0.35)',
+		paddingHorizontal: 6,
+		paddingVertical: 2,
+		borderRadius: 8,
+		overflow: 'hidden',
+	},
+});

--- a/apps/tag-und-jahr/frontend/helpers/gridLayout.ts
+++ b/apps/tag-und-jahr/frontend/helpers/gridLayout.ts
@@ -1,0 +1,42 @@
+// Shared grid geometry of the food widget: used by the in-app preview and
+// (inline-duplicated, the 'widget' directive forbids imports) by
+// widgets/FoodWidget.tsx - keep both in sync.
+
+export type GridLayout = {
+	columns: number;
+	rows: number;
+	/** Edge length of the square cells. */
+	cellSize: number;
+	/** Total cells of the full grid; cells beyond the item count are placeholders. */
+	cellCount: number;
+};
+
+/**
+ * Square cells covering the whole canvas: for each possible row count the
+ * cell size is chosen so the grid covers the canvas in BOTH dimensions
+ * (tiles may bleed past the edge - the widget mask clips them), and the
+ * (columns, rows) combination with the least total overshoot wins. The grid
+ * is always filled up completely - e.g. 3 items on a square canvas become a
+ * 2x2 grid with one placeholder cell, never a centered orphan row.
+ */
+export function computeGridLayout(count: number, canvasWidth: number, canvasHeight: number, spacing: number): GridLayout {
+	if (count <= 0 || canvasWidth <= 0 || canvasHeight <= 0) {
+		return { columns: 0, rows: 0, cellSize: 0, cellCount: 0 };
+	}
+	let best: GridLayout = { columns: count, rows: 1, cellSize: canvasHeight, cellCount: count };
+	let bestOvershoot = Number.POSITIVE_INFINITY;
+	for (let rows = 1; rows <= count; rows++) {
+		const columns = Math.ceil(count / rows);
+		const cellSize = Math.ceil(
+			Math.max((canvasWidth - spacing * (columns - 1)) / columns, (canvasHeight - spacing * (rows - 1)) / rows)
+		);
+		const gridWidth = columns * cellSize + spacing * (columns - 1);
+		const gridHeight = rows * cellSize + spacing * (rows - 1);
+		const overshoot = gridWidth - canvasWidth + (gridHeight - canvasHeight);
+		if (overshoot < bestOvershoot) {
+			bestOvershoot = overshoot;
+			best = { columns, rows, cellSize, cellCount: columns * rows };
+		}
+	}
+	return best;
+}

--- a/apps/tag-und-jahr/frontend/helpers/widgetSync.ts
+++ b/apps/tag-und-jahr/frontend/helpers/widgetSync.ts
@@ -15,14 +15,19 @@ export const TIMELINE_STEP_MINUTES = 30;
 export const TIMELINE_DAYS = 7;
 
 // Auto-pagination of the food widget: the timeline advances to the next page
-// every 10 seconds for the first hour after a sync, afterwards once per
-// minute until the end of the day (keeps the entry count bounded). NOTE:
-// WidgetKit treats entry dates as the EARLIEST render moment and may coalesce
-// sub-minute entries depending on system budget - the timeline offers the
-// 10s cadence, iOS decides how closely it follows it.
+// every 10 seconds for the first 15 minutes after a sync, then once per
+// minute for three hours, then every 30 minutes until the end of the day.
+// The tapering keeps the total entry count around ~300 - the widget
+// extension parses the WHOLE stored timeline on every reload, and thousands
+// of entries can blow its tight memory/time budget (blank/black widget).
+// NOTE: WidgetKit treats entry dates as the EARLIEST render moment and may
+// coalesce sub-minute entries depending on system budget - the timeline
+// offers the 10s cadence, iOS decides how closely it follows it.
 export const FOOD_FAST_STEP_SECONDS = 10;
-export const FOOD_FAST_WINDOW_MINUTES = 60;
+export const FOOD_FAST_WINDOW_MINUTES = 15;
 export const FOOD_SLOW_STEP_SECONDS = 60;
+export const FOOD_SLOW_WINDOW_MINUTES = 180;
+export const FOOD_TAIL_STEP_SECONDS = 30 * 60;
 
 /**
  * The dates of all clock timeline entries: every half hour boundary from the
@@ -47,11 +52,15 @@ export function getTimelineEntryDates(now: Date, days: number = TIMELINE_DAYS): 
 export function getFoodTimelineEntryDates(now: Date): Date[] {
 	const endOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).getTime();
 	const fastUntil = Math.min(now.getTime() + FOOD_FAST_WINDOW_MINUTES * 60 * 1000, endOfDay);
+	const slowUntil = Math.min(fastUntil + FOOD_SLOW_WINDOW_MINUTES * 60 * 1000, endOfDay);
 	const dates: Date[] = [];
 	for (let time = now.getTime(); time < fastUntil; time += FOOD_FAST_STEP_SECONDS * 1000) {
 		dates.push(new Date(time));
 	}
-	for (let time = fastUntil; time < endOfDay; time += FOOD_SLOW_STEP_SECONDS * 1000) {
+	for (let time = fastUntil; time < slowUntil; time += FOOD_SLOW_STEP_SECONDS * 1000) {
+		dates.push(new Date(time));
+	}
+	for (let time = slowUntil; time < endOfDay; time += FOOD_TAIL_STEP_SECONDS * 1000) {
 		dates.push(new Date(time));
 	}
 	return dates;

--- a/apps/tag-und-jahr/frontend/widgets/FoodWidget.tsx
+++ b/apps/tag-und-jahr/frontend/widgets/FoodWidget.tsx
@@ -1,14 +1,15 @@
 import { HStack, Image, Rectangle, Text, VStack, ZStack } from '@expo/ui/swift-ui';
-import { containerBackground, cornerRadius, font, foregroundStyle, frame, padding, resizable } from '@expo/ui/swift-ui/modifiers';
+import { containerBackground, font, foregroundStyle, frame, padding, resizable } from '@expo/ui/swift-ui/modifiers';
 import { createWidget, type WidgetEnvironment } from 'expo-widgets';
 
-// Experimental widget: a pure photo grid of today's meals - no texts, square
-// images filling the widget with light spacing. The app fetches the data,
-// downloads the photos into the shared app group container and schedules the
-// pages as timeline entries: WidgetKit cannot swipe, so the timeline
-// auto-paginates instead (10-second steps for the first hour, then
-// per-minute; iOS may coalesce sub-minute entries depending on its budget -
-// see helpers/widgetSync.ts).
+// Experimental widget: a pure photo grid of today's meals - square,
+// edge-to-edge images with a light 2pt gap. No corner radius on the tiles:
+// the widget's own mask rounds the outer corners, and the tiles may bleed
+// slightly past the edge (the canvas estimate errs on the large side).
+// Incomplete pages are padded with placeholder tiles so e.g. 3 meals on a
+// square widget render as a 2x2 grid with one dummy cell instead of a
+// centered orphan. Auto-pagination happens via timeline entries (see
+// helpers/widgetSync.ts).
 export type FoodWidgetProps = {
 	/** Meals of the current page; imagePath is a file:// photo in the app group. */
 	meals?: { name: string; price: string; imagePath?: string }[];
@@ -17,7 +18,8 @@ export type FoodWidgetProps = {
 const FoodWidgetLayout = (props: FoodWidgetProps, environment: WidgetEnvironment) => {
 	'widget';
 	// The 'widget' directive isolates this function: no imports and no module
-	// scope values are available in here, so colors and sizes live inline.
+	// scope values are available in here, so colors, sizes and the grid math
+	// (mirrors helpers/gridLayout.ts) live inline.
 	// NOTE: the widget renderer drops nested arrays inside mixed children, so
 	// mapped rows/cells always live in their own stack (sole child = array).
 	const isDark = environment.colorScheme === 'dark';
@@ -37,28 +39,46 @@ const FoodWidgetLayout = (props: FoodWidgetProps, environment: WidgetEnvironment
 		);
 	}
 
-	// Grid geometry: content margins are disabled, so the canvas is roughly the
-	// full widget. Sizes are conservative estimates of the smallest device
-	// variant per family (no GeometryReader in the widget runtime).
+	// Canvas estimates err on the LARGE side so the grid always covers the
+	// whole widget - overflow is clipped by the widget mask (deliberate bleed).
 	const family = environment.widgetFamily;
 	const isMedium = family === 'systemMedium';
 	const isLarge = family === 'systemLarge' || family === 'systemExtraLarge';
-	const canvasWidth = isLarge ? 322 : isMedium ? 310 : 148;
-	const canvasHeight = isLarge ? 322 : 148;
+	const canvasWidth = isLarge ? 358 : isMedium ? 348 : 160;
+	const canvasHeight = isLarge ? 358 : 160;
 	const spacing = 2;
 
-	// Square-ish grid: on the 2:1 medium widget twice as many columns as rows.
+	// Grid math - mirrors helpers/gridLayout.ts: square cells covering the
+	// whole canvas in both dimensions (tiles may bleed, the widget mask
+	// clips), picking the (columns, rows) combination with the least total
+	// overshoot. The grid is always filled up completely with placeholders.
 	const count = meals.length;
-	const columns = Math.max(1, Math.ceil(Math.sqrt(isMedium ? count * 2 : count)));
-	const rows = Math.max(1, Math.ceil(count / columns));
-	const cellSize = Math.floor(
-		Math.min((canvasWidth - spacing * (columns - 1)) / columns, (canvasHeight - spacing * (rows - 1)) / rows)
-	);
+	let columns = count;
+	let rows = 1;
+	let cellSize = canvasHeight;
+	let bestOvershoot = Number.POSITIVE_INFINITY;
+	for (let tryRows = 1; tryRows <= count; tryRows++) {
+		const tryColumns = Math.ceil(count / tryRows);
+		const tryCell = Math.ceil(
+			Math.max((canvasWidth - spacing * (tryColumns - 1)) / tryColumns, (canvasHeight - spacing * (tryRows - 1)) / tryRows)
+		);
+		const overshoot = tryColumns * tryCell + spacing * (tryColumns - 1) - canvasWidth + (tryRows * tryCell + spacing * (tryRows - 1) - canvasHeight);
+		if (overshoot < bestOvershoot) {
+			bestOvershoot = overshoot;
+			columns = tryColumns;
+			rows = tryRows;
+			cellSize = tryCell;
+		}
+	}
 
-	// Chunk the meals into grid rows (plain loops - keep the isolated runtime simple).
-	const gridRows: { name: string; imagePath?: string }[][] = [];
-	for (let index = 0; index < count; index += columns) {
-		gridRows.push(meals.slice(index, index + columns));
+	// Pad to the full grid with null placeholders, then chunk into rows.
+	const cells: ({ name: string; imagePath?: string } | null)[] = [];
+	for (let index = 0; index < columns * rows; index++) {
+		cells.push(index < count ? meals[index] : null);
+	}
+	const gridRows: (typeof cells)[] = [];
+	for (let index = 0; index < cells.length; index += columns) {
+		gridRows.push(cells.slice(index, index + columns));
 	}
 
 	return (
@@ -68,15 +88,12 @@ const FoodWidgetLayout = (props: FoodWidgetProps, environment: WidgetEnvironment
 					<HStack key={`row-${rowIndex}`} spacing={spacing}>
 						{row.map((meal, cellIndex) => (
 							<ZStack key={`cell-${rowIndex}-${cellIndex}`} modifiers={[frame({ width: cellSize, height: cellSize })]}>
-								{meal.imagePath ? (
-									<Image
-										uiImage={meal.imagePath}
-										modifiers={[resizable(), frame({ width: cellSize, height: cellSize }), cornerRadius(4)]}
-									/>
+								{meal?.imagePath ? (
+									<Image uiImage={meal.imagePath} modifiers={[resizable(), frame({ width: cellSize, height: cellSize })]} />
 								) : (
 									<ZStack modifiers={[frame({ width: cellSize, height: cellSize })]}>
-										<Rectangle modifiers={[frame({ width: cellSize, height: cellSize }), foregroundStyle(placeholderColor), cornerRadius(4)]} />
-										<Image systemName="fork.knife" size={Math.max(12, cellSize * 0.3)} color={mutedColor} />
+										<Rectangle modifiers={[frame({ width: cellSize, height: cellSize }), foregroundStyle(placeholderColor)]} />
+										{meal ? <Image systemName="fork.knife" size={Math.max(12, cellSize * 0.25)} color={mutedColor} /> : null}
 									</ZStack>
 								)}
 							</ZStack>


### PR DESCRIPTION
## Food-Widget: randlos, quadratisch, mit Dummy-Platzhaltern

- **Kein Eckenradius mehr auf den Kacheln** — die äußere Widget-Maske rundet die Außenecken selbst; innen trennen nur die 2-pt-Abstände. Die Zellen dürfen bewusst leicht **über den Rand bleeden** (Canvas-Schätzung errt nach oben, die Maske clippt).
- **Coverage-optimierte Grid-Geometrie**: quadratische Zellen, die den Canvas in *beiden* Dimensionen füllen; die (Spalten, Zeilen)-Kombination mit dem geringsten Überstand gewinnt. Geteilt in `helpers/gridLayout.ts` (App-Vorschau) und inline im Widget.
- **Platzhalter-Padding**: 3 Speisen im quadratischen Widget = 2×2-Raster mit einer Dummy-Kachel — nie mehr eine zentrierte Restzeile.
- **Timeline-Taper** (Fix fürs gelegentlich schwarze Widget im Screenshot): 10-s-Takt für 15 min, dann minütlich für 3 h, dann halbstündlich bis Tagesende — ~300 statt ~1800 Einträge. Die Widget-Extension parst die gesamte gespeicherte Timeline bei jedem Reload; zu viele Einträge sprengen ihr enges Speicher-/Zeitbudget und iOS zeigt dann eine schwarze Kachel.

## Widget-Vorschau im Settings-Screen (Playbook)

- Oben im Settings-Screen: **Umschalter „Kalender" / „Food-Widget"** über einer quadratischen Live-Vorschau in Widget-Optik (gerundete Ecken, Widget-Hintergrund).
- Die Kalender-Vorschau rendert die Uhr live mit den gewählten Theme-Optionen (Jahresbeginn, Sonne & Mond) — Änderungen sind sofort sichtbar.
- Die Food-Vorschau zeigt das echte Tagesmenü als Raster und **blättert live alle 10 Sekunden** (mit Seitenzähler) — genau der Takt, den die Widget-Timeline iOS anbietet. Die Speisen laden automatisch, sobald Server und Mensa bekannt sind (auch aus gespeicherten Einstellungen).

## Version

Reines JavaScript → kommt per **OTA auf Build 3**; Version bleibt bewusst 0.3.0, damit die an `appVersion` gekoppelte `runtimeVersion` das installierte Binary weiter erreicht.

## Verifikation

- Jest: 33 Tests grün (neu: Grid-Coverage in beiden Dimensionen, 3→2×2-Padding, leeres Layout).
- `tsc --noEmit` ✅, voller `expo export --platform ios` ✅.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KLQgQiSBunjAoEHazLStp)_