### PR TITLE
fix(frontend): repair photo upload broken by Expo SDK 57

### DIFF
--- a/apps/frontend/app/app/(app)/form-queue/index.tsx
+++ b/apps/frontend/app/app/(app)/form-queue/index.tsx
@@ -45,14 +45,22 @@ const resolveDateValueField = (value: any, fieldType: string): Record<string, an
     return { value_date: formattedDate };
 };
 
+// Only web reads the bytes upfront - on native the local uri is handed to the upload helper
+// as is, `fetch` cannot read `file://`/`data:` uris there.
+const uploadLocalFile = async (value: any, folderId: string | null) => {
+    if (!isWeb) {
+        return uploadToDirectusFromMobile({ name: value.name, type: value.type, buffer: value.image, edit: true }, folderId);
+    }
+    const response = await fetch(value.image);
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = MyBuffer.from(arrayBuffer);
+    return uploadToDirectus({ name: value.name, type: value.type, buffer, edit: true }, folderId);
+};
+
 const resolveImageValueField = async (value: any, fieldId: string, imageFolderId: string | null): Promise<Record<string, any>> => {
     if (value?.name) {
         try {
-            const response = await fetch(value.image);
-            const arrayBuffer = await response.arrayBuffer();
-            const buffer = MyBuffer.from(arrayBuffer);
-            const fileData = { name: value.name, type: value.type, buffer: isWeb ? buffer : value.image, edit: true };
-            const fileId = isWeb ? await uploadToDirectus(fileData, imageFolderId) : await uploadToDirectusFromMobile(fileData, imageFolderId);
+            const fileId = await uploadLocalFile(value, imageFolderId);
             return { value_image: fileId };
         } catch (uploadError) {
             console.error('Queue sync: image upload failed for field', fieldId, uploadError);
@@ -70,15 +78,7 @@ const resolveFilesValueField = async (value: any, fieldId: string, filesFolderId
         try {
             const newFiles = value.filter((file: any) => !file?.edit);
             if (newFiles.length > 0) {
-                const uploadedIds = await Promise.all(
-                    newFiles.map(async (file: any) => {
-                        const response = await fetch(file.image);
-                        const arrayBuffer = await response.arrayBuffer();
-                        const buffer = MyBuffer.from(arrayBuffer);
-                        const fileData = { name: file.name, type: file.type, buffer: isWeb ? buffer : file.image, edit: true };
-                        return isWeb ? uploadToDirectus(fileData, filesFolderId) : uploadToDirectusFromMobile(fileData, filesFolderId);
-                    })
-                );
+                const uploadedIds = await Promise.all(newFiles.map((file: any) => uploadLocalFile(file, filesFolderId)));
                 return {
                     value_files: {
                         create: uploadedIds.filter(Boolean).map((fileId: any) => ({ directus_files_id: fileId })),

--- a/apps/frontend/app/app/(app)/form-submission/index.tsx
+++ b/apps/frontend/app/app/(app)/form-submission/index.tsx
@@ -854,22 +854,23 @@ const Index = () => {
 	);
 
 	const getDirectusUploadId = async (value: any, folderId?: string | null) => {
+		// Only web reads the bytes upfront - on native the local uri is handed to the upload
+		// helper as is, `fetch` cannot read `file://`/`data:` uris there.
+		if (!isWeb) {
+			const nativeFileData = { name: value.name, type: value.type, buffer: value.image, edit: true };
+			return uploadToDirectusFromMobile(nativeFileData, folderId);
+		}
+
 		const response = await fetch(value.image);
 		const arrayBuffer = await response.arrayBuffer();
 		const buffer = MyBuffer.from(arrayBuffer);
 		const fileData = {
 			name: value.name,
 			type: value.type,
-			buffer: isWeb ? buffer : value.image,
+			buffer,
 			edit: true,
 		};
-		let fileId;
-		if (isWeb) {
-			fileId = await uploadToDirectus(fileData, folderId);
-		} else {
-			fileId = await uploadToDirectusFromMobile(fileData, folderId);
-		}
-		return fileId;
+		return uploadToDirectus(fileData, folderId);
 	};
 
 	const handleAddToQueue = () => {

--- a/apps/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
+++ b/apps/frontend/app/components/ImageManagementSheet/ImageManagementSheet.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Alert, Dimensions, Platform, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Alert, Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
@@ -10,6 +10,7 @@ import { ImageManagementSheetProps } from './types';
 import { ServerAPI } from '@/redux/actions';
 import { uploadFiles } from '@directus/sdk';
 import { CollectionHelper } from '@/helper/collectionHelper';
+import { buildDirectusUploadFormData } from '@/helper/fileUploadHelper';
 import { useAppSelector } from '@/redux/hooks';
 import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -41,51 +42,6 @@ async function resizeImageIfTooLarge(uri: string, width: number, height: number,
 	const resizedImage = await ImageManipulator.manipulateAsync(uri, [{ resize: newDimensions }], { compress: 1, format: ImageManipulator.SaveFormat.JPEG });
 
 	return resizedImage.uri;
-}
-
-/**
- * Builds the FormData payload for an image upload, using the platform-specific
- * way of turning a local file uri into a file/blob part.
- */
-async function buildImageFormData(finalUri: string, file_name: string, storage: string): Promise<FormData> {
-	const formData = new FormData();
-
-	if (Platform.OS === 'web') {
-		const blob: Blob = await new Promise((resolve, reject) => {
-			const xhr = new XMLHttpRequest();
-			xhr.onload = function () {
-				resolve(xhr.response);
-			};
-			xhr.onerror = function (e) {
-				console.log(e);
-				reject(new TypeError('Network request failed'));
-			};
-			xhr.responseType = 'blob';
-			xhr.open('GET', finalUri, true);
-			xhr.send(null);
-		});
-
-		if (storage) {
-			formData.append('folder', storage);
-		}
-		formData.append('image', blob, file_name);
-	} else {
-		const uriParts = finalUri.split('.');
-		const fileType = uriParts.at(-1);
-		const fileExtension = `.${fileType}`;
-
-		const file: any = {
-			uri: finalUri,
-			name: file_name + fileExtension,
-			type: `image/${fileType}`,
-		};
-		if (storage) {
-			formData.append('folder', storage);
-		}
-		formData.append('image', file, file_name);
-	}
-
-	return formData;
 }
 
 const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet, selectedFoodId, handleFetch, fileName }) => {
@@ -163,11 +119,14 @@ const ImageManagementSheet: React.FC<ImageManagementSheetProps> = ({ closeSheet,
 			if (fileName === 'foods') {
 				storage = getFolder();
 			}
-			const formData = await buildImageFormData(finalUri, file_name, storage);
+			const formData = await buildDirectusUploadFormData({
+				uri: finalUri,
+				fileName: file_name,
+				folderId: storage,
+				title: file_name,
+			});
 
 			const client = ServerAPI.getClient();
-			formData.append('title', file_name);
-
 			const resultFileUpload = await client.request(uploadFiles(formData));
 
 			const file_id = resultFileUpload.id;

--- a/apps/frontend/app/config.ts
+++ b/apps/frontend/app/config.ts
@@ -73,7 +73,8 @@ export function getVersionPatch() {
         // 16: SonarCloud/data-clumps clean-up (shared redirect button, license and
         //     Google service account types)
         // 17: MyMap (web): message origin check kept inline at the listener
-        return 17;
+        // 18: image and file uploads fixed for Expo SDK 57 (expo/fetch form parts)
+        return 18;
 }
 
 export function getVersionInternalForAppsettingsScreen() {

--- a/apps/frontend/app/constants/HelperFunctions.ts
+++ b/apps/frontend/app/constants/HelperFunctions.ts
@@ -4,6 +4,7 @@ import { Platform } from 'react-native';
 import Server from './ServerUrl';
 import { DatabaseTypes, NumberHelper, StringHelper } from 'repo-depkit-common';
 import { ServerAPI } from '@/redux/actions';
+import { buildDirectusUploadFormData } from '@/helper/fileUploadHelper';
 import { configureStore } from '@/redux/store';
 import { PriceGroupKey } from '@/app/(app)/settings/types';
 
@@ -96,11 +97,13 @@ export const uploadToDirectus = async (image: any, folderId?: string | null) => 
 
 		const blob = new Blob([image.buffer], { type: image.type || '' });
 
+		// Directus only applies the payload fields it has already read when it reaches the
+		// file part, so the file has to be appended last.
 		const formData = new FormData();
-		formData.append('file', blob, image.name);
 		formData.append('filename_download', image.name);
 		if (folderId) formData.append('folder', folderId);
 		formData.append('type', image.type);
+		formData.append('file', blob, image.name);
 
 		const uploadResponse = await fetch(`${Server.ServerUrl}/files`, {
 			method: 'POST',
@@ -130,15 +133,13 @@ export const uploadToDirectusFromMobile = async (image: any, folderId?: string |
 	try {
 		const token = await ServerAPI.getClient().getToken();
 
-		const formData = new FormData();
-		formData.append('file', {
+		// image.buffer is the local uri of the picked file (or a data uri for a signature).
+		const formData = await buildDirectusUploadFormData({
 			uri: image.buffer,
-			name: image.name || 'signature.png',
-			type: image.type || 'image/png',
-		} as any);
-		formData.append('filename_download', image.name);
-		if (folderId) formData.append('folder', folderId);
-		formData.append('type', image.type);
+			fileName: image.name || 'signature.png',
+			folderId,
+			mimeType: image.type || 'image/png',
+		});
 
 		const uploadResponse = await fetch(`${Server.ServerUrl}/files`, {
 			method: 'POST',

--- a/apps/frontend/app/helper/fileUploadHelper.test.ts
+++ b/apps/frontend/app/helper/fileUploadHelper.test.ts
@@ -1,0 +1,199 @@
+// Regression tests for the Expo SDK 57 upload break: `expo/fetch` (the global `fetch` since
+// SDK 57) builds the multipart body in JavaScript and rejects React Native's proprietary
+// `{ uri, name, type }` form part with "Unsupported FormDataPart implementation".
+// `isSupportedByExpoFetch` below mirrors the check in `expo/src/winter/fetch/convertFormData.ts`.
+
+jest.mock('@/constants/Constants', () => ({ isWeb: false }));
+
+jest.mock('repo-depkit-common-ui', () => ({ MyBuffer: require('buffer').Buffer }));
+
+const cacheDirectory = 'file:///cache';
+
+// Minimal stand-in for the `expo-file-system` `File`: it keeps the parts of the real class that
+// `expo/fetch` relies on - `name`, `type` and `bytes()`.
+class MockFileSystemFile {
+	static writtenFiles: Record<string, Uint8Array> = {};
+
+	public readonly uri: string;
+
+	constructor(...uris: string[]) {
+		this.uri = uris.join('/');
+	}
+
+	get name() {
+		return this.uri.split('/').pop() ?? '';
+	}
+
+	get type() {
+		return this.name.endsWith('.png') ? 'image/png' : 'image/jpeg';
+	}
+
+	create() {
+		MockFileSystemFile.writtenFiles[this.uri] = new Uint8Array();
+	}
+
+	write(bytes: Uint8Array) {
+		MockFileSystemFile.writtenFiles[this.uri] = bytes;
+	}
+
+	async bytes(): Promise<Uint8Array> {
+		return MockFileSystemFile.writtenFiles[this.uri] ?? new Uint8Array();
+	}
+}
+
+jest.mock('expo-file-system', () => ({
+	File: MockFileSystemFile,
+	Paths: { cache: cacheDirectory },
+}));
+
+type RecordedPart = [string, unknown, string?];
+
+// React Native's `FormData` exposes its parts only through internals, jsdom's only through
+// `entries()` - and neither keeps a non-`Blob` object intact. This stand-in records the
+// `append` calls, which is all the assertions below need.
+class RecordingFormData {
+	public readonly parts: RecordedPart[] = [];
+
+	append(name: string, value: unknown, fileName?: string) {
+		this.parts.push([name, value, fileName]);
+	}
+
+	// `expo/fetch` reads the parts through `entries()`, exactly like the patched React Native
+	// `FormData` provides them (see `expo/src/winter/FormData.ts`).
+	entries(): [string, unknown][] {
+		return this.parts.map(part => [part[0], part[1]]);
+	}
+}
+
+/** The exact acceptance check `expo/fetch` performs for every form part. */
+function isSupportedByExpoFetch(part: unknown): boolean {
+	return typeof part === 'string' || part instanceof Blob || (typeof part === 'object' && part !== null && 'bytes' in part);
+}
+
+describe('fileUploadHelper', () => {
+	let fileUploadHelper: typeof import('./fileUploadHelper');
+	let originalFormData: typeof FormData;
+
+	const getParts = (formData: FormData): RecordedPart[] => (formData as unknown as RecordingFormData).parts;
+	const getFieldValue = (formData: FormData, name: string) => getParts(formData).find(part => part[0] === name)?.[1];
+	const getFilePart = (formData: FormData) => getParts(formData).at(-1);
+
+	beforeEach(() => {
+		jest.resetModules();
+		MockFileSystemFile.writtenFiles = {};
+		originalFormData = global.FormData;
+		global.FormData = RecordingFormData as unknown as typeof FormData;
+		fileUploadHelper = require('./fileUploadHelper');
+	});
+
+	afterEach(() => {
+		global.FormData = originalFormData;
+	});
+
+	it('appends a file part that expo/fetch can serialize instead of a { uri } object', async () => {
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: 'file:///data/user/0/cache/ImageManipulator/abc-123.jpg',
+			fileName: 'foods_42',
+		});
+
+		const filePart = getFilePart(formData);
+		expect(filePart?.[0]).toBe('file');
+		expect(isSupportedByExpoFetch(filePart?.[1])).toBe(true);
+		// The React Native form part that SDK 57 rejects.
+		expect(isSupportedByExpoFetch({ uri: 'file:///abc.jpg', name: 'foods_42.jpg', type: 'image/jpeg' })).toBe(false);
+	});
+
+	it('appends the file last, because Directus ignores payload fields sent after it', async () => {
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: 'file:///cache/abc-123.jpg',
+			fileName: 'foods_42',
+			folderId: 'folder-uuid',
+			title: 'foods_42',
+		});
+
+		const parts = getParts(formData);
+		expect(parts.map(part => part[0])).toEqual(['folder', 'title', 'filename_download', 'type', 'file']);
+	});
+
+	it('adds the missing extension and the mime type to the uploaded file name', async () => {
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: 'file:///cache/abc-123.jpg',
+			fileName: 'foods_42',
+		});
+
+		expect(getFieldValue(formData, 'filename_download')).toBe('foods_42.jpg');
+		expect(getFieldValue(formData, 'type')).toBe('image/jpeg');
+	});
+
+	it('keeps an extension that the file name already carries', async () => {
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: 'file:///cache/abc-123.png',
+			fileName: 'signature_1700000000.png',
+		});
+
+		expect(getFieldValue(formData, 'filename_download')).toBe('signature_1700000000.png');
+		expect(getFieldValue(formData, 'type')).toBe('image/png');
+	});
+
+	it('writes a data uri (signature) into a cache file, since native cannot build a Blob from bytes', async () => {
+		const base64 = Buffer.from('signature-bytes').toString('base64');
+
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: `data:image/png;base64,${base64}`,
+			fileName: 'signature_1700000000',
+		});
+
+		expect(getFieldValue(formData, 'filename_download')).toBe('signature_1700000000.png');
+		expect(getFieldValue(formData, 'type')).toBe('image/png');
+
+		const filePart = getFilePart(formData)?.[1] as MockFileSystemFile;
+		expect(isSupportedByExpoFetch(filePart)).toBe(true);
+		expect(Buffer.from(await filePart.bytes()).toString()).toBe('signature-bytes');
+	});
+
+	it('prefers the explicitly known mime type over the one derived from the uri', async () => {
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: 'file:///cache/document-without-extension',
+			fileName: 'report',
+			mimeType: 'application/pdf',
+		});
+
+		expect(getFieldValue(formData, 'type')).toBe('application/pdf');
+		expect(getFieldValue(formData, 'filename_download')).toBe('report.pdf');
+	});
+
+	it('is serialized by the real expo/fetch multipart conversion', async () => {
+		// The code that threw "Unsupported FormDataPart implementation" in SDK 57.
+		const { convertFormDataAsync } = require('expo/src/winter/fetch/convertFormData');
+		const base64 = Buffer.from('signature-bytes').toString('base64');
+
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: `data:image/png;base64,${base64}`,
+			fileName: 'signature_1700000000',
+			folderId: 'folder-uuid',
+		});
+
+		const { body } = await convertFormDataAsync(formData, 'TEST_BOUNDARY');
+		const serializedBody = Buffer.from(body).toString();
+
+		expect(serializedBody).toContain('content-disposition: form-data; name="file"; filename="signature_1700000000.png"');
+		expect(serializedBody).toContain('content-type: image/png');
+		expect(serializedBody).toContain('signature-bytes');
+		expect(serializedBody).toContain('name="folder"');
+
+		// ... while the form part the app built before this fix reproduces the reported error.
+		const legacyFormData = new RecordingFormData();
+		legacyFormData.append('image', { uri: 'file:///cache/abc-123.jpg', name: 'foods_42.jpg', type: 'image/jpg' });
+		await expect(convertFormDataAsync(legacyFormData, 'TEST_BOUNDARY')).rejects.toThrow('Unsupported FormDataPart implementation');
+	});
+
+	it('omits the folder and title fields when they are not set', async () => {
+		const formData = await fileUploadHelper.buildDirectusUploadFormData({
+			uri: 'file:///cache/abc-123.jpg',
+			fileName: 'foods_42',
+			folderId: '',
+		});
+
+		expect(getParts(formData).map(part => part[0])).toEqual(['filename_download', 'type', 'file']);
+	});
+});

--- a/apps/frontend/app/helper/fileUploadHelper.ts
+++ b/apps/frontend/app/helper/fileUploadHelper.ts
@@ -1,0 +1,207 @@
+import { File as FileSystemFile, Paths } from 'expo-file-system';
+import { StringHelper } from 'repo-depkit-common';
+import { MyBuffer } from 'repo-depkit-common-ui';
+import { isWeb } from '@/constants/Constants';
+
+/**
+ * Building the multipart body for a Directus `/files` upload.
+ *
+ * Since Expo SDK 57 the global `fetch` is `expo/fetch` (see `expo/src/winter/runtime.native.ts`),
+ * which assembles the multipart body in JavaScript instead of handing the `FormData` to React
+ * Native's networking layer. `expo/fetch` only understands form parts that carry their own bytes -
+ * a string, a `Blob`, or an object with a `bytes()` method - and throws
+ * `Unsupported FormDataPart implementation` for React Native's proprietary
+ * `{ uri, name, type }` file part (see `expo/src/winter/fetch/convertFormData.ts`).
+ *
+ * Therefore every upload has to append a real payload:
+ * - web: a `Blob` read from the picked object/data uri,
+ * - native: an `expo-file-system` `File`, which implements `Blob` and exposes `bytes()`.
+ */
+
+const DATA_URI_PREFIX = 'data:';
+const DEFAULT_FILE_EXTENSION = 'jpg';
+const DEFAULT_MIME_TYPE = 'application/octet-stream';
+
+const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	png: 'image/png',
+	gif: 'image/gif',
+	webp: 'image/webp',
+	heic: 'image/heic',
+	heif: 'image/heif',
+	pdf: 'application/pdf',
+};
+
+const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+	'image/jpeg': 'jpg',
+	'image/jpg': 'jpg',
+	'image/png': 'png',
+	'image/gif': 'gif',
+	'image/webp': 'webp',
+	'image/heic': 'heic',
+	'image/heif': 'heif',
+	'application/pdf': 'pdf',
+};
+
+/**
+ * A form part that carries its own bytes and is therefore accepted by `expo/fetch`.
+ * `FileSystemFile` is not a `Blob` subclass, it only implements the interface.
+ */
+export type UploadFilePart = Blob | FileSystemFile;
+
+export type DirectusUploadFormDataOptions = {
+	/** Local uri of the file: a `file://`/`content://` uri on native, an object/data uri on web. */
+	uri: string;
+	/** Name of the uploaded file. The extension is added when it is missing. */
+	fileName: string;
+	/** Id of the Directus folder the file should be stored in. */
+	folderId?: string | null;
+	/** Mime type of the file, derived from the uri when omitted. */
+	mimeType?: string | null;
+	/** Title stored on the Directus file. */
+	title?: string | null;
+};
+
+function isDataUri(uri: string): boolean {
+	return uri.startsWith(DATA_URI_PREFIX);
+}
+
+function getMimeTypeFromDataUri(dataUri: string): string | null {
+	const separatorIndex = dataUri.indexOf(',');
+	if (separatorIndex < 0) {
+		return null;
+	}
+	// "data:image/png;base64," -> "image/png"
+	const header = dataUri.slice(DATA_URI_PREFIX.length, separatorIndex);
+	const mimeType = header.split(';')[0];
+	return mimeType ? mimeType.toLowerCase() : null;
+}
+
+function getExtensionFromMimeType(mimeType: string | null | undefined): string | null {
+	if (!mimeType) {
+		return null;
+	}
+	const normalizedMimeType = mimeType.toLowerCase();
+	const knownExtension = EXTENSION_BY_MIME_TYPE[normalizedMimeType];
+	if (knownExtension) {
+		return knownExtension;
+	}
+	const subtype = normalizedMimeType.split('/')[1];
+	return subtype && /^[a-z0-9]{1,5}$/.test(subtype) ? subtype : null;
+}
+
+/**
+ * Extension of the given uri or file name, without the leading dot. `null` when there is none.
+ */
+export function getFileExtension(uriOrFileName: string): string | null {
+	if (isDataUri(uriOrFileName)) {
+		return getExtensionFromMimeType(getMimeTypeFromDataUri(uriOrFileName));
+	}
+	const withoutQuery = uriOrFileName.split('?')[0] ?? uriOrFileName;
+	const withoutFragment = withoutQuery.split('#')[0] ?? withoutQuery;
+	const lastSegment = withoutFragment.split('/').pop() ?? '';
+	const dotIndex = lastSegment.lastIndexOf('.');
+	if (dotIndex <= 0) {
+		return null;
+	}
+	const extension = lastSegment.slice(dotIndex + 1).toLowerCase();
+	return /^[a-z0-9]{1,5}$/.test(extension) ? extension : null;
+}
+
+/**
+ * Mime type for the file behind the uri: the explicitly known one, otherwise derived
+ * from the data uri header or from the file extension.
+ */
+export function resolveMimeType(uri: string, mimeType?: string | null): string {
+	if (mimeType) {
+		return mimeType;
+	}
+	if (isDataUri(uri)) {
+		return getMimeTypeFromDataUri(uri) ?? DEFAULT_MIME_TYPE;
+	}
+	const extension = getFileExtension(uri);
+	return (extension ? MIME_TYPE_BY_EXTENSION[extension] : null) ?? DEFAULT_MIME_TYPE;
+}
+
+/**
+ * File name that always carries an extension, so that Directus stores a downloadable
+ * file name instead of an extension-less one.
+ */
+export function resolveFileNameWithExtension(fileName: string, uri: string, mimeType?: string | null): string {
+	if (getFileExtension(fileName)) {
+		return fileName;
+	}
+	const extension = getFileExtension(uri) ?? getExtensionFromMimeType(resolveMimeType(uri, mimeType)) ?? DEFAULT_FILE_EXTENSION;
+	return `${fileName}.${extension}`;
+}
+
+function sanitizeFileName(fileName: string): string {
+	return StringHelper.replaceAllLiteralWithOptions({ str: fileName, find: '/', replace: '_' });
+}
+
+async function readBlobFromUri(uri: string): Promise<Blob> {
+	return new Promise((resolve, reject) => {
+		const xhr = new XMLHttpRequest();
+		xhr.onload = () => resolve(xhr.response);
+		xhr.onerror = () => reject(new TypeError(`Could not read the file at ${uri}`));
+		xhr.responseType = 'blob';
+		xhr.open('GET', uri, true);
+		xhr.send(null);
+	});
+}
+
+/**
+ * Writes the payload of a data uri (for example a signature drawn in the app) into a cache
+ * file, because native has no way to build a `Blob` from raw bytes.
+ */
+function writeDataUriToCacheFile(dataUri: string, fileNameWithExtension: string): FileSystemFile {
+	const base64Content = dataUri.slice(dataUri.indexOf(',') + 1);
+	const bytes = new Uint8Array(MyBuffer.from(base64Content, 'base64'));
+
+	const file = new FileSystemFile(Paths.cache, sanitizeFileName(fileNameWithExtension));
+	file.create({ overwrite: true, intermediates: true });
+	file.write(bytes);
+	return file;
+}
+
+/**
+ * Creates the form part for the file behind the given uri.
+ */
+export async function createUploadFilePart(uri: string, fileNameWithExtension: string): Promise<UploadFilePart> {
+	if (isWeb) {
+		return readBlobFromUri(uri);
+	}
+	if (isDataUri(uri)) {
+		return writeDataUriToCacheFile(uri, fileNameWithExtension);
+	}
+	return new FileSystemFile(uri);
+}
+
+/**
+ * Builds the `FormData` for a Directus `/files` upload.
+ *
+ * Directus applies only those payload fields that it has already read when it reaches the file
+ * part, so every metadata field is appended *before* the file.
+ */
+export async function buildDirectusUploadFormData(options: DirectusUploadFormDataOptions): Promise<FormData> {
+	const { uri, fileName, folderId, mimeType, title } = options;
+
+	const resolvedMimeType = resolveMimeType(uri, mimeType);
+	const fileNameWithExtension = resolveFileNameWithExtension(fileName, uri, resolvedMimeType);
+	const filePart = await createUploadFilePart(uri, fileNameWithExtension);
+
+	const formData = new FormData();
+	if (folderId) {
+		formData.append('folder', folderId);
+	}
+	if (title) {
+		formData.append('title', title);
+	}
+	formData.append('filename_download', fileNameWithExtension);
+	formData.append('type', resolvedMimeType);
+	// Directus reads the uploaded file from the file part regardless of the field name.
+	formData.append('file', filePart as Blob, fileNameWithExtension);
+
+	return formData;
+}

--- a/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
+++ b/apps/frontend/app/hooks/useMyScrollviewDirectusImageEditModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Alert, Platform, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, Text, View } from 'react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
@@ -15,6 +15,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { isWeb, settingsListSectionGap } from '@/constants/Constants';
 import { ServerAPI } from '@/redux/actions';
 import { CollectionHelper } from '@/helper/collectionHelper';
