### PR TITLE
Expo Go workflow: upstream-only guard + SDK version dropdown with free-text override

### DIFF
--- a/.github/workflows/expo-go-testflight.yml
+++ b/.github/workflows/expo-go-testflight.yml
@@ -15,9 +15,20 @@ on:
   workflow_dispatch:
     inputs:
       sdk_version:
-        description: 'Expo SDK Version (z.B. 57); leer = neueste von EAS unterstützte'
-        required: false
+        description: 'Expo SDK Version (Dropdown); "latest" = neueste von EAS unterstützte'
+        required: true
+        type: choice
         default: '57'
+        options:
+          - '57'
+          - '56'
+          - '55'
+          - '54'
+          - 'latest'
+      sdk_version_custom:
+        description: 'Expo SDK Version (Freitext, z.B. 58) - übersteuert das Dropdown, falls gesetzt'
+        required: false
+        default: ''
       app_name:
         description: 'App-Name in App Store Connect / TestFlight'
         required: false
@@ -33,7 +44,7 @@ concurrency:
 
 jobs:
   build-expo-go:
-    name: "🚀 Build Expo Go SDK ${{ github.event.inputs.sdk_version || 'latest' }} & submit to TestFlight"
+    name: "🚀 Build Expo Go SDK ${{ github.event.inputs.sdk_version_custom || github.event.inputs.sdk_version }} & submit to TestFlight"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     # Nur im Upstream-Repository ausführen - Tenant-Forks sollen keinen
@@ -92,13 +103,15 @@ jobs:
         if: steps.guard.outputs.available == 'true'
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          SDK_VERSION: ${{ github.event.inputs.sdk_version }}
+          # Freitext übersteuert das Dropdown; 'latest' bedeutet: kein
+          # --sdk-version-Flag, EAS nimmt die neueste unterstützte Version.
+          SDK_VERSION: ${{ github.event.inputs.sdk_version_custom || github.event.inputs.sdk_version }}
           APP_NAME: ${{ github.event.inputs.app_name }}
           BUNDLE_ID: ${{ github.event.inputs.bundle_id }}
         run: |
           set -euo pipefail
           ARGS=()
-          if [ -n "$SDK_VERSION" ]; then
+          if [ -n "$SDK_VERSION" ] && [ "$SDK_VERSION" != "latest" ]; then
             ARGS+=(--sdk-version "$SDK_VERSION")
           fi
           if [ -n "$APP_NAME" ]; then
@@ -113,7 +126,7 @@ jobs:
       - name: "🖨️ Summary"
         if: steps.guard.outputs.available == 'true'
         env:
-          SDK_VERSION: ${{ github.event.inputs.sdk_version }}
+          SDK_VERSION: ${{ github.event.inputs.sdk_version_custom || github.event.inputs.sdk_version }}
           APP_NAME: ${{ github.event.inputs.app_name }}
         run: |
           {

--- a/.github/workflows/expo-go-testflight.yml
+++ b/.github/workflows/expo-go-testflight.yml
@@ -36,6 +36,9 @@ jobs:
     name: "🚀 Build Expo Go SDK ${{ github.event.inputs.sdk_version || 'latest' }} & submit to TestFlight"
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # Nur im Upstream-Repository ausführen - Tenant-Forks sollen keinen
+    # eigenen Expo-Go-Client bauen (gleiche Absicht wie check-repository in ci.yml).
+    if: github.repository == 'rocket-meals/rocket-meals'
     steps:
       - name: "🔄 Checkout Repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
## Zusammenfassung

Zwei Follow-ups zu #4295 am Workflow **„🧪 Expo Go Client → TestFlight"**:

### 1. Nur im Upstream-Repository ausführen
- Job-Level-Guard `if: github.repository == 'rocket-meals/rocket-meals'` — in Tenant-Forks wird der Job übersprungen, bevor irgendetwas ausgeführt wird (gleiche Absicht wie der `check-repository`-Check in `ci.yml`).
- Der bestehende Secret-Guard bleibt als zweite Verteidigungslinie erhalten.

### 2. SDK-Version als Dropdown + Freitext
- `sdk_version` ist jetzt ein **Dropdown** (`type: choice`) mit `57` / `56` / `55` / `54` / `latest` (Default `57`).
- Neues optionales Freitext-Feld `sdk_version_custom` (z. B. `58`), das das Dropdown **übersteuert** — so lassen sich künftige SDK-Versionen starten, ohne den Workflow anzupassen.
- `latest` lässt das `--sdk-version`-Flag weg; EAS baut dann die neueste unterstützte Version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJNY2AnodQukEPch84j2w3