### PR TITLE
ci: publish all generated files in one commit per workflow run

### DIFF
--- a/.github/actions/backend-build/action.yml
+++ b/.github/actions/backend-build/action.yml
@@ -1,5 +1,5 @@
 name: 'Build Directus Backend'
-description: 'Build Directus extension and push updated dist'
+description: 'Build Directus extension and stage the updated dist for the publish job'
 inputs:
   EXPO_TOKEN:
     description: 'Expo token for dependency install'
@@ -36,18 +36,15 @@ runs:
           echo "dist_changed=false" >> $GITHUB_ENV
         fi
       shell: bash
-    - name: Commit and push changes if dist changed
+    # The dist is not pushed from here - it is staged as a patch and published
+    # together with everything else by the workflow's single publish job.
+    - name: Stage dist changes
       if: steps.repo_check.outputs.is_main_repo == 'true' && env.dist_changed == 'true'
-      run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
-        git stash --include-untracked
-        git pull --rebase
-        git stash pop
-        git add -f apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist
-        git commit -m "Update dist after backend build"
-        git push
-      shell: bash
+      uses: ./.github/actions/stage-changes
+      with:
+        name: backend-dist
+        paths: apps/backend/Backend/directusExtensions/directus-extension-rocket-meals-bundle/dist
+        description: "update dist after backend build"
     - name: Upload Dist Artifact
       if: steps.repo_check.outputs.is_main_repo == 'true' && env.dist_changed == 'true'
       uses: actions/upload-artifact@v4

--- a/.github/actions/geonexia-expo-update/action.yml
+++ b/.github/actions/geonexia-expo-update/action.yml
@@ -155,22 +155,18 @@ runs:
       env:
         EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
 
-    - name: "💾 Commit EAS config changes"
-      run: |
-        git config --global user.name 'Rocket Meals'
-        git config --global user.email 'nils@baumgartner-software.de'
-        git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-        if ! git diff --quiet; then
-          git add -A && git commit -m "chore: update geonexia EAS config [skip ci]"
-          for i in 1 2 3 4 5; do
-            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)" && git push && break
-            echo "Push attempt $i failed, retrying..."
-            sleep 5
-          done
-        fi
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+    # The EAS config is not pushed from here - it is staged as a patch and
+    # published together with everything else by the workflow's single
+    # publish job, so parallel jobs cannot race on the branch.
+    - name: "💾 Stage EAS config changes"
+      uses: ./.github/actions/stage-changes
+      with:
+        name: eas-config-geonexia
+        paths: |
+          apps/geonexia/frontend/app.config.ts
+          apps/geonexia/frontend/app.json
+          apps/geonexia/frontend/eas.json
+        description: "update geonexia EAS config"
 
     - name: "🚀 Publish OTA update"
       run: |

