### PR TITLE
feat: publish Expo Go-compatible EAS updates for PR previews

### DIFF
--- a/.github/workflows/pr-expo-preview.yml
+++ b/.github/workflows/pr-expo-preview.yml
@@ -114,6 +114,11 @@ jobs:
           eas update --branch "pr-${{ github.event.pull_request.number }}" \
             --message "PR #${{ github.event.pull_request.number }}: $PR_TITLE" \
             --platform all --non-interactive
+          # Second publish with an exposdk:<version> runtime so the PR can be
+          # opened in Expo Go (development builds use the appVersion runtime above).
+          EXPO_GO_PREVIEW=true eas update --branch "pr-${{ github.event.pull_request.number }}" \
+            --message "PR #${{ github.event.pull_request.number }} (Expo Go): $PR_TITLE" \
+            --platform all --non-interactive
         working-directory: ./apps/frontend/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -125,6 +130,9 @@ jobs:
           eas update --branch "pr-${{ github.event.pull_request.number }}" \
             --message "PR #${{ github.event.pull_request.number }}: $PR_TITLE" \
             --platform all --non-interactive
+          EXPO_GO_PREVIEW=true eas update --branch "pr-${{ github.event.pull_request.number }}" \
+            --message "PR #${{ github.event.pull_request.number }} (Expo Go): $PR_TITLE" \
+            --platform all --non-interactive
         working-directory: ./apps/geonexia/frontend
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -135,6 +143,9 @@ jobs:
         run: |
           eas update --branch "pr-${{ github.event.pull_request.number }}" \
             --message "PR #${{ github.event.pull_request.number }}: $PR_TITLE" \
+            --platform all --non-interactive
+          EXPO_GO_PREVIEW=true eas update --branch "pr-${{ github.event.pull_request.number }}" \
+            --message "PR #${{ github.event.pull_request.number }} (Expo Go): $PR_TITLE" \
             --platform all --non-interactive
         working-directory: ./apps/score-tracker/frontend
         env:
@@ -152,6 +163,9 @@ jobs:
           fi
           eas update --branch "pr-${{ github.event.pull_request.number }}" \
             --message "PR #${{ github.event.pull_request.number }}: $PR_TITLE" \
+            --platform all --non-interactive
+          EXPO_GO_PREVIEW=true eas update --branch "pr-${{ github.event.pull_request.number }}" \
+            --message "PR #${{ github.event.pull_request.number }} (Expo Go): $PR_TITLE" \
             --platform all --non-interactive
         working-directory: ./apps/tag-und-jahr/frontend
         env:
@@ -187,12 +201,17 @@ jobs:
               marker,
               '## 📱 Expo Preview Update',
               '',
-              `An EAS Update has been published for this PR on branch \`${branch}\`.`,
+              `An EAS Update has been published for this PR on branch \`${branch}\`. Each app receives two updates: one for development builds (appVersion runtime) and one for Expo Go (exposdk runtime).`,
               '',
-              '**How to test:**',
+              '**How to test in a Development Build:**',
               `1. Open a **Development Build** of the app`,
               `2. Switch the update channel/branch to \`${branch}\``,
               '3. The app will load the latest code from this PR',
+              '',
+              '**How to test in Expo Go:**',
+              `1. Open **Expo Go** – its SDK version must match this PR's Expo SDK`,
+              `2. Sign in, open the project and select branch \`${branch}\``,
+              '3. Open the update marked **(Expo Go)**',
               '',
               '**Apps updated:**',
               ...appLines,

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -376,7 +376,11 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 			},
 			owner: 'baumgartner-software',
 			runtimeVersion: {
-				policy: 'appVersion',
+				// Production builds are tied to the app version, but Expo Go only
+				// loads updates whose runtime version has the exposdk:<version>
+				// form. The PR preview workflow publishes an additional update
+				// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
+				policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
 			},
 		},
 	};

--- a/apps/geonexia/frontend/app.config.ts
+++ b/apps/geonexia/frontend/app.config.ts
@@ -173,7 +173,11 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			fallbackToCacheTimeout: 10 * 1000,
 		},
 		runtimeVersion: {
-			policy: 'appVersion',
+			// Production builds are tied to the app version, but Expo Go only
+			// loads updates whose runtime version has the exposdk:<version>
+			// form. The PR preview workflow publishes an additional update
+			// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
+			policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
 		},
 		experiments: {
 			typedRoutes: true,

--- a/apps/score-tracker/frontend/app.config.ts
+++ b/apps/score-tracker/frontend/app.config.ts
@@ -81,7 +81,11 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			fallbackToCacheTimeout: 10 * 1000,
 		},
 		runtimeVersion: {
-			policy: 'appVersion',
+			// Production builds are tied to the app version, but Expo Go only
+			// loads updates whose runtime version has the exposdk:<version>
+			// form. The PR preview workflow publishes an additional update
+			// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
+			policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
 		},
 		plugins: [
 			'expo-router',

--- a/apps/tag-und-jahr/frontend/app.config.ts
+++ b/apps/tag-und-jahr/frontend/app.config.ts
@@ -77,7 +77,11 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			fallbackToCacheTimeout: 10 * 1000,
 		},
 		runtimeVersion: {
-			policy: 'appVersion',
+			// Production builds are tied to the app version, but Expo Go only
+			// loads updates whose runtime version has the exposdk:<version>
+			// form. The PR preview workflow publishes an additional update
+			// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
+			policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
 		},
 		plugins: [
 			'expo-router',


### PR DESCRIPTION
Expo Go can only load updates whose runtime version has the
exposdk:<version> form, so the PR preview updates published with the
appVersion runtime policy never showed up as openable projects in
Expo Go (they are only loadable by development/production builds).

All four app configs now switch the runtimeVersion policy to
'sdkVersion' when EXPO_GO_PREVIEW=true is set, and the PR preview
workflow publishes a second update per app with that flag on the same
pr-<number> branch. Both runtimes coexist on the branch; each client
picks the newest compatible update. Production publishes are untouched
and keep the appVersion runtime.

The PR comment now explains both test paths (development build and
Expo Go).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NwtJHSmDT4PwAijizYcL8S