+import { buildDirectusUploadFormData } from '@/helper/fileUploadHelper';
 import { TranslationKeys } from '@/locales/keys';
 import { fetchSpecificField } from '@/redux/actions/Fields/Fields';
 import { CollectionNames } from 'repo-depkit-common';
@@ -147,51 +148,6 @@ async function resizeImageIfTooLarge(uri: string, width: number, height: number,
 	return resizedImage.uri;
 }
 
-/**
- * Builds the FormData payload for an image upload, using the platform-specific
- * way of turning a local file uri into a file/blob part.
- */
-async function buildImageFormData(finalUri: string, fileName: string, storage: string): Promise<FormData> {
-	const formData = new FormData();
-
-	if (Platform.OS === 'web') {
-		const blob: Blob = await new Promise((resolve, reject) => {
-			const xhr = new XMLHttpRequest();
-			xhr.onload = function () {
-				resolve(xhr.response);
-			};
-			xhr.onerror = function (e) {
-				console.log(e);
-				reject(new TypeError('Network request failed'));
-			};
-			xhr.responseType = 'blob';
-			xhr.open('GET', finalUri, true);
-			xhr.send(null);
-		});
-
-		if (storage) {
-			formData.append('folder', storage);
-		}
-		formData.append('image', blob, fileName);
-	} else {
-		const uriParts = finalUri.split('.');
-		const fileType = uriParts.at(-1);
-		const fileExtension = `.${fileType}`;
-		const file: any = {
-			uri: finalUri,
-			name: fileName + fileExtension,
-			type: `image/${fileType}`,
-		};
-
-		if (storage) {
-			formData.append('folder', storage);
-		}
-		formData.append('image', file, fileName);
-	}
-
-	return formData;
-}
-
 const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps> = ({ field, collection, itemId, onUpdated, onClose }) => {
 	const { theme } = useTheme();
 	const { translate } = useLanguage();
@@ -259,11 +215,14 @@ const DirectusImageEditModalContent: React.FC<DirectusImageEditModalContentProps
 				setLoading(prev => ({ ...prev, camera: useCamera, image: !useCamera }));
 
 				const fileName = `${collection}_${itemId}`;
-				const formData = await buildImageFormData(finalUri, fileName, storage);
+				const formData = await buildDirectusUploadFormData({
+					uri: finalUri,
+					fileName,
+					folderId: storage,
+					title: fileName,
+				});
 
 				const client = ServerAPI.getClient();
-				formData.append('title', fileName);
-
 				const resultFileUpload = await client.request(uploadFiles(formData));
 				const fileId = resultFileUpload.id;
 


### PR DESCRIPTION
## Problem

Beim Hochladen eines Fotos in der App (nativ) erscheint:

> Fehler beim Hochladen: Unsupported FormDataPart implementation

## Ursache

Nicht base64 – der Auslöser ist der Wechsel auf **Expo SDK 57**. Seitdem ersetzt Expo das globale `fetch` durch `expo/fetch` (`expo/src/winter/runtime.native.ts`, abschaltbar nur über `EXPO_PUBLIC_USE_RN_FETCH=1`). `expo/fetch` baut den Multipart-Body **in JavaScript** zusammen, statt die `FormData` an die Netzwerk-Schicht von React Native zu übergeben.

`expo/src/winter/fetch/convertFormData.ts` akzeptiert dabei nur Form-Parts, die ihre Bytes selbst mitbringen – einen String, ein `Blob` oder ein Objekt mit `bytes()`-Methode – und wirft für alles andere:

```ts
} else {
  throw new Error('Unsupported FormDataPart implementation');
}
```

Die App hat auf Nativ genau das nicht mehr unterstützte React-Native-Form-Part angehängt:

```ts
formData.append('image', { uri: finalUri, name: fileName + ext, type: `image/${fileType}` });
```

Ein `Blob` lässt sich auf Nativ nicht aus Bytes bauen (React Natives `BlobManager` wirft bei `ArrayBuffer`/`ArrayBufferView`), deshalb kommt jetzt die `File`-Klasse aus `expo-file-system` zum Einsatz: sie implementiert das `Blob`-Interface und stellt `bytes()`, `name` und `type` bereit – genau das, was `expo/fetch` erwartet.

## Änderungen

- **Neuer gemeinsamer Helper `apps/frontend/app/helper/fileUploadHelper.ts`**, der die Upload-`FormData` für Directus baut:
  - Web: `Blob` aus der Objekt-/Data-URI
  - Nativ: `expo-file-system`-`File`
  - Data-URIs (Unterschriften) werden auf Nativ in eine Cache-Datei geschrieben, da dort kein `Blob` aus rohen Bytes erzeugt werden kann
- Ersetzt die **zwei duplizierten** `buildImageFormData`-Implementierungen (`ImageManagementSheet`, `useMyScrollviewDirectusImageEditModal`) und den Upload in `uploadToDirectusFromMobile` (Formulare/Unterschriften – dort trat derselbe Fehler auf).
- **Datei-Part wird zuletzt angehängt.** Directus übernimmt nur die Payload-Felder, die es *vor* dem File-Part gelesen hat – `title` und `filename_download` wurden bisher still verworfen.
- Hochgeladene Dateien behalten **Endung und korrekten Mime-Type** (vorher `image/jpg` statt `image/jpeg`, Dateiname ohne Endung).
- Formular-Uploads rufen auf Nativ kein `fetch()` mehr auf der lokalen `file://`/`data:`-URI auf – das kann `expo/fetch` ebenfalls nicht lesen.
- Patch-Version auf 18 erhöht (AGENTS.md).

## Tests

`apps/frontend/app/helper/fileUploadHelper.test.ts` (8 Tests). Der Kern-Test schickt die gebaute `FormData` durch die **echte** Konvertierung von `expo/fetch` und prüft beide Richtungen:

```ts
const { convertFormDataAsync } = require('expo/src/winter/fetch/convertFormData');
// neu: wird sauber serialisiert (Body enthält Bytes, Dateiname, Content-Type)
// alt: reproduziert exakt den gemeldeten Fehler
await expect(convertFormDataAsync(legacyFormData, 'TEST_BOUNDARY'))
  .rejects.toThrow('Unsupported FormDataPart implementation');
```

Weitere Tests: Reihenfolge der Felder (File zuletzt), Endung/Mime-Type-Ableitung, Data-URI-Signatur, explizit gesetzter Mime-Type.

```
Test Suites: 7 passed, 7 total     (gesamte Frontend-Suite)
Tests:       50 passed, 50 total
```

Zusätzlich: `yarn export:web` läuft durch (Import von `expo-file-system` bricht den Web-Build nicht), `tsc --noEmit` bringt keine neuen Fehler in den geänderten Dateien.

**Kein Maestro-Test:** Der Maestro-Harness im Repo läuft gegen Web, der Bug ist aber nativ-spezifisch und hängt am System-Bildauswahl-Dialog – das lässt sich dort nicht automatisieren.

## Nicht verifiziert

Ein Live-Test gegen `test.rocket-meals.de` war aus dieser Umgebung nicht möglich (Netzwerk-Policy blockt die Domain, CONNECT → 403). Der Upload sollte deshalb einmal manuell in einem Dev-Client geprüft werden – am besten Foto **und** Formular-Unterschrift.

Screenshot der Änderung entfällt: rein funktionaler Fix, die UI ist unverändert (bei Erfolg schließt sich das Sheet wie bisher, statt das Fehler-Modal aus dem Ticket zu zeigen).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXhsMrWaQQR4Rbt14A5eH7)_