--- a/.github/actions/publish-staged-changes/action.yml
+++ b/.github/actions/publish-staged-changes/action.yml
@@ -1,0 +1,186 @@
+name: "Publish staged changes"
+description: >-
+  Collects every patch staged by `stage-changes` during this workflow run,
+  applies them onto the target branch, and pushes them as a single commit. This
+  is the only place in the workflow that writes to the branch, which removes the
+  race between parallel jobs that used to cause "cannot lock ref" push failures.
+  The calling job must check out `branch` with `fetch-depth: 0` and a token that
+  is allowed to push.
+
+inputs:
+  branch:
+    description: "Branch to push to. Defaults to the branch the run was triggered on."
+    required: false
+    default: ${{ github.ref_name }}
+  commit-message:
+    description: "Subject line of the single commit."
+    required: false
+    default: "chore: update generated files [skip ci]"
+  max-attempts:
+    description: "How often the push is retried when the branch moved underneath us."
+    required: false
+    default: '6'
+
+outputs:
+  pushed:
+    description: "'true' when a commit was pushed, 'false' when there was nothing to publish."
+    value: ${{ steps.publish.outputs.pushed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "🔍 Look for staged changes"
+      id: check
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const artifacts = await github.paginate(
+            github.rest.actions.listWorkflowRunArtifacts,
+            { owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId, per_page: 100 },
+          );
+          const staged = artifacts.filter(a => a.name.startsWith('ci-staged-changes-') && !a.expired);
+          if (staged.length === 0) {
+            core.info('No staged changes in this run, nothing to publish.');
+          } else {
+            core.info(`Found ${staged.length} staged change artifact(s): ${staged.map(a => a.name).join(', ')}`);
+          }
+          core.setOutput('has-staged', staged.length > 0 ? 'true' : 'false');
+
+    - name: "📥 Download staged changes"
+      if: steps.check.outputs.has-staged == 'true'
+      uses: actions/download-artifact@v4
+      with:
+        pattern: ci-staged-changes-*
+        merge-multiple: true
+        # Outside the repository, so `git clean` during patching cannot eat it.
+        path: ${{ runner.temp }}/ci-staged
+
+    - name: "📤 Apply patches and push"
+      id: publish
+      if: steps.check.outputs.has-staged == 'true'
+      shell: bash
+      env:
+        STAGED_DIR: ${{ runner.temp }}/ci-staged
+        TARGET_BRANCH: ${{ inputs.branch }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+      run: |
+        set -euo pipefail
+
+        shopt -s nullglob
+        patches=("$STAGED_DIR"/*.patch)
+        shopt -u nullglob
+
+        if [ ${#patches[@]} -eq 0 ]; then
+          echo "No patch files downloaded, nothing to publish."
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+
+        # `git apply --3way` resolves the patches against the blobs they were
+        # built from, so the full history has to be present.
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          echo "Repository is shallow, fetching full history for 3-way merges..."
+          git fetch --unshallow origin "$TARGET_BRANCH"
+        fi
+
+        base="$(git rev-parse HEAD)"
+        summaries=()
+        failed=()
+
+        # Each patch is committed on its own so a conflicting patch can be rolled
+        # back with `git reset --hard` without losing the ones already applied.
+        # The temporary commits are squashed into one at the end.
+        for patch in $(printf '%s\n' "${patches[@]}" | sort); do
+          name="$(basename "$patch" .patch)"
+          summary="$name"
+          if [ -f "${patch%.patch}.txt" ]; then
+            summary="$(head -n 1 "${patch%.patch}.txt")"
+          fi
+
+          echo "::group::Applying $name"
+          if git apply --reverse --check "$patch" >/dev/null 2>&1; then
+            echo "Patch '$name' is already contained in the branch, skipping."
+            echo "::endgroup::"
+            continue
+          fi
+
+          if git apply --3way --whitespace=nowarn "$patch"; then
+            git add -A
+            if git diff --cached --quiet; then
+              echo "Patch '$name' is already contained in the branch, skipping."
+              echo "::endgroup::"
+              continue
+            fi
+            git commit -q -m "staged: $name"
+            summaries+=("$summary")
+            echo "Applied '$name'."
+          else
+            # Roll back to the last good state; untracked leftovers of the failed
+            # patch are removed, everything already committed survives.
+            git reset --hard -q HEAD
+            git clean -fdq
+            failed+=("$name")
+            echo "::error::Could not apply staged patch '$name' - it conflicts with the current state of $TARGET_BRANCH."
+          fi
+          echo "::endgroup::"
+        done
+
+        if [ "$(git rev-parse HEAD)" = "$base" ]; then
+          echo "Nothing to commit after applying patches."
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::All staged patches failed to apply: ${failed[*]}"
+            exit 1
+          fi
+          exit 0
+        fi
+
+        # Squash the per-patch commits into the single commit we publish.
+        body="$(printf -- '- %s\n' "${summaries[@]}")"
+        git reset --soft -q "$base"
+        git commit -q -m "$COMMIT_MESSAGE" -m "$body"
+
+        echo "Publishing:"
+        git --no-pager show --stat --oneline HEAD | head -n 40 || true
+
+        attempts="$MAX_ATTEMPTS"
+        delay=2
+        for attempt in $(seq 1 "$attempts"); do
+          if git push origin "HEAD:refs/heads/${TARGET_BRANCH}"; then
+            echo "Pushed on attempt $attempt."
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            if [ ${#failed[@]} -gt 0 ]; then
+              echo "::error::Pushed, but these staged patches were dropped because they conflicted: ${failed[*]}"
+              exit 1
+            fi
+            exit 0
+          fi
+
+          if [ "$attempt" -eq "$attempts" ]; then
+            break
+          fi
+
+
+          # The branch moved between our fetch and our push. Rebase our single
+          # commit on top of the new tip and try again. The jitter keeps two
+          # colliding runs from retrying in lockstep forever.
+          jitter=$(( RANDOM % 4 ))
+          echo "Push attempt $attempt failed, retrying in $(( delay + jitter ))s..."
+          sleep $(( delay + jitter ))
+          delay=$(( delay * 2 ))
+
+          git fetch origin "$TARGET_BRANCH"
+          if ! git rebase "origin/${TARGET_BRANCH}"; then
+            git rebase --abort || true
+            echo "::error::Our commit conflicts with new commits on $TARGET_BRANCH and cannot be rebased automatically."
+            exit 1
+          fi
+        done
+
+        echo "pushed=false" >> "$GITHUB_OUTPUT"
+        echo "::error::Could not push to $TARGET_BRANCH after $attempts attempts."
+        exit 1

--- a/.github/actions/score-tracker-expo-update/action.yml
+++ b/.github/actions/score-tracker-expo-update/action.yml
@@ -155,22 +155,18 @@ runs:
       env:
         EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
 
-    - name: "💾 Commit EAS config changes"
-      run: |
-        git config --global user.name 'Rocket Meals'
-        git config --global user.email 'nils@baumgartner-software.de'
-        git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-        if ! git diff --quiet; then
-          git add -A && git commit -m "chore: update score-tracker EAS config [skip ci]"
-          for i in 1 2 3 4 5; do
-            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)" && git push && break
-            echo "Push attempt $i failed, retrying..."
-            sleep 5
-          done
-        fi
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+    # The EAS config is not pushed from here - it is staged as a patch and
+    # published together with everything else by the workflow's single
+    # publish job, so parallel jobs cannot race on the branch.
+    - name: "💾 Stage EAS config changes"
+      uses: ./.github/actions/stage-changes
+      with:
+        name: eas-config-score-tracker
+        paths: |
+          apps/score-tracker/frontend/app.config.ts
+          apps/score-tracker/frontend/app.json
+          apps/score-tracker/frontend/eas.json
+        description: "update score-tracker EAS config"
 
     - name: "🚀 Publish OTA update"
       run: |

--- a/.github/actions/stage-changes/action.yml
+++ b/.github/actions/stage-changes/action.yml
@@ -1,0 +1,105 @@
+name: "Stage repository changes"
+description: >-
+  Captures the working-tree changes of a job as a git patch and uploads it as an
+  artifact instead of pushing to the branch. A single publish job at the end of
+  the workflow applies all staged patches and pushes them in one commit, so
+  parallel jobs never race each other on the same ref.
+
+inputs:
+  name:
+    description: >-
+      Unique slug for this set of changes, e.g. "data-clumps" or
+      "readme-android-preview-frontend". Becomes part of the artifact name, so it
+      must be unique within the workflow run.
+    required: true
+  paths:
+    description: >-
+      Whitespace/newline separated list of paths to stage. Everything outside
+      these paths is ignored, so build leftovers never end up in the commit.
+    required: true
+  description:
+    description: >-
+      Human readable summary of the change, listed in the body of the final
+      commit. Defaults to the value of `name`.
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: "📦 Build patch"
+      id: patch
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.name }}
+        STAGE_PATHS: ${{ inputs.paths }}
+        STAGE_DESCRIPTION: ${{ inputs.description }}
+      run: |
+        set -euo pipefail
+
+        name="$STAGE_NAME"
+        summary="${STAGE_DESCRIPTION:-}"
+        [ -n "$summary" ] || summary="$name"
+
+        # The name ends up in an artifact name and a file name, so keep it to
+        # characters that are legal on every runner OS.
+        case "$name" in
+          ''|*[!A-Za-z0-9._-]*)
+            echo "::error::stage-changes: name '$name' must be non-empty and only contain [A-Za-z0-9._-]"
+            exit 1
+            ;;
+        esac
+
+        # A path that neither exists on disk nor is tracked would make `git add`
+        # fail with "pathspec did not match any files". Jobs legitimately produce
+        # only a subset of their declared paths (a badge but no report, say), so
+        # skip those instead of failing the build.
+        paths=()
+        while read -r path; do
+          [ -n "$path" ] || continue
+          if [ -e "$path" ] || git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+            paths+=("$path")
+          else
+            echo "Path '$path' does not exist and is not tracked, skipping."
+          fi
+        done <<< "$(printf '%s' "$STAGE_PATHS" | tr ' \t' '\n\n')"
+
+        if [ ${#paths[@]} -eq 0 ]; then
+          echo "No existing paths to stage for '$name'."
+          echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Stage into the index so the diff covers added and deleted files too.
+        # -f because report output directories are frequently gitignored.
+        git add -A -f -- "${paths[@]}"
+
+        if git diff --cached --quiet; then
+          echo "No changes for '$name', nothing to stage."
+          echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          git reset -q
+          exit 0
+        fi
+
+        mkdir -p .ci-staged
+        # --binary keeps PNG screenshots and other non-text output intact.
+        git diff --cached --binary > ".ci-staged/${name}.patch"
+        printf '%s\n' "$summary" > ".ci-staged/${name}.txt"
+
+        echo "Staged changes for '$name':"
+        git diff --cached --stat
+
+        # Restore the index so later steps in the same job are not surprised by
+        # a fully staged working tree.
+        git reset -q
+
+        echo "has-changes=true" >> "$GITHUB_OUTPUT"
+
+    - name: "📤 Upload staged changes"
+      if: steps.patch.outputs.has-changes == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-staged-changes-${{ inputs.name }}
+        path: .ci-staged/
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/actions/tag-und-jahr-expo-update/action.yml
+++ b/.github/actions/tag-und-jahr-expo-update/action.yml
@@ -146,22 +146,18 @@ runs:
       env:
         EXPO_TOKEN: ${{ inputs.EXPO_TOKEN }}
 
-    - name: "💾 Commit EAS config changes"
-      run: |
-        git config --global user.name 'Rocket Meals'
-        git config --global user.email 'nils@baumgartner-software.de'
-        git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-        if ! git diff --quiet; then
-          git add -A && git commit -m "chore: update tag-und-jahr EAS config [skip ci]"
-          for i in 1 2 3 4 5; do
-            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)" && git push && break
-            echo "Push attempt $i failed, retrying..."
-            sleep 5
-          done
-        fi
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+    # The EAS config is not pushed from here - it is staged as a patch and
+    # published together with everything else by the workflow's single
+    # publish job, so parallel jobs cannot race on the branch.
+    - name: "💾 Stage EAS config changes"
+      uses: ./.github/actions/stage-changes
+      with:
+        name: eas-config-tag-und-jahr
+        paths: |
+          apps/tag-und-jahr/frontend/app.config.ts
+          apps/tag-und-jahr/frontend/app.json
+          apps/tag-und-jahr/frontend/eas.json
+        description: "update tag-und-jahr EAS config"
 
     - name: "🚀 Publish OTA update"
       run: |

--- a/.github/workflows/backend-schema-sync-pull.yml
+++ b/.github/workflows/backend-schema-sync-pull.yml
@@ -65,17 +65,36 @@ jobs:
           fi
           yarn workspace backend-sync sync:pull-from-test-system
 
-      - name: "🤖 Configure Git"
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: "💾 Stage schema changes"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: backend-schema
+          paths: |
+            data/directus-sync-data
+            packages/common/src/databaseTypes
+          description: "pull database schema from test system"
 
-      - name: "📤 Commit and push schema changes"
-        run: |
-          git add data/directus-sync-data packages/common/src/databaseTypes
-          if git diff --cached --quiet; then
-            echo "ℹ️ No schema changes detected, nothing to commit."
-          else
-            git commit -m "${{ github.event.inputs.commit_message || 'chore: pull database schema from test system [skip ci]' }}"
-            git push origin HEAD:${{ github.ref_name }}
-          fi
+  # Single writer to the branch: the job above only uploads its changes as a
+  # patch artifact, this job applies it and pushes it with a rebase-retry.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [sync]
+    if: always()
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "${{ github.event.inputs.commit_message || 'chore: pull database schema from test system [skip ci]' }}"

--- a/.github/workflows/build-and-update-rocket-meals.yml
+++ b/.github/workflows/build-and-update-rocket-meals.yml
@@ -119,20 +119,12 @@ jobs:
           app-key: frontend
           app-label: "Rocket Meals (Frontend)"
           update-readme: 'true'
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Android preview APK link in README [skip ci]"
-            git pull --rebase --autostash origin master
-            git push origin HEAD:master
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-android-preview-frontend
+          paths: README.md
+          description: "update Rocket Meals Android preview APK link in README"
 
   build-ios:
     name: "📦 Build & 🚀 Submit iOS App (forced)"
@@ -154,3 +146,28 @@ jobs:
         working-directory: ./apps/frontend/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+  # Single writer to the branch: the jobs above only upload their changes as
+  # patch artifacts, this job applies them and creates exactly one commit.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [guard, build-android-preview]
+    if: always() && needs.guard.result == 'success'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: master
+          commit-message: "chore: update generated files [skip ci]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,25 +197,12 @@ jobs:
               labels: labels,
             });
             console.log(`Created issue #${created.number}`);
-      - name: "💾 Commit reports"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-          if [ -d reports/sonarCloud ]; then
-            echo "Committing reports from reports/sonarCloud"
-            git add -f reports/sonarCloud
-            if git diff --cached --quiet; then
-              echo "No changes to commit"
-            else
-              git commit -m "chore: update sonarcloud reports [skip ci]"
-              git push
-            fi
-          else
-            echo "No reports generated at reports/sonarCloud, skipping commit"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage reports"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: sonarcloud-reports
+          paths: reports/sonarCloud
+          description: "update sonarcloud reports"
 
   data-clumps-report:
     name: "🩺 Analyse Data Clumps"
@@ -263,19 +250,14 @@ jobs:
           only-update-if-changes: 'false'
           refactor-amount: 15
           detector-options-paths-ignored-in-detection-comparison: '**/databaseTypes/types.ts'
-      - name: "💾 Commit reports"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add -f reports/data-clumps-doctor/data-clumps.json reports/data-clumps-doctor/badges/data-clumps.svg
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update data-clumps reports [skip ci]"
-            git push --force
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage reports"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: data-clumps
+          paths: |
+            reports/data-clumps-doctor/data-clumps.json
+            reports/data-clumps-doctor/badges/data-clumps.svg
+          description: "update data-clumps reports"
 
   backend-directus:
     name: "🔨 Directus Backend Build"
@@ -367,20 +349,12 @@ jobs:
           app-label: "Rocket Meals (Frontend)"
           update-readme: 'true'
 
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Android preview APK link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-android-preview-frontend
+          paths: README.md
+          description: "update Rocket Meals Android preview APK link in README"
 
   build-ios:
     name: "📦 Build & 🚀 Submit iOS App"
@@ -499,20 +473,12 @@ jobs:
           app-label: "Geonexia"
           update-readme: 'true'
 
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Geonexia Android preview APK link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-android-preview-geonexia
+          paths: README.md
+          description: "update Geonexia Android preview APK link in README"
 
   score-tracker-check-build:
     name: "🔍 Score Tracker Check iOS Build Number (online)"
@@ -609,20 +575,12 @@ jobs:
           app-label: "Score Tracker"
           update-readme: 'true'
 
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Score Tracker Android preview APK link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-android-preview-score-tracker
+          paths: README.md
+          description: "update Score Tracker Android preview APK link in README"
 
   tag-und-jahr-check-build:
     name: "🔍 Tag und Jahr Check iOS Build Number (online)"
@@ -741,20 +699,12 @@ jobs:
           app-label: "Tag und Jahr"
           update-readme: 'true'
 
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Tag und Jahr Android preview APK link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-android-preview-tag-und-jahr
+          paths: README.md
+          description: "update Tag und Jahr Android preview APK link in README"
 
   deploy-gh-pages:
     name: "🌍 Deploy to GitHub Pages"
@@ -783,23 +733,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#  push-changes:
-#    name: "📤 Push Changes"
-#    runs-on: ubuntu-latest
-#    needs: [backend-directus, sonarcloud-report, data-clumps-report, check-repository]
-#    if: ${{ needs.check-repository.outputs.is-upstream == 'true' }}
-#    steps:
-#      - name: "🔄 Checkout Repository"
-#        uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.ref_name }}
-#          fetch-depth: 0
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: "📤 Push accumulated changes"
-#        run: |
-#          git config user.name "github-actions"
-#          git config user.email "github-actions@github.com"
-#          git push
+  # Single writer to the branch. Every job above only uploads its changes as a
+  # patch artifact; this job applies all of them and creates exactly one commit.
+  # `if: always()` so that a failing build (e.g. one iOS preview) does not throw
+  # away the results of all the jobs that did succeed.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs:
+      - check-repository
+      - sonarcloud-report
+      - data-clumps-report
+      - backend-directus
+      - geonexia-expo-update
+      - score-tracker-expo-update
+      - tag-und-jahr-expo-update
+      - build-android-preview
+      - geonexia-build-android-preview
+      - score-tracker-build-android-preview
+      - tag-und-jahr-build-android-preview
+      - build-ios-preview
+      - geonexia-build-ios-preview
+      - score-tracker-build-ios-preview
+      - tag-und-jahr-build-ios-preview
+    if: always() && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update generated files [skip ci]"
 
   # iOS previews (ad-hoc) mirror the Android preview APK jobs: only
   # master@rocket-meals/rocket-meals builds them and publishes the install
@@ -831,20 +805,12 @@ jobs:
           app-key: frontend
           app-label: "Rocket Meals (Frontend)"
           update-readme: 'true'
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update iOS preview link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-ios-preview-frontend
+          paths: README.md
+          description: "update Rocket Meals iOS preview link in README"
 
   geonexia-build-ios-preview:
     name: "🧪 Geonexia Build iOS Preview (Ad-hoc)"
@@ -872,20 +838,12 @@ jobs:
           app-key: geonexia
           app-label: "Geonexia"
           update-readme: 'true'
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Geonexia iOS preview link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-ios-preview-geonexia
+          paths: README.md
+          description: "update Geonexia iOS preview link in README"
 
   score-tracker-build-ios-preview:
     name: "🧪 Score Tracker Build iOS Preview (Ad-hoc)"
@@ -913,20 +871,12 @@ jobs:
           app-key: score-tracker
           app-label: "Score Tracker"
           update-readme: 'true'
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Score Tracker iOS preview link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-ios-preview-score-tracker
+          paths: README.md
+          description: "update Score Tracker iOS preview link in README"
 
   tag-und-jahr-build-ios-preview:
     name: "🧪 Tag und Jahr Build iOS Preview (Ad-hoc)"
@@ -954,17 +904,9 @@ jobs:
           app-key: tag-und-jahr
           app-label: "Tag und Jahr"
           update-readme: 'true'
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Tag und Jahr iOS preview link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-ios-preview-tag-und-jahr
+          paths: README.md
+          description: "update Tag und Jahr iOS preview link in README"

--- a/.github/workflows/data-clumps-force.yml
+++ b/.github/workflows/data-clumps-force.yml
@@ -40,16 +40,36 @@ jobs:
           only-update-if-changes: 'false'
           refactor-amount: ${{ github.event.inputs.amount || '5' }}
           detector-options-paths-ignored-in-detection-comparison: '**/databaseTypes/types.ts'
-      - name: "💾 Commit reports"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add -f reports/data-clumps-doctor/data-clumps.json reports/data-clumps-doctor/badges/data-clumps.svg
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update data-clumps reports [skip ci]"
-            git push --force
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage reports"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: data-clumps
+          paths: |
+            reports/data-clumps-doctor/data-clumps.json
+            reports/data-clumps-doctor/badges/data-clumps.svg
+          description: "update data-clumps reports"
+
+  # Single writer to the branch. This used to be a `git push --force`, which
+  # could silently drop commits other jobs had pushed in the meantime.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [data-clumps-force]
+    if: always()
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update data-clumps reports [skip ci]"

--- a/.github/workflows/frontend-accessibility.yml
+++ b/.github/workflows/frontend-accessibility.yml
@@ -60,17 +60,35 @@ jobs:
           name: accessibility-reports
           path: reports/accessibility/
 
-      - name: "💾 Commit reports"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git pull --rebase --autostash origin ${{ github.ref_name }}
-          git add -f reports/accessibility/
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update accessibility reports [skip ci]"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "💾 Stage reports"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: accessibility-report
+          paths: reports/accessibility
+          description: "update accessibility reports"
+
+  # Single writer to the branch: the job above only uploads its reports as a
+  # patch artifact, this job applies it and pushes it with a rebase-retry so a
+  # concurrent CI push cannot make it fail.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [accessibility-audit]
+    if: always() && github.repository == 'rocket-meals/rocket-meals'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update accessibility reports [skip ci]"

--- a/.github/workflows/frontend-dev-client.yml
+++ b/.github/workflows/frontend-dev-client.yml
@@ -239,15 +239,37 @@ jobs:
           # URL needs these as fallback (same values as the PR comment step).
           EAS_ACCOUNT_NAME: baumgartner-software
           EAS_PROJECT_SLUG: rocket-meals-dev
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Rocket Meals dev client links in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-dev-client-frontend
+          paths: README.md
+          description: "update Rocket Meals dev client links in README"
+
+  # Single writer to the branch: the job above only uploads its README
+  # change as a patch artifact, this job applies it and pushes it with a
+  # rebase-retry so a concurrent CI push cannot make it fail.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [check-repository, update-readme]
+    if: >-
+      always() && github.event_name == 'push'
+      && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update Rocket Meals dev client links in README [skip ci]"

--- a/.github/workflows/geonexia-dev-client.yml
+++ b/.github/workflows/geonexia-dev-client.yml
@@ -239,15 +239,37 @@ jobs:
           # URL needs these as fallback (same values as the PR comment step).
           EAS_ACCOUNT_NAME: baumgartner-software
           EAS_PROJECT_SLUG: geonexia
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Geonexia dev client links in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-dev-client-geonexia
+          paths: README.md
+          description: "update Geonexia dev client links in README"
+
+  # Single writer to the branch: the job above only uploads its README
+  # change as a patch artifact, this job applies it and pushes it with a
+  # rebase-retry so a concurrent CI push cannot make it fail.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [check-repository, update-readme]
+    if: >-
+      always() && github.event_name == 'push'
+      && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update Geonexia dev client links in README [skip ci]"

--- a/.github/workflows/score-tracker-dev-client.yml
+++ b/.github/workflows/score-tracker-dev-client.yml
@@ -239,15 +239,37 @@ jobs:
           # URL needs these as fallback (same values as the PR comment step).
           EAS_ACCOUNT_NAME: baumgartner-software
           EAS_PROJECT_SLUG: score-tracker
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Score Tracker dev client links in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-dev-client-score-tracker
+          paths: README.md
+          description: "update Score Tracker dev client links in README"
+
+  # Single writer to the branch: the job above only uploads its README
+  # change as a patch artifact, this job applies it and pushes it with a
+  # rebase-retry so a concurrent CI push cannot make it fail.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [check-repository, update-readme]
+    if: >-
+      always() && github.event_name == 'push'
+      && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update Score Tracker dev client links in README [skip ci]"

--- a/.github/workflows/tag-und-jahr-dev-client.yml
+++ b/.github/workflows/tag-und-jahr-dev-client.yml
@@ -239,15 +239,37 @@ jobs:
           # URL needs these as fallback (same values as the PR comment step).
           EAS_ACCOUNT_NAME: baumgartner-software
           EAS_PROJECT_SLUG: tag-und-jahr
-      - name: "💾 Commit README update"
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update Tag und Jahr dev client links in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
+      - name: "💾 Stage README update"
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-dev-client-tag-und-jahr
+          paths: README.md
+          description: "update Tag und Jahr dev client links in README"
+
+  # Single writer to the branch: the job above only uploads its README
+  # change as a patch artifact, this job applies it and pushes it with a
+  # rebase-retry so a concurrent CI push cannot make it fail.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [check-repository, update-readme]
+    if: >-
+      always() && github.event_name == 'push'
+      && needs.check-repository.outputs.is-upstream == 'true'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: update Tag und Jahr dev client links in README [skip ci]"

--- a/.github/workflows/test-android-preview-apk.yml
+++ b/.github/workflows/test-android-preview-apk.yml
@@ -61,18 +61,35 @@ jobs:
         run: |
           echo "APK URL: ${{ steps.build.outputs.apk-url }}"
 
-      - name: "💾 Commit README update"
+      - name: "💾 Stage README update"
         if: github.event.inputs.update_readme == 'true'
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add README.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: test Android preview APK link in README [skip ci]"
-            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/stage-changes
+        with:
+          name: readme-android-preview-test
+          paths: README.md
+          description: "test Android preview APK link in README"
+
+  # Single writer to the branch: the job above only uploads its README change as
+  # a patch artifact, this job applies it and pushes it with a rebase-retry.
+  publish-staged-changes:
+    name: "📤 Publish Staged Changes"
+    runs-on: ubuntu-latest
+    needs: [test-build-android-preview-apk]
+    if: always() && github.event.inputs.update_readme == 'true'
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # fetch-depth: 0 is required - `git apply --3way` needs the blobs the
+      # staged patches were built against.
+      - name: "🔄 Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📤 Apply and push all staged changes"
+        uses: ./.github/actions/publish-staged-changes
+        with:
+          branch: ${{ github.ref_name }}
+          commit-message: "chore: test Android preview APK link in README [skip ci]"


### PR DESCRIPTION
Up to 14 jobs of a single CI run pushed to master independently. Between a
job's `git pull --rebase` and its `git push` another job could land, and the
push failed with "cannot lock ref ... is at X but expected Y". The data-clumps
job papered over this with `git push --force`, which could silently drop
commits other jobs had already pushed.

Jobs no longer write to the branch at all. Each one stages its changes as a
binary-safe git patch and uploads it as an artifact; a single publish job at
the end of the run applies all patches and creates exactly one commit.

- .github/actions/stage-changes: builds the patch and uploads it as
  ci-staged-changes-<name>. Missing paths are skipped, no-op jobs upload
  nothing.
- .github/actions/publish-staged-changes: applies every staged patch with
  `git apply --3way` (so two jobs editing different README sections merge
  instead of overwriting each other), squashes them into one commit and pushes
  with a rebase-retry using exponential backoff plus jitter. A patch that
  conflicts is rolled back individually, the remaining ones still get
  published, and the job fails loudly instead of silently losing the update.
- The publish job runs with `if: always()` so a failing build does not discard
  the results of the jobs that succeeded.

Both `git push --force` call sites are gone. sync-dev-to-master, sync-fork and
pr-expo-preview keep their own pushes - they write branches/tags rather than
generated files.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SCvLC88esdgGLpuk6PwtC3