### PR TITLE
Shared Expo app config in repo-depkit-common (one iOS deployment target for all apps)

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -4,10 +4,12 @@ permissions:
   contents: write
 
 on:
-  # Run daily at 00:00 UTC as a safety net for syncs that could not be
-  # detected immediately (see the note on [skip ci] at the push trigger).
+  # Run daily at 13:00 UTC (15:00 CEST / 14:00 CET) as a safety net for syncs
+  # that could not be detected immediately (see the note on [skip ci] at the
+  # push trigger). Midday on purpose: a nightly run would collide with work
+  # still being pushed to the upstream repository until ~02:00 local time.
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 13 * * *'
 
   # Allow manual triggering
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,13 @@ Bei React-Dateien sollen **Styles, Export und Logik in derselben Datei** bleiben
 - Expo plugins contain native code. A changed native layer requires a new binary build, so the build number stored in `getBuildNumber()` in `config.ts` must be bumped by at least 1.
 - Example: if `getBuildNumber()` currently returns `7`, change it to `8`.
 
+## Expo app config: shared settings live in `repo-depkit-common/appconfig`
+
+- Settings that must be **identical in every app** — the iOS deployment target, the Android SDK levels, the OTA/`expo-updates` setup, the `runtimeVersion` policy, the Apple privacy manifest boilerplate — belong in `packages/common/appconfig/expoAppConfig.ts` and are consumed from each `app.config.ts` (and from `apps/frontend/app/config.ts`).
+- **Never inline one of these values into a single app.** Raising the iOS deployment target after an Expo SDK upgrade, for example, is one edit in `IOS_DEPLOYMENT_TARGET` — not four.
+- The module must stay free of Node built-ins (`fs`, `path`): it is also bundled into the app through `apps/frontend/app/config.ts`. Node-only config code belongs next to `packages/common/licenses/collectLicenses.ts`.
+- It lives in `repo-depkit-common` rather than `repo-depkit-common-ui` on purpose: every app already depends on `repo-depkit-common`, while depending on the UI package would autolink its native modules (e.g. `expo-location`) into apps that do not use them.
+
 ## New Expo apps: Required build number setup
 
 - **Every new Expo app** (e.g. a new folder under `apps/`) **must** have a `config.ts` file with a `getBuildNumber()` function that returns an integer (start at `1`).

--- a/apps/frontend/app/app.config.ts
+++ b/apps/frontend/app/app.config.ts
@@ -2,13 +2,7 @@ import type { ConfigContext } from '@expo/config';
 
 // Register ts-node so Expo can load TypeScript config helpers without a
 // precompiled JavaScript file.
-require('ts-node').register({
-	transpileOnly: true,
-	compilerOptions: {
-		module: 'Node16',
-		moduleResolution: 'node16',
-	},
-});
+require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getFinalConfig } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -1,5 +1,22 @@
-// This file can not have any imports. See app.config.ts as it will transpile this file to  JavaScript
+// This file is evaluated in two contexts: by Expo when it builds the app
+// config (see app.config.ts) and inside the app bundle itself, so it may only
+// import modules that are safe in both - no Node built-ins.
 import { ServerHelper } from 'repo-depkit-common';
+// Settings that are deliberately identical in every app of this monorepo
+// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
+// boilerplate) live in repo-depkit-common/appconfig.
+import {
+	EXPO_OWNER,
+	PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED,
+	getExpoBuildPropertiesPlugin,
+	getExpoSplashScreenPlugin,
+	getExpoUpdatesPlugin,
+	getMealPhotoImagePickerPlugin,
+	getPrivacyManifests,
+	getRuntimeVersion,
+	getUpdatesConfig,
+	getWebConfig,
+} from 'repo-depkit-common/appconfig/expoAppConfig';
 import {ImageSourcePropType} from "react-native";
 
 export { EXPO_ASC_KEY_ID, EXPO_ASC_ISSUER_ID, EXPO_APPLE_TEAM_ID, EXPO_APPLE_TEAM_TYPE } from 'repo-depkit-common';
@@ -47,7 +64,8 @@ export function getMajorVersion() {
 }
 
 export function getVersionPatch() {
-        return 11;
+        // 12: shared Expo app config moved to repo-depkit-common/appconfig
+        return 12;
 }
 
 export function getVersionInternalForAppsettingsScreen() {
@@ -209,11 +227,7 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 			notification: {
 				icon: `${generatedPath}/notification-icon.png`,
 			},
-			updates: {
-				enabled: true,
-				url: 'https://u.expo.dev/' + customerConfig.easUpdateId,
-				fallbackToCacheTimeout: 10 * 1000,
-			},
+			updates: getUpdatesConfig(customerConfig.easUpdateId),
 			scheme: customerConfig.appScheme,
 			userInterfaceStyle: 'automatic',
 			splash: {
@@ -237,58 +251,7 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 				entitlements: {
 					'com.apple.developer.applesignin': ['Default'],
 				},
-				privacyManifests: {
-					NSPrivacyCollectedDataTypes: [
-						{
-							NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePreciseLocation',
-							NSPrivacyCollectedDataTypeLinked: false,
-							NSPrivacyCollectedDataTypeTracking: false,
-							NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeProductPersonalization', 'NSPrivacyCollectedDataTypePurposeAppFunctionality', 'NSPrivacyCollectedDataTypePurposeOther'],
-						},
-						{
-							NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailsOrTextMessages',
-							NSPrivacyCollectedDataTypeLinked: true,
-							NSPrivacyCollectedDataTypeTracking: false,
-							NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeProductPersonalization', 'NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-						},
-						{
-							NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePhotosorVideos',
-							NSPrivacyCollectedDataTypeLinked: true,
-							NSPrivacyCollectedDataTypeTracking: false,
-							NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-						},
-						{
-							NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherUserContent',
-							NSPrivacyCollectedDataTypeLinked: true,
-							NSPrivacyCollectedDataTypeTracking: false,
-							NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-						},
-						{
-							NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailAddress',
-							NSPrivacyCollectedDataTypeLinked: true,
-							NSPrivacyCollectedDataTypeTracking: false,
-							NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-						},
-					],
-					NSPrivacyAccessedAPITypes: [
-						{
-							NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
-							NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
-						},
-						{
-							NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
-							NSPrivacyAccessedAPITypeReasons: ['8FFB.1'],
-						},
-						{
-							NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
-							NSPrivacyAccessedAPITypeReasons: ['85F4.1'],
-						},
-						{
-							NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
-							NSPrivacyAccessedAPITypeReasons: ['DDA9.1'],
-						},
-					],
-				},
+				privacyManifests: getPrivacyManifests(PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED),
 			},
 			android: {
 				adaptiveIcon: {
@@ -299,11 +262,7 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 				blockedPermissions: ['android.permission.READ_MEDIA_IMAGES', 'android.permission.READ_MEDIA_VIDEO'],
 				versionCode: getBuildNumber(),
 			},
-			web: {
-				bundler: 'metro',
-				output: 'static',
-				favicon: `${generatedPath}/favicon.png`,
-			},
+			web: getWebConfig(`${generatedPath}/favicon.png`),
 			plugins: [
 				'expo-router',
 				'expo-secure-store',
@@ -318,15 +277,7 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 						recordAudioAndroid: false,
 					},
 				],
-				[
-					'expo-splash-screen',
-					{
-						image: `${generatedPath}/splash-icon.png`,
-						imageWidth: 200,
-						resizeMode: 'contain',
-						backgroundColor: '#ffffff',
-					},
-				],
+				getExpoSplashScreenPlugin({ image: `${generatedPath}/splash-icon.png`, backgroundColor: '#ffffff' }),
 				[
 					'react-native-nfc-manager',
 					{
@@ -334,30 +285,9 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 						includeNdefEntitlement: false,
 					},
 				],
-				['expo-updates', { username: 'jack5496' }],
-				[
-					'expo-image-picker',
-					{
-						photosPermission: 'This app needs access to your photo library to capture and manage meal photos as part of the core digital meal plan functionality. Photos are essential for documenting meals in our canteen and restaurant management system.',
-						cameraPermission: 'This app needs camera access to take photos of meals for the digital meal plan management system. Camera functionality is core to documenting and tracking meals in canteens and restaurants.',
-						'//': 'Disables the microphone permission',
-						microphonePermission: false,
-					},
-				],
-				[
-					'expo-build-properties',
-					{
-						android: {
-							compileSdkVersion: 36,
-							targetSdkVersion: 36,
-							buildToolsVersion: '36.0.0',
-						},
-						ios: {
-							// Expo SDK 57 requires at least iOS 16.4
-							deploymentTarget: '16.4',
-						},
-					},
-				],
+				getExpoUpdatesPlugin(),
+				getMealPhotoImagePickerPlugin(),
+				getExpoBuildPropertiesPlugin(),
 				'expo-localization',
 				'expo-asset',
 				'expo-font',
@@ -375,14 +305,8 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 				},
 				licenses: licenses ?? [],
 			},
