### PR TITLE
feat: Modal-Titel „Speise Info“ + Versionsnummer im Drawer

### DIFF
--- a/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
+++ b/apps/frontend/app/components/Drawer/CustomDrawerContent.tsx
@@ -24,6 +24,7 @@ import CollectibleSpot from '@/components/CollectibleItem/CollectibleSpot';
 import useConfirmLogoutModal from '@/hooks/useConfirmLogoutModal';
 import useLogoutButtonTranslation from '@/hooks/useLogoutButtonTranslation';
 import { AppDrawer, DrawerItem, DrawerItemBaseFields } from 'repo-depkit-common-ui';
+import { getVersionInternalForAppsettingsScreen } from '@/config';
 import useCustomerConfig from '@/hooks/useCustomerConfig';
 
 export const iconLibraries: Record<string, any> = {
@@ -371,6 +372,7 @@ const CustomDrawerContent: React.FC<DrawerContentComponentProps> = ({ navigation
 			activeKey={activeKey}
 			primaryColor={projectColor}
 			footerContent={footerContent}
+			version={getVersionInternalForAppsettingsScreen()}
 		/>
 	);
 };

--- a/apps/frontend/app/components/FoodItem/FoodItem.tsx
+++ b/apps/frontend/app/components/FoodItem/FoodItem.tsx
@@ -306,7 +306,7 @@ export const FoodItemBase: React.FC<FoodItemProps> = memo(
       if (!foodDescription) return;
       showScrollViewModal(
         {
-          title: translate(TranslationKeys.description),
+          title: translate(TranslationKeys.food_info),
           children: (
             <View style={{ gap: 20 }}>
               <MyMarkdownProjectColored content={foodDescription} textColor={theme.screen.text} />

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -73,7 +73,8 @@ export function getVersionPatch() {
         // 16: SonarCloud/data-clumps clean-up (shared redirect button, license and
         //     Google service account types)
         // 17: MyMap (web): message origin check kept inline at the listener
-        return 17;
+        // 18: food info modal titled "Speise Info" instead of "Beschreibung"
+        return 18;
 }
 
 export function getVersionInternalForAppsettingsScreen() {

--- a/apps/frontend/app/locales/keys.ts
+++ b/apps/frontend/app/locales/keys.ts
@@ -130,6 +130,7 @@ export enum TranslationKeys {
 	description = 'description',
 	information = 'information',
 	no_data_currently_calculating = 'no_data_currently_calculating',
+	food_info = 'food_info',
 	food_data = 'food_data',
 	food_feedbacks = 'food_feedbacks',
 	to_the_forum = 'to_the_forum',

--- a/apps/frontend/app/locales/translations.json
+++ b/apps/frontend/app/locales/translations.json
@@ -1339,6 +1339,16 @@
     "tr": "Veri bulunamadı veya şu anda hesaplanıyor.",
     "zh": "未找到数据或当前正在计算。"
   },
+  "food_info": {
+    "de": "Speise Info",
+    "en": "Food Info",
+    "ar": "معلومات الطعام",
+    "es": "Información del plato",
+    "fr": "Info sur le plat",
+    "ru": "Информация о блюде",
+    "tr": "Yemek Bilgisi",
+    "zh": "菜品信息"
+  },
   "food_data": {
     "de": "Speisedaten",
     "en": "Food Data",

--- a/apps/geonexia/frontend/app/_layout.tsx
+++ b/apps/geonexia/frontend/app/_layout.tsx
@@ -40,7 +40,7 @@ import { loadHexTileFeatureCache, mergeHexTileFeatureCache, type HexTileFeatureC
 import { queryTileFeaturesForHexCell } from '../helpers/TileFeatureHelper';
 import { isAvailable as isH3Available } from '../helpers/H3Helper';
 import type { RootState } from '../store/store';
-import { getAppIconInsideExpoLocalSaved } from '../config';
+import { getAppIconInsideExpoLocalSaved, getVersionInternalForAppsettingsScreen } from '../config';
 import ExpoUpdateLoader from '../components/ExpoUpdateLoader';
 import { useExpoUpdateForegroundCheck } from '../hooks/useExpoUpdateForegroundCheck';
 
@@ -406,6 +406,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
 			primaryColor="#2563eb"
 			onLogoPress={() => props.navigation.navigate('index')}
 			footerContent={footerContent}
+			version={getVersionInternalForAppsettingsScreen()}
 		/>
 	);
 }

--- a/apps/geonexia/frontend/config.ts
+++ b/apps/geonexia/frontend/config.ts
@@ -41,7 +41,8 @@ export function getVersionPatch() {
 	// 15: SonarCloud/data-clumps clean-up (live speed kept in a ref, shared
 	//     modal/license/sqlite settings types)
 	// 16: MyMap (web): message origin check kept inline at the listener
-	return 16;
+	// 17: app version shown at the bottom of the drawer
+	return 17;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/score-tracker/frontend/app/_layout.tsx
+++ b/apps/score-tracker/frontend/app/_layout.tsx
@@ -26,7 +26,7 @@ import { loadAppSettings } from '../helpers/AppSettingsStorage';
 import { loadDebugState } from '../helpers/DebugStorage';
 import { installGlobalDebugErrorHandler } from '../helpers/DebugLogger';
 import type { RootState } from '../store/store';
-import { getAppIconInsideExpoLocalSaved, getCustomerConfig } from '../config';
+import { getAppIconInsideExpoLocalSaved, getCustomerConfig, getVersionInternalForAppsettingsScreen } from '../config';
 import { ComponentIds } from '../constants/ComponentIds';
 import ExpoUpdateLoader from '../components/ExpoUpdateLoader';
 import OnboardingScreen from '../components/OnboardingScreen';
@@ -285,6 +285,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
 			primaryColor={PRIMARY_COLOR}
 			onLogoPress={() => props.navigation.navigate('index')}
 			footerContent={footerContent}
+			version={getVersionInternalForAppsettingsScreen()}
 		/>
 	);
 }

--- a/apps/score-tracker/frontend/config.ts
+++ b/apps/score-tracker/frontend/config.ts
@@ -38,7 +38,8 @@ export function getVersionPatch() {
 	// 9: data-clumps clean-up (shared app settings, match record and customer
 	//    config types)
 	// 10: MyMap (web): message origin check kept inline at the listener
-	return 10;
+	// 11: app version shown at the bottom of the drawer
+	return 11;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/apps/tag-und-jahr/frontend/app/_layout.tsx
+++ b/apps/tag-und-jahr/frontend/app/_layout.tsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { Drawer } from 'expo-router/drawer';
+import { Drawer, DrawerContentComponentProps, DrawerContentScrollView, DrawerItemList } from 'expo-router/drawer';
 import { StatusBar } from 'expo-status-bar';
-import { ColorValue } from 'react-native';
+import { ColorValue, StyleSheet, Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { CLOCK_COLORS } from '../helpers/clockDesign';
+import { getVersionInternalForAppsettingsScreen } from '../config';
 
 function makeDrawerIcon(name: keyof typeof Ionicons.glyphMap) {
 	return ({ color, size }: { color: ColorValue; size: number }) => <Ionicons name={name} size={size} color={color} />;
+}
+
+// Default drawer content plus the app version at the very bottom, below the
+// menu entries - the same value the other apps show in their settings screen,
+// so users can verify which OTA update they are running.
+function DrawerContent(props: DrawerContentComponentProps) {
+	return (
+		<DrawerContentScrollView {...props} contentContainerStyle={styles.drawerContent}>
+			<DrawerItemList {...props} />
+			<Text style={styles.version}>{`v${getVersionInternalForAppsettingsScreen()}`}</Text>
+		</DrawerContentScrollView>
+	);
 }
 
 export default function Layout() {
@@ -15,6 +28,7 @@ export default function Layout() {
 		<GestureHandlerRootView style={{ flex: 1 }}>
 			<StatusBar style="light" />
 			<Drawer
+				drawerContent={(props) => <DrawerContent {...props} />}
 				screenOptions={{
 					headerStyle: { backgroundColor: CLOCK_COLORS.background },
 					headerTintColor: '#e8ebf1',
@@ -44,3 +58,19 @@ export default function Layout() {
 		</GestureHandlerRootView>
 	);
 }
+
+const styles = StyleSheet.create({
+	drawerContent: {
+		flexGrow: 1,
+		justifyContent: 'space-between',
+	},
+	version: {
+		marginTop: 10,
+		paddingHorizontal: 16,
+		paddingBottom: 16,
+		fontSize: 12,
+		color: CLOCK_COLORS.background,
+		opacity: 0.8,
+		textAlign: 'center',
+	},
+});

--- a/apps/tag-und-jahr/frontend/config.ts
+++ b/apps/tag-und-jahr/frontend/config.ts
@@ -32,7 +32,8 @@ export function getVersionPatch() {
 	// 4: SonarCloud clean-up (widget settings sync split into helpers)
 	// 5: SonarCloud/data-clumps clean-up (settings screen split into panels,
 	//    shared customer config type)
-	return 5;
+	// 6: app version shown at the bottom of the drawer
+	return 6;
 }
 
 // Version used for app.config.ts (`version`, and thus the expo-updates

--- a/packages/common-ui/src/components/AppDrawer/AppDrawer.tsx
+++ b/packages/common-ui/src/components/AppDrawer/AppDrawer.tsx
@@ -14,6 +14,7 @@ const AppDrawer: React.FC<AppDrawerProps> = ({
 	activeKey,
 	primaryColor,
 	footerContent,
+	version,
 }) => {
 	const { theme, isDark } = useTheme();
 	const resolvedPrimaryColor = primaryColor ?? theme.primary;
@@ -113,8 +114,13 @@ const AppDrawer: React.FC<AppDrawerProps> = ({
 						) : null}
 					</View>
 				</View>
-				{footerContent ? (
-					<View style={styles.footer}>{footerContent}</View>
+				{footerContent || version ? (
+					<View>
+						{footerContent ? <View style={styles.footer}>{footerContent}</View> : null}
+						{version ? (
+							<Text style={[styles.version, { color: theme.inactiveText }]}>{`v${version}`}</Text>
+						) : null}
+					</View>
 				) : null}
 			</ScrollView>
 		</SafeAreaView>
@@ -213,5 +219,13 @@ const styles = StyleSheet.create({
 		flexWrap: 'wrap',
 		marginTop: 10,
 		paddingHorizontal: 15,
+	},
+	version: {
+		width: '100%',
+		marginTop: 10,
+		paddingHorizontal: 15,
+		fontSize: 12,
+		opacity: 0.6,
+		textAlign: 'center',
 	},
 });

--- a/packages/common-ui/src/components/AppDrawer/types.ts
+++ b/packages/common-ui/src/components/AppDrawer/types.ts
@@ -23,4 +23,11 @@ export interface AppDrawerProps {
 	activeKey?: string;
 	primaryColor?: string;
 	footerContent?: React.ReactNode;
+	/**
+	 * App version shown at the very bottom of the drawer, below the bottom items
+	 * and the footer content. Pass the same value the settings screen shows
+	 * (`getVersionInternalForAppsettingsScreen()`), so users can verify which OTA
+	 * update they are running without opening the settings screen.
+	 */
+	version?: string;
 }


### PR DESCRIPTION
## 1. Modal-Titel „Speise Info“ statt „Beschreibung“

Das Modal, das über das **Info-Icon** auf einer Speisen-Karte geöffnet wird (nicht das Details-Modal beim Klick auf die Speise selbst), hatte den Titel **„Beschreibung“**. Es heißt jetzt **„Speise Info“**.

- `apps/frontend/app/locales/translations.json`: neuer Key `food_info` mit Übersetzungen für alle 8 Sprachen (de/en/ar/es/fr/ru/tr/zh) — `de: "Speise Info"`, `en: "Food Info"`.
- `apps/frontend/app/locales/keys.ts`: `food_info` in `TranslationKeys` ergänzt.
- `apps/frontend/app/components/FoodItem/FoodItem.tsx`: `handleDescriptionModal` nutzt jetzt `TranslationKeys.food_info` statt `TranslationKeys.description` als Modal-Titel.

Der bestehende Key `description` bleibt unverändert, da er weiterhin für Campus- und Wohnungs-Details verwendet wird.

## 2. Versionsnummer im Drawer (alle Apps)

Die Versionsnummer war bisher nur im Settings-Screen sichtbar. Sie wird jetzt in **allen Apps** ganz unten im Drawer angezeigt — unter den Bottom-Items und den Footer-Links — mit derselben Funktion wie im Settings-Screen (`getVersionInternalForAppsettingsScreen()`), damit Nutzer ohne Umweg prüfen können, welches OTA-Update läuft.

- `packages/common-ui/src/components/AppDrawer/`: neue optionale Prop `version`; wird als `v<major>.<build>.<patch>` unterhalb des Footers gerendert. Der Footer-Block bleibt ein einzelnes Kind des `space-between`-Containers, damit sich das bestehende Layout nicht verschiebt.
- Rocket Meals (`CustomDrawerContent.tsx`), Geonexia und Score Tracker (`app/_layout.tsx`) übergeben die Prop.
- Tag und Jahr nutzt den Standard-Drawer von `expo-router` und hat keine Bottom-Items. Dort kommt ein eigenes `drawerContent` (Standard-`DrawerItemList` + Versionszeile) zum Einsatz — über die Drawer-Views, die `expo-router/drawer` bereits re-exportiert, also **ohne neue Dependency**.

## Versionen

Patch-Version in allen betroffenen Apps erhöht (gemäß AGENTS.md, inkl. der Apps, die `packages/common-ui` konsumieren):

| App | Patch |
| --- | --- |
| `apps/frontend/app` | 17 → 19 (18 kam zwischenzeitlich aus master) |
| `apps/geonexia/frontend` | 16 → 17 |
| `apps/score-tracker/frontend` | 10 → 11 |
| `apps/tag-und-jahr/frontend` | 5 → 6 |

## Prüfung

`npx tsc --noEmit` in allen vier Apps ausgeführt. Tag und Jahr sowie Score Tracker sind sauber; Rocket Meals und Geonexia melden nur bereits vorher bestehende Fehler — keiner davon in den hier geänderten Zeilen (`CustomDrawerContent.tsx` fehlerfrei, die `FoodItem.tsx`-Meldungen betreffen die Zeilen 337/519/520, nicht den geänderten Modal-Titel).

## Hinweise

- **Kein Screenshot beigefügt** — in dieser Session war kein lauffähiger App-Build/Simulator verfügbar.
- Die Übersetzungen für ar/es/fr/ru/tr/zh sind neu gesetzt und nicht aus einer bestehenden Quelle übernommen; falls es dafür einen Review-Prozess gibt, sollte der noch drüberlaufen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3HuaQffMqpreHbizJmMAb