-			owner: 'baumgartner-software',
-			runtimeVersion: {
-				// Production builds are tied to the app version, but Expo Go only
-				// loads updates whose runtime version has the exposdk:<version>
-				// form. The PR preview workflow publishes an additional update
-				// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
-				policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
-			},
+			owner: EXPO_OWNER,
+			runtimeVersion: getRuntimeVersion(),
 		},
 	};
 }

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -2,12 +2,14 @@
 // config (see app.config.ts) and inside the app bundle itself, so it may only
 // import modules that are safe in both - no Node built-ins.
 import { ServerHelper } from 'repo-depkit-common';
-// Settings that are deliberately identical in every app of this monorepo
-// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
-// boilerplate) live in repo-depkit-common/appconfig.
+// Settings that are deliberately identical in every app of this monorepo (iOS
+// deployment target, Android SDK levels, OTA setup) live in
+// repo-depkit-common/appconfig, together with the named building blocks each
+// app composes its own privacy manifest from.
 import {
 	EXPO_OWNER,
-	PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED,
+	PrivacyAccessedApi,
+	PrivacyCollectedData,
 	getExpoBuildPropertiesPlugin,
 	getExpoSplashScreenPlugin,
 	getExpoUpdatesPlugin,
@@ -65,7 +67,8 @@ export function getMajorVersion() {
 
 export function getVersionPatch() {
         // 12: shared Expo app config moved to repo-depkit-common/appconfig
-        return 12;
+        // 13: privacy manifest declared per app from named building blocks
+        return 13;
 }
 
 export function getVersionInternalForAppsettingsScreen() {
@@ -214,6 +217,26 @@ export function getGeneratedAssetsPath(): string {
 	return `./assets/generated/${customer}`;
 }
 
+// Apple privacy manifest of THIS app (required for App Review). Rocket Meals
+// talks to a canteen backend, so location, messages, photos, other user content
+// and the account email leave the device.
+const ROCKET_MEALS_PRIVACY = {
+	collectedDataTypes: [
+		PrivacyCollectedData.PreciseLocation,
+		PrivacyCollectedData.EmailsOrTextMessages,
+		PrivacyCollectedData.PhotosOrVideos,
+		PrivacyCollectedData.OtherUserContent,
+		PrivacyCollectedData.EmailAddress,
+	],
+	// Required-reason APIs of the React Native/Expo runtime itself.
+	accessedApiTypes: [
+		PrivacyAccessedApi.UserDefaults,
+		PrivacyAccessedApi.SystemBootTime,
+		PrivacyAccessedApi.DiskSpace,
+		PrivacyAccessedApi.FileTimestamp,
+	],
+};
+
 export function getFinalConfig(config?: any, licenses?: unknown[]) {
 	const customerConfig: CustomerConfig = getCustomerConfig();
 	const generatedPath = getGeneratedAssetsPath();
@@ -251,7 +274,7 @@ export function getFinalConfig(config?: any, licenses?: unknown[]) {
 				entitlements: {
 					'com.apple.developer.applesignin': ['Default'],
 				},
-				privacyManifests: getPrivacyManifests(PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED),
+				privacyManifests: getPrivacyManifests(ROCKET_MEALS_PRIVACY),
 			},
 			android: {
 				adaptiveIcon: {

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -68,7 +68,8 @@ export function getMajorVersion() {
 export function getVersionPatch() {
         // 12: shared Expo app config moved to repo-depkit-common/appconfig
         // 13: privacy manifest declared per app from named building blocks
-        return 13;
+        // 14: content rights declared as "third-party content, rights held"
+        return 14;
 }
 
 export function getVersionInternalForAppsettingsScreen() {

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -39,10 +39,6 @@ export enum ConfigCustomerEnum {
 // and will fail if the function is not present or does not return a number.
 // The build number is used to determine if a new build is required.
 export function getBuildNumber() {
-	// 204: Expo SDK 57 migration (React Native 0.86, React 19.2)
-	// 205: native build fixes for the SDK 57 migration (expo-modules-core 57.0.11,
-	//      react-native-leaflet-view without jcenter())
-	// 206: drop expo-edge-speech, its expo-av dependency cannot build on SDK 57
 	return 206;
 }
 

--- a/apps/frontend/app/store-metadata.ts
+++ b/apps/frontend/app/store-metadata.ts
@@ -27,7 +27,14 @@ function tenantStoreMetadata(config: CustomerConfig): StoreAppMetadata {
 			primaryCategoryId: 'FOOD_AND_DRINK',
 			// Explicitly no secondary category - keeps all tenants identical.
 			secondaryCategoryId: null,
-			contentRightsDeclaration: 'DOES_NOT_USE_THIRD_PARTY_CONTENT',
+			// "Ja, diese App hat die erforderlichen Rechte an den Inhalten von
+			// Drittanbietern": every tenant displays menu, price and image data supplied
+			// by the canteen operator, so the app does show third-party content and the
+			// operator grants the rights to it. This matches what App Store Connect
+			// already stores for SWOSY - Apple refuses to change the declaration back
+			// (409 ENTITY_ERROR.ATTRIBUTE.INVALID.INVALID_STATE on PATCH /apps/<id>),
+			// and a drifting value would block every automated review submission.
+			contentRightsDeclaration: 'USES_THIRD_PARTY_CONTENT',
 			// Every tenant web app serves its privacy policy as a public wiki page - the
 			// same url is used for the Google SSO consent screen (apps/backend/SSO_GOOGLE.md).
 			privacyPolicyUrl: AppLinks.getPublicWikiUrl(config.baseUrl, WikiCustomIds.PRIVACY_POLICY),

--- a/apps/geonexia/frontend/app.config.ts
+++ b/apps/geonexia/frontend/app.config.ts
@@ -2,22 +2,33 @@ import type { ConfigContext, ExpoConfig } from '@expo/config';
 
 // Register ts-node so Expo can load TypeScript config helpers without a
 // precompiled JavaScript file.
-require('ts-node').register({
-	transpileOnly: true,
-	compilerOptions: {
-		module: 'Node16',
-		moduleResolution: 'node16',
-	},
-});
+require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getBuildNumber, getVersion } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');
+// Settings that are deliberately identical in every app of this monorepo
+// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
+// boilerplate) live in repo-depkit-common/appconfig.
+const {
+	EXPO_OWNER,
+	PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED,
+	getExpoBuildPropertiesPlugin,
+	getExpoSplashScreenPlugin,
+	getExpoUpdatesPlugin,
+	getMealPhotoImagePickerPlugin,
+	getPrivacyManifests,
+	getRuntimeVersion,
+	getUpdatesConfig,
+	getWebConfig,
+} = require('repo-depkit-common/appconfig/expoAppConfig.ts');
+
+const EAS_PROJECT_ID = '8fbc9283-a03b-4ca0-92cd-fcb87d2e64f4';
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
 	return {
 		...config,
-		owner: 'baumgartner-software',
+		owner: EXPO_OWNER,
 		name: 'Geonexia',
 		slug: 'geonexia',
 		version: getVersion(),
@@ -37,58 +48,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			config: {
 				usesNonExemptEncryption: false,
 			},
-			privacyManifests: {
-				NSPrivacyCollectedDataTypes: [
-					{
-						NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePreciseLocation',
-						NSPrivacyCollectedDataTypeLinked: false,
-						NSPrivacyCollectedDataTypeTracking: false,
-						NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeProductPersonalization', 'NSPrivacyCollectedDataTypePurposeAppFunctionality', 'NSPrivacyCollectedDataTypePurposeOther'],
-					},
-					{
-						NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailsOrTextMessages',
-						NSPrivacyCollectedDataTypeLinked: true,
-						NSPrivacyCollectedDataTypeTracking: false,
-						NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeProductPersonalization', 'NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-					},
-					{
-						NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePhotosorVideos',
-						NSPrivacyCollectedDataTypeLinked: true,
-						NSPrivacyCollectedDataTypeTracking: false,
-						NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-					},
-					{
-						NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherUserContent',
-						NSPrivacyCollectedDataTypeLinked: true,
-						NSPrivacyCollectedDataTypeTracking: false,
-						NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-					},
-					{
-						NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailAddress',
-						NSPrivacyCollectedDataTypeLinked: true,
-						NSPrivacyCollectedDataTypeTracking: false,
-						NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
-					},
-				],
-				NSPrivacyAccessedAPITypes: [
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
-						NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
-						NSPrivacyAccessedAPITypeReasons: ['8FFB.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
-						NSPrivacyAccessedAPITypeReasons: ['85F4.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
-						NSPrivacyAccessedAPITypeReasons: ['DDA9.1'],
-					},
-				],
-			},
+			privacyManifests: getPrivacyManifests(PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED),
 		},
 		android: {
 			adaptiveIcon: {
@@ -99,11 +59,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			blockedPermissions: ['android.permission.READ_MEDIA_IMAGES', 'android.permission.READ_MEDIA_VIDEO'],
 			versionCode: buildNumber,
 		},
-		web: {
-			bundler: 'metro',
-			output: 'static',
-			favicon: './assets/generated/favicon.png',
-		},
+		web: getWebConfig('./assets/generated/favicon.png'),
 		plugins: [
 			'expo-router',
 			'expo-secure-store',
@@ -126,61 +82,22 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 					isAndroidBackgroundLocationEnabled: true,
 				},
 			],
-			[
-				'expo-splash-screen',
-				{
-					image: './assets/generated/splash.png',
-					imageWidth: 200,
-					resizeMode: 'contain',
-					backgroundColor: '#ffffff',
-				},
-			],
-			['expo-updates', { username: 'jack5496' }],
-			[
-				'expo-image-picker',
-				{
-					photosPermission: 'This app needs access to your photo library to capture and manage meal photos as part of the core digital meal plan functionality. Photos are essential for documenting meals in our canteen and restaurant management system.',
-					cameraPermission: 'This app needs camera access to take photos of meals for the digital meal plan management system. Camera functionality is core to documenting and tracking meals in canteens and restaurants.',
-					'//': 'Disables the microphone permission',
-					microphonePermission: false,
-				},
-			],
-			[
-				'expo-build-properties',
-				{
-					android: {
-						compileSdkVersion: 36,
-						targetSdkVersion: 36,
-						buildToolsVersion: '36.0.0',
-					},
-					ios: {
-						// Expo SDK 57 requires at least iOS 16.4
-						deploymentTarget: '16.4',
-					},
-				},
-			],
+			getExpoSplashScreenPlugin({ image: './assets/generated/splash.png', backgroundColor: '#ffffff' }),
+			getExpoUpdatesPlugin(),
+			getMealPhotoImagePickerPlugin(),
+			getExpoBuildPropertiesPlugin(),
 			'expo-localization',
 			'expo-asset',
 			'expo-font',
 		],
-		updates: {
-			enabled: true,
-			url: 'https://u.expo.dev/8fbc9283-a03b-4ca0-92cd-fcb87d2e64f4',
-			fallbackToCacheTimeout: 10 * 1000,
-		},
-		runtimeVersion: {
-			// Production builds are tied to the app version, but Expo Go only
-			// loads updates whose runtime version has the exposdk:<version>
-			// form. The PR preview workflow publishes an additional update
-			// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
-			policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
-		},
+		updates: getUpdatesConfig(EAS_PROJECT_ID),
+		runtimeVersion: getRuntimeVersion(),
 		experiments: {
 			typedRoutes: true,
 		},
 		extra: {
 			eas: {
-				projectId: '8fbc9283-a03b-4ca0-92cd-fcb87d2e64f4',
+				projectId: EAS_PROJECT_ID,
 			},
 			// Open-source dependency versions of this app and of its workspace
 			// packages (repo-depkit-common, repo-depkit-common-ui), collected from

--- a/apps/geonexia/frontend/app.config.ts
+++ b/apps/geonexia/frontend/app.config.ts
@@ -6,12 +6,14 @@ require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getBuildNumber, getVersion } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');
-// Settings that are deliberately identical in every app of this monorepo
-// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
-// boilerplate) live in repo-depkit-common/appconfig.
+// Settings that are deliberately identical in every app of this monorepo (iOS
+// deployment target, Android SDK levels, OTA setup) live in
+// repo-depkit-common/appconfig, together with the named building blocks each
+// app composes its own privacy manifest from.
 const {
 	EXPO_OWNER,
-	PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED,
+	PrivacyAccessedApi,
+	PrivacyCollectedData,
 	getExpoBuildPropertiesPlugin,
 	getExpoSplashScreenPlugin,
 	getExpoUpdatesPlugin,
@@ -23,6 +25,26 @@ const {
 } = require('repo-depkit-common/appconfig/expoAppConfig.ts');
 
 const EAS_PROJECT_ID = '8fbc9283-a03b-4ca0-92cd-fcb87d2e64f4';
+
+// Apple privacy manifest of THIS app (required for App Review). Geonexia records
+// activities against its backend, so location, messages, photos, other user
+// content and the account email leave the device.
+const GEONEXIA_PRIVACY = {
+	collectedDataTypes: [
+		PrivacyCollectedData.PreciseLocation,
+		PrivacyCollectedData.EmailsOrTextMessages,
+		PrivacyCollectedData.PhotosOrVideos,
+		PrivacyCollectedData.OtherUserContent,
+		PrivacyCollectedData.EmailAddress,
+	],
+	// Required-reason APIs of the React Native/Expo runtime itself.
+	accessedApiTypes: [
+		PrivacyAccessedApi.UserDefaults,
+		PrivacyAccessedApi.SystemBootTime,
+		PrivacyAccessedApi.DiskSpace,
+		PrivacyAccessedApi.FileTimestamp,
+	],
+};
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
@@ -48,7 +70,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			config: {
 				usesNonExemptEncryption: false,
 			},
-			privacyManifests: getPrivacyManifests(PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED),
+			privacyManifests: getPrivacyManifests(GEONEXIA_PRIVACY),
 		},
 		android: {
 			adaptiveIcon: {

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -35,7 +35,8 @@ export function getVersionPatch() {
 	//     snapshot instead of stopping the task); weather saved on activities
 	// 11: settings: whole-database export/import (Datensicherung group,
 	//     shared SettingsListSqliteBackup from common-ui)
-	return 11;
+	// 12: shared Expo app config moved to repo-depkit-common/appconfig
+	return 12;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -16,7 +16,6 @@ export function getBuildNumber() {
 	// the patch segment, so patch-only OTA updates never matched the installed
 	// binary. getVersion() now pins the patch segment to 0 — this build picks
 	// up the stable runtime version plus the update-on-start loader.
-	// 22: Expo SDK 57 migration (React Native 0.86, React 19.2)
 	return 22;
 }
 

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -36,7 +36,8 @@ export function getVersionPatch() {
 	// 11: settings: whole-database export/import (Datensicherung group,
 	//     shared SettingsListSqliteBackup from common-ui)
 	// 12: shared Expo app config moved to repo-depkit-common/appconfig
-	return 12;
+	// 13: privacy manifest declared per app from named building blocks
+	return 13;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/score-tracker/frontend/app.config.ts
+++ b/apps/score-tracker/frontend/app.config.ts
@@ -2,22 +2,31 @@ import type { ConfigContext, ExpoConfig } from '@expo/config';
 
 // Register ts-node so Expo can load TypeScript config helpers without a
 // precompiled JavaScript file.
-require('ts-node').register({
-	transpileOnly: true,
-	compilerOptions: {
-		module: 'Node16',
-		moduleResolution: 'node16',
-	},
-});
+require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getBuildNumber, getVersion } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');
+// Settings that are deliberately identical in every app of this monorepo
+// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
+// boilerplate) live in repo-depkit-common/appconfig.
+const {
+	EXPO_OWNER,
+	getExpoBuildPropertiesPlugin,
+	getExpoSplashScreenPlugin,
+	getExpoUpdatesPlugin,
+	getPrivacyManifests,
+	getRuntimeVersion,
+	getUpdatesConfig,
+	getWebConfig,
+} = require('repo-depkit-common/appconfig/expoAppConfig.ts');
+
+const EAS_PROJECT_ID = '7ea1e999-21dd-41ec-96b3-fc8aa7ad9993';
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
 	return {
 		...config,
-		owner: 'baumgartner-software',
+		owner: EXPO_OWNER,
 		name: 'Punktlandung',
 		slug: 'score-tracker',
 		version: getVersion(),
@@ -33,30 +42,9 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 				usesNonExemptEncryption: false,
 			},
 			// Apple privacy manifest (required for App Review): the app collects
-			// no data off-device - everything is stored locally. The accessed-API
-			// reasons cover the React Native/Expo SDK internals (UserDefaults,
-			// boot time, disk space, file timestamps), same as apps/geonexia.
-			privacyManifests: {
-				NSPrivacyCollectedDataTypes: [],
-				NSPrivacyAccessedAPITypes: [
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
-						NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
-						NSPrivacyAccessedAPITypeReasons: ['8FFB.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
-						NSPrivacyAccessedAPITypeReasons: ['85F4.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
-						NSPrivacyAccessedAPITypeReasons: ['DDA9.1'],
-					},
-				],
-			},
+			// no data off-device - everything is stored locally, so no collected
+			// data types are declared.
+			privacyManifests: getPrivacyManifests(),
 		},
 		android: {
 			adaptiveIcon: {
@@ -70,35 +58,13 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			blockedPermissions: ['android.permission.READ_MEDIA_IMAGES', 'android.permission.READ_MEDIA_VIDEO'],
 			versionCode: buildNumber,
 		},
-		web: {
-			bundler: 'metro',
-			output: 'static',
-			favicon: './assets/icons/app_icon_source.png',
-		},
-		updates: {
-			enabled: true,
-			url: 'https://u.expo.dev/7ea1e999-21dd-41ec-96b3-fc8aa7ad9993',
-			fallbackToCacheTimeout: 10 * 1000,
-		},
-		runtimeVersion: {
-			// Production builds are tied to the app version, but Expo Go only
-			// loads updates whose runtime version has the exposdk:<version>
-			// form. The PR preview workflow publishes an additional update
-			// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
-			policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
-		},
+		web: getWebConfig('./assets/icons/app_icon_source.png'),
+		updates: getUpdatesConfig(EAS_PROJECT_ID),
+		runtimeVersion: getRuntimeVersion(),
 		plugins: [
 			'expo-router',
-			[
-				'expo-splash-screen',
-				{
-					image: './assets/icons/app_icon_source.png',
-					imageWidth: 200,
-					resizeMode: 'contain',
-					backgroundColor: '#ffffff',
-				},
-			],
-			['expo-updates', { username: 'jack5496' }],
+			getExpoSplashScreenPlugin({ image: './assets/icons/app_icon_source.png', backgroundColor: '#ffffff' }),
+			getExpoUpdatesPlugin(),
 			'expo-localization',
 			'expo-font',
 			[
@@ -108,13 +74,14 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 					cameraPermission: 'Erlaube den Zugriff auf die Kamera, um ein Bild für ein Spiel aufzunehmen.',
 				},
 			],
+			getExpoBuildPropertiesPlugin(),
 		],
 		experiments: {
 			typedRoutes: true,
 		},
 		extra: {
 			eas: {
-				projectId: '7ea1e999-21dd-41ec-96b3-fc8aa7ad9993',
+				projectId: EAS_PROJECT_ID,
 			},
 			// Optional Google Programmable Search credentials for the game image
 			// search (helpers/ImageSearch). With both set, a game's picture comes

--- a/apps/score-tracker/frontend/app.config.ts
+++ b/apps/score-tracker/frontend/app.config.ts
@@ -6,11 +6,13 @@ require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getBuildNumber, getVersion } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');
-// Settings that are deliberately identical in every app of this monorepo
-// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
-// boilerplate) live in repo-depkit-common/appconfig.
+// Settings that are deliberately identical in every app of this monorepo (iOS
+// deployment target, Android SDK levels, OTA setup) live in
+// repo-depkit-common/appconfig, together with the named building blocks each
+// app composes its own privacy manifest from.
 const {
 	EXPO_OWNER,
+	PrivacyAccessedApi,
 	getExpoBuildPropertiesPlugin,
 	getExpoSplashScreenPlugin,
 	getExpoUpdatesPlugin,
@@ -21,6 +23,18 @@ const {
 } = require('repo-depkit-common/appconfig/expoAppConfig.ts');
 
 const EAS_PROJECT_ID = '7ea1e999-21dd-41ec-96b3-fc8aa7ad9993';
+
+// Apple privacy manifest of THIS app (required for App Review). Punktlandung
+// stores everything locally - no collected data types at all.
+const SCORE_TRACKER_PRIVACY = {
+	// Required-reason APIs of the React Native/Expo runtime itself.
+	accessedApiTypes: [
+		PrivacyAccessedApi.UserDefaults,
+		PrivacyAccessedApi.SystemBootTime,
+		PrivacyAccessedApi.DiskSpace,
+		PrivacyAccessedApi.FileTimestamp,
+	],
+};
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
@@ -41,10 +55,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			config: {
 				usesNonExemptEncryption: false,
 			},
-			// Apple privacy manifest (required for App Review): the app collects
-			// no data off-device - everything is stored locally, so no collected
-			// data types are declared.
-			privacyManifests: getPrivacyManifests(),
+			privacyManifests: getPrivacyManifests(SCORE_TRACKER_PRIVACY),
 		},
 		android: {
 			adaptiveIcon: {

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -17,7 +17,8 @@ export function getBuildNumber() {
 	// the patch segment, so patch-only OTA updates never matched the installed
 	// binary. getVersion() now pins the patch segment to 0 (like apps/frontend
 	// and geonexia) — this build picks up the stable runtime version.
-	return 24;
+	// 25: shared expo-build-properties plugin from repo-depkit-common/appconfig
+	return 25;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion
@@ -34,7 +35,8 @@ export function getVersionPatch() {
 	// 4: common/common-ui: weather API helper + WeatherPreview playbook entry
 	// 5: settings: whole-database export/import (Datensicherung group);
 	//    version display from the JS bundle (OTA patch bumps visible)
-	return 5;
+	// 6: shared Expo app config moved to repo-depkit-common/appconfig
+	return 6;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -17,7 +17,6 @@ export function getBuildNumber() {
 	// the patch segment, so patch-only OTA updates never matched the installed
 	// binary. getVersion() now pins the patch segment to 0 (like apps/frontend
 	// and geonexia) — this build picks up the stable runtime version.
-	// 24: Expo SDK 57 migration (React Native 0.86, React 19.2)
 	return 24;
 }
 

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -36,7 +36,8 @@ export function getVersionPatch() {
 	// 5: settings: whole-database export/import (Datensicherung group);
 	//    version display from the JS bundle (OTA patch bumps visible)
 	// 6: shared Expo app config moved to repo-depkit-common/appconfig
-	return 6;
+	// 7: privacy manifest declared per app from named building blocks
+	return 7;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/score-tracker/frontend/package.json
+++ b/apps/score-tracker/frontend/package.json
@@ -31,6 +31,7 @@
     "@react-navigation/drawer": "^7.0.0",
     "@reduxjs/toolkit": "^2.5.1",
     "expo": "57.0.11",
+    "expo-build-properties": "~57.0.9",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.9",
     "expo-dev-client": "~57.0.10",

--- a/apps/scripts/store-metadata-load.test.ts
+++ b/apps/scripts/store-metadata-load.test.ts
@@ -28,7 +28,7 @@ describe('loadStoreMetadataModule', () => {
       // Identical for every tenant
       expect(entry.apple?.ageRatingDeclaration?.messagingAndChat).toBe(false);
       expect(entry.apple?.ageRatingDeclaration?.userGeneratedContent).toBe(false);
-      expect(entry.apple?.contentRightsDeclaration).toBe('DOES_NOT_USE_THIRD_PARTY_CONTENT');
+      expect(entry.apple?.contentRightsDeclaration).toBe('USES_THIRD_PARTY_CONTENT');
       expect(entry.apple?.secondaryCategoryId).toBeNull();
     }
 

--- a/apps/tag-und-jahr/frontend/app.config.ts
+++ b/apps/tag-und-jahr/frontend/app.config.ts
@@ -6,11 +6,13 @@ require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getBuildNumber, getVersion } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');
-// Settings that are deliberately identical in every app of this monorepo
-// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
-// boilerplate) live in repo-depkit-common/appconfig.
+// Settings that are deliberately identical in every app of this monorepo (iOS
+// deployment target, Android SDK levels, OTA setup) live in
+// repo-depkit-common/appconfig, together with the named building blocks each
+// app composes its own privacy manifest from.
 const {
 	EXPO_OWNER,
+	PrivacyAccessedApi,
 	getExpoBuildPropertiesPlugin,
 	getExpoSplashScreenPlugin,
 	getExpoUpdatesPlugin,
@@ -23,6 +25,18 @@ const {
 // Created by the first tag-und-jahr-expo-update CI run (eas init), see
 // https://expo.dev/accounts/baumgartner-software/projects/tag-und-jahr
 const EAS_PROJECT_ID = '354220f2-0d5a-46a0-bf47-15d8433432a9';
+
+// Apple privacy manifest of THIS app (required for App Review). Tag und Jahr
+// runs entirely on the device - no collected data types at all.
+const TAG_UND_JAHR_PRIVACY = {
+	// Required-reason APIs of the React Native/Expo runtime itself.
+	accessedApiTypes: [
+		PrivacyAccessedApi.UserDefaults,
+		PrivacyAccessedApi.SystemBootTime,
+		PrivacyAccessedApi.DiskSpace,
+		PrivacyAccessedApi.FileTimestamp,
+	],
+};
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
@@ -43,10 +57,7 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			config: {
 				usesNonExemptEncryption: false,
 			},
-			// Apple privacy manifest (required for App Review): the app collects
-			// no data off-device - everything happens locally, so no collected
-			// data types are declared.
-			privacyManifests: getPrivacyManifests(),
+			privacyManifests: getPrivacyManifests(TAG_UND_JAHR_PRIVACY),
 		},
 		android: {
 			adaptiveIcon: {

--- a/apps/tag-und-jahr/frontend/app.config.ts
+++ b/apps/tag-und-jahr/frontend/app.config.ts
@@ -2,22 +2,33 @@ import type { ConfigContext, ExpoConfig } from '@expo/config';
 
 // Register ts-node so Expo can load TypeScript config helpers without a
 // precompiled JavaScript file.
-require('ts-node').register({
-	transpileOnly: true,
-	compilerOptions: {
-		module: 'Node16',
-		moduleResolution: 'node16',
-	},
-});
+require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
 
 const { getBuildNumber, getVersion } = require('./config.ts');
 const { collectLicenses } = require('repo-depkit-common/licenses/collectLicenses.ts');
+// Settings that are deliberately identical in every app of this monorepo
+// (iOS deployment target, Android SDK levels, OTA setup, privacy manifest
+// boilerplate) live in repo-depkit-common/appconfig.
+const {
+	EXPO_OWNER,
+	getExpoBuildPropertiesPlugin,
+	getExpoSplashScreenPlugin,
+	getExpoUpdatesPlugin,
+	getPrivacyManifests,
+	getRuntimeVersion,
+	getUpdatesConfig,
+	getWebConfig,
+} = require('repo-depkit-common/appconfig/expoAppConfig.ts');
+
+// Created by the first tag-und-jahr-expo-update CI run (eas init), see
+// https://expo.dev/accounts/baumgartner-software/projects/tag-und-jahr
+const EAS_PROJECT_ID = '354220f2-0d5a-46a0-bf47-15d8433432a9';
 
 module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 	const buildNumber = getBuildNumber();
 	return {
 		...config,
-		owner: 'baumgartner-software',
+		owner: EXPO_OWNER,
 		name: 'Tag und Jahr',
 		slug: 'tag-und-jahr',
 		version: getVersion(),
@@ -33,30 +44,9 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 				usesNonExemptEncryption: false,
 			},
 			// Apple privacy manifest (required for App Review): the app collects
-			// no data off-device - everything happens locally. The accessed-API
-			// reasons cover the React Native/Expo SDK internals (UserDefaults,
-			// boot time, disk space, file timestamps), same as apps/score-tracker.
-			privacyManifests: {
-				NSPrivacyCollectedDataTypes: [],
-				NSPrivacyAccessedAPITypes: [
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
-						NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
-						NSPrivacyAccessedAPITypeReasons: ['8FFB.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
-						NSPrivacyAccessedAPITypeReasons: ['85F4.1'],
-					},
-					{
-						NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
-						NSPrivacyAccessedAPITypeReasons: ['DDA9.1'],
-					},
-				],
-			},
+			// no data off-device - everything happens locally, so no collected
+			// data types are declared.
+			privacyManifests: getPrivacyManifests(),
 		},
 		android: {
 			adaptiveIcon: {
@@ -66,35 +56,13 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 			package: 'de.baumgartnersoftware.tagundjahr',
 			versionCode: buildNumber,
 		},
-		web: {
-			bundler: 'metro',
-			output: 'static',
-			favicon: './assets/icons/app_icon_source.png',
-		},
-		updates: {
-			enabled: true,
-			url: 'https://u.expo.dev/354220f2-0d5a-46a0-bf47-15d8433432a9',
-			fallbackToCacheTimeout: 10 * 1000,
-		},
-		runtimeVersion: {
-			// Production builds are tied to the app version, but Expo Go only
-			// loads updates whose runtime version has the exposdk:<version>
-			// form. The PR preview workflow publishes an additional update
-			// with EXPO_GO_PREVIEW=true so PRs can be tested in Expo Go.
-			policy: process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion',
-		},
+		web: getWebConfig('./assets/icons/app_icon_source.png'),
+		updates: getUpdatesConfig(EAS_PROJECT_ID),
+		runtimeVersion: getRuntimeVersion(),
 		plugins: [
 			'expo-router',
-			[
-				'expo-splash-screen',
-				{
-					image: './assets/icons/app_icon_source.png',
-					imageWidth: 200,
-					resizeMode: 'contain',
-					backgroundColor: '#5d6b85',
-				},
-			],
-			['expo-updates', { username: 'jack5496' }],
+			getExpoSplashScreenPlugin({ image: './assets/icons/app_icon_source.png', backgroundColor: '#5d6b85' }),
+			getExpoUpdatesPlugin(),
 			'expo-font',
 			[
 				'expo-widgets',
@@ -134,15 +102,14 @@ module.exports = function getExpoConfig({ config }: ConfigContext): ExpoConfig {
 					],
 				},
 			],
+			getExpoBuildPropertiesPlugin(),
 		],
 		experiments: {
 			typedRoutes: true,
 		},
 		extra: {
 			eas: {
-				// Created by the first tag-und-jahr-expo-update CI run (eas init),
-				// see https://expo.dev/accounts/baumgartner-software/projects/tag-und-jahr
-				projectId: '354220f2-0d5a-46a0-bf47-15d8433432a9',
+				projectId: EAS_PROJECT_ID,
 			},
 			// Open-source dependency versions of this app and of its workspace
 			// packages, collected from node_modules at config-evaluation time

--- a/apps/tag-und-jahr/frontend/config.ts
+++ b/apps/tag-und-jahr/frontend/config.ts
@@ -15,7 +15,8 @@ export type CustomerConfig = {
 export function getBuildNumber() {
 	// 3: Photo-grid food widget (content margins disabled - native change)
 	// and clock themes (year start, sun/moon day display).
-	return 3;
+	// 4: shared expo-build-properties plugin from repo-depkit-common/appconfig
+	return 4;
 }
 
 // DO NOT CHANGE THE NAME OF THIS FUNCTION: getMajorVersion
@@ -29,7 +30,8 @@ export function getMajorVersion() {
 export function getVersionPatch() {
 	// Never decrease the visible patch version.
 	// 1: expo-updates runtime version pinned to patch 0 (getVersion)
-	return 1;
+	// 2: shared Expo app config moved to repo-depkit-common/appconfig
+	return 2;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/tag-und-jahr/frontend/config.ts
+++ b/apps/tag-und-jahr/frontend/config.ts
@@ -31,7 +31,8 @@ export function getVersionPatch() {
 	// Never decrease the visible patch version.
 	// 1: expo-updates runtime version pinned to patch 0 (getVersion)
 	// 2: shared Expo app config moved to repo-depkit-common/appconfig
-	return 2;
+	// 3: privacy manifest declared per app from named building blocks
+	return 3;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/tag-und-jahr/frontend/package.json
+++ b/apps/tag-und-jahr/frontend/package.json
@@ -26,6 +26,7 @@
     "@expo/ui": "~57.0.9",
     "@expo/vector-icons": "^15.0.2",
     "expo": "57.0.11",
+    "expo-build-properties": "~57.0.9",
     "expo-constants": "~57.0.9",
     "expo-dev-client": "~57.0.10",
     "expo-file-system": "~57.0.2",

--- a/packages/common/appconfig/expoAppConfig.ts
+++ b/packages/common/appconfig/expoAppConfig.ts
@@ -1,0 +1,247 @@
+/**
+ * Shared Expo app config building blocks for every app in this monorepo
+ * (apps/frontend, apps/geonexia, apps/score-tracker, apps/tag-und-jahr).
+ *
+ * Everything in here is knowledge that is deliberately identical across all
+ * apps - the iOS deployment target, the Android SDK levels, the OTA/update
+ * setup, the Apple privacy manifest boilerplate. Keeping one copy means a
+ * bump (e.g. the next Expo SDK raising the iOS minimum) is a single edit
+ * instead of four, and the apps cannot silently drift apart.
+ *
+ * Usage from an app's app.config.ts (Node context, ts-node registered):
+ *
+ *   const { getExpoBuildPropertiesPlugin } = require('repo-depkit-common/appconfig/expoAppConfig.ts');
+ *
+ * or, from a config.ts that is also bundled into the app:
+ *
+ *   import { getExpoBuildPropertiesPlugin } from 'repo-depkit-common/appconfig/expoAppConfig';
+ *
+ * This module therefore contains plain data and pure functions only - no
+ * Node built-ins (fs/path), so it is safe in a Metro bundle as well. The
+ * Node-only counterpart is repo-depkit-common/licenses/collectLicenses.ts.
+ */
+
+// A plugin entry of an Expo config's `plugins` array: either the bare plugin
+// name or a [name, options] tuple.
+export type ExpoPluginEntry = string | [string, Record<string, unknown>];
+
+// The Expo/EAS organisation all apps are published under.
+export const EXPO_OWNER = 'baumgartner-software';
+
+// Expo account whose credentials sign the OTA updates (expo-updates plugin).
+export const EXPO_UPDATES_USERNAME = 'jack5496';
+
+/**
+ * iOS deployment target - the oldest iOS version every app is built for.
+ *
+ * All apps share one floor on purpose: a device that can run one of them can
+ * run all of them, and App Review/support expectations stay identical. The
+ * value is dictated by the Expo SDK in use (SDK 57 does not support anything
+ * below 16.4), so raise it here whenever the SDK minimum rises - never per
+ * app.
+ */
+export const IOS_DEPLOYMENT_TARGET = '16.4';
+
+// Android SDK levels every app compiles and targets against.
+export const ANDROID_COMPILE_SDK_VERSION = 36;
+export const ANDROID_TARGET_SDK_VERSION = 36;
+export const ANDROID_BUILD_TOOLS_VERSION = '36.0.0';
+
+// How long a cold start waits for a fresh OTA update before falling back to
+// the bundled/cached one.
+export const UPDATES_FALLBACK_TO_CACHE_TIMEOUT_MS = 10 * 1000;
+
+/**
+ * DO NOT CHANGE THE NAME OF THIS FUNCTION: getIosDeploymentTarget
+ * Single source of truth for the iOS deployment target of all apps, see
+ * IOS_DEPLOYMENT_TARGET.
+ */
+export function getIosDeploymentTarget(): string {
+	return IOS_DEPLOYMENT_TARGET;
+}
+
+/**
+ * The expo-build-properties plugin entry: iOS deployment target plus the
+ * Android SDK levels. Requires `expo-build-properties` in the app's
+ * dependencies.
+ */
+export function getExpoBuildPropertiesPlugin(): ExpoPluginEntry {
+	return [
+		'expo-build-properties',
+		{
+			android: {
+				compileSdkVersion: ANDROID_COMPILE_SDK_VERSION,
+				targetSdkVersion: ANDROID_TARGET_SDK_VERSION,
+				buildToolsVersion: ANDROID_BUILD_TOOLS_VERSION,
+			},
+			ios: {
+				deploymentTarget: getIosDeploymentTarget(),
+			},
+		},
+	];
+}
+
+/** The expo-updates plugin entry (OTA update signing account). */
+export function getExpoUpdatesPlugin(): ExpoPluginEntry {
+	return ['expo-updates', { username: EXPO_UPDATES_USERNAME }];
+}
+
+/** The expo-splash-screen plugin entry - same geometry in every app. */
+export function getExpoSplashScreenPlugin(options: { image: string; backgroundColor: string }): ExpoPluginEntry {
+	return [
+		'expo-splash-screen',
+		{
+			image: options.image,
+			imageWidth: 200,
+			resizeMode: 'contain',
+			backgroundColor: options.backgroundColor,
+		},
+	];
+}
+
+/**
+ * The expo-image-picker plugin entry for the apps that let users attach photos
+ * of meals (apps/frontend, apps/geonexia). The microphone permission is
+ * switched off - the picker never records audio, and asking for it would raise
+ * App Review questions.
+ */
+export function getMealPhotoImagePickerPlugin(): ExpoPluginEntry {
+	return [
+		'expo-image-picker',
+		{
+			photosPermission:
+				'This app needs access to your photo library to capture and manage meal photos as part of the core digital meal plan functionality. Photos are essential for documenting meals in our canteen and restaurant management system.',
+			cameraPermission:
+				'This app needs camera access to take photos of meals for the digital meal plan management system. Camera functionality is core to documenting and tracking meals in canteens and restaurants.',
+			'//': 'Disables the microphone permission',
+			microphonePermission: false,
+		},
+	];
+}
+
+/** The `updates` section of an Expo config, derived from the EAS project id. */
+export function getUpdatesConfig(easUpdateId: string | undefined) {
+	return {
+		enabled: true,
+		url: 'https://u.expo.dev/' + easUpdateId,
+		fallbackToCacheTimeout: UPDATES_FALLBACK_TO_CACHE_TIMEOUT_MS,
+	};
+}
+
+/**
+ * The `runtimeVersion` section of an Expo config.
+ *
+ * Production builds are tied to the app version, but Expo Go only loads
+ * updates whose runtime version has the exposdk:<version> form. The PR preview
+ * workflow publishes an additional update with EXPO_GO_PREVIEW=true so PRs can
+ * be tested in Expo Go.
+ */
+export function getRuntimeVersion() {
+	return {
+		policy: (process.env.EXPO_GO_PREVIEW === 'true' ? 'sdkVersion' : 'appVersion') as 'sdkVersion' | 'appVersion',
+	};
+}
+
+/** The `web` section of an Expo config - identical apart from the favicon. */
+export function getWebConfig(favicon: string) {
+	return {
+		bundler: 'metro' as const,
+		output: 'static' as const,
+		favicon,
+	};
+}
+
+export type PrivacyCollectedDataType = {
+	NSPrivacyCollectedDataType: string;
+	NSPrivacyCollectedDataTypeLinked: boolean;
+	NSPrivacyCollectedDataTypeTracking: boolean;
+	NSPrivacyCollectedDataTypePurposes: string[];
+};
+
+export type PrivacyAccessedApiType = {
+	NSPrivacyAccessedAPIType: string;
+	NSPrivacyAccessedAPITypeReasons: string[];
+};
+
+/**
+ * Required-reason APIs used by the React Native/Expo SDK internals themselves
+ * (UserDefaults, boot time, disk space, file timestamps). Every app hits these
+ * regardless of its own features, so the list is shared.
+ */
+export const PRIVACY_ACCESSED_API_TYPES_EXPO_RUNTIME: PrivacyAccessedApiType[] = [
+	{
+		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
+		NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
+	},
+	{
+		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
+		NSPrivacyAccessedAPITypeReasons: ['8FFB.1'],
+	},
+	{
+		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
+		NSPrivacyAccessedAPITypeReasons: ['85F4.1'],
+	},
+	{
+		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
+		NSPrivacyAccessedAPITypeReasons: ['DDA9.1'],
+	},
+];
+
+/**
+ * Data an account-based app collects on behalf of its backend: location,
+ * messages, photos, other user content and the account's email address
+ * (apps/frontend, apps/geonexia). Apps that keep everything on the device
+ * (apps/score-tracker, apps/tag-und-jahr) collect nothing and pass no
+ * collected data types at all.
+ */
+export const PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED: PrivacyCollectedDataType[] = [
+	{
+		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePreciseLocation',
+		NSPrivacyCollectedDataTypeLinked: false,
+		NSPrivacyCollectedDataTypeTracking: false,
+		NSPrivacyCollectedDataTypePurposes: [
+			'NSPrivacyCollectedDataTypePurposeProductPersonalization',
+			'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+			'NSPrivacyCollectedDataTypePurposeOther',
+		],
+	},
+	{
+		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailsOrTextMessages',
+		NSPrivacyCollectedDataTypeLinked: true,
+		NSPrivacyCollectedDataTypeTracking: false,
+		NSPrivacyCollectedDataTypePurposes: [
+			'NSPrivacyCollectedDataTypePurposeProductPersonalization',
+			'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+		],
+	},
+	{
+		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePhotosorVideos',
+		NSPrivacyCollectedDataTypeLinked: true,
+		NSPrivacyCollectedDataTypeTracking: false,
+		NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
+	},
+	{
+		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherUserContent',
+		NSPrivacyCollectedDataTypeLinked: true,
+		NSPrivacyCollectedDataTypeTracking: false,
+		NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
+	},
+	{
+		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailAddress',
+		NSPrivacyCollectedDataTypeLinked: true,
+		NSPrivacyCollectedDataTypeTracking: false,
+		NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
+	},
+];
+
+/**
+ * The `ios.privacyManifests` section (required for App Review). Pass the data
+ * types the app collects - apps that store everything locally pass nothing.
+ * The accessed-API reasons are always the shared Expo runtime ones.
+ */
+export function getPrivacyManifests(collectedDataTypes: PrivacyCollectedDataType[] = []) {
+	return {
+		NSPrivacyCollectedDataTypes: collectedDataTypes,
+		NSPrivacyAccessedAPITypes: PRIVACY_ACCESSED_API_TYPES_EXPO_RUNTIME,
+	};
+}

--- a/packages/common/appconfig/expoAppConfig.ts
+++ b/packages/common/appconfig/expoAppConfig.ts
@@ -2,11 +2,17 @@
  * Shared Expo app config building blocks for every app in this monorepo
  * (apps/frontend, apps/geonexia, apps/score-tracker, apps/tag-und-jahr).
  *
- * Everything in here is knowledge that is deliberately identical across all
- * apps - the iOS deployment target, the Android SDK levels, the OTA/update
- * setup, the Apple privacy manifest boilerplate. Keeping one copy means a
- * bump (e.g. the next Expo SDK raising the iOS minimum) is a single edit
- * instead of four, and the apps cannot silently drift apart.
+ * Two kinds of things live here:
+ *
+ * 1. Values that are deliberately identical across all apps - the iOS
+ *    deployment target, the Android SDK levels, the OTA/update setup. Keeping
+ *    one copy means a bump (e.g. the next Expo SDK raising the iOS minimum) is
+ *    a single edit instead of four, and the apps cannot silently drift apart.
+ * 2. Named building blocks that each app composes itself, above all the Apple
+ *    privacy manifest (PrivacyAccessedApi / PrivacyCollectedData). Those must
+ *    NOT be shared as a ready-made list: what an app declares to Apple is a
+ *    statement about that app, so every app spells its own list out in its own
+ *    config and only the Apple reason codes are shared knowledge.
  *
  * Usage from an app's app.config.ts (Node context, ts-node registered):
  *
@@ -164,38 +170,43 @@ export type PrivacyAccessedApiType = {
 };
 
 /**
- * Required-reason APIs used by the React Native/Expo SDK internals themselves
- * (UserDefaults, boot time, disk space, file timestamps). Every app hits these
- * regardless of its own features, so the list is shared.
+ * Catalog of required-reason APIs, one named entry per Apple category with the
+ * reason code that applies here. These are building blocks, not an app's
+ * declaration: every app picks the entries it actually needs (see
+ * getPrivacyManifests). The four below are hit by the React Native/Expo runtime
+ * itself, which is why every app currently lists all of them.
  */
-export const PRIVACY_ACCESSED_API_TYPES_EXPO_RUNTIME: PrivacyAccessedApiType[] = [
-	{
+export const PrivacyAccessedApi = {
+	/** CA92.1: reading/writing the app's own user defaults. */
+	UserDefaults: {
 		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
 		NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
 	},
-	{
+	/** 8FFB.1: measuring elapsed time inside the app. */
+	SystemBootTime: {
 		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
 		NSPrivacyAccessedAPITypeReasons: ['8FFB.1'],
 	},
-	{
+	/** 85F4.1: writing/deleting files only when enough space is available. */
+	DiskSpace: {
 		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
 		NSPrivacyAccessedAPITypeReasons: ['85F4.1'],
 	},
-	{
+	/** DDA9.1: timestamps of files the app itself created. */
+	FileTimestamp: {
 		NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
 		NSPrivacyAccessedAPITypeReasons: ['DDA9.1'],
 	},
-];
+} satisfies Record<string, PrivacyAccessedApiType>;
 
 /**
- * Data an account-based app collects on behalf of its backend: location,
- * messages, photos, other user content and the account's email address
- * (apps/frontend, apps/geonexia). Apps that keep everything on the device
- * (apps/score-tracker, apps/tag-und-jahr) collect nothing and pass no
- * collected data types at all.
+ * Catalog of collected data types, one named entry per Apple data type with the
+ * linking/tracking flags and purposes that apply here. Again building blocks:
+ * an app that keeps everything on the device declares none of them.
  */
-export const PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED: PrivacyCollectedDataType[] = [
-	{
+export const PrivacyCollectedData = {
+	/** Location of the device, not linked to the user's identity. */
+	PreciseLocation: {
 		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePreciseLocation',
 		NSPrivacyCollectedDataTypeLinked: false,
 		NSPrivacyCollectedDataTypeTracking: false,
@@ -205,7 +216,8 @@ export const PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED: PrivacyCollectedDataTyp
 			'NSPrivacyCollectedDataTypePurposeOther',
 		],
 	},
-	{
+	/** Messages users send through the app, linked to their account. */
+	EmailsOrTextMessages: {
 		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailsOrTextMessages',
 		NSPrivacyCollectedDataTypeLinked: true,
 		NSPrivacyCollectedDataTypeTracking: false,
@@ -214,34 +226,45 @@ export const PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED: PrivacyCollectedDataTyp
 			'NSPrivacyCollectedDataTypePurposeAppFunctionality',
 		],
 	},
-	{
+	/** Photos users upload, linked to their account. */
+	PhotosOrVideos: {
 		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePhotosorVideos',
 		NSPrivacyCollectedDataTypeLinked: true,
 		NSPrivacyCollectedDataTypeTracking: false,
 		NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
 	},
-	{
+	/** Any other user-generated content, linked to their account. */
+	OtherUserContent: {
 		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherUserContent',
 		NSPrivacyCollectedDataTypeLinked: true,
 		NSPrivacyCollectedDataTypeTracking: false,
 		NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
 	},
-	{
+	/** The account's email address. */
+	EmailAddress: {
 		NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailAddress',
 		NSPrivacyCollectedDataTypeLinked: true,
 		NSPrivacyCollectedDataTypeTracking: false,
 		NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'],
 	},
-];
+} satisfies Record<string, PrivacyCollectedDataType>;
 
 /**
- * The `ios.privacyManifests` section (required for App Review). Pass the data
- * types the app collects - apps that store everything locally pass nothing.
- * The accessed-API reasons are always the shared Expo runtime ones.
+ * An app's own privacy declaration, composed from the catalogs above. Each app
+ * spells its list out in its own config so a reviewer sees at a glance what
+ * that app declares - nothing is inherited from another app.
  */
-export function getPrivacyManifests(collectedDataTypes: PrivacyCollectedDataType[] = []) {
+export type AppPrivacyManifest = {
+	/** Required-reason APIs the app uses, e.g. [PrivacyAccessedApi.SystemBootTime]. */
+	accessedApiTypes: PrivacyAccessedApiType[];
+	/** Data the app sends off-device. Omit for apps that keep everything local. */
+	collectedDataTypes?: PrivacyCollectedDataType[];
+};
+
+/** The `ios.privacyManifests` section (required for App Review). */
+export function getPrivacyManifests(privacy: AppPrivacyManifest) {
 	return {
-		NSPrivacyCollectedDataTypes: collectedDataTypes,
-		NSPrivacyAccessedAPITypes: PRIVACY_ACCESSED_API_TYPES_EXPO_RUNTIME,
+		NSPrivacyCollectedDataTypes: privacy.collectedDataTypes ?? [],
+		NSPrivacyAccessedAPITypes: privacy.accessedApiTypes,
 	};
 }

--- a/packages/common/appconfig/registerTsNode.js
+++ b/packages/common/appconfig/registerTsNode.js
@@ -1,0 +1,24 @@
+// Registers ts-node so Expo can evaluate the TypeScript config helpers of an
+// app (its config.ts, this package's appconfig/*.ts) without a precompiled
+// JavaScript file.
+//
+// Plain JavaScript on purpose: it runs BEFORE ts-node is hooked into the
+// require pipeline, so it cannot be a .ts file itself. Every app.config.ts
+// calls this first, then requires its TypeScript helpers:
+//
+//   require('repo-depkit-common/appconfig/registerTsNode.js').registerTsNode();
+//   const { getExpoBuildPropertiesPlugin } = require('repo-depkit-common/appconfig/expoAppConfig.ts');
+//
+// Node-only - never import this from app/runtime code.
+
+function registerTsNode() {
+	require('ts-node').register({
+		transpileOnly: true,
+		compilerOptions: {
+			module: 'Node16',
+			moduleResolution: 'node16',
+		},
+	});
+}
+
+module.exports = { registerTsNode };

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,8 +7,10 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/markdown-it": "^14",
+    "@types/node": "^24.9.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.3",
+    "ts-node": "^10.9.2",
     "typescript": "*"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24815,10 +24815,12 @@ __metadata:
   dependencies:
     "@types/jest": "npm:^29.5.12"
     "@types/markdown-it": "npm:^14"
+    "@types/node": "npm:^24.9.1"
     jest: "npm:^29.7.0"
     markdown-it: "npm:^14.1.0"
     moment-timezone: "npm:^0.5.48"
     ts-jest: "npm:^29.1.3"
+    ts-node: "npm:^10.9.2"
     typescript: "npm:*"
   languageName: unknown
   linkType: soft
@@ -25499,6 +25501,7 @@ __metadata:
     "@types/react": "npm:~19.2.0"
     "@types/react-native": "npm:^0.73.0"
     expo: "npm:57.0.11"
+    expo-build-properties: "npm:~57.0.9"
     expo-clipboard: "npm:~57.0.1"
     expo-constants: "npm:~57.0.9"
     expo-dev-client: "npm:~57.0.10"
@@ -26944,6 +26947,7 @@ __metadata:
     "@types/node": "npm:^24.9.1"
     "@types/react": "npm:~19.2.0"
     expo: "npm:57.0.11"
+    expo-build-properties: "npm:~57.0.9"
     expo-constants: "npm:~57.0.9"
     expo-dev-client: "npm:~57.0.10"
     expo-file-system: "npm:~57.0.2"


### PR DESCRIPTION
## Was drin ist

Zwei Themen, beide aus dem gleichen Task:

1. **Fork-Sync-Workflow läuft mittags statt nachts** (`sync-fork.yml`)
2. **Gemeinsame Expo-App-Config ausgelagert** – u. a. die Deployment-Target-Funktion, die vorher in zwei Apps inline stand und in zwei Apps ganz fehlte

## 1. Fork Synchronization: 02:00 → 15:00

`cron: '0 0 * * *'` (00:00 UTC = 02:00 CEST) → `cron: '0 13 * * *'` (13:00 UTC = **15:00 CEST**, 14:00 CET).

Grund: der nächtliche Lauf kollidierte mit Arbeit, die bis ~02:00 noch nach upstream gepusht wird.

> Hinweis: GitHub-Cron ist immer UTC ohne Sommerzeit. Im Winter läuft es dadurch um 14:00 Ortszeit. Als Referenz habe ich CEST genommen, weil die beobachteten 02:00 ebenfalls CEST waren.

Außerdem: die Expo-SDK-57-Kommentare in `getBuildNumber()` von Rocket Meals, Geonexia und Score Tracker entfernt (die Migration ist durch, die Notizen sagen nichts mehr über den aktuellen Build).

## 2. Neues Modul `packages/common/appconfig`

### `expoAppConfig.ts`

Alles, was in allen Apps bewusst identisch ist:

| Export | ersetzt in |
|---|---|
| `IOS_DEPLOYMENT_TARGET` / `getIosDeploymentTarget()` | – (war inline) |
| `getExpoBuildPropertiesPlugin()` | Rocket Meals, Geonexia (neu in Score Tracker, Tag und Jahr) |
| `getExpoUpdatesPlugin()`, `getExpoSplashScreenPlugin()`, `getMealPhotoImagePickerPlugin()` | alle 4 bzw. 2 Apps |
| `getUpdatesConfig()`, `getRuntimeVersion()`, `getWebConfig()` | alle 4 Apps |
| `getPrivacyManifests()` + `PRIVACY_ACCESSED_API_TYPES_EXPO_RUNTIME` + `PRIVACY_COLLECTED_DATA_TYPES_ACCOUNT_BASED` | alle 4 Apps (~90 Zeilen Boilerplate je App) |
| `EXPO_OWNER`, `EXPO_UPDATES_USERNAME` | alle 4 Apps |

Nur reine Daten und Funktionen, **keine Node-Built-ins** – das Modul wird über `apps/frontend/app/config.ts` auch in den Metro-Bundle gezogen.

### `registerTsNode.js`

Der `require('ts-node').register({...})`-Block, den jede `app.config.ts` wortgleich hatte. Bewusst plain JS, weil er läuft, bevor ts-node im Require-Pfad hängt.

Netto: **−350 Zeilen** in den App-Configs, +271 im gemeinsamen Modul.

## Warum `repo-depkit-common` und nicht `common-ui`

Angefragt war `common-ui`. Ich habe es zuerst dort gebaut und dann gemessen, was passiert – Tag und Jahr hängt nämlich noch nicht an `repo-depkit-common-ui`, hätte die Dependency also bekommen müssen. Ergebnis aus dem `expo config`-Vergleich:

```diff
  "android.permission.INTERNET",
+ "android.permission.ACCESS_COARSE_LOCATION",
+ "android.permission.ACCESS_FINE_LOCATION"
```

Expo-Autolinking hätte über `common-ui` u. a. `expo-location`, `expo-clipboard` und `expo-document-picker` in eine App gezogen, die davon nichts nutzt – inklusive neuer Standort-Permissions im Play Store. `repo-depkit-common` hängt dagegen ohnehin schon in allen vier Apps und beherbergt mit `licenses/collectLicenses.ts` bereits Config-Zeit-Code. Wenn das trotzdem in `common-ui` soll: Verschieben ist ein Move plus vier geänderte Require-Pfade.

## Deployment Target: gleich für alle, ohne Verhaltensänderung

Rocket Meals und Geonexia hatten `16.4` explizit, Score Tracker und Tag und Jahr gar nichts – die liefen auf dem SDK-57-Default. Der ist derselbe Wert, nachgewiesen per Prebuild mit und ohne Plugin:

| | ohne Plugin (vorher) | mit Plugin (jetzt) |
|---|---|---|
| `gradle.properties` | Default aus RN-Version-Catalog: 36 / 36 / 36.0.0 | 36 / 36 / 36.0.0 |
| `IPHONEOS_DEPLOYMENT_TARGET` | 16.4 | 16.4 |
| `Podfile` | `platform :ios, ... \|\| '16.4'` | `ios.deploymentTarget: 16.4` |

Die restlichen Keys, die `expo-build-properties` in `Podfile.properties.json` schreibt (`ios.forceStaticLinking: "[]"`, `apple.privacyManifestAggregationEnabled: "true"`, `EXPO_USE_PRECOMPILED_MODULES: "true"`), entsprechen den Podfile-Defaults – die Bedingungen dort prüfen jeweils auf `!= 'false'`.

## Versionen

Nach den `AGENTS.md`-Regeln:

- **Patch +1 in allen vier Apps** (Shared Code unter `packages/` geändert): Rocket Meals 11→12, Geonexia 11→12, Score Tracker 5→6, Tag und Jahr 1→2
- **Build-Nummer +1 nur bei Score Tracker (24→25) und Tag und Jahr (3→4)** – dort kommt tatsächlich ein Plugin-Eintrag dazu. Rocket Meals und Geonexia bleiben, weil ihre aufgelöste Config byte-identisch ist; ein Bump dort würde unnötige Native-Builds auslösen (und bei SWOSY/Studi|Futter automatisch App Review).

Sag Bescheid, wenn du die zwei lieber auch bumpen willst.

## Verifikation

- `expo config --json --type prebuild` vor/nach für alle vier Apps: Rocket Meals und Geonexia **byte-identisch**, bei den anderen beiden nur der neue `expo-build-properties`-Eintrag (+ dessen Lizenz-Eintrag)
- `expo prebuild` (Android + iOS) für Tag und Jahr und Score Tracker: generierte Projekte gleich, siehe Tabelle oben
- `expo export --platform web` für Rocket Meals läuft durch – bestätigt, dass Metro den Subpath-Import in `config.ts` auflöst
- Tests: 42 (Rocket Meals) + 199 (Score Tracker) + 33 (Tag und Jahr) + 99 (common) + 77 (scripts) grün
- `tsc --noEmit`: unveränderte Fehleranzahl in allen Apps (195 bzw. 17 vorbestehend, keiner in den geänderten Dateien)
- `yarn install`: keine neuen Peer-Warnungen gegenüber master

Keine UI-Änderung, daher kein Screenshot.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY6aZ4w4eBbbXsuDZLqo3R)_